### PR TITLE
Ensure "ice" veg type is also permanent ice soil - #234

### DIFF
--- a/src/offline/cable_parameters.F90
+++ b/src/offline/cable_parameters.F90
@@ -1759,7 +1759,7 @@ CONTAINS
   SUBROUTINE derived_parameters(soil, sum_flux, bal, ssnow, veg, rough)
     ! Gives values to parameters that are derived from other parameters.
     TYPE (soil_snow_type),      INTENT(INOUT)    :: ssnow
-    TYPE (veg_parameter_type),  INTENT(IN)    :: veg
+    TYPE (veg_parameter_type),  INTENT(INOUT)    :: veg
     TYPE (soil_parameter_type), INTENT(INOUT) :: soil
     TYPE (sum_flux_type),       INTENT(INOUT) :: sum_flux
     TYPE (balances_type),       INTENT(INOUT) :: bal
@@ -1774,8 +1774,10 @@ CONTAINS
     REAL(r_2), DIMENSION(mp,ms) :: psi_tmp
     REAL(r_2), DIMENSION(ms) :: soil_depth
 
+    ! ccc. Ensure consitency between permanent ice soil type and ice vegetation 
     ! line below inserted by rk4417 - phase2
     where(veg%iveg .eq. 17) soil%isoilm = 9   ! 
+    where(soil%isoilm .eq. 9) veg%iveg = 17
     
     soil_depth(1) = REAL(soil%zse(1),r_2)
     DO klev=2,ms

--- a/src/offline/cable_parameters.F90
+++ b/src/offline/cable_parameters.F90
@@ -1774,6 +1774,9 @@ CONTAINS
     REAL(r_2), DIMENSION(mp,ms) :: psi_tmp
     REAL(r_2), DIMENSION(ms) :: soil_depth
 
+    ! line below inserted by rk4417 - phase2
+    where(veg%iveg .eq. 17) soil%isoilm = 9   ! 
+    
     soil_depth(1) = REAL(soil%zse(1),r_2)
     DO klev=2,ms
        soil_depth(klev) = soil_depth(klev-1) + REAL(soil%zse(klev),r_2)


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

The GW work introduces this change. It ensures that points with "ice" for vegetation type are also classified as "permanent ice" for the soil type.

#234

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix
- [X] New 

## Checklist

- [ ] The new content is accessible and located in the appropriate section.
- [ ] I have checked that links are valid and point to the intended content.
- [ ] I have checked my code/text and corrected any misspellings

Please add a reviewer when ready for review.


<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--235.org.readthedocs.build/en/235/

<!-- readthedocs-preview cable end -->