### PR TITLE
Fix syntax error in cbl_latent_heat.F90

### DIFF
--- a/src/science/canopy/cbl_latent_heat.F90
+++ b/src/science/canopy/cbl_latent_heat.F90
@@ -18,8 +18,6 @@ SUBROUTINE Latent_heat_flux( mp, CTFRZ, dels, soil_zse, soil_swilt,           &
                              ssnow_pudsto, ssnow_pudsmx, ssnow_potev,          &
                              ssnow_wetfac, ssnow_evapfbl, ssnow_cls,          & 
                              ssnow_tss, canopy_fes, canopy_fess, canopy_fesp  )
-  vkfeopge
-
   !*## Purpose
   !
   ! This SUBROUTINE converts the previously evaluated rate of potential


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

The build script fails when building the serial executable and produces the following error:
```
ifort -O2 -fp-model precise  -I/apps/netcdf/4.6.3/include/Intel -c cbl_latent_heat.F90
cbl_latent_heat.F90(21): error #5082: Syntax error, found END-OF-STATEMENT when expecting one of: ( : % [ . = =>
  vkfeopge
----------^
cbl_latent_heat.F90(21): error #6218: This statement is positioned incorrectly and/or has syntax errors.
  vkfeopge
--^
compilation aborted for cbl_latent_heat.F90 (code 1)
make: *** [Makefile:167: cbl_latent_heat.o] Error 1
```

This change fixes the syntax error in cbl_latent_heat.F90.

Fixes #153

## Type of change

Please delete options that are not relevant.

- [X] Bug fix

## Checklist

- [X] The new content is accessible and located in the appropriate section.
- [X] I have checked that links are valid and point to the intended content.
- [X] I have checked my code/text and corrected any misspellings

Please add a reviewer when ready for review.


<!-- readthedocs-preview cable start -->
----
:books: Documentation preview :books:: https://cable--154.org.readthedocs.build/en/154/

<!-- readthedocs-preview cable end -->