### PR TITLE
Fix testcase from Uber Quick guide.

### DIFF
--- a/documentation/docs/user_guide/uber_quick_guide.md
+++ b/documentation/docs/user_guide/uber_quick_guide.md
@@ -13,7 +13,8 @@ Assuming you have computing resources on gadi@NCI, installing and running CABLE 
 
 1. Execute this serial version of CABLE
 
-        ./bin/cable
+        cd src/offline
+        ../../bin/cable
 
 ## In slightly more detail
 


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

Fixes #(285)
Change Uber Quick guide instructions to run the testcase from src/offline/ since for now CABLE needs the namelists in the run directory.

## Type of change

Please delete options that are not relevant.

- [X] New or updated documentation

## Checklist

- [x] The new content is accessible and located in the appropriate section.
- [x] I have checked that links are valid and point to the intended content.
- [x] I have checked my code/text and corrected any misspellings

Please add a reviewer when ready for review.


<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--286.org.readthedocs.build/en/286/

<!-- readthedocs-preview cable end -->