### PR TITLE
Correct array constructor for strings in CABLE-POP_TRENDY

### DIFF
--- a/core/biogeochem/POPLUC.F90
+++ b/core/biogeochem/POPLUC.F90
@@ -1459,14 +1459,14 @@ CONTAINS
              irp = ilu + j -1
              ! Update tile area
              if (ilu == p) then
-                POPLUC%primf(g) = min(1.0, max(patch(irp)%frac + dA_r(ilu) + dA_d(ilu), 0.0_dp))
+                POPLUC%primf(g) = min(1.0_dp, max(patch(irp)%frac + dA_r(ilu) + dA_d(ilu), 0.0_dp))
              elseif (ilu == s) then
-                POPLUC%secdf(g) = min(1.0, max(patch(irp)%frac + dA_r(ilu) + dA_d(ilu), 0.0_dp))
+                POPLUC%secdf(g) = min(1.0_dp, max(patch(irp)%frac + dA_r(ilu) + dA_d(ilu), 0.0_dp))
                 if (eq(POPLUC%secdf(g), 0.0_dp)) then
                    POPLUC%freq_age_secondary(g,:) = 0.0_dp
                 endif
              elseif (ilu == gr) then
-                POPLUC%grass(g) = min(1.0, max(patch(irp)%frac + dA_r(ilu) + dA_d(ilu), 0.0_dp))
+                POPLUC%grass(g) = min(1.0_dp, max(patch(irp)%frac + dA_r(ilu) + dA_d(ilu), 0.0_dp))
 
                 ! Update crop and pasture fraction within the grass land use type 
                 POPLUC%past(g) = min(max(POPLUC%past(g) + (POPLUC%ptoq(g) + POPLUC%stoq(g) + POPLUC%ctoq(g) + POPLUC%rtoq(g)) &

--- a/core/biogeochem/casa_inout.F90
+++ b/core/biogeochem/casa_inout.F90
@@ -2110,7 +2110,7 @@ contains
     use casavariable,         only: casa_met, casa_pool, casa_balance, casa_flux, &
          casafile, casa_timeunits
     use cable_common_module,  only: cable_user, filename, handle_err
-    use cable_def_types_mod,  only: veg_parameter_type, mp
+    use cable_def_types_mod,  only: veg_parameter_type
 !    use netcdf,               only: nf90_noerr, &
 !         nf90_put_var, nf90_clobber, nf90_create, nf90_global, nf90_put_att, &
 !#ifdef __NETCDF3__
@@ -2764,7 +2764,6 @@ contains
 
    ! writes casa vars to file with dimensions x,y,patch,t
    
-   use casadimension, only: mplant, mlitter, msoil, icycle
    use cable_common_module,  only: handle_err
 
    implicit none
@@ -2810,7 +2809,6 @@ SUBROUTINE put_casa_var_grid_patch_average(file_id,var_id,var_vals,outdim,cnt,tm
    ! writes casa vars to file with dimensions x,y,outdim,t
    ! averages 3rd dimension (outdim) over patches
 
-   use casadimension, only: mplant, mlitter, msoil, icycle
    use cable_common_module,  only: handle_err
 
    implicit none
@@ -2866,7 +2864,7 @@ END SUBROUTINE put_casa_var_grid_patch_average
     use casavariable,         only: casa_met, casa_pool, casa_balance, casa_flux, &
          casafile, casa_timeunits
     use cable_common_module,  only: cable_user, filename, handle_err
-    use cable_def_types_mod,  only: veg_parameter_type, mp
+    use cable_def_types_mod,  only: veg_parameter_type
 !    use netcdf,               only: nf90_noerr, &
 !         nf90_put_var, nf90_clobber, nf90_create, nf90_global, nf90_put_att, &
 !#ifdef __NETCDF3__
@@ -3534,7 +3532,6 @@ END SUBROUTINE put_casa_var_grid_patch_average
 
    ! writes casa vars to file with dimensions land,patch,t
    
-   use casadimension, only: mplant, mlitter, msoil, icycle
    use cable_common_module,  only: handle_err
 
    implicit none
@@ -3573,7 +3570,6 @@ SUBROUTINE put_casa_var_patch_average(file_id,var_id,var_vals,outdim,cnt,tmp_arr
 
    ! writes casa vars to file with dimensions land,outdim,t
 
-   use casadimension, only: mplant, mlitter, msoil, icycle
    use cable_common_module,  only: handle_err
 
    implicit none

--- a/core/biogeophys/cable_common.F90
+++ b/core/biogeophys/cable_common.F90
@@ -719,8 +719,8 @@ CONTAINS
       END IF
     END DO CheckNames
 
-    CALL handle_err(ok, "Failed to find any "//TRIM(DimNames(1))//" dimensions&
-      from the list.")
+    CALL handle_err(ok, "Failed to find any "//TRIM(DimNames(1))// &
+         " dimensions from the list.")
 
   END FUNCTION get_dimid
 

--- a/core/biogeophys/cable_common.F90
+++ b/core/biogeophys/cable_common.F90
@@ -33,12 +33,12 @@ MODULE cable_common_module
   INTEGER, SAVE :: CurYear  ! current year of multiannual run
 
   ! Dimension name lists for searching NetCDF dimensions IDs
-  CHARACTER(LEN=16), DIMENSION(5), PARAMETER :: LatNames = &
-    ["latitude", "lat", "lats", "y", "Latitude"]
-  CHARACTER(LEN=16), DIMENSION(5), PARAMETER :: LonNames = &
-    ["longitude", "lon", "lons", "x", "Longitude"]
-  CHARACTER(LEN=16), DIMENSION(3), PARAMETER :: TimeNames = &
-    ["time", "t", "Time"]
+  CHARACTER(LEN=*), DIMENSION(*), PARAMETER :: LatNames = &
+    [CHARACTER(LEN=8) :: "latitude", "lat", "lats", "y", "Latitude"]
+  CHARACTER(LEN=*), DIMENSION(*), PARAMETER :: LonNames = &
+    [CHARACTER(LEN=9) :: "longitude", "lon", "lons", "x", "Longitude"]
+  CHARACTER(LEN=*), DIMENSION(*), PARAMETER :: TimeNames = &
+    [CHARACTER(LEN=4) :: "time", "t", "Time"]
 
   ! user switches turned on/off by the user thru namelists
 

--- a/offline/cable_cru_TRENDY.F90
+++ b/offline/cable_cru_TRENDY.F90
@@ -76,7 +76,7 @@ INTEGER, PRIVATE, PARAMETER  :: rain = 1, lwdn = 2, swdn = 3, pres = 4, qair = 5
                                 tmax = 6, tmin = 7, uwind = 8, vwind = 9, fdiff = 10,&
                                 prevTmax = 11, nextTmin = 12
 INTEGER, PRIVATE, PARAMETER  :: sp = kind(1.0)
-INTEGER, PRIVATE             :: ErrStatus
+! INTEGER, PRIVATE             :: ErrStatus
 
 CONTAINS
 
@@ -98,15 +98,11 @@ SUBROUTINE CRU_INIT(CRU)
   ! We want one filename for each variable, stored in a predefined index.
   CHARACTER(LEN=256), dimension(13) :: InputFiles
 
-  ! Landmask to spatially filter the data
-  INTEGER, DIMENSION(:,:), ALLOCATABLE  :: LandMask
-
   ! Iterator variable for the variables
   INTEGER   :: VarIndx
 
   ! Checker for the NetCDF io
   INTEGER   :: ok
-  LOGICAL :: IsOpen
 
   ! Start with the things we want from the namelist. The namelist must set
   ! the filenames to read from, the method of choosing atmospheric carbon and
@@ -167,7 +163,6 @@ SUBROUTINE CRU_GET_SUBDIURNAL_MET(CRU, MET, CurYear, ktau, kend)
   logical   :: newday, LastDayOfYear  ! Flags for occurence of a new day (0 hrs) and the last day of the year.
   INTEGER   :: iland                  ! Loop counter through 'land' cells (cells in the spatial domain)
   INTEGER   :: itimestep              ! Loop counter through subdiurnal timesteps in a day
-  INTEGER   :: imetvar                ! Loop counter through met variables
   INTEGER   :: dM, dD                 ! Met date as year, month, and day returned from DOYSOD2YMDHMS
   INTEGER   :: is, ie                 ! Starting and ending vegetation type per land cell
   REAL      :: dt                     ! Timestep in seconds
@@ -175,7 +170,6 @@ SUBROUTINE CRU_GET_SUBDIURNAL_MET(CRU, MET, CurYear, ktau, kend)
   REAL, DIMENSION(:), ALLOCATABLE    :: CO2air                 ! CO2 concentration in ppm
   type(WEATHER_GENERATOR_TYPE), save :: WG
   logical,                      save :: CALL1 = .true.  ! A *local* variable recording the first call of this routine
-  INTEGER :: VarIter
 
   ! Purely for readability...
   dt = CRU%DTsecs

--- a/offline/cable_input.F90
+++ b/offline/cable_input.F90
@@ -167,7 +167,7 @@ TYPE SPATIO_TEMPORAL_DATASET
   ! The start and end years of each dataset
   INTEGER, DIMENSION(:), ALLOCATABLE            :: StartYear, EndYear
   ! List of possible variable names for the desired variable in the dataset
-  CHARACTER(LEN=16), DIMENSION(:), ALLOCATABLE  :: VarNames
+  CHARACTER(LEN=32), DIMENSION(:), ALLOCATABLE  :: VarNames
 
   ! Metadata about the currently open file
   INTEGER :: CurrentFileID, CurrentVarID, CurrentFileIndx

--- a/offline/cable_input.F90
+++ b/offline/cable_input.F90
@@ -2958,9 +2958,6 @@ SUBROUTINE prepare_spatiotemporal_dataset(FileTemplate, Dataset)
   ! without destroying the original template.
   CHARACTER(len=256):: CurrentFile
 
-  ! We read the start and end years to strings before writing them to the key.
-  CHARACTER(len=4)  :: StartYear, EndYear
-
   ! Integers to store the status of the command.
   INTEGER           :: ExStat, CStat
 
@@ -2979,7 +2976,7 @@ SUBROUTINE prepare_spatiotemporal_dataset(FileTemplate, Dataset)
   INTEGER           :: FileCounter
 
   ! Iterators
-  INTEGER           :: CharIndx, FileIndx
+  INTEGER           :: FileIndx
 
   ! Get a unique file ID here.
   CALL get_unit(InputUnit)
@@ -3246,7 +3243,7 @@ SUBROUTINE read_metvals(STD, DataArr, LandIDx, LandIDy, Year, DayOfYear,&
   INTEGER     :: YearIndex, TimeIndex
 
   ! Loop Iterators
-  INTEGER     :: FileIndx, VarNameIndx, YearIter, LandCell
+  INTEGER     :: YearIter, LandCell
 
   ! Status checker
   INTEGER  :: ok


### PR DESCRIPTION
# CABLE

## Description

The model did not compile with gfortran v14.2.

Possible dimension names in input files are defined as a character arrays in cable_common_module. They have different character lengths. The current notation is not Fortran standard compliant. I replaced
```
CHARACTER(LEN=16), DIMENSION(5), PARAMETER :: LatNames = &
    ["latitude", "lat", "lats", "y", "Latitude"]

```
with
```
CHARACTER(LEN=*), DIMENSION(*), PARAMETER :: LatNames = &
    [CHARACTER(LEN=8) :: "latitude", "lat", "lats", "y", "Latitude"]

```
Same for `LonNames` and `TimeNames`.
I found this very cool notation on [stackoverflow](https://stackoverflow.com/questions/21552430/gfortran-does-not-allow-character-arrays-with-varying-component-lengths).

Another error was also in cable_common, where the continuation character was within the string:
```
CALL handle_err(ok, "Failed to find any "//TRIM(DimNames(1))//" dimensions&
    from the list.")

```
The compiler does not know if `&` is part of the string or the continuation character. I pulled it out of the string.

I also extended VarNames in spatio_temporal_dataset from 16 to length 32 because they are used currently only in cable_cru_Trendy and the names used there had a maximum of 32 characters.

I finally compiled with debug flags, made both arguments of Fortran intrinsics (min) the same kind, removed all unused variables and unused module variables mainly in cable_input and casa_inout.

I would suggest adding '-e03' to the Intel debug flags for better standard compliance. I have not tested that and have not changed CMakeLists.txt.

## Type of change

- [x] Bug fix

## Checklist

- [x] The new content is accessible and located in the appropriate section.
- [x] I have checked that links are valid and point to the intended content.
- [x] I have checked my code/text and corrected any misspellings
