### PR TITLE
(#303): reducing left and right margins

### DIFF
--- a/documentation/docs/css/cable.css
+++ b/documentation/docs/css/cable.css
@@ -1,5 +1,5 @@
 .md-grid {
    margin-left: auto;
    margin-right: auto;
-   max-width: 70rem;
+   max-width: 120rem;
 }


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

Increase the overall width of the page. This removes the large left and right margins and tend to improve the rendering of the tables throughout the documentation.

You can link issues by using a supported keyword in the pull request's description or in a commit message:

Fixes #(303)

## Type of change

Please delete options that are not relevant.

- [X] New or updated documentation

## Checklist

- [X] The new content is accessible and located in the appropriate section.
- [X] I have checked that links are valid and point to the intended content.
- [X] I have checked my code/text and corrected any misspellings

Please add a reviewer when ready for review.


<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--305.org.readthedocs.build/en/305/

<!-- readthedocs-preview cable end -->