### PR TITLE
Reinstate dry and cold stress, remove double summation of btran

### DIFF
--- a/src/science/casa-cnp/casa_cnp.F90
+++ b/src/science/casa-cnp/casa_cnp.F90
@@ -795,7 +795,7 @@ CONTAINS
     ! outputs:
     !     klitter(mp,mlitter):      decomposition rate of litter pool (1/day)
     !     ksoil(mp,msoil):          decomposition rate of soil pool (1/day)
-    !     fromLtoS(mp,mlitter,msoil):  fraction of decomposed litter to soil (fraction)
+    !     fromLtoS(mp,msoil,mlitter):  fraction of decomposed litter to soil (fraction)
     !     fromStoS(mp,msoil,msoil):    fraction of decomposed soil C to another soil pool (fraction)
     !     fromLtoCO2(mp,mlitter):      fraction of decomposed litter emitted as CO2 (fraction)
     !     fromStoCO2(mp,msoil):        fraction of decomposed soil C emitted as Co2 (fraction)
@@ -1483,8 +1483,8 @@ END SUBROUTINE casa_delplant
 
   SUBROUTINE avgsoil(veg,soil,casamet)
     ! Get avg soil moisture, avg soil temperature
-    ! need to estimate the land cell mean soil temperature and moisture weighted by the area fraction
-    ! of each tile within the land cell
+    ! need to estimate the mean soil temperature and moisture averaged over the
+    ! soil column and weighted by root fraction for each tile 
 
     IMPLICIT NONE
     TYPE (veg_parameter_type),    INTENT(INOUT) :: veg  ! vegetation parameters


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

As described in #275, this change reinstates code that had been removed in 2022 with little justification. Reinstating the code provides consistency with ACCESS-ESM1.5 and also with relevant code in src_pop/core/biogeochem. Testing for a small sample of sites showed a large impact if this change was made alone. The related issue (#279) incorrectly calculates btran by summing over layers twice. This calculation is only used if the removed code in #275 is reinstated. Site tests with both changes showed only small differences.
Change only impacts runs with CASA-CNP active.
Also dealt with corrections to comment for subroutine avgsoil as noted in #279 and subroutine casa_coeffsoil (#277).
Fixes #275, #277, #279.

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix
- [ ] New or updated documentation

## Checklist

- [ ] The new content is accessible and located in the appropriate section.
- [ ] I have checked that links are valid and point to the intended content.
- [ ] I have checked my code/text and corrected any misspellings

Please add a reviewer when ready for review.


<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--372.org.readthedocs.build/en/372/

<!-- readthedocs-preview cable end -->