### PR TITLE
Fix typo in publish action of documentation

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -61,5 +61,5 @@ runs:
       working-directory: documentation
       run: |
         # outputs to "site/gw/api" directory
-        ford -g gw_ford.md
+        ford -g GW_ford.md
       shell: bash


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

The file to configure FORD for GW is named GW_ford.md and the action was looking for gw_ford.md

You can link issues by using a supported keyword in the pull request's description or in a commit message:

## Type of change

Please delete options that are not relevant.

- [x] Bug fix
- [ ] New or updated documentation

## Checklist

- [x] The new content is accessible and located in the appropriate section.
- [x] I have checked that links are valid and point to the intended content.
- [x] I have checked my code/text and corrected any misspellings

Please add a reviewer when ready for review.
