### PR TITLE
Initialise casaflux%frac_sapwood=1 for use in casa_rplant (#373)

### DIFF
--- a/src/coupled/ESM1.5/casa_um_inout.F90
+++ b/src/coupled/ESM1.5/casa_um_inout.F90
@@ -281,6 +281,9 @@ IMPLICIT NONE
   casaflux%clabloss(:)   = 0.0
 !print *,'Lest - Crsoil',casaflux%Crsoil
 
+  ! R. Law 19/8/24 Initialise casaflux%frac_sapwood=1 (#373,#274,#163)
+  ! for correct calculation of rmplant(:,wood) in casa_rplant.
+  casaflux%frac_sapwood = 1.0
 
   ! Lest 19/2/14 - will work for coupled and amip
   ! mtau is the step number of the day (1,2,..47,0)


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

casaflux%frac_sapwood needs to be initialised to 1 for the correct calculation of casaflux%crmplant(:,wood) in casa_rplant when cable_user%CALL_climate is not true.
This had been done in casa_inout at #274 but this subroutine is only used for offline simulations.
This change does the initialisation, in casa_init_pk, for ESM1.5/ESM1.6 cases.

Fixes #373

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix


## Checklist

- [ ] The new content is accessible and located in the appropriate section.
- [ ] I have checked that links are valid and point to the intended content.
- [ ] I have checked my code/text and corrected any misspellings

Please add a reviewer when ready for review.


<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--374.org.readthedocs.build/en/374/

<!-- readthedocs-preview cable end -->