### PR TITLE
Add routine to search for dimension IDs by name.

### DIFF
--- a/core/biogeophys/cable_common.F90
+++ b/core/biogeophys/cable_common.F90
@@ -24,7 +24,7 @@
 
 MODULE cable_common_module
 
-  USE NetCDF,   only: NF90_INQ_DIMID, NF90_NOERR, NF90_EDIMMETA
+  USE NetCDF,   only: NF90_INQ_DIMID, NF90_NOERR, NF90_BADDIM
   IMPLICIT NONE
 
   !---allows reference to "gl"obal timestep in run (from atm_step)
@@ -709,7 +709,7 @@ CONTAINS
 
     ! Iterator and status checker- use NF90_EDIMMETA so we throw error when an
     ! empty list of names is passed.
-    INTEGER :: i, ok = NF90_EDIMMETA
+    INTEGER :: i, ok = NF90_EBADDIM
 
     ! Run through the possible names until we find the correct one
     CheckNames: DO i = 1, SIZE(DimNames)

--- a/core/biogeophys/cable_common.F90
+++ b/core/biogeophys/cable_common.F90
@@ -24,7 +24,7 @@
 
 MODULE cable_common_module
 
-  USE NetCDF,   only: NF90_INQ_DIMID, NF90_NOERR
+  USE NetCDF,   only: NF90_INQ_DIMID, NF90_NOERR, NF90_EDIMMETA
   IMPLICIT NONE
 
   !---allows reference to "gl"obal timestep in run (from atm_step)
@@ -707,9 +707,9 @@ CONTAINS
     INTEGER :: FileID, get_dimid
     CHARACTER(LEN=*), DIMENSION(:)  :: DimNames
 
-    ! Iterator and status checker- use NF90_EINVAL so we throw error when an
+    ! Iterator and status checker- use NF90_EDIMMETA so we throw error when an
     ! empty list of names is passed.
-    INTEGER :: i, ok = NF90_EINVAL
+    INTEGER :: i, ok = NF90_EDIMMETA
 
     ! Run through the possible names until we find the correct one
     CheckNames: DO i = 1, SIZE(DimNames)

--- a/core/biogeophys/cable_common.F90
+++ b/core/biogeophys/cable_common.F90
@@ -33,12 +33,12 @@ MODULE cable_common_module
   INTEGER, SAVE :: CurYear  ! current year of multiannual run
 
   ! Dimension name lists for searching NetCDF dimensions IDs
-  CHARACTER(LEN=16), DIMENSION(5) :: LatNames = &
-    (/"latitude", "lat", "lats", "y", "Latitude"/)
-  CHARACTER(LEN=16), DIMENSION(5) :: LonNames = &
-    (/"longitude", "lon", "lons", "x", "Longitude"/)
-  CHARACTER(LEN=16), DIMENSION(3) :: TimeNames = &
-    (/"time", "t", "Time"/)
+  CHARACTER(LEN=16), DIMENSION(5), PARAMETER :: LatNames = &
+    ["latitude", "lat", "lats", "y", "Latitude"]
+  CHARACTER(LEN=16), DIMENSION(5), PARAMETER :: LonNames = &
+    ["longitude", "lon", "lons", "x", "Longitude"]
+  CHARACTER(LEN=16), DIMENSION(3), PARAMETER :: TimeNames = &
+    ["time", "t", "Time"]
 
   ! user switches turned on/off by the user thru namelists
 

--- a/core/biogeophys/cable_common.F90
+++ b/core/biogeophys/cable_common.F90
@@ -707,7 +707,7 @@ CONTAINS
 
     ! Run through the possible names until we find the correct one
     CheckNames: DO i = 1, SIZE(LatNames)
-      ok = NF90_INQ_DIMID(FileID, TRIM(LatNames(i), latitude_dimid))
+      ok = NF90_INQ_DIMID(FileID, TRIM(LatNames(i)), latitude_dimid)
       IF (ok == NF90_NOERR) THEN
         EXIT CheckNames
       END IF
@@ -740,7 +740,7 @@ CONTAINS
 
     ! Run through the possible names until we find the correct one
     CheckNames: DO i = 1, SIZE(LonNames)
-      ok = NF90_INQ_DIMID(FileID, TRIM(LonNames(i), longitude_dimid))
+      ok = NF90_INQ_DIMID(FileID, TRIM(LonNames(i)), longitude_dimid)
       IF (ok == NF90_NOERR) THEN
         EXIT CheckNames
       END IF
@@ -772,7 +772,7 @@ CONTAINS
 
     ! Run through the possible names until we find the correct one
     CheckNames: DO i = 1, SIZE(TimeNames)
-      ok = NF90_INQ_DIMID(FileID, TRIM(TimeNames(i), time_dimid))
+      ok = NF90_INQ_DIMID(FileID, TRIM(TimeNames(i)), time_dimid)
       IF (ok == NF90_NOERR) THEN
         EXIT CheckNames
       END IF

