### PR TITLE
Update build-ci version

### DIFF
--- a/.github/workflows/model-build-test-ci.yml
+++ b/.github/workflows/model-build-test-ci.yml
@@ -10,6 +10,6 @@ on:
 jobs:
   build:
     name: Build ${{ github.repository }} via spack
-    uses: access-nri/build-ci/.github/workflows/model-1-build.yml@3c0840d775d8f3d67cfeedb44173caa2682fa27e
+    uses: access-nri/build-ci/.github/workflows/model-1-build.yml@e90ea37002e4f3aed6515482eb2cca9ac5cd2a94
     permissions:
       packages: read


### PR DESCRIPTION
The build-ci action has now been fixed (see https://github.com/ACCESS-NRI/build-ci/pull/179).

Fixes #408

<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--409.org.readthedocs.build/en/409/

<!-- readthedocs-preview cable end -->