### PR TITLE
97 coding standards rebranch

### DIFF
--- a/documentation/docs/developer_guide/coding_standards.md
+++ b/documentation/docs/developer_guide/coding_standards.md
@@ -52,6 +52,7 @@ Subroutines should be of the form "*_cbl()". Following from the above file egNam
 
 ### 8. Miscellaneous
 
+ * It will not be permitted to `USE` data through `MODULE`s. Data will be be passed through argument lists. 
  * The last character of a line **must** not be placed beyond column 80. 
  * `SAVE` attributes are not permitted.
  * Intrinsic Fortran subroutines, functions, etc should be capitalized
@@ -81,7 +82,7 @@ The Next Generation Modelling System (NGMS) is a major program at the UKMO to ad
 The NGMS is an initiative to optimize the software of their entire suite of models.
 The specific coding standards required by the NGMS have not yet been strictly defined. 
 
-In general, models (including CABLE) have evolved over decades, involving dozens of developers. A key feature emerging from NGMS is the tight reign on memory. As such, it will not be permitted to `USE` data through `MODULE`s. Data will be be passed through argument lists. There are further rules emerging in this respect which relax the rules slightly to allow time independent scalars to be `USE`d. Nevertheless, it is straightforward enough to pass these as well. 
+In general, models (including CABLE) have evolved over decades, involving dozens of developers. A key feature emerging from NGMS is the tight reign on memory. As listed above, it will not be permitted to `USE` data through `MODULE`s. Data will be be passed through argument lists. There are further rules emerging in this respect which relax the rules slightly to allow time independent scalars to be `USE`d. Nevertheless, it is straightforward enough to pass these as well. 
 
 ## Specific Develoments
 Code developments broadly fall into two categories. Bug fixes and new developments. Both can involve a wide range of complexity. However, at the extremes a bug fix may be as simple as moving a bracket. Alternatively, the bug fix might require you to rewrite a section, or even several sections of code. 

--- a/documentation/docs/developer_guide/coding_standards.md
+++ b/documentation/docs/developer_guide/coding_standards.md
@@ -11,7 +11,7 @@ Submitted developments that are inconsistent with the standards discussed below,
 ## Coding Standards
 Generic code examples are given below as well as a link to the JULES coding standards, to which CABLE is somewhat bound through the JULES and CABLE (JAC) project.  
 Whilst syntax/text formatting style is relatively trivial, it must still be adhered to. Some more significant general rules that should be followed are: 
