### PR TITLE
Add model build CI for CABLE offline

### DIFF
--- a/.github/workflows/model-build-test-ci.yml
+++ b/.github/workflows/model-build-test-ci.yml
@@ -1,0 +1,15 @@
+name: Test model build
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - "master"
+
+jobs:
+  build:
+    name: Build ${{ github.repository }} via spack
+    uses: access-nri/build-ci/.github/workflows/model-1-build.yml@983fb50caaf0fe7e93bb3b13e09e81a7b846f7d1
+    permissions:
+      packages: read


### PR DESCRIPTION
Making CABLE available as a [spack](https://spack.io/) package allows us to test the model compiles successfully inside a continuous integration (CI) environment which gets triggered automatically on a pull request. This change adds the model build CI workflow developed by the ACCESS-NRI release team to compile CABLE offline via spack (see [build-ci](https://github.com/ACCESS-NRI/build-ci) for more details). This workflow compiles CABLE using the intel compiler. The CI for other compilers will follow after this pull request.

Fixes #202

<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--223.org.readthedocs.build/en/223/

<!-- readthedocs-preview cable end -->