### PR TITLE
Port branch CABLE-POP_TRENDY to CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+bin/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,129 @@
+# Set minimum CMake version to latest version on Gadi:
+cmake_minimum_required(VERSION 3.24.2)
+
+project(
+    CABLE
+    LANGUAGES Fortran
+)
+
+option(CABLE_MPI "Build the MPI executable" OFF)
+
+if(CABLE_MPI)
+    # The MPI implementation is currently not supported in CABLE-POP_TRENDY:
+    message(FATAL_ERROR "MPI compilation not supported.")
+endif()
+
+# third party libs
+if(CABLE_MPI)
+    find_package(MPI REQUIRED COMPONENTS Fortran)
+endif()
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(NETCDF REQUIRED IMPORTED_TARGET "netcdf-fortran")
+
+set(CABLE_Intel_Fortran_FLAGS -fp-model precise -fpp -nofixed -assume byterecl -D__INTEL__ -D__INTEL_COMPILER__ -D__NETCDF3__)
+set(CABLE_Intel_Fortran_FLAGS_DEBUG -O0 -g -traceback -fpe0 -debug extended -check all -warn all -fp-stack-check)
+set(CABLE_Intel_Fortran_FLAGS_RELEASE -O3 -ip)
+if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
+    add_compile_options(
+        ${CABLE_Intel_Fortran_FLAGS}
+        "$<$<CONFIG:Release>:${CABLE_Intel_Fortran_FLAGS_RELEASE}>"
+        "$<$<CONFIG:Debug>:${CABLE_Intel_Fortran_FLAGS_DEBUG}>"
+    )
+endif()
+
+set(CABLE_GNU_Fortran_FLAGS -cpp -ffree-form -ffixed-line-length-132 -D__GFORTRAN__ -D__gFortran__ -D__NETCDF3__)
+set(CABLE_GNU_Fortran_FLAGS_DEBUG -O -g -pedantic-errors -Wall -W -Wno-maybe-uninitialized -fbacktrace -ffpe-trap=zero,overflow,underflow -finit-real=nan)
+set(CABLE_GNU_Fortran_FLAGS_RELEASE -O3 -Wno-aggressive-loop-optimizations)
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
+    add_compile_options(
+        ${CABLE_GNU_Fortran_FLAGS}
+        "$<$<CONFIG:Release>:${CABLE_GNU_Fortran_FLAGS_RELEASE}>"
+        "$<$<CONFIG:Debug>:${CABLE_GNU_Fortran_FLAGS_DEBUG}>"
+    )
+endif()
+
+add_library(
+    cable_common_objlib
+    OBJECT
+    core/biogeochem/cable_adjustJVgm.F90
+    core/biogeochem/cable_optimiseJVratio.F90
+    core/biogeochem/cable_phenology.F90
+    core/biogeochem/casa_cable.F90
+    core/biogeochem/casa_cnp.F90
+    core/biogeochem/casa_inout.F90
+    core/biogeochem/CASAONLY_LUC.F90
+    core/biogeochem/casa_variable.F90
+    core/biogeochem/POP.F90
+    core/biogeochem/pop_io.F90
+    core/biogeochem/POPLUC.F90
+    core/biogeochem/spincasacnp.F90
+    core/biogeophys/cable_air.F90
+    core/biogeophys/cable_albedo.F90
+    core/biogeophys/cable_c13o2_def.F90
+    core/biogeophys/cable_c13o2.F90
+    core/biogeophys/cable_canopy.F90
+    core/biogeophys/cable_carbon.F90
+    core/biogeophys/cable_cbm.F90
+    core/biogeophys/cable_climate.F90
+    core/biogeophys/cable_common.F90
+    core/biogeophys/cable_data.F90
+    core/biogeophys/cable_define_types.F90
+    core/biogeophys/cable_diag.F90
+    core/biogeophys/cable_radiation.F90
+    core/biogeophys/cable_roughness.F90
+    core/biogeophys/cable_sli_main.F90
+    core/biogeophys/cable_sli_numbers.F90
+    core/biogeophys/cable_sli_roots.F90
+    core/biogeophys/cable_sli_solve.F90
+    core/biogeophys/cable_sli_utils.F90
+    core/biogeophys/cable_soilsnow.F90
+    core/biogeophys/mo_c13o2_photosynthesis.f90
+    core/biogeophys/mo_constants.f90
+    core/biogeophys/mo_isotope.f90
+    core/biogeophys/mo_isotope_luc_model.f90
+    core/biogeophys/mo_isotope_pool_model.f90
+    core/biogeophys/mo_kind.f90
+    core/biogeophys/mo_utils.f90
+    core/blaze/blaze_driver.F90
+    core/blaze/blaze.F90
+    core/blaze/simfire.F90
+    core/utils/minpack.f90
+    offline/cable_abort.F90
+    offline/cable_bios_met_obs_params.F90
+    offline/cable_checks.F90
+    offline/cable_cru_TRENDY.F90
+    offline/cable_initialise.F90
+    offline/cable_input.F90
+    offline/cable_iovars.F90
+    offline/cable_LUC_EXPT.F90
+    offline/cable_output.F90
+    offline/cable_parameters.F90
+    offline/cable_plume_mip.F90
+    offline/cable_read.F90
+    offline/cable_site.F90
+    offline/cable_weathergenerator.F90
+    offline/cable_write.F90
+)
+target_link_libraries(cable_common_objlib PRIVATE PkgConfig::NETCDF)
+
+add_executable(
+    cable
+    offline/cable_driver.F90
+    "$<TARGET_OBJECTS:cable_common_objlib>"
+)
+target_link_libraries(cable PRIVATE PkgConfig::NETCDF)
+install(TARGETS cable RUNTIME)
+
+if(CABLE_MPI)
+    add_executable(
+        cable-mpi
+        src/offline/cable_mpicommon.F90
+        src/offline/cable_mpidrv.F90
+        src/offline/cable_mpimaster.F90
+        src/offline/cable_mpiworker.F90
+        src/science/pop/pop_mpi.F90
+        "$<TARGET_OBJECTS:cable_common_objlib>"
+    )
+    target_link_libraries(cable-mpi PRIVATE PkgConfig::NETCDF MPI::MPI_Fortran)
+    install(TARGETS cable-mpi RUNTIME)
+endif()

