### PR TITLE
Fix LDFLAGS definition and usage

### DIFF
--- a/src/offline/Makefile
+++ b/src/offline/Makefile
@@ -147,26 +147,23 @@ PROG_MPI = cable-mpi
 # from the compiled object files
 OBJS := ${LSRC:.F90=.o}
 
-#compiler switches and flags
-CINC = -I$(NCMOD)
-
 #suffixes we use
 .SUFFIXES:
 .SUFFIXES: .F90 .o
 #default rules for these suffixes
 .F90.o:
-	$(FC) $(CFLAGS) $(CINC) -c $<
+	$(FC) $(CFLAGS) -c $<
 
 SUPPRESS_FLAGS := -warn nostderrors -diag-disable 10145
 
 # the first target is the default target
 .PHONY: serial
 serial: cable_driver.F90 $(OBJS)
-	$(FC) $(SUPPRESS_FLAGS) $(CFLAGS) $(LDFLAGS) $(LD) -o $(PROG_SERIAL) $^ $(CINC)
+	$(FC) $(SUPPRESS_FLAGS) $(CFLAGS) -o $(PROG_SERIAL) $^ $(LDFLAGS)
 
 .PHONY: mpi
 mpi: cable_mpidrv.F90 cable_mpicommon.o cable_mpimaster.o cable_mpiworker.o pop_mpi.o $(OBJS)
-	$(FC) $(SUPPRESS_FLAGS) $(CFLAGS) $(LDFLAGS) -o $(PROG_MPI) $^ $(CINC) $(LD)
+	$(FC) $(SUPPRESS_FLAGS) $(CFLAGS) -o $(PROG_MPI) $^ $(LDFLAGS)
 
 cable_mpicommon.o: cable_mpicommon.F90 $(OBJS)
 pop_mpi.o: pop_mpi.F90 cable_mpicommon.o $(OBJS)


### PR DESCRIPTION
`ld` flags are currently specified incorrectly. For example:
1. `-lnetcdf` is not required since it is a dependency of the netCDF Fortran library - only `-lnetcdff` is needed.
2. `ld` flags are being split across two variables: `LDFLAGS` and `LD` when there should only be one (`LD` typically refers to the path  to the `ld` executable). Having the flags split across two variables allows for the flags to be passed to the compiler in an inconsistent way.

See #198 for more details.

This change removes the `LD` variable and any hard-coded linker flags or include flags in the Makefile or build script. Linker flags and include flags are replaced with a query to `pkg-config` so that the correct flags are used. Using `pkg-config` also insulates the build system from changes to library versions and dependencies.

~~This PR should ideally be done after #197 is merged so that we can verify compiled object files have not been altered as a result of this change.~~

Compiled object files are identical between this branch and the main branch. However, the executables differ between the two branches due to changes in the compiler arguments at the linking step.

Regression tests using [benchcab](https://github.com/CABLE-LSM/benchcab)* (bitwise comparison of model output via nccmp) show that model output is bitwise identical between the current branch and the main branch for serial and MPI model runs.

*executables were built manually for the spatial case (see this related issue: https://github.com/CABLE-LSM/benchcab/issues/244).

Fixes #198

<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--199.org.readthedocs.build/en/199/

<!-- readthedocs-preview cable end -->