### PR TITLE
Defined ncid_mask for met data files with multiple sites. Fixes #306.

### DIFF
--- a/src/offline/cable_input.F90
+++ b/src/offline/cable_input.F90
@@ -483,9 +483,9 @@ CONTAINS
        IF (ok /= NF90_NOERR) CALL nc_abort &
             (ok,'Error opening netcdf met forcing file '//TRIM(filename%met)// &
             ' (SUBROUTINE open_met_file)')
-    ! R. Law (rml599gh) 30/05/24 ncid_mask needs to be set to ncid_met 
-    ! if reading a met data file otherwise code crashes if trying to do 
-    ! multiple sites with a met data file
+       ! R. Law (rml599gh) 30/05/24 ncid_mask needs to be set to ncid_met 
+       ! if reading a met data file otherwise code crashes if trying to do 
+       ! multiple sites with a met data file
        ncid_mask = ncid_met
     ENDIF
 

--- a/src/offline/cable_input.F90
+++ b/src/offline/cable_input.F90
@@ -483,6 +483,10 @@ CONTAINS
        IF (ok /= NF90_NOERR) CALL nc_abort &
             (ok,'Error opening netcdf met forcing file '//TRIM(filename%met)// &
             ' (SUBROUTINE open_met_file)')
+    ! R. Law (rml599gh) 30/05/24 ncid_mask needs to be set to ncid_met 
+    ! if reading a met data file otherwise code crashes if trying to do 
+    ! multiple sites with a met data file
+       ncid_mask = ncid_met
     ENDIF
 
     !=====================VV Determine spatial details VV=================


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

The model crashed when trying to run multiple sites in the met data file. This was because ncid_mask was not defined.


Fixes #306

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix


## Checklist

- [x] The new content is accessible and located in the appropriate section.
- [ ] I have checked that links are valid and point to the intended content.
- [x] I have checked my code/text and corrected any misspellings

Please add a reviewer when ready for review.


<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--308.org.readthedocs.build/en/308/

<!-- readthedocs-preview cable end -->