-## The JAC project 
+ 
 The JAC project is a long term initiative to include CABLE as an inter-operable Land-Surface Model (LSM) within the Unified Model (UM). For several reasons, CABLE is coupled to the UM via its native LSM, JULES. From a coding standards perspective, both the UM and JULES developments are strictly goverened by the UK Met Office and thus CABLE's coding standards are somewhat constrained by JULES' coding standards. 
 
 The [JULES coding standards](http://jules-lsm.github.io/coding_standards/) are described in this comprehensive document.

--- a/documentation/docs/developer_guide/coding_standards.md
+++ b/documentation/docs/developer_guide/coding_standards.md
@@ -16,7 +16,7 @@ Whilst syntax/text formatting style is relatively trivial, it must still be adhe
 
 ### 1. IO must be restricted to the top level
 
-In terms of the offline application of the model this means IO should be restricted to the offline/ directory. Coupled to the UM/JULES there should be no IO code in the CABLE directory. 
+In terms of the offline application of the model this means IO should be restricted to the offline/ directory. There should be no IO code elsewhere in the CABLE directory. 
 
 ### 2. Comment liberally
 

--- a/documentation/docs/developer_guide/coding_standards.md
+++ b/documentation/docs/developer_guide/coding_standards.md
@@ -44,7 +44,7 @@ Please maintain consistent naming between files, subroutines and modules.
 ### 6. MODULE names
 
 Everything should be contained within modules.
-Modules should be of the form "*_mod_cbl". Following from the above file egName_cbl.F90 **MODULE egName_mod_cbl**.
+Modules should be named of the form `*_mod_cbl`. Following from the above example, the file `egName_cbl.F90` should contain the module declaration `MODULE egName_mod_cbl`
 
 ### 7. SUBROUTINE names
 
@@ -52,21 +52,20 @@ Subroutines should be of the form "*_cbl()". Following from the above file egNam
 
 ### 8. Miscellaneous
 
- * The last character of a line MUST not be placed beyond column 80. 
- * SAVE attributes will not be permitted.
- * Intrinsic FORTRAN subroutines, functions, etc should be capitalized
+ * The last character of a line **must** not be placed beyond column 80. 
+ * `SAVE` attributes are not permitted.
+ * Intrinsic Fortran subroutines, functions, etc should be capitalized
  * Subroutines start on the margin. As do headers. Indentation of two spaces
    occurs in loops 
- * Specify IMPLICIT NONE ! prevents accidents 
- * Recieved arguments need to be (re)declared with the INTENT() attribute 
- * Declare in a MODULE header what is to be PUBLIC
- * Specify ONLY in USE statements. To avoid inadvertent inheritance and
+ * Specify `IMPLICIT NONE` in all modules to prevent type mismatch errors 
+ * Dummy arguments must be declared with the `INTENT()` attribute
+ * Declare in the `MODULE` preamble which elements are `PUBLIC`
+ * Import specific components using `ONLY` with `USE` statements to avoid inadvertent inheritance and
    increase transparency of underlying data flow 
- * It is very useful to label either side of a loop. Especially if it covers
+ * Label each side of a loop, especially if it extends
    more than a page.
- * Specify IMPLICIT NONE 
- * All IF constructs must be of the form:
-```
+ * All `IF` constructs must be of the form:
+```fortran
 IF() THEN 
   Even if they only contain a simple, single line statement following the IF. 
 END IF
@@ -79,11 +78,11 @@ The UKMO is in the process of revising their entire suite of models, as part of 
 The specific coding standards required of the NGMS have not yet been strictly defined. 
 However, from a technical perspective the necessity of the project can be summarized as follows. 
 Excluding a quantum computing breakthrough, we as a community can no longer expect advances in hardware to enable higher performance. This means higher resolution, more sophisticated process description etc. We can however better  organize the software. 
-In the main our models (including CABLE), have evolved over decades, involving dozens of developers. A key feature emerging from NGMS is the tight reign on memory. As such it will not be permitted to USE data through MODULEs. Data must be passed through argument lists. There are further rules emerging in this respect which relax the rules slightly to allow time independent scalars to be USEd. Nevertheless it is straight-forward enough to pass these as well. 
+In general, models (including CABLE) have evolved over decades, involving dozens of developers. A key feature emerging from NGMS is the tight reign on memory. As such, it will not be permitted to `USE` data through `MODULE`s. Data will be be passed through argument lists. There are further rules emerging in this respect which relax the rules slightly to allow time independent scalars to be `USE`d. Nevertheless, it is straightforward enough to pass these as well. 
 
 ## Specific Develoments
-Code developments broadly fall into two categories. Bug fixes and new developments. Both can of course involve a wide range of complexity. However, at the extremes a bug fix may be as simple as moving a bracket. Alternatively, the bug fix might require you to rewrite a section, or even several sections of code. 
-A new development might be as simple as an alternative section or calculation, or it might be an entirely new model that can be plugged in to CABLE. Either as an alternative model, or an extra feature to be used in the standard model.
+Code developments broadly fall into two categories. Bug fixes and new developments. Both can involve a wide range of complexity. However, at the extremes a bug fix may be as simple as moving a bracket. Alternatively, the bug fix might require you to rewrite a section, or even several sections of code. 
+A new development might be as simple as an alternative section or calculation, or it might be an entirely new model that can be plugged in to CABLE, either as an alternative model, or an extra feature to be used in the standard model.
 
 In all cases, an issue should be raised. The accompanying fix contained should then be implemented in a unique branch, corresponding to the raised issue. A bugfix might simply involve reference to this issue. For a more complicated, added feature, it is a requirement that this addition can be isolated and switched off via a configuration switch, so that the model can be also run as if there had been no alteration. There is of course every possibility that this feature will be accepted as a standard part of the model. Although this is not the expectation initially and the developer should be mindful of this fundamental requirement. 
 

--- a/documentation/docs/developer_guide/coding_standards.md
+++ b/documentation/docs/developer_guide/coding_standards.md
@@ -1,45 +1,56 @@
-## Foreword
-!!! Note "Current standards compliance"
-
-    Currently not all of the CABLE code is compliant with the standards described here. Work is in progress to apply these standards across the existing code base, however these standards are expected to be met by any new development.
 
 ## Introduction
+
 CABLE is a community software project. 
 For the benefit of the whole community, developers are required to adhere to certain coding standards that better enable portability, efficient maintenance, future development, performance and readability. 
 
 Submitted developments that are inconsistent with the standards discussed below, and/or poorly commented/documented code will not be accepted without revision. 
-## Coding Standards
-Generic code examples are given below as well as a link to the JULES coding standards, to which CABLE is somewhat bound through the JULES and CABLE (JAC) project.  
-Whilst syntax/text formatting style is relatively trivial, it must still be adhered to. Some more significant general rules that should be followed are: 
- 
-The JAC project is a long term initiative to include CABLE as an inter-operable Land-Surface Model (LSM) within the Unified Model (UM). For several reasons, CABLE is coupled to the UM via its native LSM, JULES. From a coding standards perspective, both the UM and JULES developments are strictly goverened by the UK Met Office and thus CABLE's coding standards are somewhat constrained by JULES' coding standards. 
 
-The [JULES coding standards](http://jules-lsm.github.io/coding_standards/) are described in this comprehensive document.
+The JULES and CABLE (JAC) project is a long term initiative to include CABLE as an inter-operable Land-Surface Model (LSM) within the Unified Model (UM). For several reasons, CABLE is coupled to the UM via its native LSM, JULES. From a coding standards perspective, both the UM and JULES developments are strictly goverened by the UK Met Office and thus CABLE's coding standards are somewhat constrained the [JULES coding standards](http://jules-lsm.github.io/coding_standards/).
+
+Currently not all of the CABLE code is compliant with the standards described here. Work is in progress to apply these standards across the existing code base, however these standards are expected to be met by any new development.
+
+Whilst syntax/text formatting style is relatively trivial, it must still be adhered to. Some more significant general rules follow.
+
+## General Rules
+
 ### 1. IO must be restricted to the top level
+
 In terms of the offline application of the model this means IO should be restricted to the offline/ directory. Coupled to the UM/JULES there should be no IO code in the CABLE directory. 
 
 ### 2. Comment liberally
+
 Detrimental to any model is the lack of meaningful and/or outdated comments. 
 Liberal inline commenting is expected aswell as thorough commenting in the MarkDown. See [cable_roughness.F90](https://github.com/CABLE-LSM/CABLE/blob/main/src/science/roughness/cable_roughness.F90) for an example, which is then redered as ?????
+
 ### 3. Avoid WHERE loops
+
 WHERE loops effectively replace DO/IF loops. In some circumstances these may improve readability. They certainly make it easier to write code. However they are nightmare to debug and hamper portability. Especially nested WHERE loops. 
 Moreover it will not pass JULES coding standards. 
+
 ### 4. Variable names
+
 We are not so limited by the number of character spaces available as we once were. Developers are encouraged to name variables meaningfully. Of course commenting might make it clear what the variable corresponds to however it is helpful to be able to understand what is going on whilst reading a line of code.
 
 Please maintain globally consistent names of variables across files/subroutines/modules. 
+
 ### 5. File names
+
 To include CABLE code identifiably across applications, please include the "_cbl" suffix in your filename **eg. egName_cbl.F90**. 
 
 Please maintain consistent naming between files/subroutines/modules. 
+
 ### 6. MODULE names
+
 Everything should be contained within modules.
 Modules should be of the form "*_mod_cbl". Following from the above file egName_cbl.F90 **MODULE egName_mod_cbl**.
 
 ### 7. SUBROUTINE names
+
 Subroutines should be of the form "*_cbl()". Following from the above file egName_cbl.F90 **SUBROUTINE egName_cbl()**.
 
 ### 8. Miscellaneous
+
  * The last character of a line MUST not be placed beyond column 80. 
  * SAVE attributes will not be permitted.
  * Intrinsic FORTRAN subroutines, functions, etc should be capitalized
@@ -62,6 +73,7 @@ END IF
  * In summary, be pedantic, be clear
 
 ## Final Note about JAC
+
 The UKMO is in the process of revising their entire suite of models, as part of a major program to create a Next Generation Modelling System (NGMS). 
 The specific coding standards required of the NGMS have not yet been strictly defined. 
 However, from a technical perspective the necessity of the project can be summarized as follows. 
@@ -72,13 +84,14 @@ In the main our models (including CABLE), have evolved over decades, involving d
 Code developments broadly fall into two categories. Bug fixes and new developments. Both can of course involve a wide range of complexity. However, at the extremes a bug fix may be as simple as moving a bracket. Alternatively, the bug fix might require you to rewrite a section, or even several sections of code. 
 A new development might be as simple as an alternative section or calculation, or it might be an entirely new model that can be plugged in to CABLE. Either as an alternative model, or an extra feature to be used in the standard model.
 
-In all cases an issue should be raised. The accompanying fix contained should then be implemented in a unique branch, corresponding to the raised issue. A bugfix might simply ivolve reference to this issue. For a more complicated, added feature, it is a requirement that this addition can be isolated, switched off via a configuration switch. So that the model can be run, and return results as if there had been no addition. There is of course every possibility that this feature will be accepted as a standard part of the model. Although this is not the expectation initially and the developer should be mindful of this fundamental requirement. 
+In all cases, an issue should be raised. The accompanying fix contained should then be implemented in a unique branch, corresponding to the raised issue. A bugfix might simply involve reference to this issue. For a more complicated, added feature, it is a requirement that this addition can be isolated and switched off via a configuration switch, so that the model can be also run as if there had been no alteration. There is of course every possibility that this feature will be accepted as a standard part of the model. Although this is not the expectation initially and the developer should be mindful of this fundamental requirement. 
 
 We proceed assuming that the "issue" raised requires adding a new and significant feature to CABLE, requiring the addition of new files/modules to CABLE. Lesser modifications are covered under this assumption anyway.
 
 For discussion purposes we assume that you are including a new model to do some new stuff. This can conveniently be added in a single file. 
 
 ## Code Template 
+
 Assuming the *new* model is called from eg_driver.F90.
 
 ```
@@ -159,4 +172,4 @@ END DO                              ! DO:over ilen
 
 RETURN
 END SUBROUTINE eg_subr 
-
+```

--- a/documentation/docs/developer_guide/coding_standards.md
+++ b/documentation/docs/developer_guide/coding_standards.md
@@ -32,7 +32,7 @@ Moreover it will not pass JULES coding standards.
 
 We are not so limited by the number of character spaces available as we once were. Developers are encouraged to name variables meaningfully. Commenting might make it clear what the variable corresponds to, however, it is helpful to be able to understand what is going on whilst reading a line of code.
 
-Please maintain globally consistent names of variables across files/subroutines/modules. 
+Please maintain globally consistent names of variables across files, subroutines and modules. 
 
 ### 5. File names
 

--- a/documentation/docs/developer_guide/coding_standards.md
+++ b/documentation/docs/developer_guide/coding_standards.md
@@ -36,7 +36,8 @@ Please maintain globally consistent names of variables across files, subroutines
 
 ### 5. File names
 
-To include CABLE code identifiably across applications, please include the "_cbl" suffix in your filename **eg. egName_cbl.F90**. 
+To include CABLE code identifiably across applications, please name the file with a `_cbl` suffix in your filename.
+For example: `egName_cbl.F90`. 
 
 Please maintain consistent naming between files/subroutines/modules. 
 

--- a/documentation/docs/developer_guide/coding_standards.md
+++ b/documentation/docs/developer_guide/coding_standards.md
@@ -109,7 +109,7 @@ END PROGRAM eg_driver
 ```
 Where,
 
-```
+```fortran
 MODULE eg_mod_cbl
 ! Module description in markdown - see??
 
@@ -127,7 +127,7 @@ END MODULE eg_mod_cbl
 
 Where,
 
-```
+```fortran
 SUBROUTINE eg_subr( eg_arg, ilen, jlen, sometype )
 ! Subroutine description in markdown - see??
 

--- a/documentation/docs/developer_guide/coding_standards.md
+++ b/documentation/docs/developer_guide/coding_standards.md
@@ -45,7 +45,7 @@ Modules should be named using the filename followed by a `_mod` suffix. For exam
 
 ### 7. SUBROUTINE names
 
-Subroutines should be of the form "\*_cbl()". Following from the above file `egName_cbl.F90` `SUBROUTINE egName_cbl()`. This is not only helpful for consistency but necessary within JULES/UM applications where it distinguishes the CABLE version of an analogous JULES subroutine. 
+Subroutines should be of the form "\*_cbl()". The above file `cbl_egName.F90` would contain the subroutine: `SUBROUTINE egName_cbl()`. The name of the subroutine should be chosen to reflect what the subroutine does. This name does not need to have any link with the module or file names. This is not only helpful for consistency but necessary within JULES/UM applications where it distinguishes the CABLE version of an analogous JULES subroutine. 
 
 ### 8. Miscellaneous
 
@@ -87,12 +87,12 @@ In general, models (including CABLE) have evolved over decades, involving dozens
 ```fortran
 PROGRAM eg_driver()
 
-USE cbl_eg_mod, ONLY : eg_subr
+USE cbl_eg_mod, ONLY : eg_subr_cbl
 
 IMPLICIT NONE
 Header Declarations
 ...
-CALL eg_subr( Arguments )
+CALL eg_subr_cbl( Arguments )
 ...
 
 END PROGRAM eg_driver
@@ -103,14 +103,14 @@ Where,
 MODULE cbl_eg_mod
 ! Module description in markdown - e.g. [cable_roughness.F90](https://github.com/CABLE-LSM/CABLE/blob/main/src/science/roughness/cable_roughness.F90) for an example, which is then rendered [here](https://cable.readthedocs.io/en/latest/api/module/cable_roughness_module.html)
 
-PUBLIC :: eg_subr 
+PUBLIC :: eg_subr_cbl 
 PRIVATE
 
 CONTAINS
 
-SUBROUTINE eg_subr ( Arguments )
+SUBROUTINE eg_subr_cbl ( Arguments )
 ...
-END SUBROUTINE eg_subr 
+END SUBROUTINE eg_subr_cbl 
 
 END MODULE cbl_eg_mod
 ```
@@ -118,7 +118,7 @@ END MODULE cbl_eg_mod
 Where,
 
 ```fortran
-SUBROUTINE eg_subr( eg_arg, ilen, jlen, sometype )
+SUBROUTINE eg_subr_cbl( eg_arg, ilen, jlen, sometype )
 ! Subroutine description in markdown - see??
 
 USE cbl_some_type_mod, ONLY : some_type
@@ -161,5 +161,5 @@ ilen_loop: DO i=1,ilen
 END DO ilen_loop
 
 RETURN
-END SUBROUTINE eg_subr 
+END SUBROUTINE eg_subr_cbl 
 ```

--- a/documentation/docs/developer_guide/coding_standards.md
+++ b/documentation/docs/developer_guide/coding_standards.md
@@ -48,15 +48,15 @@ Modules should be named of the form `*_mod_cbl`. Following from the above exampl
 
 ### 7. SUBROUTINE names
 
-Subroutines should be of the form "*_cbl()". Following from the above file egName_cbl.F90 **SUBROUTINE egName_cbl()**.
+Subroutines should be of the form "*_cbl()". Following from the above file egName_cbl.F90 **SUBROUTINE egName_cbl()**. This is not only helpful for consonsistency but necessary within JULES/UM applications where it distinguishes the CABLE version of an analagous JULES subroutine. 
 
 ### 8. Miscellaneous
 
  * The last character of a line **must** not be placed beyond column 80. 
  * `SAVE` attributes are not permitted.
  * Intrinsic Fortran subroutines, functions, etc should be capitalized
- * Subroutines start on the margin. As do headers. Indentation of two spaces
-   occurs in loops 
+ * Subroutines start on the margin. This includes MODULE, CONTAINS, SUBROUTINE, USE statements, and declarations. Indentation of two spaces occurs in loops/layers. This is vital in readily identifying the extent of loops/layers. i.e. Under which condition(s) a section of code is relevantin an IF layer, or at what index is being traversed in a DO loop. 
+
  * Specify `IMPLICIT NONE` in all modules to prevent type mismatch errors 
  * Dummy arguments must be declared with the `INTENT()` attribute
  * Declare in the `MODULE` preamble which elements are `PUBLIC`
@@ -74,10 +74,13 @@ END IF
 
 ## Final Note about JAC
 
-The UKMO is in the process of revising their entire suite of models, as part of a major program to create a Next Generation Modelling System (NGMS). 
-The specific coding standards required of the NGMS have not yet been strictly defined. 
-However, from a technical perspective the necessity of the project can be summarized as follows. 
-Excluding a quantum computing breakthrough, we as a community can no longer expect advances in hardware to enable higher performance. This means higher resolution, more sophisticated process description etc. We can however better  organize the software. 
+Scientific models have naturally evolved over time to include increasing complexity. Coupled with the demand for higher resolution, larger ensembles etc, this has required ever increasing computational performance.
+For several decades, this icreasing performance demand has been met by technological advances in hardware.   
+This era has come to an end.
+The Next Generation Modelling System (NGMS) is a major program at the UKMO to address this issue.  
+The NGMS is an initiative to optimize the software of their entire suite of models.
+The specific coding standards required by the NGMS have not yet been strictly defined. 
+
 In general, models (including CABLE) have evolved over decades, involving dozens of developers. A key feature emerging from NGMS is the tight reign on memory. As such, it will not be permitted to `USE` data through `MODULE`s. Data will be be passed through argument lists. There are further rules emerging in this respect which relax the rules slightly to allow time independent scalars to be `USE`d. Nevertheless, it is straightforward enough to pass these as well. 
 
 ## Specific Develoments
@@ -111,7 +114,7 @@ Where,
 
 ```fortran
 MODULE eg_mod_cbl
-! Module description in markdown - see??
+! Module description in markdown - e.g. [cable_roughness.F90](https://github.com/CABLE-LSM/CABLE/blob/main/src/science/roughness/cable_roughness.F90) for an example, which is then redered [here](https://cable.readthedocs.io/en/latest/api/module/cable_roughness_module.html)
 
 PUBLIC :: eg_subr 
 PRIVATE

--- a/documentation/docs/developer_guide/coding_standards.md
+++ b/documentation/docs/developer_guide/coding_standards.md
@@ -83,7 +83,6 @@ In general, models (including CABLE) have evolved over decades, involving dozens
 
 ## Code Template 
 
-Assuming the *new* model is called from eg_driver.F90.
 
 ```fortran
 PROGRAM eg_driver()

--- a/documentation/docs/developer_guide/coding_standards.md
+++ b/documentation/docs/developer_guide/coding_standards.md
@@ -39,7 +39,7 @@ Please maintain globally consistent names of variables across files, subroutines
 To include CABLE code identifiably across applications, please name the file with a `_cbl` suffix in your filename.
 For example: `egName_cbl.F90`. 
 
-Please maintain consistent naming between files/subroutines/modules. 
+Please maintain consistent naming between files, subroutines and modules. 
 
 ### 6. MODULE names
 

--- a/documentation/docs/developer_guide/coding_standards.md
+++ b/documentation/docs/developer_guide/coding_standards.md
@@ -81,16 +81,6 @@ The specific coding standards required by the NGMS have not yet been strictly de
 
 In general, models (including CABLE) have evolved over decades, involving dozens of developers. A key feature emerging from NGMS is the tight reign on memory. As listed above, it will not be permitted to `USE` data through `MODULE`s. Data will be be passed through argument lists. There are further rules emerging in this respect which relax the rules slightly to allow time independent scalars to be `USE`d. Nevertheless, it is straightforward enough to pass these as well. 
 
-## Specific Develoments
-Code developments broadly fall into two categories: bug fixes and new developments. Both can involve a wide range of complexity. However, at the extremes a bug fix may be as simple as moving a bracket. Alternatively, the bug fix might require you to rewrite a section, or even several sections of code. 
-A new development might be as simple as an alternative section or calculation, or it might be an entirely new model that can be plugged in to CABLE, either as an alternative model, or an extra feature to be used in the standard model.
-
-In all cases, an issue should be raised. The accompanying fix contained should then be implemented in a unique branch, corresponding to the raised issue. A bugfix might simply involve reference to this issue. For a more complicated, added feature, it is a requirement that this addition can be isolated and switched off via a configuration switch, so that the model can be also run as if there had been no alteration. There is of course every possibility that this feature will be accepted as a standard part of the model. Although this is not the expectation initially and the developer should be mindful of this fundamental requirement. 
-
-We proceed assuming that the "issue" raised requires adding a new and significant feature to CABLE, requiring the addition of new files/modules to CABLE. Lesser modifications are covered under this assumption anyway.
-
-For discussion purposes we assume that you are including a new model to do some new stuff. This can conveniently be added in a single file. 
-
 ## Code Template 
 
 Assuming the *new* model is called from eg_driver.F90.

--- a/documentation/docs/developer_guide/coding_standards.md
+++ b/documentation/docs/developer_guide/coding_standards.md
@@ -5,7 +5,7 @@
 
 ## Introduction
 CABLE is a community software project. 
-For the benefit of the whole community, developers are required to adhere to certain coding standards that better enable portability, efficient maintenance, future development, performance, readability. 
+For the benefit of the whole community, developers are required to adhere to certain coding standards that better enable portability, efficient maintenance, future development, performance and readability. 
 
 Submitted developments that are inconsistent with the standards discussed below, and/or poorly commented/documented code will not be accepted without revision. 
 ## Coding Standards

--- a/documentation/docs/developer_guide/coding_standards.md
+++ b/documentation/docs/developer_guide/coding_standards.md
@@ -87,7 +87,7 @@ In general, models (including CABLE) have evolved over decades, involving dozens
 ```fortran
 PROGRAM eg_driver()
 
-USE new_mod_cbl, ONLY : new
+USE cbl_eg_mod, ONLY : eg_subr
 
 IMPLICIT NONE
 Header Declarations

--- a/documentation/docs/developer_guide/coding_standards.md
+++ b/documentation/docs/developer_guide/coding_standards.md
@@ -1,5 +1,7 @@
 ## Foreword
-Currently not all of the CABLE code is compliant with the standards described here. Work is in progress to apply these standards across the existing code base, however these standards are expected to be met by any new development.
+!!! Note "Current standards compliance"
+
+    Currently not all of the CABLE code is compliant with the standards described here. Work is in progress to apply these standards across the existing code base, however these standards are expected to be met by any new development.
 
 ## Introduction
 CABLE is a community software project. 


### PR DESCRIPTION
# CABLE


## Description

Add coding standards information to the Developer's Guide. The original branch was corrupted and it was unclear if the automated tests worked correctly. It was easier to restart than try to resolve within the first branch.

Fixes #97 

## Type of change

- [x] New or updated documentation

## Checklist

- [x] The new content is accessible and located in the appropriate section.
- [x] I have checked that links are valid and point to the intended content.
- [x] I have checked my code/text and corrected any misspellings

<!-- readthedocs-preview cable start -->
----
:books: Documentation preview :books:: https://cable--128.org.readthedocs.build/en/128/

<!-- readthedocs-preview cable end -->