### PR TITLE
Pipe BIOS met data through CRU routines for weather generation

### DIFF
--- a/offline/cable_cru_TRENDY.F90
+++ b/offline/cable_cru_TRENDY.F90
@@ -72,8 +72,10 @@ END TYPE CRU_TYPE
 ! Set some private parameters
 REAL, PRIVATE, PARAMETER  :: SecDay = 86400.
 INTEGER, PRIVATE, PARAMETER  :: rain = 1, lwdn = 2, swdn = 3, pres = 4, qair = 5,&
-                                tmax = 6, tmin = 7, uwind = 8, vwind = 9, fdiff = 10,&
-                                prevTmax = 11, nextTmin = 12
+                                tmax = 6, tmin = 7, wind = 8, uwind = 8, vwind = 9,&
+                                vaporpres0900 = 10, vaporpres1500 = 11, fdiff = 12,&
+                                prevTmax = 13, nextTmin = 14, prevvaporpres0900 = 15,&
+                                prevvaporpres1500 = 16
 INTEGER, PRIVATE, PARAMETER  :: sp = kind(1.0)
 INTEGER, PRIVATE             :: ErrStatus
 

--- a/offline/cable_driver.F90
+++ b/offline/cable_driver.F90
@@ -125,7 +125,8 @@ PROGRAM cable_offline_driver
   use CABLE_PLUME_MIP,      only: PLUME_MIP_TYPE, PLUME_MIP_GET_MET, &
        PLUME_MIP_INIT
 
-  use CABLE_CRU,            only: CRU_TYPE, CRU_GET_SUBDIURNAL_MET, CRU_INIT, cru_close
+  use CABLE_CRU,            only: CRU_TYPE, CRU_GET_SUBDIURNAL_MET,&
+                                  BIOS_GET_SUBDIURNAL_MET, CRU_INIT, cru_close
   use CABLE_site,           only: site_TYPE, site_INIT, site_GET_CO2_Ndep
 
   ! BIOS only
@@ -516,7 +517,7 @@ PROGRAM cable_offline_driver
      NREP: do RRRR=1, NRRRR
 
         if (trim(cable_user%MetType) == "bios") then
-           call cable_bios_init(dels,curyear,met,kend,ktauday)
+           !call cable_bios_init(dels,curyear,met,kend,ktauday)
            koffset   = 0
            leaps = .true.
            write(str1,'(i4)') curyear
@@ -591,7 +592,8 @@ PROGRAM cable_offline_driver
            else if (trim(cable_user%MetType) == 'bios') then
               ! BIOS run
               kend = nint(24.0 * 3600.0 / dels) * LOY
-           else if (trim(cable_user%MetType) == 'cru') then
+           else if ((trim(cable_user%MetType) == 'cru') .OR. &
+             (TRIM(cable_user%MetType) == 'bios')) then
               ! TRENDY experiment using CRU-NCEP
               if (CALL1) then
                  call cru_init(cru)
@@ -837,11 +839,11 @@ PROGRAM cable_offline_driver
                  end if
               else if (trim(cable_user%MetType) == 'bios') then
                  if ((.not. CASAONLY) .or. (CASAONLY .and. CALL1)) then
-                    call cable_bios_read_met(MET, CurYear, ktau, dels)
+                    call BIOS_GET_SUBDIURNAL_MET(CRU, met, YYYY, ktau)
                  end if
               else if (trim(cable_user%MetType) == 'cru') then
                  if ((.not. CASAONLY) .or. (CASAONLY .and. CALL1)) then
-                    call CRU_GET_SUBDIURNAL_MET(CRU, met, YYYY, ktau, kend)
+                    call CRU_GET_SUBDIURNAL_MET(CRU, met, YYYY, ktau)
                  end if
               else
                  if (trim(cable_user%MetType) == 'site') &
@@ -1296,6 +1298,7 @@ PROGRAM cable_offline_driver
 
            CALL1 = .false.
 
