### PR TITLE
implemented generalised procedure for determining woody fraction.

### DIFF
--- a/core/biogeochem/POPLUC.F90
+++ b/core/biogeochem/POPLUC.F90
@@ -773,6 +773,13 @@ CONTAINS
     integer  :: iwtile, iwpool
 #endif
 
+    ! Harvest indices (harvested component / total AG biomass)
+    ! see e.g. Yang et al. 2010, Journal of Experimental Botany (Table 1) for a range of HIs of major crops
+    ! similar HI of pastures (e.g. Carlassare et al. 2002, Agronomy Journal), certainly management-dependent
+    ! and thus varies with region.
+    REAL(dp), PARAMETER :: HIcrop = 0.5_dp
+    REAL(dp), PARAMETER :: HIpast = 0.5_dp
+
     ! turnover rates for harvest and clearance products (y-1)
     kHarvProd(1) = 1.0_dp ! / 1.0_dp
     kHarvProd(2) = 1.0_dp / 10.0_dp
@@ -1493,8 +1500,8 @@ CONTAINS
           POPLUC%AgProd(g)     = POPLUC%AgProd(g) + casaflux%Charvest(l)*patch(l)%frac - POPLUC%AgProdLoss(g)
           casaflux%charvest(l) = 0.0_dp
           casaflux%nharvest(l) = 0.0_dp
-          casaflux%fharvest(l) = min(POPLUC%past(g)/POPLUC%grass(g),1.0_dp)*0.5_dp + &
-               min(POPLUC%crop(g)/POPLUC%grass(g),1.0_dp)*0.9_dp !  fraction grass AGB to be removed next year
+          casaflux%fharvest(l) = min(POPLUC%past(g)/POPLUC%grass(g),1.0_dp) * HIpast + &
+               min(POPLUC%crop(g)/POPLUC%grass(g),1.0_dp) * HIcrop !  fraction grass AGB to be removed next year
           !write(*,*)'harvest', g,   patch(l)%frac,  casaflux%fharvest(l), POPLUC%crop(g),  POPLUC%past(g)
           !casaflux%fharvest(l) = 0; ! test vh!
           casaflux%fcrop(l) = min(POPLUC%crop(g)/POPLUC%grass(g), 1.0_dp)

--- a/offline/cable_LUC_EXPT.F90
+++ b/offline/cable_LUC_EXPT.F90
@@ -930,9 +930,6 @@ CONTAINS
        write(*,'(a)') 'warning: past end of LUH2 record'
     endif
 
-    ! Determine woody fraction (forest and shrub cover).
-    call get_woody_fraction(LUC_EXPT)
-
     ! Adjust transition areas based on primary wooded fraction
     LUC_EXPT%INPUT(ptos)%VAL   =  LUC_EXPT%INPUT(ptos)%VAL   * LUC_EXPT%woodfrac
     LUC_EXPT%INPUT(ptog)%VAL   =  LUC_EXPT%INPUT(ptog)%VAL   * LUC_EXPT%woodfrac

--- a/offline/cable_LUC_EXPT.F90
+++ b/offline/cable_LUC_EXPT.F90
@@ -942,6 +942,13 @@ CONTAINS
     LUC_EXPT%INPUT(smharv)%VAL =  LUC_EXPT%INPUT(smharv)%VAL * LUC_EXPT%woodfrac
     LUC_EXPT%INPUT(syharv)%VAL =  LUC_EXPT%INPUT(syharv)%VAL * LUC_EXPT%woodfrac
 
+    LUC_EXPT%INPUT(ptoc)%VAL = LUC_EXPT%INPUT(ptoc)%VAL * LUC_EXPT%woodfrac
+    LUC_EXPT%INPUT(ptoq)%VAL = LUC_EXPT%INPUT(ptoq)%VAL * LUC_EXPT%woodfrac
+    LUC_EXPT%INPUT(stoc)%VAL = LUC_EXPT%INPUT(stoc)%VAL * LUC_EXPT%woodfrac
+    LUC_EXPT%INPUT(stoq)%VAL = LUC_EXPT%INPUT(stoq)%VAL * LUC_EXPT%woodfrac
+    LUC_EXPT%INPUT(ctos)%VAL = LUC_EXPT%INPUT(ctos)%VAL * LUC_EXPT%woodfrac
+    LUC_EXPT%INPUT(qtos)%VAL = LUC_EXPT%INPUT(qtos)%VAL * LUC_EXPT%woodfrac
+
   END SUBROUTINE READ_LUH2
 
 

--- a/offline/cable_LUC_EXPT.F90
+++ b/offline/cable_LUC_EXPT.F90
@@ -299,13 +299,17 @@ CONTAINS
     LUC_EXPT%secdf    = max(1.0-LUC_EXPT%grass-LUC_EXPT%primaryf, 0.0)
     
     !! JK Debug
+    ! For some reason the transition from secdf does not work correctly
+    ! if there is secdf = 0.0 at first timestep (1580). This is a bandaid
+    ! solution that allows a 'correct' transition. Minimum fraction of 0.01
+    ! was required for it to work correctly.
     where (LUC_EXPT%secdf < 0.01 .and. LUC_EXPT%prim_only .eqv. .FALSE. )
-      LUC_EXPT%secdf = 0.01
-      LUC_EXPT%primaryf = LUC_EXPT%primaryf - 0.01
+    LUC_EXPT%primaryf = LUC_EXPT%primaryf + LUC_EXPT%secdf - 0.01  
+    LUC_EXPT%secdf = 0.01
     endwhere
     where (LUC_EXPT%primaryf < 0.0)
-      LUC_EXPT%primaryf = 0.0
       LUC_EXPT%grass = LUC_EXPT%grass + LUC_EXPT%primaryf
+      LUC_EXPT%primaryf = 0.0
     endwhere
     !! JK Debug
     

--- a/offline/cable_LUC_EXPT.F90
+++ b/offline/cable_LUC_EXPT.F90
@@ -22,6 +22,7 @@ MODULE CABLE_LUC_EXPT
      integer :: ctstep
      real,    allocatable :: primaryf(:), grass(:), secdf(:), crop(:), past(:)
      real,    allocatable :: mtemp_min20(:)
+     real,    allocatable :: woodfrac(:)
      character(len=200),   dimension(17) :: TransFile
      character(len=12) ,   dimension(17) :: var_name
      integer,              dimension(17) :: f_id, v_id