--- a/build.bash
+++ b/build.bash
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+
+ncpus_default=4
+
+script_name=$(basename "${0}")
+
+show_help() {
+    cat << EOF
+Usage: ./${script_name} [OPTIONS]
+
+Build script wrapper around CMake. Supplied arguments that do not match the
+options below will be passed to CMake when generating the build system.
+
+Options:
+  -c, --clean   Delete build directory before invoking CMake.
+  -m, --mpi     Compile MPI executable.
+  -C, --compiler <compiler>
+                Specify the compiler to use.
+  -n, --ncpus <ncpus>
+                Specify the number of parallel jobs in the compilation. By
+                default this value is set to ${ncpus_default}.
+  -h, --help    Show this screen.
+
+Enabling debug mode:
+
+  The release build is default. To enable debug mode, specify the CMake option
+  -DCMAKE_BUILD_TYPE=Debug when invoking ${script_name}.
+
+Enabling verbose output from Makefile builds:
+
+  To enable more verbose output from Makefile builds, specify the CMake option
+  -DCMAKE_VERBOSE_MAKEFILE=ON when invoking ${script_name}.
+
+EOF
+}
+
+cmake_args=(-DCMAKE_BUILD_TYPE=Release -DCABLE_MPI=OFF)
+
+# Argument parsing adapted and stolen from http://mywiki.wooledge.org/BashFAQ/035#Complex_nonstandard_add-on_utilities
+while [ ${#} -gt 0 ]; do
+    case ${1} in
+        -c|--clean)
+            rm -r bin build
+            exit
+            ;;
+        -m|--mpi)
+            mpi=1
+            cmake_args+=(-DCABLE_MPI="ON")
+            ;;
+        -C|--compiler)
+            compiler=${2}
+            shift
+            ;;
+        -n|--ncpus)
+            CMAKE_BUILD_PARALLEL_LEVEL=${2}
+            shift
+            ;;
+        -h|--help)
+            show_help
+            exit
+            ;;
+        ?*)
+            cmake_args+=("${1}")
+            ;;
+    esac
+    shift
+done
+
+if hostname -f | grep gadi.nci.org.au > /dev/null; then
+    : "${compiler:=intel}"
+
+    . /etc/bashrc
+    module purge
+    module add cmake/3.24.2
+    module add netcdf/4.9.2
+    case ${compiler} in
+        intel)
+            module add intel-compiler-llvm/2023.0.0
+            compiler_lib_install_dir=Intel
+            [[ -n ${mpi} ]] && module add intel-mpi/2019.5.281
+
+            # This is required to use ifort instead of ifx (default):
+            cmake_args+=(-DCMAKE_Fortran_COMPILER="ifort")
+
+            # This is required to build with runtime dispatch for all
+            # architectures on Gadi (see
+            # https://opus.nci.org.au/display/Help/Sapphire+Rapids+Compute+Nodes
+            # for more information):
+            cmake_args+=(-DCMAKE_Fortran_FLAGS_RELEASE_INIT="-march=broadwell -axSKYLAKE-AVX512,CASCADELAKE,SAPPHIRERAPIDS -diag-disable=15009")
+            ;;
+        gnu)
+            module add gcc/13.2.0
+            compiler_lib_install_dir=GNU
+            [[ -n ${mpi} ]] && module add openmpi/4.1.4
+            ;;
+        ?*)
+            echo -e "\nError: compiler ${compiler} is not supported.\n"
+            exit 1
+            ;;
+    esac
+
+    # This is required so that the netcdf-fortran library is discoverable by
+    # pkg-config:
+    prepend_path PKG_CONFIG_PATH "${NETCDF_BASE}/lib/${compiler_lib_install_dir}/pkgconfig"
+
+    if module is-loaded openmpi; then
+        # This is required so that the openmpi MPI libraries are discoverable
+        # via CMake's `find_package` mechanism:
+        prepend_path CMAKE_PREFIX_PATH "${OPENMPI_BASE}/include/${compiler_lib_install_dir}"
+    fi
+
+elif hostname -f | grep -E '(mc16|mcmini)' > /dev/null; then
+    : "${compiler:=gnu}"
+
+    case ${compiler} in
+        gnu)
+            export PKG_CONFIG_PATH=/usr/local/netcdf-fortran-4.6.1-gfortran/lib/pkgconfig:${PKG_CONFIG_PATH}
+            export PKG_CONFIG_PATH=${HOMEBREW_PREFIX}/lib/pkgconfig:${PKG_CONFIG_PATH}
+            cmake_args+=(-DCMAKE_Fortran_COMPILER=gfortran)
+            ;;
+        ?*)
+            echo -e "\nError: compiler ${compiler} is not supported.\n"
+            exit 1
+            ;;
+    esac
+fi
+
+export CMAKE_BUILD_PARALLEL_LEVEL="${CMAKE_BUILD_PARALLEL_LEVEL:=${ncpus_default}}"
+
+cmake -S . -B build "${cmake_args[@]}" &&\
+cmake --build build &&\
+cmake --install build --prefix .


