### PR TITLE
Remove ESM15 special case related to lnonwood condition on dNplantdt(wood)

### DIFF
--- a/src/science/casa-cnp/casa_cnp.F90
+++ b/src/science/casa-cnp/casa_cnp.F90
@@ -1,4 +1,3 @@
-!#define ESM15 YES
 !==============================================================================
 ! This source code is part of the
 ! Australian Community Atmosphere Biosphere Land Exchange (CABLE) model.
@@ -1027,14 +1026,15 @@ DO npt=1,mp
                                       * casabiome%ftransNPtoL(veg%iveg(npt),leaf)
       ENDIF
 
-      casapool%dNplantdt(npt,wood) = 0.0
-#ifndef ESM15
-      ! offline/trunk uses this condition
-      IF (casamet%lnonwood(npt)==0)                                            & 
-#endif
-      casapool%dNplantdt(npt,wood) = - casaflux%kplant(npt,wood)             &
+      !R. Law 25/10/24 removed ESM15 case as no need to exclude the condition
+      !that is in offline/trunk. Also re-write as IF / THEN
+      IF (casamet%lnonwood(npt)==0) THEN                                          
+        casapool%dNplantdt(npt,wood) = - casaflux%kplant(npt,wood)             &
                                      * casapool%Nplant(npt,wood)               &
                                      * casabiome%ftransNPtoL(veg%iveg(npt),wood)
+      ELSE
+        casapool%dNplantdt(npt,wood) = 0.0
+      ENDIF
 
       casapool%dNplantdt(npt,froot) = - casaflux%kplant(npt,froot)             &
                                     * casapool%Nplant(npt,froot)               &
@@ -1066,9 +1066,14 @@ DO npt=1,mp
                                      * casabiome%ftransPPtoL(veg%iveg(npt),leaf)
       ENDIF
   
-      casapool%dPplantdt(npt,wood) = - casaflux%kplant(npt,wood)               &
+      !R. Law 25/10/24 Add similar lnonwood condition as used in nitrogen case
+      IF (casamet%lnonwood(npt)==0) THEN                                          
+        casapool%dPplantdt(npt,wood) = - casaflux%kplant(npt,wood)             &
                                    * casapool%Pplant(npt,wood)                 &
                                    * casabiome%ftransPPtoL(veg%iveg(npt),wood)
+      ELSE
+        casapool%dPplantdt(npt,wood) = 0.0
+      ENDIF
   
       casapool%dPplantdt(npt,froot) = - casaflux%kplant(npt,froot)             &
                                     * casapool%Pplant(npt,froot)               &


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

Non-ESM15 code versions had a condition on the calculation of dNplantdt(:.wood) to only do the calculation for woody pfts, having first set it to zero for all pfts. An ifndef was used to ignore the condition when ESM15 was defined YES.
The was no apparent reason why ESM15 could not use the condition so the special case was removed.
For clarity the condition was re-written as an IF/THEN.
dPplantdt(:,wood) is calculated in the same way as dNplantdt but had no condition. For consistency, a similar condition has been added so that nitrogen and phosphorus are treated the same way.

Fixes #423

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix / code clean up
- [ ] New or updated documentation

## Checklist

- [ ] The new content is accessible and located in the appropriate section.
- [ ] I have checked that links are valid and point to the intended content.
- [X ] I have checked my code/text and corrected any misspellings

Please add a reviewer when ready for review.


<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--434.org.readthedocs.build/en/434/

<!-- readthedocs-preview cable end -->