### PR TITLE
Update build-ci version

### DIFF
--- a/.github/workflows/model-build-test-ci.yml
+++ b/.github/workflows/model-build-test-ci.yml
@@ -10,6 +10,6 @@ on:
 jobs:
   build:
     name: Build ${{ github.repository }} via spack
-    uses: access-nri/build-ci/.github/workflows/model-1-build.yml@983fb50caaf0fe7e93bb3b13e09e81a7b846f7d1
+    uses: access-nri/build-ci/.github/workflows/model-1-build.yml@3c0840d775d8f3d67cfeedb44173caa2682fa27e
     permissions:
       packages: read


### PR DESCRIPTION
Issues in the [build-ci](https://github.com/ACCESS-NRI/build-ci) pipeline have now been fixed. This change updates the build-ci version to incorporate these changes.

Fixes #236

<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--271.org.readthedocs.build/en/271/

<!-- readthedocs-preview cable end -->