### PR DESCRIPTION
PR for porting the CABLE-POP_TRENDY branch to CMake.

**Context:**

- We want to consolidate the build systems across CABLE to use CMake to improve ease of testing with tools such as [benchcab][benchcab] and [spack][spack].
- With the current CABLE-4 development around CABLE-POP_TRENDY, it makes sense to port this branch first.

**Checklist:**

- [x] Review compiler flags for default, release and debug configurations for the following compilers in `CABLE-POP_TRENDY` and compare against build configurations used in `main` (see #268):
    1. Intel compiler (classic)
    2. Intel compiler (llvm)
    3. GNU compiler
- [x] Ensure model outputs are bitwise identical between Makefile and CMake builds of CABLE-POP_TRENDY on Gadi.
  - Model outputs were generated using the [TRENDY_V12][TRENDY_V12] configuration for a reduced domain (`extent="64.0,66.0,60.0,62.0"` in `run_TRENDY.sh`). Model outputs were compared using `nccmp -d <file_a> <file_b>`. The model outputs being compared are all `cru_out_cable_1901_2022.nc` and `cru_out_casa_1901_2022.nc` outputs (as these two files are the final products) for each serial CABLE run.
- [x] Ensure compiled object files are identical between Makefile and CMake builds of CABLE-POP_TRENDY on Gadi.

[benchcab]: https://github.com/CABLE-LSM/benchcab
[spack]: https://spack.io/
[TRENDY_V12]: https://github.com/CABLE-LSM/TRENDY_V12