### PR TITLE
Changed link to Tumbarumba fluxnet info at fluxnet.org

### DIFF
--- a/documentation/docs/user_guide/uber_quick_guide.md
+++ b/documentation/docs/user_guide/uber_quick_guide.md
@@ -27,5 +27,5 @@ ACCESS-CM2 uses a version of CABLE that is closer to the HEAD of the trunk at th
 
 For a more detailed discussion of CABLE offline please see the other sections of the [Cable's User Guide][userguide].
 
-[fluxnet-tumba]: http://sites.fluxdata.org/AU-Tum/
+[fluxnet-tumba]: https://fluxnet.org/sites/siteinfo/AU-Tum
 [userguide]: index.md


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

Fix a broken link in the documentation to the fluxnet.org Tumbarumba info page.
https://fluxnet.org/sites/siteinfo/AU-Tum

Fixes #124

## Type of change

- [ ] New or updated documentation

## Checklist

- [ ] The new content is accessible and located in the appropriate section.
- [ ] I have checked that links are valid and point to the intended content.
- [ ] I have checked my code/text and corrected any misspellings