+           WRITE(*,*) "Spinup:", spinup, "spinConv:", spinConv, "CASAONLY:", CASAONLY
            ! see if spinup (if conducting one) has converged
            if (spinup .and. (.not.spinConv) .and. (.not.CASAONLY)) then
 

--- a/offline/cable_input.F90
+++ b/offline/cable_input.F90
@@ -162,6 +162,13 @@ TYPE SPATIO_TEMPORAL_DATASET
 ! index of the currently open file with the associated NetCDF file and variable
 ! ID.
 
+  ! A logical to check whether we should proceed with reading. With the merging
+  ! of the Met input interfaces, we have many more "possible" Met variables
+  ! than is required for a given weather generator. However, when we perform a
+  ! GET_SUBDIURNAL_MET call, we still iterate over all possible variables. This
+  ! gives us an easy out for variables that are not valid for the current set of
+  ! inputs.
+  LOGICAL :: IsInitialised = .FALSE.
   ! List of filenames in the dataset
   CHARACTER(LEN=256), DIMENSION(:), ALLOCATABLE :: FileNames
   ! The start and end years of each dataset
@@ -3085,6 +3092,12 @@ SUBROUTINE prepare_spatiotemporal_dataset(FileTemplate, Dataset)
   ! Finished the work (we assign the VarNames later). Now delete the temporary
   ! file we used to store the `ls` output.
   CALL execute_command_line("rm __FileNameWithNoClashes__.txt")
+
+  ! Open the dataset at the first file, so that it's ready for reading
+  CALL open_at_first_file(Dataset)
+  
+  Dataset.IsInitialised = .TRUE.
+
 END SUBROUTINE prepare_spatiotemporal_dataset
 
 SUBROUTINE open_at_first_file(Dataset)
