### PR TITLE
Fix: uninitialised variables in cable_canopy.F90

### DIFF
--- a/src/science/canopy/cable_canopy.F90
+++ b/src/science/canopy/cable_canopy.F90
@@ -189,8 +189,9 @@ logical :: sunlit_veg_mask(mp)
     ! Initialise canopy%DvLitt and canopy%kthLitt. This value is only used if
     ! cable_user%litter is .TRUE.
     ! Reference:
-    ! Mathews (2006), A process-based model of offine fuel moisture,
+    ! Matthews (2006), A process-based model of fine fuel moisture,
     !                 International Journal of Wildland Fire 15,155-168
+    !                 https://doi.org/10.1071/WF05063
     ! assuming here u=1.0 ms-1, bulk litter density 63.5 kgm-3
     canopy%kthLitt = 0.3_r_2 ! ~ 0.2992125984251969 = 0.2+0.14*0.045*1000.0/63.5
     canopy%DvLitt = 3.1415841138194147e-05_r_2 ! = 2.17e-5*exp(1.0*2.6)*exp(-0.5*(2.08+(1.0*2.38)))

--- a/src/science/canopy/cable_canopy.F90
+++ b/src/science/canopy/cable_canopy.F90
@@ -234,6 +234,9 @@ CALL radiation( ssnow, veg, air, met, rad, canopy, sunlit_veg_mask, &
     canopy%zetash(:,1) = CZETA0 ! stability correction terms
     canopy%zetash(:,2) = CZETPOS + 1
 
+    sum_rad_rniso = SUM(rad%rniso,2)
+    sum_rad_gradis = SUM(rad%gradis,2)
+
 
     DO iter = 1, NITER
 
@@ -389,8 +392,6 @@ CALL radiation( ssnow, veg, air, met, rad, canopy, sunlit_veg_mask, &
        hcy = 0.0              ! init current estimate lat heat
        ecy = rny - hcy        ! init current estimate lat heat
 
-       sum_rad_rniso = SUM(rad%rniso,2)
-
        CALL dryLeaf( dels, rad, rough, air, met,                             &
                   veg, canopy, soil, ssnow, dsx,                             &
                   fwsoil, tlfx, tlfy, ecy, hcy,                              &
@@ -418,8 +419,6 @@ CALL radiation( ssnow, veg, air, met, rad, canopy, sunlit_veg_mask, &
        canopy%fnv = REAL(ftemp)
 
        ! canopy rad. temperature calc from long-wave rad. balance
-       sum_rad_gradis = SUM(rad%gradis,2)
-
        DO j=1,mp
 
           IF ( canopy%vlaiw(j) > CLAI_THRESH .AND.                             &

--- a/src/science/canopy/cable_canopy.F90
+++ b/src/science/canopy/cable_canopy.F90
@@ -388,7 +388,7 @@ CALL radiation( ssnow, veg, air, met, rad, canopy, sunlit_veg_mask, &
        ENDDO
 
 
-       rny = SUM(rad%rniso,2) ! init current estimate net rad
+       rny = sum_rad_rniso ! init current estimate net rad
        hcy = 0.0              ! init current estimate lat heat
        ecy = rny - hcy        ! init current estimate lat heat
 
@@ -396,7 +396,7 @@ CALL radiation( ssnow, veg, air, met, rad, canopy, sunlit_veg_mask, &
                   veg, canopy, soil, ssnow, dsx,                             &
                   fwsoil, tlfx, tlfy, ecy, hcy,                              &
                   rny, gbhu, gbhf, csx, cansat,                              &
-            ghwet,  iter,climate )
+            ghwet,  iter,climate, sum_rad_gradis, sum_rad_rniso )
 
 
       CALL wetLeaf( dels,                                 &
@@ -648,7 +648,7 @@ write(6,*) "SLI is not an option right now"
 
 
 
-       canopy%rniso = SUM(rad%rniso,2) + rad%qssabs + rad%transd*met%fld + &
+       canopy%rniso = sum_rad_rniso + rad%qssabs + rad%transd*met%fld + &
             (1.0-rad%transd)*CEMLEAF* &
             CSBOLTZ*met%tvrad**4 - CEMSOIL*CSBOLTZ*met%tvrad**4
 
@@ -1003,11 +1003,11 @@ ssnow%ddq_dtg = (Crmh2o/Crmair) /met%pmb * CTETENA*CTETENB * CTETENC   &
 ssnow%dfe_dtg = ssnow%dfe_ddq * ssnow%ddq_dtg
 canopy%dgdtg = ssnow%dfn_dtg - ssnow%dfh_dtg - ssnow%dfe_dtg
 
-bal%drybal = REAL(ecy+hcy) - SUM(rad%rniso,2)                               &
-     + CCAPP*Crmair*(tlfy-met%tk)*SUM(rad%gradis,2)  ! YP nov2009
+bal%drybal = REAL(ecy+hcy) - sum_rad_rniso                               &
+     + CCAPP*Crmair*(tlfy-met%tk)*sum_rad_gradis  ! YP nov2009
 
-bal%wetbal = canopy%fevw + canopy%fhvw - SUM(rad%rniso,2) * canopy%fwet      &
-     + CCAPP*Crmair * (tlfy-met%tk) * SUM(rad%gradis,2) *          &
+bal%wetbal = canopy%fevw + canopy%fhvw - sum_rad_rniso * canopy%fwet      &
+     + CCAPP*Crmair * (tlfy-met%tk) * sum_rad_gradis *          &
      canopy%fwet  ! YP nov2009
 
 DEALLOCATE(cansat,gbhu)

--- a/src/science/canopy/cable_canopy.F90
+++ b/src/science/canopy/cable_canopy.F90
@@ -186,6 +186,15 @@ logical :: sunlit_veg_mask(mp)
     canopy%tv = met%tvair
     canopy%fwsoil = 1.0
 
+    ! Initialise canopy%DvLitt and canopy%kthLitt. This value is only used if
+    ! cable_user%litter is .TRUE.
+    ! Reference:
+    ! Mathews (2006), A process-based model of offine fuel moisture,
+    !                 International Journal of Wildland Fire 15,155-168
+    ! assuming here u=1.0 ms-1, bulk litter density 63.5 kgm-3
+    canopy%kthLitt = 0.3_r_2 ! ~ 0.2992125984251969 = 0.2+0.14*0.045*1000.0/63.5
+    canopy%DvLitt = 3.1415841138194147e-05_r_2 ! = 2.17e-5*exp(1.0*2.6)*exp(-0.5*(2.08+(1.0*2.38)))
+
     CALL define_air (met, air)
 
     CALL qsatfjh(mp, qstvair, CRMH2o, Crmair, CTETENA, CTETENB, CTETENC, met%tvair-CTfrz,met%pmb)
@@ -314,14 +323,6 @@ CALL radiation( ssnow, veg, air, met, rad, canopy, sunlit_veg_mask, &
 
        ELSE ! NOT sli
           rt0 = MAX(rt_min,rough%rt0us / canopy%us)
-
-          IF (cable_user%litter) THEN
-             ! Mathews (2006), A process-based model of offine fuel moisture,
-             !                 International Journal of Wildland Fire 15,155-168
-             ! assuming here u=1.0 ms-1, bulk litter density 63.5 kgm-3
-             canopy%kthLitt = 0.3_r_2 ! ~ 0.2992125984251969 = 0.2+0.14*0.045*1000.0/63.5
-             canopy%DvLitt = 3.1415841138194147e-05_r_2 ! = 2.17e-5*exp(1.0*2.6)*exp(-0.5*(2.08+(1.0*2.38)))
-          ENDIF
 
        ENDIF
 


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

Fixes #351. 

Move the definition of sum_rad_gradis and sum_rad_rniso out of the NITER loop in `define_canopy()` since these variables do not change in the loop. Having a quick comparison between the outputs before and after this commit [the effect is negligeable](https://github.com/CABLE-LSM/CABLE/pull/352#issuecomment-2249656007).

Use `sum_rad_gradis` and `sum_rad_rniso` as calculated in define_canopy() everywhere in define_canopy(), dryLeaf() and wetLeaf(), instead of recalculating them sometimes.

Move the initialisation of `canopy%DvLitt` and `canopy%kthLitt` to the top of `define_canopy()` since these variables are constant throughout the run. We also want these variables to be defined in all cases to avoid errors in function calls, but only used with `cable_user%litter` turned on. 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix

## Testing

benchcab/me.org analysis: https://modelevaluation.org/analyses/anywhere/BPLvifw3DyARokYdg/s6k22L3WajmiS9uGv/CJGXP5GQWhGf3nH28/all

Tested in benchcab the changes for DvLitt and kthLitt on their own. benchcab showed bitwise identical results when moving the initialisation compared to the previous implementation with the litter option on.

Please add a reviewer when ready for review.


<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--352.org.readthedocs.build/en/352/

<!-- readthedocs-preview cable end -->