### PR TITLE
added potential evaporation to offline output, changed checks range, …

### DIFF
--- a/src/offline/cable.nml
+++ b/src/offline/cable.nml
@@ -23,7 +23,7 @@
    output%params    = .TRUE.  ! input parameters used to produce run
    output%patch     = .TRUE.  ! write per patch  
    output%balances  = .TRUE.  ! energy and water balances
-   check%ranges     = .FALSE.  ! variable ranges, input and output
+   check%ranges     = 0       ! variable ranges, input and output
    check%energy_bal = .TRUE.  ! energy balance
    check%mass_bal   = .TRUE.  ! water/mass balance
    verbose = .TRUE. ! write details of every grid cell init and params to log?

--- a/src/offline/cable_checks.F90
+++ b/src/offline/cable_checks.F90
@@ -84,7 +84,7 @@ MODULE cable_checks_module
       ESoil = [-0.0015, 0.0015], &
       TVeg = [-0.0003, 0.0003], &
       ECanop = [-0.0003, 0.0003], &
-      PotEvap = [-0.0006, 0.0006], &
+      PotEvap = [-0.005, 0.005], &  !note should encompass Evap
       ACond = [0.0, 1.0], &
       SoilWet = [-0.4, 1.2], &
       Albedo = [0.0, 1.0], &

--- a/src/offline/cable_iovars.F90
+++ b/src/offline/cable_iovars.F90
@@ -494,6 +494,7 @@ CONTAINS
       output%Qsb = .TRUE.
       output%Evap = .TRUE.
       output%ECanop = .TRUE.
+      output%PotEvap = .TRUE.
       output%TVeg = .TRUE.
       output%ESoil = .TRUE.
       output%HVeg = .TRUE.

--- a/src/offline/cable_output.F90
+++ b/src/offline/cable_output.F90
@@ -57,7 +57,7 @@ MODULE cable_output_module
           Qmom, Qle, Qh, Qg, NEE, SWnet,                             &
           LWnet, SoilMoist, SoilTemp, Albedo,                        &
           visAlbedo, nirAlbedo, SoilMoistIce,                        &
-          Qs, Qsb, Evap, BaresoilT, SWE, SnowT,                      &
+          Qs, Qsb, Evap, PotEvap, BaresoilT, SWE, SnowT,             &
           RadT, VegT, Ebal, Wbal, AutoResp, RootResp,                &
           StemResp, LeafResp, HeteroResp, GPP, NPP, LAI,             &
           ECanop, TVeg, ESoil, CanopInt, SnowDepth,                  &
@@ -548,6 +548,13 @@ CONTAINS
             xID, yID, zID, landID, patchID, tID)
        ALLOCATE(out%Evap(mp))
        out%Evap = 0.0 ! initialise
+    END IF
+    IF(output%PotEvap) THEN
+       CALL define_ovar(ncid_out, ovid%PotEvap,'PotEvap', 'kg/m^2/s',          &
+            'Potential evaporation', patchout%PotEvap, 'dummy',     &
+            xID, yID, zID, landID, patchID, tID)
+       ALLOCATE(out%PotEvap(mp))
+       out%PotEvap = 0.0 ! initialise
     END IF
     IF(output%ECanop) THEN
        CALL define_ovar(ncid_out, ovid%Ecanop, 'ECanop', 'kg/m^2/s',           &
@@ -1732,6 +1739,8 @@ CONTAINS
     CALL generate_out_write_acc(output%Qsb, ovid%Qsb, 'Qsb', out%Qsb, REAL(ssnow%rnof2/dels, 4), ranges%Qsb, patchout%Qsb, out_settings)
     ! Evap: total evapotranspiration [kg/m^2/s]
     CALL generate_out_write_acc(output%Evap, ovid%Evap, 'Evap', out%Evap, REAL(canopy%fe/air%rlam, 4), ranges%Evap, patchout%Evap, out_settings)
+    ! PotEVap: potential evapotranspiration [kg/m^2/s]
+    CALL generate_out_write_acc(output%PotEvap, ovid%PotEvap, 'PotEvap', out%PotEvap, REAL(canopy%epot/dels, 4), ranges%PotEvap, patchout%PotEvap, out_settings)
     ! ECanop: interception evaporation [kg/m^2/s]
     CALL generate_out_write_acc(output%ECanop, ovid%ECanop, 'ECanop', out%ECanop, REAL(canopy%fevw/air%rlam, 4), ranges%ECanop, patchout%ECanop, out_settings)
     ! TVeg: vegetation transpiration [kg/m^2/s]

--- a/src/science/canopy/cable_canopy.F90
+++ b/src/science/canopy/cable_canopy.F90
@@ -645,7 +645,7 @@ write(6,*) "SLI is not an option right now"
        !radiation weighted soil and canopy contributions
        !Note: If PM routine corrected then match changes here
        canopy%epot = ((1.-rad%transd)*canopy%fevw_pot +                         &
-            rad%transd*ssnow%potev/ssnow%cls) * dels/air%rlam
+            rad%transd*ssnow%potev*ssnow%cls) * dels/air%rlam
 
 
 
@@ -667,6 +667,10 @@ write(6,*) "SLI is not an option right now"
                REAL(canopy%fes(j))/ssnow%potev(j) ) ) )
 
        ENDDO
+
+       ! INH #335 - we don't need to weight components of %epot by %transd
+       ! however coupled model uses %wetfac_cs so overwrite here before testing in ACCESS
+       canopy%epot = (canopy%fevw_pot + ssnow%potev/ssnow%cls) * dels/air%rlam
 
   CALL update_zetar( mp, iterplus, NITER, canopy%zetar, iter, nrb, CVONK, CGRAV, CCAPP,  &
                      CLAI_THRESH, CZETmul, CZETPOS, CZETNEG,          &

--- a/src/science/canopy/cable_canopy.F90
+++ b/src/science/canopy/cable_canopy.F90
@@ -645,7 +645,7 @@ write(6,*) "SLI is not an option right now"
        !radiation weighted soil and canopy contributions
        !Note: If PM routine corrected then match changes here
        canopy%epot = ((1.-rad%transd)*canopy%fevw_pot +                         &
-            rad%transd*ssnow%potev*ssnow%cls) * dels/air%rlam
+            rad%transd*ssnow%potev/ssnow%cls) * dels/air%rlam
 
 
 


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

This PR adds the potential evaporation diagnostic (`canopy%epot`) to fluxes section of the cable output. 
A minor correction to the diagnostic has also been applied - which could lead to impacts in the coupled model (via `%wetfac_cs` and JULES variable `resft`) - and the checks_ranges updated.

Fixes #335

## Type of change

Please delete options that are not relevant.

- [x] Bug fix
- [x] additional output

## Checklist

- [x] The new content is accessible and located in the appropriate section.
- [ ] I have checked that links are valid and point to the intended content.
- [ ] I have checked my code/text and corrected any misspellings

Please add a reviewer when ready for review.


<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--346.org.readthedocs.build/en/346/

<!-- readthedocs-preview cable end -->