@@ -59,8 +60,6 @@ CONTAINS
 
   SUBROUTINE LUC_EXPT_INIT(LUC_EXPT)
 
-    use cable_common_module,       only: cable_user
-    use cable_bios_met_obs_params, only: cable_bios_load_biome
     use netcdf,                    only: nf90_open, nf90_nowrite, nf90_inq_varid, nf90_inq_dimid, &
          nf90_inquire_dimension, nf90_inq_varid, nf90_get_att, nf90_get_var, nf90_close
 
@@ -78,13 +77,11 @@ CONTAINS
     CHARACTER(len=400)   :: TransitionFilePath, ClimateFile, NotPrimOnlyFile
     LOGICAL :: DirectRead
     INTEGER :: YearStart, YearEnd
-    REAL, ALLOCATABLE :: tmpvec(:), tmparr3(:,:,:), CPC(:)
-    INTEGER:: MVG(mland)
+    REAL, ALLOCATABLE :: tmpvec(:), tmparr3(:,:,:)
     INTEGER :: NotPrimOnly_fID, NotPrimOnly_vID
     INTEGER :: TimeVarID, Idash
     CHARACTER(len=100)    :: time_units
     CHARACTER(len=4) :: yearstr
-    REAL :: projection_factor
 
     namelist /lucnml/  TransitionFilePath, ClimateFile, Run, DirectRead, YearStart, YearEnd, &
          NotPrimOnlyFile
@@ -108,10 +105,10 @@ CONTAINS
     ALLOCATE( LUC_EXPT%crop(mland) )
     ALLOCATE( LUC_EXPT%past(mland) )
     ALLOCATE( LUC_EXPT%mtemp_min20(mland) )
+    ALLOCATE( LUC_EXPT%woodfrac(mland))
 
     call luc_expt_zero(LUC_EXPT)
 
-    ALLOCATE( CPC(mland))
     LUC_EXPT%NotPrimOnlyFile = 'none'
     ! READ LUC_EXPT settings
     call get_unit(iu)
@@ -315,117 +312,13 @@ CONTAINS
     LUC_EXPT%crop     = max(min(LUC_EXPT%crop, LUC_EXPT%grass), 0.0)
     LUC_EXPT%past     = max(min(LUC_EXPT%grass-LUC_EXPT%crop, LUC_EXPT%past), 0.0)
 
-    IF (TRIM(cable_user%MetType) .EQ. "bios") THEN
+   ! Determine woody fraction (forest and shrub cover).
+    call get_woody_fraction(LUC_EXPT)
 
-       ! read bios parameter file to NVIS Major Vegetation Group "biomes"
-       CALL cable_bios_load_biome(MVG)
-       ! adjust fraction woody cover based on Major Vegetation Group
-       LUC_EXPT%biome = MVG
-       LUC_EXPT%ivegp = 2
-       projection_factor = 0.65
-       WHERE (LUC_EXPT%biome .eq. 1)
-          CPC = 0.89
-       ELSEWHERE (LUC_EXPT%biome .eq. 2)
-          CPC = 0.81
-       ELSEWHERE (LUC_EXPT%biome .eq. 3)
-          CPC = 0.79
-       ELSEWHERE (LUC_EXPT%biome .eq. 4)
-          CPC = 0.50
-       ELSEWHERE (LUC_EXPT%biome .eq. 5)
-          CPC = 0.31
-       ELSEWHERE (LUC_EXPT%biome .eq. 6)
-          CPC = 0.15
-       ELSEWHERE (LUC_EXPT%biome .eq. 7)
-          CPC = 0.37
-       ELSEWHERE (LUC_EXPT%biome .eq. 8)
-          CPC = 0.27
-       ELSEWHERE (LUC_EXPT%biome .eq. 9)
-          CPC = 0.23
-       ELSEWHERE (LUC_EXPT%biome .eq. 10)
-          CPC = 0.24
-       ELSEWHERE (LUC_EXPT%biome .eq. 11)
-          CPC = 0.19
-       ELSEWHERE (LUC_EXPT%biome .eq. 12)
-          CPC = 0.25
-       ELSEWHERE (LUC_EXPT%biome .eq. 13)
-          CPC = 0.14
-       ELSEWHERE (LUC_EXPT%biome .eq. 14)
-          CPC = 0.33
-       ELSEWHERE (LUC_EXPT%biome .eq. 15)
-          CPC = 0.29
-       ELSEWHERE (LUC_EXPT%biome .eq. 16)
-          CPC = 0.13
-       ELSEWHERE (LUC_EXPT%biome .eq. 17)
-          CPC = 0.21
-       ELSEWHERE (LUC_EXPT%biome .eq. 18)
-          CPC = 0.34
-       ELSEWHERE (LUC_EXPT%biome .eq. 19)
-          CPC = 0.05
-       ELSEWHERE (LUC_EXPT%biome .eq. 20)
-          CPC = 0.16
-       ELSEWHERE (LUC_EXPT%biome .eq. 21)
-          CPC = 0.11
-       ELSEWHERE (LUC_EXPT%biome .eq. 22)
-          CPC = 0.06
-       ELSEWHERE (LUC_EXPT%biome .eq. 23)
-          CPC = 1.0
-       ELSEWHERE (LUC_EXPT%biome .eq. 24)
-          CPC = 0.04
-       ELSEWHERE (LUC_EXPT%biome .eq. 25)
-          CPC= 0.1
-       ELSEWHERE (LUC_EXPT%biome .eq. 26)
-          CPC= 0.1
-       ELSEWHERE (LUC_EXPT%biome .eq. 27)
-          CPC = 0.02
-       ELSEWHERE (LUC_EXPT%biome .eq. 28)
-          CPC = 0.1
-       ELSEWHERE (LUC_EXPT%biome .eq. 29)
-          CPC = 0.1
-       ELSEWHERE (LUC_EXPT%biome .eq. 30)
-          CPC = 0.5
-       ELSEWHERE (LUC_EXPT%biome .eq. 31)
-          CPC= 0.20
-       ELSEWHERE (LUC_EXPT%biome .eq. 32)
-          CPC = 0.24
-       ELSEWHERE
-          CPC= 0.1
-       ENDWHERE
-
-       CPC = min(CPC/projection_factor, 1.0)
-
-       ! write(*,*)  LUC_EXPT%grass(93), LUC_EXPT%primaryf(93), LUC_EXPT%secdf(93), CPC
-
-       LUC_EXPT%grass    = LUC_EXPT%grass + (LUC_EXPT%primaryf+LUC_EXPT%secdf) * (1.0-CPC)
-       LUC_EXPT%primaryf = LUC_EXPT%primaryf * CPC
-       LUC_EXPT%secdf    = LUC_EXPT%secdf    * CPC
-       ! write(*,*)  LUC_EXPT%grass(93), LUC_EXPT%primaryf(93), LUC_EXPT%secdf(93)
-    ELSE
-       CALL READ_ClimateFile(LUC_EXPT)
-       ! hot desert
-       WHERE (LUC_EXPT%biome .eq. 15)
-          LUC_EXPT%ivegp = 14
-       ENDWHERE
-
-       WHERE (LUC_EXPT%biome .eq. 3 .or. LUC_EXPT%biome .eq. 11) ! savanna/ xerophytic woods
-          LUC_EXPT%grass    = LUC_EXPT%grass + (LUC_EXPT%primaryf+LUC_EXPT%secdf) * 0.6
-          LUC_EXPT%primaryf = LUC_EXPT%primaryf * 0.4
-          LUC_EXPT%secdf    = LUC_EXPT%secdf    * 0.4
-       ELSEWHERE (LUC_EXPT%biome .eq. 12 .or. LUC_EXPT%biome .eq. 13 & ! shrub
-            .or. LUC_EXPT%biome .eq. 15 .or. LUC_EXPT%biome .eq. 16  )
-          LUC_EXPT%grass    = LUC_EXPT%grass + (LUC_EXPT%primaryf+LUC_EXPT%secdf) * 0.8
-          LUC_EXPT%primaryf = LUC_EXPT%primaryf * 0.2
-          LUC_EXPT%secdf    = LUC_EXPT%secdf    * 0.2
-       ELSEWHERE (LUC_EXPT%biome .eq. 7 .or. LUC_EXPT%biome .eq. 8 &  ! boreal
-            .or. LUC_EXPT%biome .eq. 9 .or. LUC_EXPT%biome .eq. 10  )
-          LUC_EXPT%grass    = LUC_EXPT%grass + (LUC_EXPT%primaryf+LUC_EXPT%secdf) * 0.2
-          LUC_EXPT%primaryf = LUC_EXPT%primaryf * 0.8
-          LUC_EXPT%secdf    = LUC_EXPT%secdf    * 0.8
-       ELSEWHERE (LUC_EXPT%biome .eq. 5 .or. LUC_EXPT%biome .eq. 6 ) ! DBL
-          LUC_EXPT%grass    = LUC_EXPT%grass + (LUC_EXPT%primaryf+LUC_EXPT%secdf) * 0.3
-          LUC_EXPT%primaryf = LUC_EXPT%primaryf * 0.7
-          LUC_EXPT%secdf    = LUC_EXPT%secdf    * 0.7
-       END WHERE
-    ENDIF
+    ! Adjust grass and forest fractions based on LUC_EXPT%woodfrac as determined in get_woody_fraction.
+    LUC_EXPT%grass    = LUC_EXPT%grass + (LUC_EXPT%primaryf+LUC_EXPT%secdf) * (1.0-LUC_EXPT%woodfrac)
+    LUC_EXPT%primaryf = LUC_EXPT%primaryf * LUC_EXPT%woodfrac
+    LUC_EXPT%secdf    = LUC_EXPT%secdf    * LUC_EXPT%woodfrac
 
     ! write(59,*) TRIM(LUC_EXPT%NotPrimOnlyFile), (TRIM(LUC_EXPT%NotPrimOnlyFile).EQ.'none')
     ! READ transitions from primary to see if primary remains primary
