### PR TITLE
Add docs on installing CABLE with spack

### DIFF
--- a/documentation/docs/user_guide/installation.md
+++ b/documentation/docs/user_guide/installation.md
@@ -113,6 +113,18 @@ To enable more verbose output from Makefile builds, specify the CMake option `-D
 ???+ tip
     Run `./build.bash --help` for information on supported options.
 
+## Installation with `spack`
+
+CABLE is available to be installed as a [spack](https://spack.io/) package via the [ACCESS-NRI/spack-packages][accessnri-spack-packages] repository:
+
+```bash
+$ spack list cable
+cable
+==> 1 packages
+```
+
+See the [README file][accessnri-spack-packages] in the package repository for instructions on how to install these packages.
+
 [cable-github]: https://github.com/CABLE-LSM/cable.git
 [NCI]: https://nci.org.au
 [registration]: https://trac.nci.org.au/trac/cable/wiki/CABLE_Registration
@@ -121,3 +133,4 @@ To enable more verbose output from Makefile builds, specify the CMake option `-D
 [clean-build]: installation.md/#cleaning-the-build
 [build-system]: ../developer_guide/other_resources/build_system.md
 [hive-forum-cable]: https://forum.access-hive.org.au/c/land/cable/18
+[accessnri-spack-packages]: https://github.com/ACCESS-NRI/spack-packages


### PR DESCRIPTION
Fixes #226 

## Type of change

Please delete options that are not relevant.

- [X] New or updated documentation

## Checklist

- [X] The new content is accessible and located in the appropriate section.
- [X] I have checked that links are valid and point to the intended content.
- [X] I have checked my code/text and corrected any misspellings


<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--227.org.readthedocs.build/en/227/

<!-- readthedocs-preview cable end -->