### PR TITLE
Remove `-O0` flag from `LDFLAGS`

### DIFF
--- a/src/offline/Makefile
+++ b/src/offline/Makefile
@@ -168,18 +168,10 @@ serial: cable_driver.F90 $(OBJS)
 mpi: cable_mpidrv.F90 cable_mpicommon.o cable_mpimaster.o cable_mpiworker.o pop_mpi.o $(OBJS)
 	$(FC) $(SUPPRESS_FLAGS) $(CFLAGS) $(LDFLAGS) -o $(PROG_MPI) $^ $(CINC) $(LD)
 
-# TODO(Sean): passing LDFLAGS to the compiler ensures bitwise reproducibility
-# for this PR (#193). This is because LDFLAGS contains the -O0 flag (see
-# build3.sh). Ideally, LDFLAGS should not contain -O0 and this should be set in
-# CFLAGS as this would let us use the default suffix rule for *.o files.
 cable_mpicommon.o: cable_mpicommon.F90 $(OBJS)
-	$(FC) $(CFLAGS) $(CINC) $(LDFLAGS) -c $<
 pop_mpi.o: pop_mpi.F90 cable_mpicommon.o $(OBJS)
-	$(FC) $(CFLAGS) $(CINC) $(LDFLAGS) -c $<
 cable_mpiworker.o: cable_mpiworker.F90 cable_mpicommon.o pop_mpi.o $(OBJS)
-	$(FC) $(CFLAGS) $(CINC) $(LDFLAGS) -c $<
 cable_mpimaster.o: cable_mpimaster.F90 cable_mpicommon.o cable_mpiworker.o pop_mpi.o $(OBJS)
-	$(FC) $(CFLAGS) $(CINC) $(LDFLAGS) -c $<
 
 # dependencies, compilation rules for ALL files needed for "all" (LSRC)
 #================================================================

--- a/src/offline/build3.sh
+++ b/src/offline/build3.sh
@@ -19,7 +19,7 @@ host_gadi()
    export NCDIR=$NETCDF_ROOT'/lib/Intel'
    export NCMOD=$NETCDF_ROOT'/include/Intel'
    export CFLAGS='-O2 -fp-model precise '
-   export LDFLAGS='-L'$NCDIR' -O0'
+   export LDFLAGS='-L'$NCDIR
    export LD='-lnetcdf -lnetcdff'
 
    if [[ $1 = 'mpi' ]]; then


### PR DESCRIPTION
In `build3.sh`, the `-O0` flag (which disables optimisations) is included in the `LDFLAGS` variable. This change removes the `-O0` flag from `LDFLAGS` so that:

1. Compiler specific flags (non `ld` flags) are removed from `LDFLAGS`
2. `-O0` flag is not applied for only a subset of source files.
3. The Makefile rules can be simplified.

See #196 for more details on why the flag should be removed.

Tools for testing binary equivalence (see `ldd`, `nm` and `objdump` tools) show that the following build artifacts differ when comparing against the main branch:

- `cable` (serial executable)
- `cable-mpi` (MPI executable)
- `cable_mpicommon.o`
- `cable_mpimaster.o`
- `cable_mpiworker.o`
- `pop_mpi.o`

Regression tests using [benchcab](https://github.com/CABLE-LSM/benchcab) (bitwise comparison of model output via `nccmp`) show that model output is bitwise identical between the current branch and the main branch for serial and MPI model runs.

Fixes #196

## Type of change

- [X] Bug fix

<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--197.org.readthedocs.build/en/197/

<!-- readthedocs-preview cable end -->