### PR TITLE
fix bug in spitter call (MAIN)

### DIFF
--- a/src/science/radiation/cbl_init_radiation.F90
+++ b/src/science/radiation/cbl_init_radiation.F90
@@ -378,8 +378,9 @@ REAL, INTENT(IN) :: SW_down(mp,nrb)           ! Downward SW [met%fsd]
 
 
 ! Define beam fraction, fbeam:
-RadFbeam(:,1) = spitter(mp, cpi, metDoy, coszen, SW_down(:,1))
-RadfBeam(:,2) = spitter(mp, cpi, metDoy, coszen, SW_down(:,2))
+! #355 beam fraction defined using total SW_down; applies to VIS&NIR equally
+RadFbeam(:,1) = spitter(mp, cpi, metDoy, coszen, SW_down(:,1)+SW_down(:,2))
+RadFbeam(:,2) = RadFbeam(:,1)
 
 ! coszen is set during met data read in.
 WHERE (coszen < Ccoszen_tols_huge )


### PR DESCRIPTION
# CABLE

## Description

Following analysis in CABLE4 and discussion in #354 we should use total SW down in the call to `spitter` and apply the resultant `Fbeam` equally to the visible and near-infrared bands.  The original intent (cable1.4) of spitter is to evaluate the fraction of SW down that is diffuse in nature - via the beam fraction `Fbeam`.  This was evaluated once based on the total shortwave down.  From CABLE2 onwards spitter was called twice - once for the visible and once for the near-infrared components.  However the function itself was not adjusted - the result is that beam fraction is universally smaller than the original intent with unknown impacts on the model trajectory.

This change set reverts the evaluation of `Fbeam` to operate on the total SW down and then applies `Fbeam` equally to the two radiation bands.

This has been implemented as a bug fix, not on a switch.  This change may require recalibration of the CABLE model (notably stomatal conductance parameters, leaf nitrogen exponential and any other parameters that impact GPP). 

Fixes #355

## Type of change
- [x] Bug fix
- [ ] New or updated documentation

## Checklist

- [x] The new content is accessible and located in the appropriate section.
- [ ] I have checked that links are valid and point to the intended content.
- [ ] I have checked my code/text and corrected any misspellings


<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--357.org.readthedocs.build/en/357/

<!-- readthedocs-preview cable end -->