### PR TITLE
Create call graphs in doc

### DIFF
--- a/documentation/.readthedocs.yaml
+++ b/documentation/.readthedocs.yaml
@@ -4,6 +4,8 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11" # choose arbitrary version of python for now
+  apt_packages:
+    - graphviz
   jobs:
     pre_build:
       # install dependencies for ford and mkdocs separately to avoid dependency conflicts


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

The creation of the call graphs (and others) by FORD in the API documentation was broken since moving to readthedocs. This should solve the issue

Fixes #9



## Type of change

Please delete options that are not relevant.

- [X] Bug fix

## Testing

We do not build the graphs in the pull request preview of the documentation since it takes >3 min to build the doc with the graphs. This was tested in this fork: https://github.com/ccarouge/CABLE_test

Result example in the documentation: https://cable-test.readthedocs.io/en/latest/api/proc/bgcdriver.html

Please add a reviewer when ready for review.


<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--399.org.readthedocs.build/en/399/

<!-- readthedocs-preview cable end -->