### PR TITLE
Remove ESM15 case as inconsistent with current input of xkpsorb (#283)

### DIFF
--- a/src/science/casa-cnp/casa_cnp.F90
+++ b/src/science/casa-cnp/casa_cnp.F90
@@ -1446,23 +1446,16 @@ END SUBROUTINE casa_delplant
              casapool%dPsoillabdt(nland)= casaflux%Psnet(nland) + fluxptase(nland)         &
                   + casaflux%Pdep(nland) + casaflux%Pwea(nland)      &
                   - casaflux%Pleach(nland)-casaflux%pupland(nland)   &
-!jhan: ESM15 is effectively using xkpsorb**2 - inadvertently?!?!?!?!
-#           ifdef ESM15
-                  - casabiome%xkpsorb(casamet%isorder(nland))*casaflux%kpsorb(nland)*casapool%Psoilsorb(nland) &
-#           else
+                  !R. Law 23/08/2024 Removed ESM15 case as inconsistent with how xkpsorb now input (#283)
                   - casaflux%kpsorb(nland)*casapool%Psoilsorb(nland) &
-#           endif
                   + casaflux%kpocc(nland) * casapool%Psoilocc(nland)
              ! here the dPsoillabdt =(dPsoillabdt+dPsoilsorbdt)
              ! dPsoilsorbdt  = xdplabsorb
              casapool%dPsoillabdt(nland)  = casapool%dPsoillabdt(nland)/xdplabsorb(nland)
              casapool%dPsoilsorbdt(nland) = 0.0
 
-#           ifdef ESM15
-             casapool%dPsoiloccdt(nland) = casabiome%xkpsorb(casamet%isorder(nland))*casaflux%kpsorb(nland)* casapool%Psoilsorb(nland) &
-#           else
+            !R. Law 23/08/2024 Removed ESM15 case as inconsistent with how xkpsorb now input (#283)
              casapool%dPsoiloccdt(nland) = casaflux%kpsorb(nland)* casapool%Psoilsorb(nland) &
-#           endif
                                          - casaflux%kpocc(nland) * casapool%Psoilocc(nland)
              ! P loss to non-available P pools
              !      casaflux%Ploss(nland)        = casaflux%kpocc(nland) * casapool%Psoilocc(nland)


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

Removed two ifdef ESM15 cases related to the use of xkpsorb. The ESM15 code option is inconsistent with
how xkpsorb is input in the CABLE3 code.

Fixes #283

## Type of change

- [X ] Bug fix


## Checklist

- [ ] The new content is accessible and located in the appropriate section.
- [ ] I have checked that links are valid and point to the intended content.
- [ ] I have checked my code/text and corrected any misspellings

Please add a reviewer when ready for review.



<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--375.org.readthedocs.build/en/375/

<!-- readthedocs-preview cable end -->