@@ -477,40 +370,16 @@ CONTAINS
        NotPrimOnly_fID = -1
     ENDIF
 
-    IF (TRIM(cable_user%MetType) .EQ. "bios") THEN
-       WHERE (LUC_EXPT%prim_only .eqv. .TRUE.)
-          LUC_EXPT%secdf    = 0.0
-          LUC_EXPT%primaryf = 1.0
-          LUC_EXPT%grass    = 0.0
-          LUC_EXPT%grass    = LUC_EXPT%primaryf * (1.0-CPC)
-          LUC_EXPT%primaryf = LUC_EXPT%primaryf * CPC
-       ENDWHERE
-       DEALLOCATE (CPC)
-    ELSE
-       ! set secondary vegetation area to be zero where land use transitions don't occur
-       ! set grass component of primary vegetation cover
-       WHERE (LUC_EXPT%prim_only .eqv. .TRUE.)
-          LUC_EXPT%secdf    = 0.0
-          LUC_EXPT%primaryf = 1.0
-          LUC_EXPT%grass    = 0.0
-          WHERE (LUC_EXPT%biome .eq. 3 .or. LUC_EXPT%biome .eq. 11) ! savanna/ xerophytic woods
-             LUC_EXPT%grass    = LUC_EXPT%primaryf * 0.6
-             LUC_EXPT%primaryf = LUC_EXPT%primaryf * 0.4
-          ELSEWHERE (LUC_EXPT%biome .eq. 12 .or. LUC_EXPT%biome .eq. 13 &
-               .or. LUC_EXPT%biome .eq. 15 .or. LUC_EXPT%biome .eq. 16  ) ! shrub
-             LUC_EXPT%grass    = LUC_EXPT%primaryf * 0.8
-             LUC_EXPT%primaryf = LUC_EXPT%primaryf * 0.2
-          ELSEWHERE (LUC_EXPT%biome .eq. 7 .or. LUC_EXPT%biome .eq. 8 &
-               .or. LUC_EXPT%biome .eq. 9 .or. LUC_EXPT%biome .eq. 10) ! boreal
-             LUC_EXPT%grass    = LUC_EXPT%primaryf * 0.2
-             LUC_EXPT%primaryf = LUC_EXPT%primaryf * 0.8
-          ELSEWHERE (LUC_EXPT%biome .eq. 5 .or. LUC_EXPT%biome .eq. 6 ) ! DBL
-             LUC_EXPT%grass    = LUC_EXPT%primaryf * 0.3
-             LUC_EXPT%primaryf = LUC_EXPT%primaryf * 0.7
-          END WHERE
-       END WHERE
-    ENDIF
-
+    ! set secondary vegetation area to be zero where land use transitions don't occur
+    ! set grass component of primary vegetation cover
+    WHERE (LUC_EXPT%prim_only .eqv. .TRUE.)
+      LUC_EXPT%secdf    = 0.0
+      LUC_EXPT%primaryf = 1.0
+      LUC_EXPT%grass    = 0.0
+      LUC_EXPT%grass    = LUC_EXPT%primaryf * (1.0-LUC_EXPT%woodfrac)
+      LUC_EXPT%primaryf = LUC_EXPT%primaryf * LUC_EXPT%woodfrac
+    ENDWHERE
+    
   END SUBROUTINE LUC_EXPT_INIT
 
   subroutine luc_expt_zero(luc_expt)
