### PR TITLE
Correction to the numerical value of the specific heat of water

### DIFF
--- a/src/params/cable_phys_constants_mod.F90
+++ b/src/params/cable_phys_constants_mod.F90
@@ -35,11 +35,11 @@ REAL, PARAMETER :: grav   = 9.8086        ! gravity acceleration (m/s2)
 REAL, PARAMETER :: rgas   = 8.3143        ! universal gas const  (J/mol/K)
 REAL, PARAMETER :: rmair  = 0.02897       ! molecular wt: dry air (kg/mol)
 REAL, PARAMETER :: rmh2o  = 0.018016      ! molecular wt: water (kg/mol)
-REAL, PARAMETER :: cgsnow = 2090.0        ! specific heat capacity for snow
+REAL, PARAMETER :: cgsnow = 2090.0        ! specific heat for snow (J/kg/K)
 REAL, PARAMETER :: cs_rho_ice = 1.9341e6  !heat capacity * density ice
 REAL, PARAMETER :: cs_rho_wat = 4.218e6   ! heat capacity * density  water
-REAL, PARAMETER :: csice = 2.100e3        ! specific heat capacity for ice
-REAL, PARAMETER :: cswat = 4.182e3        ! specific heat for water (J/kg/K)
+REAL, PARAMETER :: csice = 2.100e3        ! specific heat for ice (J/kg/K)
+REAL, PARAMETER :: cswat = 4.218e3        ! specific heat for water at 0°C (J/kg/K)
 REAL, PARAMETER :: density_liq = 1000.0   ! density of liquid water
 REAL, PARAMETER :: density_ice = 921.0    ! denisty of ice
 

--- a/src/params/cable_phys_constants_mod.F90
+++ b/src/params/cable_phys_constants_mod.F90
@@ -39,7 +39,7 @@ REAL, PARAMETER :: cgsnow = 2090.0        ! specific heat capacity for snow
 REAL, PARAMETER :: cs_rho_ice = 1.9341e6  !heat capacity * density ice
 REAL, PARAMETER :: cs_rho_wat = 4.218e6   ! heat capacity * density  water
 REAL, PARAMETER :: csice = 2.100e3        ! specific heat capacity for ice
-REAL, PARAMETER :: cswat = 4.218e3        ! specific heat capacity water
+REAL, PARAMETER :: cswat = 4.182e3        ! specific heat for water (J/kg/K)
 REAL, PARAMETER :: density_liq = 1000.0   ! density of liquid water
 REAL, PARAMETER :: density_ice = 921.0    ! denisty of ice
 

--- a/src/science/sli/cable_sli_numbers.F90
+++ b/src/science/sli/cable_sli_numbers.F90
@@ -38,14 +38,14 @@ MODULE sli_numbers
   REAL(r_2), PARAMETER :: rhow      = 1000.0_r_2   ! denisty of water [kg/m3]
   REAL(r_2), PARAMETER :: rhoi      = 920._r_2     ! density of ice (kg m-3)
 
-  REAL(r_2), PARAMETER :: rhoa      = 1.184_r_2    ! denisty of dry air at std (25 degC) [kg/m3]
+  REAL(r_2), PARAMETER :: rhoa      = 1.184_r_2    ! density of dry air at std (25 degC) [kg/m3]
   REAL(r_2), PARAMETER :: rhocp     = 1189.8_r_2   ! cpa*rhoa at std (25 degC) [J/m3K]
 
   REAL(r_2), PARAMETER :: esata_ice = 611.2_r_2   ! constants for saturated vapour pressure calculation over ice (WMO, 2008)
   REAL(r_2), PARAMETER :: esatb_ice = 22.46_r_2   ! %
   REAL(r_2), PARAMETER :: esatc_ice = 272.62_r_2  ! %
   REAL(r_2), PARAMETER :: csice     = 2.100e3_r_2 ! specific heat capacity for ice
-  REAL(r_2), PARAMETER :: cswat     = 4.218e3_r_2 ! specific heat capacity for water
+  REAL(r_2), PARAMETER :: cswat     = 4.182e3_r_2 ! specific heat for water (J/kg/K)
   REAL(r_2), PARAMETER :: rgas      = 8.3143_r_2  ! universal gas const  (J/mol/K)
   REAL(r_2), PARAMETER :: kw        = 0.58_r_2    ! dito
 

--- a/src/science/sli/cable_sli_numbers.F90
+++ b/src/science/sli/cable_sli_numbers.F90
@@ -26,7 +26,7 @@ MODULE sli_numbers
   REAL(r_2), PARAMETER :: Mw        = 0.018016_r_2        ! weight of 1 mol of water [kg]
   REAL(r_2), PARAMETER :: rmair     = 0.02897_r_2         ! molecular wt: dry air (kg/mol)
   REAL(r_2), PARAMETER :: Mw18      = 0.018_r_2           ! weight of 1 mol of water [kg] (main isotopologue only)
-  REAL(r_2), PARAMETER :: cpa       = 1004.64_r_2         ! specific heat capacity of dry air at 0-40 degC [J/kgK]
+  REAL(r_2), PARAMETER :: cpa       = 1004.64_r_2         ! specific heat of dry air at 0-40 degC [J/kgK]
   REAL(r_2), PARAMETER :: esata     = 6.106_r_2*100.0_r_2 ! constants for saturated vapour pressure calculation
   REAL(r_2), PARAMETER :: esatb     = 17.27_r_2           ! %
   REAL(r_2), PARAMETER :: esatc     = 237.3_r_2           ! %
@@ -44,8 +44,8 @@ MODULE sli_numbers
   REAL(r_2), PARAMETER :: esata_ice = 611.2_r_2   ! constants for saturated vapour pressure calculation over ice (WMO, 2008)
   REAL(r_2), PARAMETER :: esatb_ice = 22.46_r_2   ! %
   REAL(r_2), PARAMETER :: esatc_ice = 272.62_r_2  ! %
-  REAL(r_2), PARAMETER :: csice     = 2.100e3_r_2 ! specific heat capacity for ice
-  REAL(r_2), PARAMETER :: cswat     = 4.182e3_r_2 ! specific heat for water (J/kg/K)
+  REAL(r_2), PARAMETER :: csice     = 2.100e3_r_2 ! specific heat for ice (J/kg/K)
+  REAL(r_2), PARAMETER :: cswat     = 4.182e3_r_2 ! specific heat for water at 0°C (J/kg/K)
   REAL(r_2), PARAMETER :: rgas      = 8.3143_r_2  ! universal gas const  (J/mol/K)
   REAL(r_2), PARAMETER :: kw        = 0.58_r_2    ! dito
 


### PR DESCRIPTION
## Description

Change the descriptions for the specific heat for water, snow, ice and air to:
- remote "capacity"
- add a unit
- specify the temperature for the specific heat of water since it is used at 0°C and not the standard 20°C.

This is done for CABLE and SLI.

Reference:   https://www.engineeringtoolbox.com/specific-heat-capacity-water-d_660.html

Please delete options that are not relevant.

- [X ] Bug fix
- [ ] New or updated documentation

## Checklist

- [ X] The new content is accessible and located in the appropriate section.
- [X ] I have checked that links are valid and point to the intended content.
- [X ] I have checked my code/text and corrected any misspellings

Please add a reviewer when ready for review.


<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--214.org.readthedocs.build/en/214/

<!-- readthedocs-preview cable end -->