### PR TITLE
one line bug fix to address screen level temperatures #313

### DIFF
--- a/src/science/canopy/cable_canopy.F90
+++ b/src/science/canopy/cable_canopy.F90
@@ -746,12 +746,12 @@ write(6,*) "SLI is not an option right now"
 
           IF( zscl(j) < rough%disp(j) ) THEN
 
-             !Ticket #154
+             !Ticket #154 - issue #313
              !r_sc(j) = term5(j) * LOG(zscl(j)/rough%z0soilsn(j)) *              &
              !     ( EXP(2*CCSW*canopy%rghlai(j)) - term1(j) ) / term3(j)
              r_sc(j) = term5(j) * LOG(zscl(j)/rough%z0soilsn(j)) *              &
                   ( EXP(2*CCSW*canopy%rghlai(j)) - term2(j) ) / term3(j)
-             r_sc(j) = r_sc(j) + term5(j) * LOG(rough%disp(j)/rough%z0soilsn(j)) *  &
+             r_sc(j) = r_sc(j) + term5(j) * LOG(rough%disp(j)/zscl(j)) *        &
                   ( EXP(2*CCSW*canopy%rghlai(j)) - term1(j) ) / term3(j)
 
           ELSEIF( rough%disp(j) <= zscl(j) .AND.                                &


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

A single line bug fix to address cases where the diagnosed screen level temperature does not deviate from the reference level air temperature.  This only impacts some sites with tall vegetation.

Note that this change addresses the immediate issue - other aspects involving code structure and when in the calling sequence the screen level diagnostics should occur have been left untouched.

This is intended as a bug fix impacting only the screen level temperature and humidity - all other variables should remain as before.  However this change is - by design -not bitwise comparable with the MAIN so may fail Benchcab testing.

Fixes #313

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## Checklist

- [x] The new content is accessible and located in the appropriate section.
- [ ] I have checked that links are valid and point to the intended content.
- [ ] I have checked my code/text and corrected any misspellings

## Testing results
benchcab/me.org results: https://modelevaluation.org/analyses/anywhere/32ykm3nn4EfJCro8q/s6k22L3WajmiS9uGv/fHu3wwScyjcNpjApy/all
(added after approval as the analyses needed some debugging)

<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--316.org.readthedocs.build/en/316/

<!-- readthedocs-preview cable end -->