### PR TITLE
Additional CMake changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,17 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
     )
 endif()
 
+set(CABLE_GNU_Fortran_FLAGS -cpp -ffree-form -ffixed-line-length-132)
+set(CABLE_GNU_Fortran_FLAGS_DEBUG -O -g -pedantic-errors -Wall -W -Wno-maybe-uninitialized -fbacktrace -ffpe-trap=zero,overflow,underflow -finit-real=nan)
+set(CABLE_GNU_Fortran_FLAGS_RELEASE -O3 -Wno-aggressive-loop-optimizations)
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
+    add_compile_options(
+        ${CABLE_GNU_Fortran_FLAGS}
+        "$<$<CONFIG:Release>:${CABLE_GNU_Fortran_FLAGS_RELEASE}>"
+        "$<$<CONFIG:Debug>:${CABLE_GNU_Fortran_FLAGS_DEBUG}>"
+    )
+endif()
+
 add_library(
     cable_common_objlib
     OBJECT

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,31 +9,26 @@ project(
 option(CABLE_MPI "Build the MPI executable" OFF)
 
 # third party libs
+if(CABLE_MPI)
+    find_package(MPI REQUIRED COMPONENTS Fortran)
+endif()
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(NETCDF REQUIRED IMPORTED_TARGET "netcdf-fortran")
 
-set(CABLE_INTEL_Fortran_FLAGS -fp-model precise)
-set(CABLE_INTEL_Fortran_FLAGS_DEBUG -O0 -g -traceback -fpe0)
-set(CABLE_INTEL_Fortran_FLAGS_RELEASE -O2)
+set(CABLE_Intel_Fortran_FLAGS -fp-model precise)
+set(CABLE_Intel_Fortran_FLAGS_DEBUG -O0 -g -traceback -fpe0)
+set(CABLE_Intel_Fortran_FLAGS_RELEASE -O2)
+if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
+    add_compile_options(
+        ${CABLE_Intel_Fortran_FLAGS}
+        "$<$<CONFIG:Release>:${CABLE_Intel_Fortran_FLAGS_RELEASE}>"
+        "$<$<CONFIG:Debug>:${CABLE_Intel_Fortran_FLAGS_DEBUG}>"
+    )
+endif()
 
-# CMake $<...> syntax is explained here:
-# https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html#introduction
-set(CABLE_EXE_NAME "$<IF:$<BOOL:${CABLE_MPI}>,cable-mpi,cable>")
-
-set(
-    CABLE_SRCS_SERIAL
-    src/offline/cable_driver.F90
-)
-set(
-    CABLE_SRCS_MPI
-    src/offline/cable_mpidrv.F90
-    src/offline/cable_mpicommon.F90
-    src/offline/cable_mpimaster.F90
-    src/offline/cable_mpiworker.F90
-    src/science/pop/pop_mpi.F90
-)
-set(
-    CABLE_SRCS_COMMON
+add_library(
+    cable_common_objlib
+    OBJECT
     src/science/casa-cnp/bgcdriver.F90
     src/science/casa-cnp/biogeochem_casa.F90
     src/offline/cable_abort.F90
@@ -143,29 +138,26 @@ set(
     src/science/roughness/roughnessHGT_effLAI_cbl.F90
     src/offline/spincasacnp.F90
 )
-set(
-    CABLE_SRCS
-    "$<IF:$<BOOL:${CABLE_MPI}>,${CABLE_SRCS_MPI},${CABLE_SRCS_SERIAL}>"
-    ${CABLE_SRCS_COMMON}
-)
+target_link_libraries(cable_common_objlib PRIVATE PkgConfig::NETCDF)
 
-add_executable(cable ${CABLE_SRCS})
-
-set_target_properties(cable PROPERTIES OUTPUT_NAME ${CABLE_EXE_NAME})
-
-if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
-    target_compile_options(
-        cable
-        PRIVATE
-        ${CABLE_INTEL_Fortran_FLAGS}
-        "$<$<CONFIG:Release>:${CABLE_INTEL_Fortran_FLAGS_RELEASE}>"
-        "$<$<CONFIG:Debug>:${CABLE_INTEL_Fortran_FLAGS_DEBUG}>"
-    )
-endif()
-
-target_link_libraries(
+add_executable(
     cable
-    PkgConfig::NETCDF
+    src/offline/cable_driver.F90
+    "$<TARGET_OBJECTS:cable_common_objlib>"
 )
-
+target_link_libraries(cable PRIVATE PkgConfig::NETCDF)
 install(TARGETS cable RUNTIME)
+
+if(CABLE_MPI)
+    add_executable(
+        cable-mpi
+        src/offline/cable_mpidrv.F90
+        src/offline/cable_mpicommon.F90
+        src/offline/cable_mpimaster.F90
+        src/offline/cable_mpiworker.F90
+        src/science/pop/pop_mpi.F90
+        "$<TARGET_OBJECTS:cable_common_objlib>"
+    )
+    target_link_libraries(cable-mpi PRIVATE PkgConfig::NETCDF MPI::MPI_Fortran)
+    install(TARGETS cable-mpi RUNTIME)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,114 +29,114 @@ endif()
 add_library(
     cable_common_objlib
     OBJECT
-    src/science/casa-cnp/bgcdriver.F90
-    src/science/casa-cnp/biogeochem_casa.F90
     src/offline/cable_abort.F90
-    src/science/misc/cable_air.F90
-    src/science/canopy/cable_canopy.F90
-    src/science/misc/cable_carbon.F90
     src/offline/cable_checks.F90
-    src/science/misc/cable_climate.F90
-    src/util/cable_climate_type_mod.F90
-    src/util/cable_common.F90
     src/offline/cable_cru_TRENDY.F90
     src/offline/cable_define_types.F90
-    src/science/gw_hydro/cable_gw_hydro.F90
     src/offline/cable_initialise.F90
     src/offline/cable_input.F90
     src/offline/cable_iovars.F90
     src/offline/cable_LUC_EXPT.F90
-    src/params/cable_maths_constants_mod.F90
     src/offline/cable_metutils.F90
     src/offline/cable_namelist_input.F90
-    src/params/cable_other_constants_mod.F90
     src/offline/cable_output.F90
     src/offline/cable_parameters.F90
     src/offline/cable_pft_params.F90
     src/offline/cable_phenology.F90
-    src/params/cable_photo_constants_mod.F90
-    src/params/cable_phys_constants_mod.F90
     src/offline/cable_plume_mip.F90
-    src/science/gw_hydro/cable_psm.F90
     src/offline/cable_read.F90
-    src/science/roughness/cable_roughness.F90
-    src/util/cable_runtime_opts_mod.F90
     src/offline/cable_site.F90
-    src/science/sli/cable_sli_main.F90
-    src/science/sli/cable_sli_numbers.F90
-    src/science/sli/cable_sli_roots.F90
-    src/science/sli/cable_sli_solve.F90
-    src/science/sli/cable_sli_utils.F90
     src/offline/cable_soil_params.F90
     src/offline/cable_weathergenerator.F90
     src/offline/cable_write.F90
     src/offline/casa_cable.F90
+    src/offline/casa_ncdf.F90
+    src/offline/casa_offline_inout.F90
+    src/offline/CASAONLY_LUC.F90
+    src/offline/cbl_model_driver_offline.F90
+    src/offline/landuse_inout.F90
+    src/offline/spincasacnp.F90
+    src/params/cable_maths_constants_mod.F90
+    src/params/cable_other_constants_mod.F90
+    src/params/cable_photo_constants_mod.F90
+    src/params/cable_phys_constants_mod.F90
+    src/params/grid_constants_cbl.F90
+    src/science/albedo/cbl_albedo.F90
+    src/science/albedo/cbl_snow_albedo.F90
+    src/science/albedo/cbl_soilColour_albedo.F90
+    src/science/canopy/cable_canopy.F90
+    src/science/canopy/cbl_dryLeaf.F90
+    src/science/canopy/cbl_friction_vel.F90
+    src/science/canopy/cbl_fwsoil.F90
+    src/science/canopy/cbl_latent_heat.F90
+    src/science/canopy/cbl_photosynthesis.F90
+    src/science/canopy/cbl_pot_evap_snow.F90
+    src/science/canopy/cbl_qsat.F90
+    src/science/canopy/cbl_SurfaceWetness.F90
+    src/science/canopy/cbl_wetleaf.F90
+    src/science/canopy/cbl_within_canopy.F90
+    src/science/canopy/cbl_zetar.F90
+    src/science/casa-cnp/bgcdriver.F90
+    src/science/casa-cnp/biogeochem_casa.F90
     src/science/casa-cnp/casa_cnp.F90
     src/science/casa-cnp/casa_dimension.F90
     src/science/casa-cnp/casa_feedback.F90
     src/science/casa-cnp/casa_inout.F90
-    src/offline/casa_ncdf.F90
-    src/offline/casa_offline_inout.F90
-    src/offline/CASAONLY_LUC.F90
     src/science/casa-cnp/casa_param.F90
     src/science/casa-cnp/casa_phenology.F90
     src/science/casa-cnp/casa_readbiome.F90
     src/science/casa-cnp/casa_rplant.F90
     src/science/casa-cnp/casa_sumcflux.F90
     src/science/casa-cnp/casa_variable.F90
-    src/science/albedo/cbl_albedo.F90
-    src/science/soilsnow/cbl_conductivity.F90
-    src/science/canopy/cbl_dryLeaf.F90
-    src/science/canopy/cbl_friction_vel.F90
-    src/science/canopy/cbl_fwsoil.F90
-    src/science/soilsnow/cbl_GW.F90
-    src/science/soilsnow/cbl_hyd_redistrib.F90
+    src/science/gw_hydro/cable_gw_hydro.F90
+    src/science/gw_hydro/cable_psm.F90
+    src/science/landuse/landuse3.F90
+    src/science/landuse/landuse_constant.F90
+    src/science/misc/cable_air.F90
+    src/science/misc/cable_carbon.F90
+    src/science/misc/cable_climate.F90
+    src/science/pop/pop_constants.F90
+    src/science/pop/pop_def.F90
+    src/science/pop/POP.F90
+    src/science/pop/pop_io.F90
+    src/science/pop/POPLUC.F90
+    src/science/pop/pop_types.F90
     src/science/radiation/cbl_init_radiation.F90
-    src/science/canopy/cbl_latent_heat.F90
-    src/offline/cbl_model_driver_offline.F90
-    src/science/soilsnow/cbl_Oldconductivity.F90
-    src/science/canopy/cbl_photosynthesis.F90
-    src/science/canopy/cbl_pot_evap_snow.F90
-    src/science/canopy/cbl_qsat.F90
     src/science/radiation/cbl_radiation.F90
-    src/science/soilsnow/cbl_remove_trans.F90
     src/science/radiation/cbl_rhoch.F90
     src/science/radiation/cbl_sinbet.F90
+    src/science/radiation/cbl_spitter.F90
+    src/science/roughness/cable_roughness.F90
+    src/science/roughness/roughnessHGT_effLAI_cbl.F90
+    src/science/sli/cable_sli_main.F90
+    src/science/sli/cable_sli_numbers.F90
+    src/science/sli/cable_sli_roots.F90
+    src/science/sli/cable_sli_solve.F90
+    src/science/sli/cable_sli_utils.F90
+    src/science/soilsnow/cbl_conductivity.F90
+    src/science/soilsnow/cbl_GW.F90
+    src/science/soilsnow/cbl_hyd_redistrib.F90
+    src/science/soilsnow/cbl_Oldconductivity.F90
+    src/science/soilsnow/cbl_remove_trans.F90
     src/science/soilsnow/cbl_smoisturev.F90
     src/science/soilsnow/cbl_snowAccum.F90
     src/science/soilsnow/cbl_snow_aging.F90
-    src/science/albedo/cbl_snow_albedo.F90
     src/science/soilsnow/cbl_snowCheck.F90
     src/science/soilsnow/cbl_snowDensity.F90
     src/science/soilsnow/cbl_snowl_adjust.F90
     src/science/soilsnow/cbl_snowMelt.F90
-    src/science/albedo/cbl_soilColour_albedo.F90
     src/science/soilsnow/cbl_soilfreeze.F90
     src/science/soilsnow/cbl_soilsnow_data.F90
     src/science/soilsnow/cbl_soilsnow_init_special.F90
     src/science/soilsnow/cbl_soilsnow_main.F90
-    src/science/radiation/cbl_spitter.F90
     src/science/soilsnow/cbl_stempv.F90
-    src/science/canopy/cbl_SurfaceWetness.F90
     src/science/soilsnow/cbl_surfbv.F90
     src/science/soilsnow/cbl_thermal.F90
     src/science/soilsnow/cbl_trimb.F90
-    src/science/canopy/cbl_wetleaf.F90
-    src/science/canopy/cbl_within_canopy.F90
-    src/science/canopy/cbl_zetar.F90
-    src/params/grid_constants_cbl.F90
-    src/science/landuse/landuse3.F90
-    src/science/landuse/landuse_constant.F90
-    src/offline/landuse_inout.F90
+    src/util/cable_climate_type_mod.F90
+    src/util/cable_common.F90
+    src/util/cable_runtime_opts_mod.F90
     src/util/masks_cbl.F90
-    src/science/pop/pop_constants.F90
-    src/science/pop/pop_def.F90
-    src/science/pop/pop_io.F90
-    src/science/pop/POPLUC.F90
-    src/science/pop/POP.F90
-    src/science/pop/pop_types.F90
-    src/science/roughness/roughnessHGT_effLAI_cbl.F90
-    src/offline/spincasacnp.F90
 )
 target_link_libraries(cable_common_objlib PRIVATE PkgConfig::NETCDF)
 
@@ -151,8 +151,8 @@ install(TARGETS cable RUNTIME)
 if(CABLE_MPI)
     add_executable(
         cable-mpi
-        src/offline/cable_mpidrv.F90
         src/offline/cable_mpicommon.F90
+        src/offline/cable_mpidrv.F90
         src/offline/cable_mpimaster.F90
         src/offline/cable_mpiworker.F90
         src/science/pop/pop_mpi.F90

--- a/build.bash
+++ b/build.bash
@@ -46,7 +46,6 @@ while [ $# -gt 0 ]; do
         --mpi)
             mpi=1
             cmake_args+=(-DCABLE_MPI="ON")
-            cmake_args+=(-DCMAKE_Fortran_COMPILER="mpif90")
             ;;
         -h|--help)
             show_help
@@ -68,8 +67,15 @@ if hostname -f | grep gadi.nci.org.au > /dev/null; then
     # This is required so that the netcdf-fortran library is discoverable by
     # pkg-config:
     prepend_path PKG_CONFIG_PATH "${NETCDF_BASE}/lib/Intel/pkgconfig"
+
     if [[ -n $mpi ]]; then
         module add intel-mpi/2019.5.281
+    fi
+
+    if module is-loaded openmpi; then
+        # This is required so that the openmpi MPI libraries are discoverable
+        # via CMake's `find_package` mechanism:
+        prepend_path CMAKE_PREFIX_PATH "${OPENMPI_BASE}/include/Intel"
     fi
 fi
 

--- a/build.bash
+++ b/build.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 nproc_default=4
 
@@ -14,6 +14,8 @@ options below will be passed to CMake when generating the build system.
 Options:
       --clean   Delete build directory before invoking CMake.
       --mpi     Compile MPI executable.
+  -j <jobs>     Specify the number of parallel jobs in the compilation. By
+                default this value is set to $nproc_default.
   -h, --help    Show this screen.
 
 Enabling debug mode:
@@ -25,12 +27,6 @@ Enabling verbose output from Makefile builds:
 
   To enable more verbose output from Makefile builds, specify the CMake option
   -DCMAKE_VERBOSE_MAKEFILE=ON when invoking $script_name.
-
-Parallel compilation:
-
-  By default, the number of parallel jobs used in the compilation is
-  $nproc_default. This value can be overwritten by setting the environment
-  variable CMAKE_BUILD_PARALLEL_LEVEL.
 
 EOF
 }
@@ -46,6 +42,10 @@ while [ $# -gt 0 ]; do
         --mpi)
             mpi=1
             cmake_args+=(-DCABLE_MPI="ON")
+            ;;
+        -j)
+            CMAKE_BUILD_PARALLEL_LEVEL=$2
+            shift
             ;;
         -h|--help)
             show_help

--- a/build.bash
+++ b/build.bash
@@ -98,6 +98,21 @@ if hostname -f | grep gadi.nci.org.au > /dev/null; then
         # via CMake's `find_package` mechanism:
         prepend_path CMAKE_PREFIX_PATH "${OPENMPI_BASE}/include/${compiler_lib_install_dir}"
     fi
+
+elif hostname -f | grep -E '(mc16|mcmini)' > /dev/null; then
+    : "${compiler:=gnu}"
+
+    case ${compiler} in
+        gnu)
+            export PKG_CONFIG_PATH=/usr/local/netcdf-fortran-4.6.1-gfortran/lib/pkgconfig:${PKG_CONFIG_PATH}
+            export PKG_CONFIG_PATH=${HOMEBREW_PREFIX}/lib/pkgconfig:${PKG_CONFIG_PATH}
+            cmake_args+=(-DCMAKE_Fortran_COMPILER=gfortran)
+            ;;
+        ?*)
+            echo -e "\nError: compiler ${compiler} is not supported.\n"
+            exit 1
+            ;;
+    esac
 fi
 
 export CMAKE_BUILD_PARALLEL_LEVEL="${CMAKE_BUILD_PARALLEL_LEVEL:=$nproc_default}"

