### PR TITLE
Removed ESM15 version with hard-wired xfpleach parameter, #278

### DIFF
--- a/documentation/docs/user_guide/inputs/pftlookup_csv.md
+++ b/documentation/docs/user_guide/inputs/pftlookup_csv.md
@@ -107,7 +107,7 @@ on soil, vegetation carbon and nutrients dynamics.
 | fpptoL(frt)    | `casabiome%ftransPPtoL(nv,froot)`             | Flux factor of root phosphorus to litter pools \( (-) \) |
 | xkmlabp        | `xkmlabp(iso)`                                | Phosphorus absorption \( (gP \cdot m^{-2}) \)  |
 | xpsorbmax      | `xpsorbmax(iso)`                              | Maximum phosphorus absorption \( (gP \cdot m^{-2}) \) |
-| xfpleach       | `xfPleach(iso)`                               | Phosphorus leaching \( (-) \) |
+| xfpleach       | `xfPleach(iso)`                               | Phosphorus leaching \( (-) \) (hard-wired in the code for CABLE2.4/ACCESS-ESM1.5 at 1.e-4 independent of pft) |
 | N:Psoil (mic)  | `ratioNPsoil(iso,mic)`                        | Nitrogen to phosphorus ratio in microbial soil pool \( (gN \cdot gP^{-2}) \) |
 | N:Psoil (slow) | `ratioNPsoil(iso,slow)`                       | Nitrogen to phosphorus ratio in slow soil pool \( (gN \cdot gP^{-2}) \) |
 | N:Psoil (pass) | `ratioNPsoil(iso,pass)`                       | Nitrogen to phosphorus ratio in passive soil pool \( (gN \cdot gP^{-2}) \) |

--- a/src/science/casa-cnp/casa_cnp.F90
+++ b/src/science/casa-cnp/casa_cnp.F90
@@ -1341,13 +1341,11 @@ END SUBROUTINE casa_delplant
                   +casaflux%Psimm(nland)
              ! net mineralization
 
-#           ifdef ESM15  
-             casaflux%Pleach(nland)  =  (1.0e-4) &
-                                              * max(0.0,casapool%Psoillab(nland))
-#           else
+             !rml 14/10/24 #278 remove ESM15 specific version as can be 
+             !accommodated by setting appropriate parameter in pftlookup
              casaflux%Pleach(nland)  =  casaflux%fPleach(nland) &
                   * MAX(0.0,casapool%Psoillab(nland))
-#            endif
+
              DO k=1,msoil
                 DO j=1,mlitter
                    casaflux%FluxPtosoil(nland,k) =  casaflux%FluxPtosoil(nland,k)  &


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

In casa_delsoil the evaluation of casaflux%Pleach had two versions, one specific to ESM1.5 (selected via an ifdef) and the alternat for all other cases. Following the code through, the ESM1.5 version had a hard-wired value (1.e-4) for casaflux%fPleach. casaflux%fPleach is filled from xfPleach which is read in from the pftlookup file. The ESM1.5 specific code can be safely removed with no change to the output if xfPleach is set to 1.e-4 in the pftlookup file. Note that there are versions of the pftlookup with xfPleach = 5.e-4. I am not aware of when/who set it to this value and whether it is considered to be better/more realistic.

Fixes #278

## Type of change

Please delete options that are not relevant.

- [X] Code clean-up

## Checklist

- [ ] The new content is accessible and located in the appropriate section.
- [ ] I have checked that links are valid and point to the intended content.
- [ ] I have checked my code/text and corrected any misspellings

Please add a reviewer when ready for review.


<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--422.org.readthedocs.build/en/422/

<!-- readthedocs-preview cable end -->