--- a/core/biogeophys/cable_common.F90
+++ b/core/biogeophys/cable_common.F90
@@ -32,6 +32,14 @@ MODULE cable_common_module
   INTEGER, SAVE :: ktau_gl, kend_gl, knode_gl, kwidth_gl
   INTEGER, SAVE :: CurYear  ! current year of multiannual run
 
+  ! Dimension name lists for searching NetCDF dimensions IDs
+  CHARACTER(LEN=16), DIMENSION(5) :: LatNames = &
+    (/"latitude", "lat", "lats", "y", "Latitude"/)
+  CHARACTER(LEN=16), DIMENSION(5) :: LonNames = &
+    (/"longitude", "lon", "lons", "x", "Longitude"/)
+  CHARACTER(LEN=16), DIMENSION(3) :: TimeNames = &
+    (/"time", "t", "Time"/)
+
   ! user switches turned on/off by the user thru namelists
 
   ! trunk modifications protected by these switches
@@ -685,105 +693,136 @@ CONTAINS
 
   end subroutine get_unit
 
-  FUNCTION latitude_dimid(FileID)
+  FUNCTION get_dimid(FileID, DimNames)
     !*## Purpose
     !
-    ! Find the id of the latitude dimension
+    ! Find the id of the desired dimension using a list of possible names.
     !
-    !## Method
+    !##
     !
-    ! Run through a list of possible names for the latitude dimension, until one
-    ! is found in the NetCDF dimensions.
+    ! Run through a list of possible names for the dimensions as defined in the
+    ! cable_common module.
 
-    INTEGER :: FileID, latitude_dimid
-    INTEGER :: i, ok
+    ! Input and output
+    INTEGER :: FileID, get_dimid
+    CHARACTER(LEN=*), DIMENSION(:)  :: DimNames
 
-    CHARACTER(LEN=16), DIMENSION(5) :: LatNames
-
-    ! Assign a set of possible latitude names
-    LatNames(1) = "y"
-    LatNames(2) = "latitude"
-    LatNames(3) = "lat"
-    LatNames(4) = "lats"
-    LatNames(5) = "Latitude"
+    ! Iterator and status checker- use NF90_EINVAL so we throw error when an
+    ! empty list of names is passed.
+    INTEGER :: i, ok = NF90_EINVAL
 
     ! Run through the possible names until we find the correct one
-    CheckNames: DO i = 1, SIZE(LatNames)
-      ok = NF90_INQ_DIMID(FileID, TRIM(LatNames(i)), latitude_dimid)
+    CheckNames: DO i = 1, SIZE(DimNames)
+      ok = NF90_INQ_DIMID(FileID, TRIM(DimNames(i)), get_dimid)
       IF (ok == NF90_NOERR) THEN
         EXIT CheckNames
       END IF
     END DO CheckNames
 
