### PR TITLE
One liner fix of leap year bug

### DIFF
--- a/offline/cable_input.F90
+++ b/offline/cable_input.F90
@@ -3269,7 +3269,7 @@ SUBROUTINE read_metvals(STD, DataArr, LandIDx, LandIDy, Year, DayOfYear,&
   ! Due to leapyears, we can't just do add 365 * number of years from startyear.
   IF (LeapYears) THEN
     CountDays: DO YearIter = STD%StartYear(STD%CurrentFileIndx), YearIndex-1
-      IF (is_leapyear(YearIndex)) THEN
+      IF (is_leapyear(YearIter)) THEN
         TimeIndex = TimeIndex + 366
       ELSE
         TimeIndex = TimeIndex + 365


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

The counter used to find the temporal index in the Met NetCDF files had a minor bug that appeared when datasets spanned many years and included leap years. The leap year checker was checking against the reference year every time, rather than the iterating year.

Fix is a one-liner.

Fixes #([418](https://github.com/CABLE-LSM/CABLE/issues/418))

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## Checklist

- [x] The new content is accessible and located in the appropriate section.
- [x] I have checked that links are valid and point to the intended content.
- [x] I have checked my code/text and corrected any misspellings