@@ -538,10 +407,142 @@ CONTAINS
     luc_expt%crop        = 0.
     luc_expt%past        = 0.
     luc_expt%mtemp_min20 = 0.
+    luc_expt%woodfrac    = 0.
 
   end subroutine luc_expt_zero
 
   ! ------------------------------------------------------------------
+
+  subroutine get_woody_fraction(LUC_EXPT) 
+    ! Determine woody fraction (forest and shrub cover) from ancillary data.
+    
+    use cable_bios_met_obs_params, only: cable_bios_load_biome
+    use cable_common_module,       only: cable_user
+
+    implicit none
+
+    type(LUC_EXPT_type), intent(inout) :: LUC_EXPT
+    real    :: CPC(mland)
+    integer :: MVG(mland)
+    real    :: projection_factor
+
+    if (TRIM(cable_user%MetType) .EQ. "bios") then
+      ! For bios, calculate crown projective cover (CPC) based on
+      ! Major Vegetation Groups from National Vegetation Information System (NVIS).
+      ! Woody fraction (woodfrac) is then calculated from CPC.
+      
+      ! read bios parameter file to NVIS Major Vegetation Group "biomes"
+      call cable_bios_load_biome(MVG)
+      
+      ! adjust fraction woody cover based on Major Vegetation Group
+      LUC_EXPT%biome = MVG
+      LUC_EXPT%ivegp = 2
+      projection_factor = 0.65
+      WHERE (LUC_EXPT%biome .eq. 1)
+         CPC = 0.89
+      ELSEWHERE (LUC_EXPT%biome .eq. 2)
+         CPC = 0.81
+      ELSEWHERE (LUC_EXPT%biome .eq. 3)
+         CPC = 0.79
+      ELSEWHERE (LUC_EXPT%biome .eq. 4)
+         CPC = 0.50
+      ELSEWHERE (LUC_EXPT%biome .eq. 5)
+         CPC = 0.31
+      ELSEWHERE (LUC_EXPT%biome .eq. 6)
+         CPC = 0.15
+      ELSEWHERE (LUC_EXPT%biome .eq. 7)
+         CPC = 0.37
+      ELSEWHERE (LUC_EXPT%biome .eq. 8)
+         CPC = 0.27
+      ELSEWHERE (LUC_EXPT%biome .eq. 9)
+         CPC = 0.23
+      ELSEWHERE (LUC_EXPT%biome .eq. 10)
+         CPC = 0.24
+      ELSEWHERE (LUC_EXPT%biome .eq. 11)
+         CPC = 0.19
+      ELSEWHERE (LUC_EXPT%biome .eq. 12)
+         CPC = 0.25
+      ELSEWHERE (LUC_EXPT%biome .eq. 13)
+         CPC = 0.14
+      ELSEWHERE (LUC_EXPT%biome .eq. 14)
+         CPC = 0.33
+      ELSEWHERE (LUC_EXPT%biome .eq. 15)
+         CPC = 0.29
+      ELSEWHERE (LUC_EXPT%biome .eq. 16)
+         CPC = 0.13
+      ELSEWHERE (LUC_EXPT%biome .eq. 17)
+         CPC = 0.21
+      ELSEWHERE (LUC_EXPT%biome .eq. 18)
+         CPC = 0.34
+      ELSEWHERE (LUC_EXPT%biome .eq. 19)
+         CPC = 0.05
+      ELSEWHERE (LUC_EXPT%biome .eq. 20)
+         CPC = 0.16
+      ELSEWHERE (LUC_EXPT%biome .eq. 21)
+         CPC = 0.11
+      ELSEWHERE (LUC_EXPT%biome .eq. 22)
+         CPC = 0.06
+      ELSEWHERE (LUC_EXPT%biome .eq. 23)
+         CPC = 1.0
+      ELSEWHERE (LUC_EXPT%biome .eq. 24)
+         CPC = 0.04
+      ELSEWHERE (LUC_EXPT%biome .eq. 25)
+         CPC= 0.1
+      ELSEWHERE (LUC_EXPT%biome .eq. 26)
+         CPC= 0.1
+      ELSEWHERE (LUC_EXPT%biome .eq. 27)
+         CPC = 0.02
+      ELSEWHERE (LUC_EXPT%biome .eq. 28)
+         CPC = 0.1
+      ELSEWHERE (LUC_EXPT%biome .eq. 29)
+         CPC = 0.1
+      ELSEWHERE (LUC_EXPT%biome .eq. 30)
+         CPC = 0.5
+      ELSEWHERE (LUC_EXPT%biome .eq. 31)
+         CPC= 0.20
+      ELSEWHERE (LUC_EXPT%biome .eq. 32)
+         CPC = 0.24
+      ELSEWHERE
+         CPC= 0.1
+      ENDWHERE
+
+      LUC_EXPT%woodfrac = min(CPC/projection_factor, 1.0)
+
+   ELSE
+      ! For all other applications, infer CPC from biome information.
+
+      ! Read climate restart file
+      CALL READ_ClimateFile(LUC_EXPT)
+
+      WHERE (LUC_EXPT%biome .eq. 15) ! hot desert
+         LUC_EXPT%ivegp = 14
+      ENDWHERE
+
+
+      WHERE (LUC_EXPT%biome .eq. 3 .or. LUC_EXPT%biome .eq. 11) ! savanna/ xerophytic woods
+         
+         LUC_EXPT%woodfrac = 0.4
+
+      ELSEWHERE (LUC_EXPT%biome .eq. 12 .or. LUC_EXPT%biome .eq. 13 & ! shrub
+            .or. LUC_EXPT%biome .eq. 15 .or. LUC_EXPT%biome .eq. 16  )
+
+         LUC_EXPT%woodfrac = 0.2
+
+      ELSEWHERE (LUC_EXPT%biome .eq. 7 .or. LUC_EXPT%biome .eq. 8 &  ! boreal
+            .or. LUC_EXPT%biome .eq. 9 .or. LUC_EXPT%biome .eq. 10  )
+
+         LUC_EXPT%woodfrac = 0.8
+
+      ELSEWHERE (LUC_EXPT%biome .eq. 5 .or. LUC_EXPT%biome .eq. 6 ) ! DBL
+         
+         LUC_EXPT%woodfrac = 0.7
+
+      END WHERE
+   ENDIF
+
+  end subroutine get_woody_fraction
+
+
 
 
   SUBROUTINE LUC_EXPT_SET_TILES(inVeg, inPfrac, LUC_EXPT)
