### PR TITLE
Auto refresh MathJax on page load

### DIFF
--- a/documentation/docs/javascripts/mathjax.js
+++ b/documentation/docs/javascripts/mathjax.js
@@ -1,16 +1,21 @@
+//https://squidfunk.github.io/mkdocs-material/reference/math/#mathjax-docsjavascriptsmathjaxjs 
+
 window.MathJax = {
-    tex: {
-      inlineMath: [["\\(", "\\)"]],
-      displayMath: [["\\[", "\\]"]],
-      processEscapes: true,
-      processEnvironments: true
-    },
-    options: {
-      ignoreHtmlClass: ".*|",
-      processHtmlClass: "arithmatex"
-    }
-  };
-  
-  document$.subscribe(() => { 
-    MathJax.typesetPromise()
-  })
+  tex: {
+    inlineMath: [["\\(", "\\)"]],
+    displayMath: [["\\[", "\\]"]],
+    processEscapes: true,
+    processEnvironments: true
+  },
+  options: {
+    ignoreHtmlClass: ".*|",
+    processHtmlClass: "arithmatex"
+  }
+};
+
+document$.subscribe(() => {
+  MathJax.startup.output.clearCache()
+  MathJax.typesetClear()
+  MathJax.texReset()
+  MathJax.typesetPromise()
+})

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -65,8 +65,8 @@ markdown_extensions:
 extra_javascript:
   - javascripts/mathjax.js
   - https://polyfill.io/v3/polyfill.min.js?features=es6
-  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
-  
+  - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
+
 # Navigation
 nav:
   - About: 


### PR DESCRIPTION
# CABLE

Resolves #298 

Recently, the [documentation](https://squidfunk.github.io/mkdocs-material/reference/math/#mathjax) for MathJax changed to reset the typeset after instant page load.

Considering that it's a cache issue, we would know for sure that the effect after it's on the main `readthedocs` is built again. Seems to work well for readthedocs PR preview (although they do hard refresh for every new page load)

Relevant issues
- https://github.com/squidfunk/mkdocs-material/issues/6661
- https://github.com/squidfunk/mkdocs-material/issues/6407

<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--304.org.readthedocs.build/en/304/

<!-- readthedocs-preview cable end -->