@@ -3254,54 +3267,57 @@ SUBROUTINE read_metvals(STD, DataArr, LandIDx, LandIDy, Year, DayOfYear,&
   ! Temporary array to store the data read from file
   REAL, DIMENSION(:, :), ALLOCATABLE  :: TmpArray
 
-  TimeIndex = DayOfYear
-  YearIndex = Year
+  ! Only act if the dataset is initialised
+  IF (STD%IsInitialised) THEN
+    TimeIndex = DayOfYear
+    YearIndex = Year
 
-  ! We've already opened a file, check whether the file containing the relevant
-  ! data is the one open
-  IF (.NOT. ((Year >= STD%StartYear(STD%CurrentFileIndx)) .AND.&
-    (Year <= STD%EndYear(STD%CurrentFileIndx)))) THEN
-    CALL open_new_data_file(STD, YearIndex, TimeIndex, LeapYears)
-  END IF
+    ! We've already opened a file, check whether the file containing the relevant
+    ! data is the one open
+    IF (.NOT. ((Year >= STD%StartYear(STD%CurrentFileIndx)) .AND.&
+      (Year <= STD%EndYear(STD%CurrentFileIndx)))) THEN
+      CALL open_new_data_file(STD, YearIndex, TimeIndex, LeapYears)
+    END IF
 
-  ! Now read the desired time step
+    ! Now read the desired time step
 
-  ! Due to leapyears, we can't just do add 365 * number of years from startyear.
-  IF (LeapYears) THEN
-    CountDays: DO YearIter = STD%StartYear(STD%CurrentFileIndx), YearIndex-1
-      IF (is_leapyear(YearIndex)) THEN
-        TimeIndex = TimeIndex + 366
-      ELSE
-        TimeIndex = TimeIndex + 365
-      END IF
-    END DO CountDays
-  ELSE
-    TimeIndex = TimeIndex + 365 * (YearIndex -&
-      STD%StartYear(STD%CurrentFileIndx))
-  END IF
+    ! Due to leapyears, we can't just do add 365 * number of years from startyear.
+    IF (LeapYears) THEN
+      CountDays: DO YearIter = STD%StartYear(STD%CurrentFileIndx), YearIndex-1
+        IF (is_leapyear(YearIndex)) THEN
+          TimeIndex = TimeIndex + 366
+        ELSE
+          TimeIndex = TimeIndex + 365
+        END IF
+      END DO CountDays
+    ELSE
+      TimeIndex = TimeIndex + 365 * (YearIndex -&
+        STD%StartYear(STD%CurrentFileIndx))
+    END IF
 
-  ! Now we have the index, we can grab the data
-  ! Read from the netCDF file to the masked array point by point
-  IF (DirectRead) THEN
-    ApplyMaskDirect: DO LandCell = 1, SIZE(LandIDx)
-      ok = NF90_GET_VAR(STD%CurrentFileID,&
-        STD%CurrentVarID, DataArr(LandCell), START = (/LandIDx(LandCell),&
-        LandIDy(LandCell), TimeIndex/))
+    ! Now we have the index, we can grab the data
+    ! Read from the netCDF file to the masked array point by point
+    IF (DirectRead) THEN
+      ApplyMaskDirect: DO LandCell = 1, SIZE(LandIDx)
+        ok = NF90_GET_VAR(STD%CurrentFileID,&
+          STD%CurrentVarID, DataArr(LandCell), START = (/LandIDx(LandCell),&
+          LandIDy(LandCell), TimeIndex/))
+        CALL handle_err(ok, "Failed reading "//TRIM(STD%FileNames&
+          (STD%CurrentFileIndx))//" in read_metvals.")
+      END DO ApplyMaskDirect
+    ELSE
+
+      ALLOCATE(TmpArray(xDimSize, yDimSize))
+
+      ok = NF90_GET_VAR(STD%CurrentFileID, STD%CurrentVarID, TmpArray,&
+        START = (/1, 1, TimeIndex/), COUNT = (/xDimSize, yDimSize, 1/))
       CALL handle_err(ok, "Failed reading "//TRIM(STD%FileNames&
         (STD%CurrentFileIndx))//" in read_metvals.")
-    END DO ApplyMaskDirect
-  ELSE
 
-    ALLOCATE(TmpArray(xDimSize, yDimSize))
-
-    ok = NF90_GET_VAR(STD%CurrentFileID, STD%CurrentVarID, TmpArray,&
-      START = (/1, 1, TimeIndex/), COUNT = (/xDimSize, yDimSize, 1/))
-    CALL handle_err(ok, "Failed reading "//TRIM(STD%FileNames&
-      (STD%CurrentFileIndx))//" in read_metvals.")
-
-    ApplyLandmaskIndirect: DO LandCell = 1, SIZE(LandIDx)
-      DataArr(LandCell) = TmpArray(LandIDx(LandCell), LandIDy(LandCell))
-    END DO ApplyLandmaskIndirect
+      ApplyLandmaskIndirect: DO LandCell = 1, SIZE(LandIDx)
+        DataArr(LandCell) = TmpArray(LandIDx(LandCell), LandIDy(LandCell))
+      END DO ApplyLandmaskIndirect
+    END IF
   END IF
 
 END SUBROUTINE read_metvals


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

Piping the BIOS met inputs (the AGCD dataset) through the routines developed for the CRU routines. There are two options:
1. Make some adjustments to the existing CRU routines to have different options for weather generators, so that it uses the appropriate fields to prepare the weather generator.
2. Leave the BIOS met routines where they are, but make the file look very similar to the ```offline/cable_cru_TRENDY.F90``` file.

Upside of 1 is that it paves the way for work necessary in the long term for generalising inputs. Only upside to 2 is that is it _probably_ easier, but not necessarily. Both approaches require some thorough investigation to determine which bits of the BIOS init routines are only relevant to the met forcing, and which are relevant to BLAZE.

Fixes #391 

## Type of change

Please delete options that are not relevant.

- [x] New feature

## Checklist

- [ ] The new content is accessible and located in the appropriate section.
- [ ] I have checked that links are valid and point to the intended content.
- [ ] I have checked my code/text and corrected any misspellings

Please add a reviewer when ready for review.