@@ -929,38 +930,16 @@ CONTAINS
        write(*,'(a)') 'warning: past end of LUH2 record'
     endif
 
+    ! Determine woody fraction (forest and shrub cover).
+    call get_woody_fraction(LUC_EXPT)
+
     ! Adjust transition areas based on primary wooded fraction
-    WHERE (LUC_EXPT%biome .eq. 3 .or. LUC_EXPT%biome .eq. 11)  ! savanna/ xerophytic woods
-       LUC_EXPT%INPUT(ptos)%VAL   =  LUC_EXPT%INPUT(ptos)%VAL   * 0.4
-       LUC_EXPT%INPUT(ptog)%VAL   =  LUC_EXPT%INPUT(ptog)%VAL   * 0.4
-       LUC_EXPT%INPUT(gtos)%VAL   =  LUC_EXPT%INPUT(gtos)%VAL   * 0.4
-       LUC_EXPT%INPUT(stog)%VAL   =  LUC_EXPT%INPUT(stog)%VAL   * 0.4
-       LUC_EXPT%INPUT(smharv)%VAL =  LUC_EXPT%INPUT(smharv)%VAL * 0.4
-       LUC_EXPT%INPUT(syharv)%VAL =  LUC_EXPT%INPUT(syharv)%VAL * 0.4
-    ELSEWHERE (LUC_EXPT%biome .eq. 12 .or. LUC_EXPT%biome .eq. 13 &
-         .or. LUC_EXPT%biome .eq. 15 .or. LUC_EXPT%biome .eq. 16  ) ! shrub
-       LUC_EXPT%INPUT(ptos)%VAL   =  LUC_EXPT%INPUT(ptos)%VAL   * 0.2
-       LUC_EXPT%INPUT(ptog)%VAL   =  LUC_EXPT%INPUT(ptog)%VAL   * 0.2
-       LUC_EXPT%INPUT(gtos)%VAL   =  LUC_EXPT%INPUT(gtos)%VAL   * 0.2
-       LUC_EXPT%INPUT(stog)%VAL   =  LUC_EXPT%INPUT(stog)%VAL   * 0.2
-       LUC_EXPT%INPUT(smharv)%VAL =  LUC_EXPT%INPUT(smharv)%VAL * 0.2
-       LUC_EXPT%INPUT(syharv)%VAL =  LUC_EXPT%INPUT(syharv)%VAL * 0.2
-    ELSEWHERE (LUC_EXPT%biome .eq. 7 .or. LUC_EXPT%biome .eq. 8 &
-         .or. LUC_EXPT%biome .eq. 9 .or. LUC_EXPT%biome .eq. 10) ! boreal
-       LUC_EXPT%INPUT(ptos)%VAL   =  LUC_EXPT%INPUT(ptos)%VAL   * 0.8
-       LUC_EXPT%INPUT(ptog)%VAL   =  LUC_EXPT%INPUT(ptog)%VAL   * 0.8
-       LUC_EXPT%INPUT(gtos)%VAL   =  LUC_EXPT%INPUT(gtos)%VAL   * 0.8
-       LUC_EXPT%INPUT(stog)%VAL   =  LUC_EXPT%INPUT(stog)%VAL   * 0.8
-       LUC_EXPT%INPUT(smharv)%VAL =  LUC_EXPT%INPUT(smharv)%VAL * 0.8
-       LUC_EXPT%INPUT(syharv)%VAL =  LUC_EXPT%INPUT(syharv)%VAL * 0.8
-    ELSEWHERE (LUC_EXPT%biome .eq. 5 .or. LUC_EXPT%biome .eq. 6 ) ! DBL
-       LUC_EXPT%INPUT(ptos)%VAL   =  LUC_EXPT%INPUT(ptos)%VAL   * 0.7
-       LUC_EXPT%INPUT(ptog)%VAL   =  LUC_EXPT%INPUT(ptog)%VAL   * 0.7
-       LUC_EXPT%INPUT(gtos)%VAL   =  LUC_EXPT%INPUT(gtos)%VAL   * 0.7
-       LUC_EXPT%INPUT(stog)%VAL   =  LUC_EXPT%INPUT(stog)%VAL   * 0.7
-       LUC_EXPT%INPUT(smharv)%VAL =  LUC_EXPT%INPUT(smharv)%VAL * 0.7
-       LUC_EXPT%INPUT(syharv)%VAL =  LUC_EXPT%INPUT(syharv)%VAL * 0.7
-    ENDWHERE
+    LUC_EXPT%INPUT(ptos)%VAL   =  LUC_EXPT%INPUT(ptos)%VAL   * LUC_EXPT%woodfrac
+    LUC_EXPT%INPUT(ptog)%VAL   =  LUC_EXPT%INPUT(ptog)%VAL   * LUC_EXPT%woodfrac
+    LUC_EXPT%INPUT(gtos)%VAL   =  LUC_EXPT%INPUT(gtos)%VAL   * LUC_EXPT%woodfrac
+    LUC_EXPT%INPUT(stog)%VAL   =  LUC_EXPT%INPUT(stog)%VAL   * LUC_EXPT%woodfrac
+    LUC_EXPT%INPUT(smharv)%VAL =  LUC_EXPT%INPUT(smharv)%VAL * LUC_EXPT%woodfrac
+    LUC_EXPT%INPUT(syharv)%VAL =  LUC_EXPT%INPUT(syharv)%VAL * LUC_EXPT%woodfrac
 
   END SUBROUTINE READ_LUH2
 