-    CALL handle_err(ok, "Failed to find any latitude dimension from the list.")
+    CALL handle_err(ok, "Failed to find any "//TRIM(DimNames(1))//" dimensions&
+      from the list.")
 
-  END FUNCTION latitude_dimid
+  END FUNCTION get_dimid
 
-  FUNCTION longitude_dimid(FileID)
-    !*## Purpose
-    !
-    ! Find the id of the longitude dimension
-    !
-    !## Method
-    !
-    ! Run through a list of possible names for the longitude dimension, until 
-    ! one is found in the NetCDF dimensions.
+  !FUNCTION latitude_dimid(FileID)
+    !!*## Purpose
+    !!
+    !! Find the id of the latitude dimension
+    !!
+    !!## Method
+    !!
+    !! Run through a list of possible names for the latitude dimension, until one
+    !! is found in the NetCDF dimensions.
 
-    INTEGER :: FileID, longitude_dimid
-    INTEGER :: i, ok
+    !INTEGER :: FileID, latitude_dimid
+    !INTEGER :: i, ok
 
-    CHARACTER(LEN=16), DIMENSION(5) :: LonNames
+    !CHARACTER(LEN=16), DIMENSION(5) :: LatNames
 
-    ! Assign a set of possible longitude names
-    LonNames(1) = "x"
-    LonNames(2) = "longitude"
-    LonNames(3) = "lon"
-    LonNames(4) = "lons"
-    LonNames(5) = "Longitude"
+    !! Assign a set of possible latitude names
+    !LatNames(1) = "y"
+    !LatNames(2) = "latitude"
+    !LatNames(3) = "lat"
+    !LatNames(4) = "lats"
+    !LatNames(5) = "Latitude"
 
-    ! Run through the possible names until we find the correct one
-    CheckNames: DO i = 1, SIZE(LonNames)
-      ok = NF90_INQ_DIMID(FileID, TRIM(LonNames(i)), longitude_dimid)
-      IF (ok == NF90_NOERR) THEN
-        EXIT CheckNames
-      END IF
-    END DO CheckNames
+    !! Run through the possible names until we find the correct one
+    !CheckNames: DO i = 1, SIZE(LatNames)
+      !ok = NF90_INQ_DIMID(FileID, TRIM(LatNames(i)), latitude_dimid)
+      !IF (ok == NF90_NOERR) THEN
+        !EXIT CheckNames
+      !END IF
+    !END DO CheckNames
 
-    CALL handle_err(ok, "Failed to find any longitude dimension from the list.")
+    !CALL handle_err(ok, "Failed to find any latitude dimension from the list.")
 
-  END FUNCTION longitude_dimid
+  !END FUNCTION latitude_dimid
 
-  FUNCTION time_dimid(FileID)
-    !*## Purpose
-    !
-    ! Find the id of the time dimension
-    !
-    !## Method
-    !
-    ! Run through a list of possible names for the time dimension, until one
-    ! is found in the NetCDF dimensions.
+  !FUNCTION longitude_dimid(FileID)
+    !!*## Purpose
+    !!
+    !! Find the id of the longitude dimension
+    !!
+    !!## Method
+    !!
+    !! Run through a list of possible names for the longitude dimension, until 
+    !! one is found in the NetCDF dimensions.
 
-    INTEGER :: FileID, time_dimid
-    INTEGER :: i, ok
+    !INTEGER :: FileID, longitude_dimid
+    !INTEGER :: i, ok
 
-    CHARACTER(LEN=16), DIMENSION(3) :: TimeNames
+    !CHARACTER(LEN=16), DIMENSION(5) :: LonNames
 
-    ! Assign a set of possible latitude names
-    TimeNames(1) = "time"
-    TimeNames(2) = "t"
-    TimeNames(3) = "Time"
+    !! Assign a set of possible longitude names
+    !LonNames(1) = "x"
+    !LonNames(2) = "longitude"
+    !LonNames(3) = "lon"
+    !LonNames(4) = "lons"
+    !LonNames(5) = "Longitude"
 
-    ! Run through the possible names until we find the correct one
-    CheckNames: DO i = 1, SIZE(TimeNames)
-      ok = NF90_INQ_DIMID(FileID, TRIM(TimeNames(i)), time_dimid)
-      IF (ok == NF90_NOERR) THEN
-        EXIT CheckNames
-      END IF
-    END DO CheckNames
+    !! Run through the possible names until we find the correct one
+    !CheckNames: DO i = 1, SIZE(LonNames)
+      !ok = NF90_INQ_DIMID(FileID, TRIM(LonNames(i)), longitude_dimid)
+      !IF (ok == NF90_NOERR) THEN
+        !EXIT CheckNames
+      !END IF
+    !END DO CheckNames
 
-    CALL handle_err(ok, "Failed to find any time dimension from the list.")
+    !CALL handle_err(ok, "Failed to find any longitude dimension from the list.")
 
-  END FUNCTION time_dimid
+  !END FUNCTION longitude_dimid
+
+  !FUNCTION time_dimid(FileID)
+    !!*## Purpose
+    !!
+    !! Find the id of the time dimension
+    !!
+    !!## Method
+    !!
+    !! Run through a list of possible names for the time dimension, until one
+    !! is found in the NetCDF dimensions.
+
+    !INTEGER :: FileID, time_dimid
+    !INTEGER :: i, ok
+
+    !CHARACTER(LEN=16), DIMENSION(3) :: TimeNames
+
+    !! Assign a set of possible latitude names
+    !TimeNames(1) = "time"
+    !TimeNames(2) = "t"
+    !TimeNames(3) = "Time"
+
+    !! Run through the possible names until we find the correct one
+    !CheckNames: DO i = 1, SIZE(TimeNames)
+      !ok = NF90_INQ_DIMID(FileID, TRIM(TimeNames(i)), time_dimid)
+      !IF (ok == NF90_NOERR) THEN
+        !EXIT CheckNames
+      !END IF
+    !END DO CheckNames
+
+    !CALL handle_err(ok, "Failed to find any time dimension from the list.")
+
+  !END FUNCTION time_dimid
 
   elemental pure function is_leapyear(yyyy)
 

--- a/core/biogeophys/cable_common.F90
+++ b/core/biogeophys/cable_common.F90
@@ -24,7 +24,7 @@
 
 MODULE cable_common_module
 
-  USE NetCDF,   only: NF90_INQ_DIMID, NF90_NOERR, NF90_BADDIM
+  USE NetCDF,   only: NF90_INQ_DIMID, NF90_NOERR, NF90_EBADDIM
   IMPLICIT NONE
 
   !---allows reference to "gl"obal timestep in run (from atm_step)
@@ -723,106 +723,6 @@ CONTAINS
       from the list.")
 
   END FUNCTION get_dimid
-
-  !FUNCTION latitude_dimid(FileID)
-    !!*## Purpose
-    !!
-    !! Find the id of the latitude dimension
-    !!
-    !!## Method
-    !!
-    !! Run through a list of possible names for the latitude dimension, until one
-    !! is found in the NetCDF dimensions.
-
-    !INTEGER :: FileID, latitude_dimid
-    !INTEGER :: i, ok
-
-    !CHARACTER(LEN=16), DIMENSION(5) :: LatNames
-
-    !! Assign a set of possible latitude names
-    !LatNames(1) = "y"
-    !LatNames(2) = "latitude"
-    !LatNames(3) = "lat"
-    !LatNames(4) = "lats"
-    !LatNames(5) = "Latitude"
-
-    !! Run through the possible names until we find the correct one
-    !CheckNames: DO i = 1, SIZE(LatNames)
-      !ok = NF90_INQ_DIMID(FileID, TRIM(LatNames(i)), latitude_dimid)
-      !IF (ok == NF90_NOERR) THEN
-        !EXIT CheckNames
-      !END IF
-    !END DO CheckNames
-
-    !CALL handle_err(ok, "Failed to find any latitude dimension from the list.")
-
-  !END FUNCTION latitude_dimid
-
-  !FUNCTION longitude_dimid(FileID)
-    !!*## Purpose
-    !!
-    !! Find the id of the longitude dimension
-    !!
-    !!## Method
-    !!
-    !! Run through a list of possible names for the longitude dimension, until 
-    !! one is found in the NetCDF dimensions.
-
-    !INTEGER :: FileID, longitude_dimid
-    !INTEGER :: i, ok
-
-    !CHARACTER(LEN=16), DIMENSION(5) :: LonNames
-
-    !! Assign a set of possible longitude names
-    !LonNames(1) = "x"
-    !LonNames(2) = "longitude"
-    !LonNames(3) = "lon"
-    !LonNames(4) = "lons"
-    !LonNames(5) = "Longitude"
-
-    !! Run through the possible names until we find the correct one
-    !CheckNames: DO i = 1, SIZE(LonNames)
-      !ok = NF90_INQ_DIMID(FileID, TRIM(LonNames(i)), longitude_dimid)
-      !IF (ok == NF90_NOERR) THEN
-        !EXIT CheckNames
-      !END IF
-    !END DO CheckNames
-
-    !CALL handle_err(ok, "Failed to find any longitude dimension from the list.")
-
-  !END FUNCTION longitude_dimid
-
-  !FUNCTION time_dimid(FileID)
-    !!*## Purpose
-    !!
-    !! Find the id of the time dimension
-    !!
-    !!## Method
-    !!
-    !! Run through a list of possible names for the time dimension, until one
-    !! is found in the NetCDF dimensions.
-
-    !INTEGER :: FileID, time_dimid
-    !INTEGER :: i, ok
-
-    !CHARACTER(LEN=16), DIMENSION(3) :: TimeNames
-
-    !! Assign a set of possible latitude names
-    !TimeNames(1) = "time"
-    !TimeNames(2) = "t"
-    !TimeNames(3) = "Time"
-
-    !! Run through the possible names until we find the correct one
-    !CheckNames: DO i = 1, SIZE(TimeNames)
-      !ok = NF90_INQ_DIMID(FileID, TRIM(TimeNames(i)), time_dimid)
-      !IF (ok == NF90_NOERR) THEN
-        !EXIT CheckNames
-      !END IF
-    !END DO CheckNames
-
-    !CALL handle_err(ok, "Failed to find any time dimension from the list.")
-
-  !END FUNCTION time_dimid
 
   elemental pure function is_leapyear(yyyy)
 

--- a/core/biogeophys/cable_common.F90
+++ b/core/biogeophys/cable_common.F90
@@ -684,6 +684,103 @@ CONTAINS
 
   end subroutine get_unit
 
+  FUNCTION latitude_dimid(FileID)
+    !*## Purpose
+    !
+    ! Find the id of the latitude dimension
+    !
+    !## Method
+    !
+    ! Run through a list of possible names for the latitude dimension, until one
+    ! is found in the NetCDF dimensions.
+
+    INTEGER :: FileID, latitude_dimid
+    INTEGER :: i, ok
+
+    CHARACTER(LEN=16), DIMENSION(4) :: LatNames
+
+    ! Assign a set of possible latitude names
+    LatNames(1) = "latitude"
+    LatNames(2) = "lat"
+    LatNames(3) = "lats"
+    LatNames(4) = "Latitude"
+
+    ! Run through the possible names until we find the correct one
+    CheckNames: DO i = 1, SIZE(LatNames)
+      ok = NF90_INQ_DIMID(FileID, TRIM(LatNames(i), latitude_dimid))
+      IF (ok == NF90_NOERR) THEN
+        EXIT CheckNames
+      END IF
+    END DO CheckNames
+
+    CALL handle_err(ok, "Failed to find any latitude dimension from the list.")
+
+  END FUNCTION latitude_dimid
+
+  FUNCTION longitude_dimid(FileID)
+    !*## Purpose
+    !
+    ! Find the id of the longitude dimension
+    !
+    !## Method
+    !
+    ! Run through a list of possible names for the longitude dimension, until 
+    ! one is found in the NetCDF dimensions.
+
+    INTEGER :: FileID, longitude_dimid
+    INTEGER :: i, ok
+
+    CHARACTER(LEN=16), DIMENSION(4) :: LonNames
+
+    ! Assign a set of possible longitude names
+    LonNames(1) = "longitude"
+    LonNames(2) = "lon"
+    LonNames(3) = "lons"
+    LonNames(4) = "Longitude"
+
+    ! Run through the possible names until we find the correct one
+    CheckNames: DO i = 1, SIZE(LonNames)
+      ok = NF90_INQ_DIMID(FileID, TRIM(LonNames(i), longitude_dimid))
+      IF (ok == NF90_NOERR) THEN
+        EXIT CheckNames
+      END IF
+    END DO CheckNames
+
+    CALL handle_err(ok, "Failed to find any longitude dimension from the list.")
+
+  END FUNCTION longitude_dimid
+
+  FUNCTION time_dimid(FileID)
+    !*## Purpose
+    !
+    ! Find the id of the time dimension
+    !
+    !## Method
+    !
+    ! Run through a list of possible names for the time dimension, until one
+    ! is found in the NetCDF dimensions.
+
+    INTEGER :: FileID, time_dimid
+    INTEGER :: i, ok
+
+    CHARACTER(LEN=16), DIMENSION(3) :: TimeNames
+
+    ! Assign a set of possible latitude names
+    TimeNames(1) = "time"
+    TimeNames(2) = "t"
+    TimeNames(3) = "Time"
+
+    ! Run through the possible names until we find the correct one
+    CheckNames: DO i = 1, SIZE(TimeNames)
+      ok = NF90_INQ_DIMID(FileID, TRIM(TimeNames(i), time_dimid))
+      IF (ok == NF90_NOERR) THEN
+        EXIT CheckNames
+      END IF
+    END DO CheckNames
+
+    CALL handle_err(ok, "Failed to find any time dimension from the list.")
+
+  END FUNCTION time_dimid
 
   elemental pure function is_leapyear(yyyy)
 

--- a/core/biogeophys/cable_common.F90
+++ b/core/biogeophys/cable_common.F90
@@ -698,13 +698,14 @@ CONTAINS
     INTEGER :: FileID, latitude_dimid
     INTEGER :: i, ok
 
-    CHARACTER(LEN=16), DIMENSION(4) :: LatNames
+    CHARACTER(LEN=16), DIMENSION(5) :: LatNames
 
     ! Assign a set of possible latitude names
-    LatNames(1) = "latitude"
-    LatNames(2) = "lat"
-    LatNames(3) = "lats"
-    LatNames(4) = "Latitude"
+    LatNames(1) = "y"
+    LatNames(2) = "latitude"
+    LatNames(3) = "lat"
+    LatNames(4) = "lats"
+    LatNames(5) = "Latitude"
 
     ! Run through the possible names until we find the correct one
     CheckNames: DO i = 1, SIZE(LatNames)
@@ -731,13 +732,14 @@ CONTAINS
     INTEGER :: FileID, longitude_dimid
     INTEGER :: i, ok
 
-    CHARACTER(LEN=16), DIMENSION(4) :: LonNames
+    CHARACTER(LEN=16), DIMENSION(5) :: LonNames
 
     ! Assign a set of possible longitude names
-    LonNames(1) = "longitude"
-    LonNames(2) = "lon"
-    LonNames(3) = "lons"
-    LonNames(4) = "Longitude"
+    LonNames(1) = "x"
+    LonNames(2) = "longitude"
+    LonNames(3) = "lon"
+    LonNames(4) = "lons"
+    LonNames(5) = "Longitude"
 
     ! Run through the possible names until we find the correct one
     CheckNames: DO i = 1, SIZE(LonNames)

--- a/core/biogeophys/cable_common.F90
+++ b/core/biogeophys/cable_common.F90
@@ -24,6 +24,7 @@
 
 MODULE cable_common_module
 
+  USE NetCDF,   only: NF90_INQ_DIMID, NF90_NOERR
   IMPLICIT NONE
 
   !---allows reference to "gl"obal timestep in run (from atm_step)

--- a/offline/cable_LUC_EXPT.F90
+++ b/offline/cable_LUC_EXPT.F90
@@ -1,6 +1,6 @@
 MODULE CABLE_LUC_EXPT
 
-  use cable_common_module,  only: is_leapyear, leap_day, handle_err, get_unit,
+  use cable_common_module,  only: is_leapyear, leap_day, handle_err, get_unit,&
                                   latitude_dimid, longitude_dimid, time_dimid
   use cable_io_vars_module, only: logn, land_x, land_y, landpt, latitude, longitude
   use cable_def_types_mod,  only: mland

--- a/offline/cable_LUC_EXPT.F90
+++ b/offline/cable_LUC_EXPT.F90
@@ -1,6 +1,7 @@
 MODULE CABLE_LUC_EXPT
 
-  use cable_common_module,  only: is_leapyear, leap_day, handle_err, get_unit
+  use cable_common_module,  only: is_leapyear, leap_day, handle_err, get_unit,
+                                  latitude_dimid, longitude_dimid, time_dimid
   use cable_io_vars_module, only: logn, land_x, land_y, landpt, latitude, longitude
   use cable_def_types_mod,  only: mland
 
@@ -216,17 +217,17 @@ CONTAINS
        ! inquire dimensions
        IF (i.eq.1) THEN
           FID = LUC_EXPT%F_ID(i)
-          STATUS = NF90_INQ_DIMID(FID,'latitude',latID)
+          latID = latitude_dimid(FID)
           STATUS = NF90_INQUIRE_DIMENSION(FID,latID,len=ydimsize)
           CALL HANDLE_ERR(STATUS, "Inquiring 'latitude'"//TRIM(LUC_EXPT%TransFile(i)))
           LUC_EXPT%ydimsize = ydimsize
 
-          STATUS = NF90_INQ_DIMID(FID,'longitude',lonID)
+          lonID = longitude_dimid(FID)
           STATUS = NF90_INQUIRE_DIMENSION(FID,lonID,len=xdimsize)
           CALL HANDLE_ERR(STATUS, "Inquiring 'longitude'"//TRIM(LUC_EXPT%TransFile(i)))
           LUC_EXPT%xdimsize = xdimsize
 
-          STATUS = NF90_INQ_DIMID(FID,'time',timID)
+          timID = time_dimid(FID)
           STATUS = NF90_INQUIRE_Dimension(FID,timID,len=tdimsize)
           CALL HANDLE_ERR(STATUS, "Inquiring 'time'"//TRIM(LUC_EXPT%TransFile(i)))
           LUC_EXPT%nrec = tdimsize

--- a/offline/cable_LUC_EXPT.F90
+++ b/offline/cable_LUC_EXPT.F90
@@ -1,7 +1,7 @@
 MODULE CABLE_LUC_EXPT
 
   use cable_common_module,  only: is_leapyear, leap_day, handle_err, get_unit,&
-                                  latitude_dimid, longitude_dimid, time_dimid
+                                  get_dimid, LatNames, LonNames, TimeNames
   use cable_io_vars_module, only: logn, land_x, land_y, landpt, latitude, longitude
   use cable_def_types_mod,  only: mland
 
@@ -217,17 +217,17 @@ CONTAINS
        ! inquire dimensions
        IF (i.eq.1) THEN
           FID = LUC_EXPT%F_ID(i)
-          latID = latitude_dimid(FID)
+          latID = get_dimid(FID, LatNames)
           STATUS = NF90_INQUIRE_DIMENSION(FID,latID,len=ydimsize)
           CALL HANDLE_ERR(STATUS, "Inquiring 'latitude'"//TRIM(LUC_EXPT%TransFile(i)))
           LUC_EXPT%ydimsize = ydimsize
 
-          lonID = longitude_dimid(FID)
+          lonID = get_dimid(FID, LonNames)
           STATUS = NF90_INQUIRE_DIMENSION(FID,lonID,len=xdimsize)
           CALL HANDLE_ERR(STATUS, "Inquiring 'longitude'"//TRIM(LUC_EXPT%TransFile(i)))
           LUC_EXPT%xdimsize = xdimsize
 
-          timID = time_dimid(FID)
+          timID = get_dimid(FID, TimeNames)
           STATUS = NF90_INQUIRE_Dimension(FID,timID,len=tdimsize)
           CALL HANDLE_ERR(STATUS, "Inquiring 'time'"//TRIM(LUC_EXPT%TransFile(i)))
           LUC_EXPT%nrec = tdimsize

--- a/offline/cable_cru_TRENDY.F90
+++ b/offline/cable_cru_TRENDY.F90
@@ -10,8 +10,8 @@ USE NetCDF,                 ONLY: NF90_OPEN, NF90_NOWRITE, NF90_INQ_DIMID,&
                                   NF90_GET_VAR, NF90_CLOSE, NF90_NOERR
 USE cable_abort_module,     ONLY: cable_abort, nc_abort
 USE cable_common_module,    ONLY: handle_err, get_unit, is_leapyear,&
-                                cable_user, doysod2ymdhms, latitude_dimid,&
-                                longitude_dimid
+                                cable_user, doysod2ymdhms, get_dimid, LatNames,&
+                                LonNames
 USE cable_io_vars_module,   ONLY: logn, land_x, land_y, exists, nMetPatches,&
                                 latitude, longitude, lat_all, lon_all, landPt,&
                                 xDimSize, yDimSize, sdoy, smoy, syear, shod,&
@@ -701,11 +701,11 @@ SUBROUTINE read_landmask(LandmaskFile, CRU)
   CALL handle_err(ok, "Error opening landmask file at "//TRIM(LandmaskFile))
 
   ! Inquire about the latitude and longitude dimensions
-  LatID = latitude_dimid(FileID)
+  LatID = get_dimid(FileID, LatNames)
   ok = NF90_INQUIRE_DIMENSION(FileID, LatID, LEN = yDimSize)
   CALL handle_err(ok, "Error inquiring latitude dimension.")
 
-  LonID = longitude_dimid(FileID)
+  LonID = get_dimid(FileID, LonNames)
   ok = NF90_INQUIRE_DIMENSION(FileID, LonID, LEN = xDimSize)
   CALL handle_err(ok, "Error inquiring longitude dimension.")
 

--- a/offline/cable_cru_TRENDY.F90
+++ b/offline/cable_cru_TRENDY.F90
@@ -10,7 +10,8 @@ USE NetCDF,                 ONLY: NF90_OPEN, NF90_NOWRITE, NF90_INQ_DIMID,&
                                   NF90_GET_VAR, NF90_CLOSE, NF90_NOERR
 USE cable_abort_module,     ONLY: cable_abort, nc_abort
 USE cable_common_module,    ONLY: handle_err, get_unit, is_leapyear,&
-                                cable_user, doysod2ymdhms
+                                cable_user, doysod2ymdhms, latitude_dimid,&
+                                longitude_dimid
 USE cable_io_vars_module,   ONLY: logn, land_x, land_y, exists, nMetPatches,&
                                 latitude, longitude, lat_all, lon_all, landPt,&
                                 xDimSize, yDimSize, sdoy, smoy, syear, shod,&
@@ -700,15 +701,11 @@ SUBROUTINE read_landmask(LandmaskFile, CRU)
   CALL handle_err(ok, "Error opening landmask file at "//TRIM(LandmaskFile))
 
   ! Inquire about the latitude and longitude dimensions
-  ok = NF90_INQ_DIMID(FileID, 'latitude', LatID)
-  CALL handle_err(ok, "Error finding latitude DIMID.")
-
+  LatID = latitude_dimid(FileID)
   ok = NF90_INQUIRE_DIMENSION(FileID, LatID, LEN = yDimSize)
   CALL handle_err(ok, "Error inquiring latitude dimension.")
 
-  ok = NF90_INQ_DIMID(FileID, 'longitude', LonID)
-  CALL handle_err(ok, "Error finding longitude DIMID.")
-
+  LonID = longitude_dimid(FileID)
   ok = NF90_INQUIRE_DIMENSION(FileID, LonID, LEN = xDimSize)
   CALL handle_err(ok, "Error inquiring longitude dimension.")
 

--- a/offline/cable_parameters.F90
+++ b/offline/cable_parameters.F90
@@ -59,7 +59,7 @@ MODULE cable_param_module
   USE phenvariable
   USE cable_abort_module
   USE cable_IO_vars_module
-  USE cable_common_module, ONLY: cable_user
+  USE cable_common_module, ONLY: cable_user, latitude_dimid, longitude_dimid
   USE CABLE_LUC_EXPT, ONLY: LUC_EXPT_TYPE, LUC_EXPT_SET_TILES, LUC_EXPT_SET_TILES_BIOS
 
   IMPLICIT NONE
@@ -219,16 +219,14 @@ CONTAINS
     ok = NF90_OPEN(trim(filename%type), 0, ncid)
     IF (ok /= NF90_NOERR) CALL nc_abort(ok, 'Error opening grid info file.')
 
-    ok = NF90_INQ_DIMID(ncid, 'longitude', xID)
-    IF (ok /= NF90_NOERR) ok = NF90_INQ_DIMID(ncid, 'x', xID)
-    IF (ok /= NF90_NOERR) CALL nc_abort(ok, 'Error inquiring x dimension.')
+    xID = longitude_dimid(ncid)
     ok = NF90_INQUIRE_DIMENSION(ncid, xID, LEN=nlon)
     IF (ok /= NF90_NOERR) CALL nc_abort(ok, 'Error getting x dimension.')
-    ok = NF90_INQ_DIMID(ncid, 'latitude', yID)
-    IF (ok /= NF90_NOERR) ok = NF90_INQ_DIMID(ncid, 'y', yID)
-    IF (ok /= NF90_NOERR) CALL nc_abort(ok, 'Error inquiring y dimension.')
+
+    yID = latitude_dimid(ncid)
     ok = NF90_INQUIRE_DIMENSION(ncid, yID, LEN=nlat)
     IF (ok /= NF90_NOERR) CALL nc_abort(ok, 'Error getting y dimension.')
+
     ok = NF90_INQ_DIMID(ncid, 'patch', pID)
     IF (ok /= NF90_NOERR) CALL nc_abort(ok, 'Error inquiring patch dimension.')
     ok = NF90_INQUIRE_DIMENSION(ncid, pID, LEN=npatch)
@@ -768,14 +766,11 @@ CONTAINS
     ok = NF90_OPEN(trim(filename%soilcolor), 0, ncid)
     IF (ok /= NF90_NOERR) CALL nc_abort(ok, 'Error opening soil color file.')
 
-    ok = NF90_INQ_DIMID(ncid, 'longitude', xID)
-    IF (ok /= NF90_NOERR) ok = NF90_INQ_DIMID(ncid, 'x', xID)
-    IF (ok /= NF90_NOERR) CALL nc_abort(ok, 'Error inquiring x dimension.')
+    xID = longitude_dimid(ncid)
     ok = NF90_INQUIRE_DIMENSION(ncid, xID, LEN=nlon)
     IF (ok /= NF90_NOERR) CALL nc_abort(ok, 'Error getting x dimension.')
-    ok = NF90_INQ_DIMID(ncid, 'latitude', yID)
-    IF (ok /= NF90_NOERR) ok = NF90_INQ_DIMID(ncid, 'y', yID)
-    IF (ok /= NF90_NOERR) CALL nc_abort(ok, 'Error inquiring y dimension.')
+
+    yID = latitude_dimid(ncid)
     ok = NF90_INQUIRE_DIMENSION(ncid, yID, LEN=nlat)
     IF (ok /= NF90_NOERR) CALL nc_abort(ok, 'Error getting y dimension.')
 

--- a/offline/cable_parameters.F90
+++ b/offline/cable_parameters.F90
@@ -59,7 +59,7 @@ MODULE cable_param_module
   USE phenvariable
   USE cable_abort_module
   USE cable_IO_vars_module
-  USE cable_common_module, ONLY: cable_user, latitude_dimid, longitude_dimid
+  USE cable_common_module, ONLY: cable_user, get_dimid, LatNames, LonNames
   USE CABLE_LUC_EXPT, ONLY: LUC_EXPT_TYPE, LUC_EXPT_SET_TILES, LUC_EXPT_SET_TILES_BIOS
 
   IMPLICIT NONE
@@ -219,11 +219,11 @@ CONTAINS
     ok = NF90_OPEN(trim(filename%type), 0, ncid)
     IF (ok /= NF90_NOERR) CALL nc_abort(ok, 'Error opening grid info file.')
 
-    xID = longitude_dimid(ncid)
+    xID = get_dimid(ncid, LonNames)
     ok = NF90_INQUIRE_DIMENSION(ncid, xID, LEN=nlon)
     IF (ok /= NF90_NOERR) CALL nc_abort(ok, 'Error getting x dimension.')
 
-    yID = latitude_dimid(ncid)
+    yID = get_dimid(ncid, LatNames)
     ok = NF90_INQUIRE_DIMENSION(ncid, yID, LEN=nlat)
     IF (ok /= NF90_NOERR) CALL nc_abort(ok, 'Error getting y dimension.')
 
@@ -766,11 +766,11 @@ CONTAINS
     ok = NF90_OPEN(trim(filename%soilcolor), 0, ncid)
     IF (ok /= NF90_NOERR) CALL nc_abort(ok, 'Error opening soil color file.')
 
-    xID = longitude_dimid(ncid)
+    xID = get_dimid(ncid, LonNames)
     ok = NF90_INQUIRE_DIMENSION(ncid, xID, LEN=nlon)
     IF (ok /= NF90_NOERR) CALL nc_abort(ok, 'Error getting x dimension.')
 
-    yID = latitude_dimid(ncid)
+    yID = get_dimid(ncid, LatNames)
     ok = NF90_INQUIRE_DIMENSION(ncid, yID, LEN=nlat)
     IF (ok /= NF90_NOERR) CALL nc_abort(ok, 'Error getting y dimension.')
 


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

The retrieving of dimension IDs from input NetCDF files is inconsistent across the code. Add routines to the ```cable_common``` module to standardise the retrieving of said IDs by searching through a list of possible names for the dimension.

Fixes #(issue)

## Type of change

- [x] Feature

## Checklist

- [x] The new content is accessible and located in the appropriate section.
- [x] I have checked that links are valid and point to the intended content.
- [x] I have checked my code/text and corrected any misspellings

Please add a reviewer when ready for review.
