### PR TITLE
Add readthedocs preview action

### DIFF
--- a/.github/workflows/pull-request-links.yaml
+++ b/.github/workflows/pull-request-links.yaml
@@ -1,0 +1,15 @@
+# .github/workflows/pull-request-links.yaml
+
+name: readthedocs/actions
+on: [pull_request]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  pull-request-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: readthedocs/actions/preview@v1
+        with:
+          project-slug: "cable"


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

Adds the [readthedocs preview action](https://github.com/readthedocs/actions/tree/v1/preview) so that documentation preview links are more easily accessible.

Fixes #130

<!-- readthedocs-preview cable start -->
----
:books: Documentation preview :books:: https://cable--133.org.readthedocs.build/en/133/

<!-- readthedocs-preview cable end -->