--- a/documentation/docs/developer_guide/other_resources/build_system.md
+++ b/documentation/docs/developer_guide/other_resources/build_system.md
@@ -11,7 +11,7 @@ Source files can be added easily by adding to the list of source files in [CMake
 
 ## Setting compiler flags
 
-The recommended compiler flags for debug and release builds are set in the [CMakeLists.txt][CMakeLists.txt] file via [`target_compile_options`](https://cmake.org/cmake/help/latest/command/target_compile_options.html). These can be modified if required.
+The recommended compiler flags for debug and release builds for each compiler are set in the [CMakeLists.txt][CMakeLists.txt] file via the `CABLE_<COMPILER_ID>_Fortran_FLAGS*` variables. These can be modified if required.
 
 ???+ warning
     Compiler flags should be guarded by a check on the compiler ID as they are generally compiler specific. See [`CMAKE_<LANG>_COMPILER_ID`](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER_ID.html) for a list of supported compiler IDs.

--- a/documentation/docs/developer_guide/other_resources/build_system.md
+++ b/documentation/docs/developer_guide/other_resources/build_system.md
@@ -7,7 +7,7 @@ For CABLE offline applications, the underlying build system is [CMake](https://c
 
 ## Adding source files
 
-Source files can be added easily by adding to the list of source files in [CMakeLists.txt][CMakeLists.txt].
+Source files can be added easily by adding to the list of source files in [CMakeLists.txt][CMakeLists.txt]. We recommend keeping the list sorted in alphabetical order when adding new source files.
 
 ## Setting compiler flags
 

--- a/documentation/docs/user_guide/installation.md
+++ b/documentation/docs/user_guide/installation.md
@@ -110,10 +110,6 @@ The release build is default. To enable debug mode, specify the CMake option `-D
 
 To enable more verbose output from Makefile builds, specify the CMake option `-DCMAKE_VERBOSE_MAKEFILE=ON` when invoking `build.bash`.
 
-### Parallel compilation
-
-By default, the compilation is done in parallel. The number of parallel jobs can be overwritten by setting the environment variable [`CMAKE_BUILD_PARALLEL_LEVEL`](https://cmake.org/cmake/help/latest/envvar/CMAKE_BUILD_PARALLEL_LEVEL.html).
-
 ???+ tip
     Run `./build.bash --help` for information on supported options.
 

--- a/documentation/docs/user_guide/installation.md
+++ b/documentation/docs/user_guide/installation.md
@@ -13,13 +13,13 @@ To install CABLE you need to have the following already installed on your system
 
 ``` mermaid
 graph TD
-    
+
     A(Clone CABLE with git):::UserAction -->|Serial?| B(Run `./build.bash`):::UserAction;
     B --> D[load modules and invoke `cmake`];
     D -->|Serial?| E;
     E[executable `cable`]:::Output;
     A -->|Parallel?| C(Run `./build.bash --mpi`):::UserAction;
-    C --> D;   
+    C --> D;
     D -->|Parallel?| F;
     F[executable `cable-mpi`]:::Output;
     click A "#getting-the-cable-source-code"
@@ -84,7 +84,6 @@ CABLE can be built using the BASH script [build.bash][build.bash] in the project
 ???+ tip "Build on other HPC"
     Gadi specific configuration is guarded by a check on the current hostname (see [here][build.bash-hostname-check]). This may be of use as a template for building CABLE on another Linux/HPC system. For advice on issues relating to porting to other HPC systems, please get in touch with ACCESS-NRI either via GitHub or the [ACCESS-Hive Forum][hive-forum-cable].
 
-
 Executables are built in the `<project_root>/build` directory. Once built successfully, they are then installed in the `<project_root>/bin` directory.
 
 To build the serial model execute:
@@ -95,12 +94,9 @@ To build the parallel model execute the same build script but with the `--mpi` f
 
     ./build.bash --mpi
 
-???+ warning
-    If you need to switch between a serial compilation and a parallel compilation, you need to completely [clean the previous build][clean-build] first.
-
 ### Cleaning the build
 
-From time to time, it might be useful to clean a previous build completely and restart the build from scratch. This is required when switching between serial and parallel builds.
+From time to time, it might be useful to clean a previous build completely and restart the build from scratch.
 
 To clean the previous build prior to compiling, specify the `--clean` flag to `build.bash`.
 


### PR DESCRIPTION
This pull request should follow after the CMake implementation (see #200). This change adds the following build system changes:

- List source files in alphabetical order in CMakeLists.txt. The order of source files was previously chosen so that we could demonstrate binary equivalence in executables between the CMake build and the Makefile build.
- Use [`find_package(MPI REQUIRED)`](https://cmake.org/cmake/help/latest/module/FindMPI.html) instead of specifying `mpif90` when invoking `cmake` for MPI case. This is done so that
    1. We can create separate targets for the serial and MPI executable and only link against the MPI libraries when needed without relying on the MPI compiler wrapper. This lets us compile all executables (serial and parallel) with a single invocation of CMake.
    2. We can use object libraries to compile the object files common to both serial and MPI builds. This saves compiling these object files for each executable (serial and MPI), reducing compilation time.
- Portability fixes and improvements to build.bash.
- Add `--compiler` flag to build.bash and GNU compiler support.
- Add Matthias's configuration for example.

Regression tests using [benchcab](https://github.com/CABLE-LSM/benchcab)* (bitwise comparison of model output via nccmp) show that model output is bitwise identical between the current branch and the main branch for serial and MPI model runs.

*executables were built manually as benchcab does not yet support the recent build system changes (see related issue: https://github.com/CABLE-LSM/benchcab/issues/258).

Fixes #215

<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--216.org.readthedocs.build/en/216/

<!-- readthedocs-preview cable end -->