--- a/offline/cable_driver.F90
+++ b/offline/cable_driver.F90
@@ -1540,7 +1540,8 @@ SUBROUTINE LUCdriver( casabiome, casapool, casaflux, POP, LUC_EXPT, POPLUC, veg,
   USE POP_Types,            Only: POP_TYPE
   USE POPMODULE,            ONLY: POP_init_single
   USE CABLE_LUC_EXPT,       ONLY: LUC_EXPT_TYPE, read_LUH2, &
-       ptos, ptog, stog, gtos, pharv, smharv, syharv
+       ptos, ptog, stog, gtos, pharv, smharv, syharv, &
+       ptoc, ptoq, stoc, stoq, ctos, qtos
   USE POPLUC_Types
   USE POPLUC_Module,        ONLY: POPLUCStep, POPLUC_weights_Transfer
   ! 13C
@@ -1577,13 +1578,12 @@ SUBROUTINE LUCdriver( casabiome, casapool, casaflux, POP, LUC_EXPT, POPLUC, veg,
      POPLUC%smharv(k) = real(LUC_EXPT%INPUT(smharv)%VAL(k), r_2)
      POPLUC%syharv(k) = real(LUC_EXPT%INPUT(syharv)%VAL(k), r_2)
 
-     !MC - from MPI code
-     ! POPLUC%ptoc(k) = real(LUC_EXPT%INPUT(ptoc)%VAL(k), r_2)
-     ! POPLUC%ptoq(k) = real(LUC_EXPT%INPUT(ptoq)%VAL(k), r_2)
-     ! POPLUC%stoc(k) = real(LUC_EXPT%INPUT(stoc)%VAL(k), r_2)
-     ! POPLUC%stoq(k) = real(LUC_EXPT%INPUT(stoq)%VAL(k), r_2)
-     ! POPLUC%ctos(k) = real(LUC_EXPT%INPUT(ctos)%VAL(k), r_2)
-     ! POPLUC%qtos(k) = real(LUC_EXPT%INPUT(qtos)%VAL(k), r_2)
+     POPLUC%ptoc(k) = real(LUC_EXPT%INPUT(ptoc)%VAL(k), r_2)
+     POPLUC%ptoq(k) = real(LUC_EXPT%INPUT(ptoq)%VAL(k), r_2)
+     POPLUC%stoc(k) = real(LUC_EXPT%INPUT(stoc)%VAL(k), r_2)
+     POPLUC%stoq(k) = real(LUC_EXPT%INPUT(stoq)%VAL(k), r_2)
+     POPLUC%ctos(k) = real(LUC_EXPT%INPUT(ctos)%VAL(k), r_2)
+     POPLUC%qtos(k) = real(LUC_EXPT%INPUT(qtos)%VAL(k), r_2)
 
      POPLUC%thisyear  = yyyy
 

--- a/scripts/TRENDY_runs/v13/preprocessing/process_LUH2_TRENDY.sh
+++ b/scripts/TRENDY_runs/v13/preprocessing/process_LUH2_TRENDY.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+
+#PBS -N LUH2_processing
+#PBS -P x45
+#PBS -q normal
+#PBS -l walltime=01:45:00
+#PBS -l mem=32GB
+#PBS -l ncpus=1
+#PBS -l storage=gdata/x45+gdata/pr09+scratch/pr09
+#PBS -l software=netCDF:MPI:Intel:GNU
+#PBS -r y
+#PBS -l wd
+#PBS -j oe
+#PBS -S /bin/bash
+
+# Script to process LUH2 data for CABLE-POP for use in TRENDY.
+# Juergen Knauer, May 2024. Gives identical results (+/- numerical precision) 
+# compared to Peter Briggs' original scripts.
+
+# The file assumes that LUH2 data are downloaded manually (see TRENDY protocol for location)
+# there should be three files: management.nc, states.nc, and transitions.nc
+
+## set up workspace
+module purge
+module load nco/5.0.5
+module load cdo/2.0.5
+module load netcdf/4.9.2
+
+#files="management.nc states.nc transitions.nc"
+files="states.nc transitions.nc"
+filepath="/g/data/x45/LUH2/test"                         # absolute path where files were downloaded to.
+outpath="/g/data/x45/LUH2/test/EXTRACT"                  # absolute path for processed files.
+gridfile="/g/data/pr09/TRENDY_v12/aux/input.grid.1deg"   # grid file used for TRENDY inputs (excluding everything below 60degS).
+
+startyear=1580
+endyear=2023   # note that LUH2 goes one year longer than climate data! (e.g. until 2023 for GCB2023)
+#endyear=$(ncap2 -v -O -s 'print(time.size(),"%ld\n");' ${filepath}/states.nc tmptime.nc) # last year of time series = size of time dimension
+
+
+mkdir -p $outpath
+cd $outpath
+
+for file in ${files} ; do
+    
+    ## 1) select time period of interest and set time axis to years since 1580 and sets calendar.
+    # latitude and longitude dimensions are renamed to lat and lon (the variables latitude(lat) and longitude(lon) remain). 
+
+    # The transitions file always has one less data record than the others.
+    if [[ "${file}" == "transitions.nc" ]] ; then
+        endyear_file=$(echo "${endyear} - 1" | bc)
+    else 
+        endyear_file=${endyear}
+    fi
+
+    cp ${filepath}/${file} ${outpath}/${file}
+    #ncks -O -d time,${startyear},${endyear_file} ${file} tmp.nc
+    #cdo -O -f nc4 -settaxis,850-01-01,0:00:00,1year -setcalendar,365_day ${file} tmp.nc
+    cdo -O -f nc4 -z zip5 selyear,${startyear}/${endyear_file} ${file} tmp1.nc
+
+
+    ## 2) Aggregate from 0.25 to 1 degree using conservative remapping
+    cdo -O -z zip5 remapcon,${gridfile} tmp1.nc tmp2.nc
+    #ncrename -d latitude,lat -d longitude,lon tmp2.nc
+
+    # set optimal netcdf chunking
+    # Note: it would be better to change order with time coming first, but that would require changes to the code.
+    nccopy -d0 -c longitude/64,latitude/64,time/1 tmp2.nc tmp3.nc
+
+
+    ## 3) Aggregate land use classes into broader categories
+    tmpfile="tmp3.nc"
+
+    if [[ "${file}" == "management.nc" ]] ; then
+
+        echo 'no variables extracted from management.nc!'
+
+    elif [[ "${file}" == "states.nc" ]] ; then
+
+        ncap2 -O -s "grass=c3ann+c4ann+c3per+c4per+c3nfx+pastr+range" -v $tmpfile ${outpath}/grass.nc
+        ncap2 -O -s "primaryf=primf+primn"                            -v $tmpfile ${outpath}/primaryf.nc
+        ncap2 -O -s "secondaryf=secdf+secdn"                          -v $tmpfile ${outpath}/secondaryf.nc
+
+        ncap2 -O -s "crop=c3ann+c4ann+c3per+c4per+c3nfx" -v $tmpfile ${outpath}/crop.nc
+        ncap2 -O -s "past=pastr"                         -v $tmpfile ${outpath}/past.nc
+        ncap2 -O -s "rang=range"                         -v $tmpfile ${outpath}/rang.nc
+
+    elif [[ "${file}" == "transitions.nc" ]] ; then
+        
+        ncap2 -O -s "pharv=primf_harv+primn_harv"  -v $tmpfile ${outpath}/pharv.nc
+        ncap2 -O -s "smharv=secmf_harv+secnf_harv" -v $tmpfile ${outpath}/smharv.nc
+        ncap2 -O -s "syharv=secyf_harv"            -v $tmpfile ${outpath}/syharv.nc
+
+        ncap2 -O -s "ptos=primf_harv+primn_to_secdf+primn_harv" -v $tmpfile ${outpath}/ptos.nc
+        ncap2 -O -s "ptog=primf_to_c3ann+primf_to_c4ann+primf_to_c3per+primf_to_c4per+primf_to_c3nfx+primf_to_pastr+
+                          primf_to_range+primn_to_c3ann+primn_to_c4ann+primn_to_c3per+primn_to_c4per+primn_to_c3nfx" -v $tmpfile ${outpath}/ptog.nc
+        ncap2 -O -s "stog=secdf_to_c3ann+secdf_to_c4ann+secdf_to_c3per+secdf_to_c4per+secdf_to_c3nfx+secdf_to_pastr+
+                          secdf_to_range+secdn_to_c3ann+secdn_to_c4ann+secdn_to_c3per+secdn_to_c4per+secdn_to_c3nfx" -v $tmpfile ${outpath}/stog.nc
+        ncap2 -O -s "gtos=c3ann_to_secdf+c4ann_to_secdf+c3per_to_secdf+c4per_to_secdf+c3nfx_to_secdf+pastr_to_secdf+
+                          range_to_secdf+c3ann_to_secdn+c4ann_to_secdn+c3per_to_secdn+c4per_to_secdn+c3nfx_to_secdn+
+                          pastr_to_secdn+range_to_secdn" -v $tmpfile ${outpath}/gtos.nc
+        ncap2 -O -s "ptoc=primf_to_c3ann+primf_to_c4ann+primf_to_c3per+primf_to_c4per+primf_to_c3nfx+primn_to_c3ann+
+                          primn_to_c4ann+primn_to_c3per+primn_to_c4per+primn_to_c3nfx" -v $tmpfile  ${outpath}/ptoc.nc
+        ncap2 -O -s "ptoq=primf_to_pastr+primn_to_pastr" -v $tmpfile  ${outpath}/ptoq.nc
+        ncap2 -O -s "stoc=secdf_to_c3ann+secdf_to_c4ann+secdf_to_c3per+secdf_to_c4per+secdf_to_c3nfx+secdn_to_c3ann+
+                          secdn_to_c4ann+secdn_to_c3per+secdn_to_c4per+secdn_to_c3nfx" -v $tmpfile ${outpath}/stoc.nc
+        ncap2 -O -s "stoq=secdf_to_pastr + secdn_to_pastr" -v $tmpfile ${outpath}/stoq.nc
+        ncap2 -O -s "ctos=c3ann_to_secdf+c4ann_to_secdf+c3per_to_secdf+c4per_to_secdf+c3nfx_to_secdf+c3ann_to_secdn+
+                          c4ann_to_secdn+c3per_to_secdn+c4per_to_secdn+c3nfx_to_secdn" -v $tmpfile ${outpath}/ctos.nc
+        ncap2 -O -s "qtos=pastr_to_secdf+pastr_to_secdn" -v $tmpfile ${outpath}/qtos.nc
+
+   fi
+done
+
+
+# Give permissions and remove intermediate files.
+chmod 775 *.nc
+rm tmp.nc tmp*.nc 
+rm states.nc transitions.nc

--- a/scripts/TRENDY_runs/v13/preprocessing/process_LUH2_TRENDY.sh
+++ b/scripts/TRENDY_runs/v13/preprocessing/process_LUH2_TRENDY.sh
@@ -54,9 +54,9 @@ for file in ${files} ; do
 
     cp ${filepath}/${file} ${outpath}/${file}
     #ncks -O -d time,${startyear},${endyear_file} ${file} tmp.nc
-    #cdo -O -f nc4 -settaxis,850-01-01,0:00:00,1year -setcalendar,365_day ${file} tmp.nc
-    cdo -O -f nc4 -z zip5 selyear,${startyear}/${endyear_file} ${file} tmp1.nc
-
+    cdo -O -f nc4 -z zip5 selyear,${startyear}/${endyear_file} ${file} tmp.nc
+    cdo -O -f nc4 -settaxis,${startyear}-01-01,00:00:00,1year -setcalendar,365_day tmp.nc tmp1.nc
+    #ncatted -O -a units,time,o,c,"years since ${startyear}-01-01 00:00:00" tmp1.nc
 
     ## 2) Aggregate from 0.25 to 1 degree using conservative remapping
     cdo -O -z zip5 remapcon,${gridfile} tmp1.nc tmp2.nc

--- a/scripts/TRENDY_runs/v13/preprocessing/process_climate_TRENDY.sh
+++ b/scripts/TRENDY_runs/v13/preprocessing/process_climate_TRENDY.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+#PBS -N climate_processing
+#PBS -P x45
+#PBS -q normal
+#PBS -l walltime=01:45:00
+#PBS -l mem=32GB
+#PBS -l ncpus=1
+#PBS -l storage=gdata/x45+gdata/pr09+scratch/pr09
+#PBS -l software=netCDF:MPI:Intel:GNU
+#PBS -r y
+#PBS -l wd
+#PBS -j oe
+#PBS -S /bin/bash
+
+# Script to process climate forcing data for CABLE-POP for use in TRENDY.
+# Juergen Knauer, May/June 2024.
+
+# The script downloads climate data from the Exeter server and processes them.
+# The script assumes the following file structure and creates it if not present:
+#   basepath/6hourly     <- original data as downloaded from server
+#   basepath/daily       <- data aggregated to daily values
+#   basepath/daily_1deg  <- daily aggregated to 1 deg (as used by CABLE)
+
+## TODO: revisit aggregation of fd (daymean) and consistency with other tswrf
+
+## set up workspace
+module purge
+module load nco/5.0.5
+module load cdo/2.0.5
+module load netcdf/4.9.2
+
+vars="dlwrf fd pre pres spfh tmax tmin tswrf ugrd vgrd"  # climate variables to process
+vars="dlwrf"
+basepath="/g/data/x45/CRUJRA2022/test"                   # absolute path where forcing files were downloaded to.
+gridfile="/g/data/pr09/TRENDY_v12/aux/input.grid.1deg"   # grid file used for TRENDY inputs (excluding everything below 60degS).
+cruversion="crujra.v2.2.5d"                              # version name of CRUJRA product to be used
+startyear=1901
+endyear=2021
+
+mkdir -p ${basepath}/6hourly
+mkdir -p ${basepath}/daily
+mkdir -p ${basepath}/daily_1deg
+
+for var in ${vars} ; do
+
+    echo "processing variable ${var}"
+    
+    for year in {${startyear}..${endyear}} ; do
+        
+        echo "year ${year}"
+
+        # base name of the file
+        basename="${cruversion}.${var}.${year}.365d.noc"
+        
+        # unzip the required file
+        gunzip ${basepath}/6hourly/${var}/${basename}.nc.gz
+
+        # set time axis to something sensible
+        # TODO: check if this is needed
+        # cdo settaxis,$year-01-01,03:00:00,6hours /datasets/work/oa-globalcable/work/CRUJRA2021/6hourly/dlwrf/crujra.v2.2.5d.dlwrf.$year.365d.noc.nc /datasets/work/oa-globalcable/work/CRUJRA2021/6hourly/dlwrf/crujra.v2.2.5d.dlwrf.$year.365d.noc.taxis.nc
+
+        ## aggregate from 6-hourly to daily, change unit attribute if necessary, and aggregate to 1deg
+        if [[ "${var}" == "pre" ]] ; then
+
+            # calculate daily sum
+            cdo -O daysum ${basepath}/6hourly/${var}/${basename}.nc ${basepath}/daily/${var}/${basename}.daytot.nc
+            ncatted -O -a units,pre,m,c,"mm d-1" ${basepath}/daily/${var}/${basename}.daytot.nc
+            cdo -O remapcon,${gridfile} ${basepath}/daily/${var}/${basename}.daytot.nc ${basepath}/daily_1deg/${var}/${basename}.daytot.1deg.nc
+
+        elif [[ "${var}" == "tmax" ]] ; then
+
+            # extract daily maximum
+            cdo -O -m 9.96921e+36 daymax ${basepath}/6hourly/${var}/${basename}.nc ${basepath}/daily/${var}/${basename}.daymax.nc     
+            cdo -O remapcon,${gridfile} ${basepath}/daily/${var}/${basename}.daymax.nc ${basepath}/daily_1deg/${var}/${basename}.daymax.1deg.nc 
+        
+        elif [[ "${var}" == "tmin" ]] ; then
+        
+            # extract daily minimum
+            cdo -O -m 9.96921e+36 daymin ${basepath}/6hourly/${var}/${basename}.nc ${basepath}/daily/${var}/${basename}.daymin.nc      
+            cdo -O remapcon,${gridfile} ${basepath}/daily/${var}/${basename}.daymin.nc ${basepath}/daily_1deg/${var}/${basename}.daymin.1deg.nc 
+
+        else    
+        
+            # calculate daily mean 
+            cdo -O daymean ${basepath}/6hourly/${var}/${basename}.nc ${basepath}/daily/${var}/${basename}.daymean.nc
+            cdo -O remapcon,${gridfile} ${basepath}/daily/${var}/${basename}.daymean.nc ${basepath}/daily_1deg/${var}/${basename}.daymean.1deg.nc 
+
+        fi
+
+        ## 3) zip the original 6-hourly file back up again
+        gzip ${basepath}/6hourly/${var}/${basename}.nc
+    
+done

--- a/scripts/aux/Readme.txt
+++ b/scripts/aux/Readme.txt
@@ -5,3 +5,9 @@ trendy.grid.1deg: same as v10 and v11
 /g/data/x45/ipbes/masks/glob_ipsl_1x1.nc
 /g/data/x45/TRENDY_test_suite/mask_1000pts/landmask_1000pts.nc
 /g/data/x45/TRENDY_test_suite/mask_1000pts/latlonlist_1000points.csv
+
+
+added May 2024:
+input.grid.1deg, which is equal to input.grid.1deg but excludes latitudes below 60degS.
+It is used primarily for input preprocessing since CABLE in the TRENDY setup does not 
+simulate this region.

--- a/scripts/aux/input.grid.1deg
+++ b/scripts/aux/input.grid.1deg
@@ -1,0 +1,14 @@
+gridtype  = lonlat
+gridsize  = 54000
+xsize     = 360
+ysize     = 150
+xname     = longitude
+xlongname = "longitude"
+xunits    = "degrees_East"
+yname     = latitude
+ylongname = "latitude"
+yunits    = "degrees_North"
+xfirst    = -179.5
+xinc      = 1
+yfirst    = 89.5
+yinc      = -1


### PR DESCRIPTION
## Description

As discussed in the email, I have restructured and streamlined the cable_LUC_EXPT.F90 routine and the way it handles the woody fraction. Specific changes:
- new soubroutine get_woody_fraction() that calculates the woody fraction of a grid cell (previously called CPC in bios and hard-coded constants in all other cases). This is now integrated into the luc_expt structure as luc_expt%woodfrac
- luc_expt%woodfrac replaces CPC and hard-coded fractions throughout the rest of the code. It is also applied to transitions. All this makes a couple of if/where statements redundant.
- I have NOT yet changed the other changes we discussed (including the ptoc transitions that were removed from the code but ought to be in there). So this version should give identical results to the preivous one. I am testing that right now.

## Question:

- in the previous version, CPC was a real, allocatable. It was allocated and deallocated in the LUC_EXPT_INIT routine. I have changed it to be a real :: cpc(mland) since I thought we know its lenght from the beginning. Would be good if you could check this explicitly.

Happy for any sort of feedback and suggestions of course.


