### PR TITLE
431 add routine for more informative namelist errors

### DIFF
--- a/core/biogeophys/cable_common.F90
+++ b/core/biogeophys/cable_common.F90
@@ -694,22 +694,19 @@ CONTAINS
 
   end subroutine get_unit
 
-  SUBROUTINE handle_namelist_iostat(ios, iomessage)
+  SUBROUTINE handle_iostat(ios, iomessage)
     !*## Purpose
     !
-    ! Take the return status of a namelist read and return an informative error
+    ! Take the return status of a read call and return an informative error
     ! message on failure status.
     !
     !## Method
     !
-    ! Use a combination of the new IOMSG specifier introduced in Fortran 2003
-    ! and the namelist checking routine [here]
-    ! (https://degenerateconic.com/namelist-error-checking.html) to throw an
-    ! informative error message when the reading of the namelist fails.
+    ! Use the IOSTAT and the new IOMSG specifier introduced in Fortran 2003
+    ! to throw an informative error message when the read errors.
 
     INTEGER, INTENT(IN) :: ios
     CHARACTER(LEN=*), INTENT(IN) :: ioMessage
-    CHARACTER(LEN=200) :: BadLine
 
     IF (ios /= 0) THEN
       ! Read of namelist failed
@@ -731,7 +728,7 @@ CONTAINS
       STOP ios
     END IF
 
-  END SUBROUTINE handle_namelist_iostat
+  END SUBROUTINE handle_iostat
 
   FUNCTION get_dimid(FileID, DimNames)
     !*## Purpose

--- a/core/biogeophys/cable_common.F90
+++ b/core/biogeophys/cable_common.F90
@@ -694,7 +694,7 @@ CONTAINS
 
   end subroutine get_unit
 
-  SUBROUTINE handle_namelist_iostat(nmlunit, ios, iomessage)
+  SUBROUTINE handle_namelist_iostat(ios, iomessage)
     !*## Purpose
     !
     ! Take the return status of a namelist read and return an informative error
@@ -707,7 +707,7 @@ CONTAINS
     ! (https://degenerateconic.com/namelist-error-checking.html) to throw an
     ! informative error message when the reading of the namelist fails.
 
-    INTEGER, INTENT(IN) :: nmlUnit, ios
+    INTEGER, INTENT(IN) :: ios
     CHARACTER(LEN=*), INTENT(IN) :: ioMessage
     CHARACTER(LEN=200) :: BadLine
 
@@ -715,10 +715,20 @@ CONTAINS
       ! Read of namelist failed
       WRITE(ERROR_UNIT, FMT='(A)') ioMessage
 
-      BACKSPACE(nmlUnit)
-      READ(nmlUnit, FMT='(A)') BadLine
-      WRITE(ERROR_UNIT, FMT='(A)') "Invalid line in namelist: "//TRIM(BadLine)
-      STOP 1
+      ! This section was originally included, based on a method found [here]
+      ! (https://degenerateconic.com/namelist-error-checking.html), which would
+      ! also write the incriminating line to the error stream. However, it
+      ! relies on undefined behaviour, as the position in a file becomes
+      ! indeterminate if an error condition occurs during input/output (see
+      ! [this
+      ! thread](https://community.intel.com/t5/Intel-Fortran-Compiler/
+      ! Regression-with-quot-backspace-quot-in-2023-0/m-p/1448175)). While
+      ! it may work as desired for most compilers, it is not guaranteed, and
+      ! may change without warning at any time as evidenced by said thread.
+      !BACKSPACE(nmlUnit)
+      !READ(nmlUnit, FMT='(A)') BadLine
+      !WRITE(ERROR_UNIT, FMT='(A)') "Invalid line in namelist: "//TRIM(BadLine)
+      STOP ios
     END IF
 
   END SUBROUTINE handle_namelist_iostat

--- a/core/biogeophys/cable_common.F90
+++ b/core/biogeophys/cable_common.F90
@@ -712,19 +712,6 @@ CONTAINS
       ! Read of namelist failed
       WRITE(ERROR_UNIT, FMT='(A)') ioMessage
 
-      ! This section was originally included, based on a method found [here]
-      ! (https://degenerateconic.com/namelist-error-checking.html), which would
-      ! also write the incriminating line to the error stream. However, it
-      ! relies on undefined behaviour, as the position in a file becomes
-      ! indeterminate if an error condition occurs during input/output (see
-      ! [this
-      ! thread](https://community.intel.com/t5/Intel-Fortran-Compiler/
-      ! Regression-with-quot-backspace-quot-in-2023-0/m-p/1448175)). While
-      ! it may work as desired for most compilers, it is not guaranteed, and
-      ! may change without warning at any time as evidenced by said thread.
-      !BACKSPACE(nmlUnit)
-      !READ(nmlUnit, FMT='(A)') BadLine
-      !WRITE(ERROR_UNIT, FMT='(A)') "Invalid line in namelist: "//TRIM(BadLine)
       STOP ios
     END IF
 

--- a/core/biogeophys/cable_common.F90
+++ b/core/biogeophys/cable_common.F90
@@ -709,7 +709,7 @@ CONTAINS
 
     INTEGER, INTENT(IN) :: nmlUnit, ios
     CHARACTER(LEN=*), INTENT(IN) :: ioMessage
-    CHARACTER(LEN=*) :: BadLine
+    CHARACTER(LEN=200) :: BadLine
 
     IF (ios /= 0) THEN
       ! Read of namelist failed

--- a/core/blaze/blaze.F90
+++ b/core/blaze/blaze.F90
@@ -1,5 +1,6 @@
 MODULE BLAZE_MOD
 
+USE cable_common_module, ONLY: handle_iostat
 TYPE TYPE_BLAZE
    INTEGER,  DIMENSION(:),  ALLOCATABLE :: DSLR,ilon, jlat, Flix
    REAL,     DIMENSION(:),  ALLOCATABLE :: RAINF, KBDI, LR, U10,RH,TMAX,TMIN,AREA, w_prior, FDI
@@ -80,9 +81,6 @@ CONTAINS
 
 SUBROUTINE INI_BLAZE ( np, LAT, LON, BLAZE)
 
-  !! Called from cable_driver now
-  USE cable_common_module, ONLY: get_unit
-
   IMPLICIT NONE
 
   INTEGER            , INTENT(IN)    :: np
@@ -92,15 +90,18 @@ SUBROUTINE INI_BLAZE ( np, LAT, LON, BLAZE)
   CHARACTER(len=400)  :: BurnedAreaFile = "", OutputMode="full" 
   CHARACTER(len=10)   :: BurnedAreaSource = "SIMFIRE", blazeTStep = "annually"
   INTEGER :: iu
+  ! I/O checkers
+  INTEGER :: ios
+  CHARACTER(LEN=200) :: ioMessage
 
   !CLNNAMELIST /blazenml/ HydePath,  BurnedAreaSource, BurnedAreaFile, BurnedAreaClimatologyFile, &
   !CLN     SIMFIRE_REGION
   namelist /blazenml/ blazeTStep,  BurnedAreaSource, BurnedAreaFile, OutputMode
 
   ! READ BLAZE settings
-  call get_unit(iu)
-  open(iu, file="blaze.nml", status='old', action='read')
-  read(iu, nml=blazenml)
+  open(NEWUNIT=iu, file="blaze.nml", status='old', action='read')
+  read(iu, nml=blazenml, IOSTAT=ios, IOMSG=ioMessage)
+  CALL handle_iostat(ios, ioMessage)
   close(iu)
 
   ! READ ini-nml

--- a/core/blaze/simfire.F90
+++ b/core/blaze/simfire.F90
@@ -1,5 +1,6 @@
 MODULE SIMFIRE_MOD
 
+USE cable_common_module, ONLY: handle_iostat
 TYPE TYPE_SIMFIRE
    INTEGER, DIMENSION(:), ALLOCATABLE    :: IGBP, BIOME, REGION, NDAY
    REAL,    DIMENSION(:), ALLOCATABLE    :: POPD, MAX_NESTEROV, CNEST, LAT, LON, FLI, FAPAR, POPDENS
@@ -71,6 +72,10 @@ SUBROUTINE INI_SIMFIRE( NCELLS, SF, modis_igbp )
   REAL, DIMENSION(360):: lat_BA
   integer :: status
 
+  ! I/O checkers
+  INTEGER :: ios
+  CHARACTER :: ioMessage
+
   namelist /simfirenml/ SIMFIRE_REGION, HydePath, BurnedAreaClimatologyFile
 
   !+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -113,9 +118,9 @@ SUBROUTINE INI_SIMFIRE( NCELLS, SF, modis_igbp )
   ! inherit modis_igbp from climate variable
 
   ! READ BLAZE settings
-  call get_unit(iu)
-  open(iu, file="blaze.nml", status='old', action='read')
-  read(iu, nml=simfirenml)
+  open(NEWUNIT=iu, file="blaze.nml", status='old', action='read')
+  read(iu, nml=simfirenml, IOSTAT=ios, IOMSG=ioMessage)
+  CALL handle_iostat(ios, ioMessage)
   close(iu)
 
   SF%HYDEPATH = TRIM(HydePath)

--- a/offline/cable_LUC_EXPT.F90
+++ b/offline/cable_LUC_EXPT.F90
@@ -1,6 +1,6 @@
 MODULE CABLE_LUC_EXPT
 
-  use cable_common_module,  only: is_leapyear, leap_day, handle_err, get_unit,&
+  use cable_common_module,  only: is_leapyear, leap_day, handle_err, handle_iostat,&
                                   get_dimid, LatNames, LonNames, TimeNames
   use cable_io_vars_module, only: logn, land_x, land_y, landpt, latitude, longitude
   use cable_def_types_mod,  only: mland
@@ -92,6 +92,10 @@ CONTAINS
     CHARACTER(len=100)    :: time_units
     CHARACTER(len=4) :: yearstr
 
+    ! I/O checker
+    INTEGER :: ios
+    CHARACTER(LEN=200) :: ioMessage
+
     namelist /lucnml/  TransitionFilePath, ClimateFile, Run, DirectRead, YearStart, YearEnd, &
          PrimOnlyFile
 
@@ -127,9 +131,9 @@ CONTAINS
 
     LUC_EXPT%PrimOnlyFile = 'none'
     ! READ LUC_EXPT settings
-    call get_unit(iu)
-    open(iu, file="luc.nml", status='old', action='read')
-    read(iu, nml=lucnml)
+    open(NEWUNIT=iu, file="luc.nml", status='old', action='read')
+    read(iu, nml=lucnml, IOSTAT=ios, IOMSG=ioMessage)
+    CALL handle_iostat(ios, ioMessage)
     close(iu)
     LUC_EXPT%TransitionFilePath = TransitionFilePath
     LUC_EXPT%ClimateFile        = ClimateFile

--- a/offline/cable_bios_met_obs_params.F90
+++ b/offline/cable_bios_met_obs_params.F90
@@ -494,7 +494,7 @@ MODULE cable_bios_met_obs_params
   USE bios_date_functions
   USE bios_misc_io
   
-  USE CABLE_COMMON_MODULE, ONLY: GET_UNIT, cable_user ! Subr assigns an unique unit number for file opens.
+  USE CABLE_COMMON_MODULE, ONLY: GET_UNIT, cable_user, handle_iostat ! Subr assigns an unique unit number for file opens.
 
   USE cable_IO_vars_module, ONLY: &
       logn, landpt , nmetpatches         ! Unit number for writing logfile entries and land point array
@@ -519,6 +519,9 @@ MODULE cable_bios_met_obs_params
   CHARACTER(len=15) :: Ndep        ! Ndep takes value      : "preind","actual"
   CHARACTER(len=15) :: MetForcing  ! MetForcing takes value: "recycled", "actual"
 
+  ! I/O checker
+  INTEGER :: ios
+  CHARACTER(LEN=200) :: ioMessage
 
   CHARACTER(200) :: met_path, param_path, landmaskflt_file, landmaskhdr_file, &
        rain_file, swdown_file, tairmax_file, tairmin_file, wind_file, &
@@ -617,9 +620,9 @@ CONTAINS
   
   ! Open and read the BIOS namelist file.
   
-  CALL GET_UNIT(iunit)
-  OPEN (iunit, FILE="bios.nml")
-  READ (iunit, NML=biosnml)
+  OPEN (NEWUNIT=iunit, FILE="bios.nml")
+  READ (iunit, NML=biosnml, IOSTAT=ios, IOMSG=ioMessage)
+  CALL handle_iostat(ios, ioMessage)
   CLOSE(iunit)
 
   metgrid = 'land'

--- a/offline/cable_driver.F90
+++ b/offline/cable_driver.F90
@@ -68,7 +68,7 @@ PROGRAM cable_offline_driver
        cable_runtime, filename, &
        redistrb, wiltParam, satuParam, CurYear, &
        IS_LEAPYEAR, IS_CASA_TIME, calcsoilalbedo, get_unit, &
-       report_version_no, kwidth_gl
+       report_version_no, kwidth_gl, handle_namelist_iostat
   use cable_data_module,    only: driver_type, point2constants
   use cable_input_module,   only: open_met_file, load_parameters, get_met_data, close_met_file, &
        ncid_rain, ncid_snow, ncid_lw, ncid_sw, ncid_ps, ncid_qa, ncid_ta, ncid_wd
@@ -144,6 +144,7 @@ PROGRAM cable_offline_driver
 
   ! CABLE namelist: model configuration, runtime/user switches
   character(len=200), parameter :: cable_namelist='cable.nml'
+  CHARACTER(LEN=200) :: ioMessage
 
   ! timing variables
   integer, parameter :: kstart = 1   ! start of simulation
@@ -335,7 +336,8 @@ PROGRAM cable_offline_driver
 
   ! Open, read and close the namelist file.
   open(10, file=cable_namelist)
-  read(10, nml=cablenml)   !where nml=cable defined above
+  read(10, nml=cablenml, IOSTAT=ios, IOMSG=ioMessage)   !where nml=cable defined above
+  CALL handle_namelist_iostat(10, ios, ioMessage)
   close(10)
 
   ! Open, read and close the consistency check file.

--- a/offline/cable_driver.F90
+++ b/offline/cable_driver.F90
@@ -68,7 +68,7 @@ PROGRAM cable_offline_driver
        cable_runtime, filename, &
        redistrb, wiltParam, satuParam, CurYear, &
        IS_LEAPYEAR, IS_CASA_TIME, calcsoilalbedo, get_unit, &
-       report_version_no, kwidth_gl, handle_namelist_iostat
+       report_version_no, kwidth_gl, handle_iostat
   use cable_data_module,    only: driver_type, point2constants
   use cable_input_module,   only: open_met_file, load_parameters, get_met_data, close_met_file, &
        ncid_rain, ncid_snow, ncid_lw, ncid_sw, ncid_ps, ncid_qa, ncid_ta, ncid_wd
@@ -145,6 +145,7 @@ PROGRAM cable_offline_driver
   ! CABLE namelist: model configuration, runtime/user switches
   character(len=200), parameter :: cable_namelist='cable.nml'
   CHARACTER(LEN=200) :: ioMessage
+  INTEGER :: cablenml_unit
 
   ! timing variables
   integer, parameter :: kstart = 1   ! start of simulation
@@ -335,10 +336,10 @@ PROGRAM cable_offline_driver
   ! END header
 
   ! Open, read and close the namelist file.
-  open(10, file=cable_namelist)
-  read(10, nml=cablenml, IOSTAT=ios, IOMSG=ioMessage)   !where nml=cable defined above
-  CALL handle_namelist_iostat(ios, ioMessage)
-  close(10)
+  open(NEWUNIT=cablenml_unit, file=cable_namelist)
+  read(cablenml_unit, nml=cablenml, IOSTAT=ios, IOMSG=ioMessage)   !where nml=cable defined above
+  CALL handle_iostat(ios, ioMessage)
+  close(cablenml_unit)
 
   ! Open, read and close the consistency check file.
   ! Check triggered by cable_user%consistency_check = .TRUE. in cable.nml

--- a/offline/cable_driver.F90
+++ b/offline/cable_driver.F90
@@ -337,7 +337,7 @@ PROGRAM cable_offline_driver
   ! Open, read and close the namelist file.
   open(10, file=cable_namelist)
   read(10, nml=cablenml, IOSTAT=ios, IOMSG=ioMessage)   !where nml=cable defined above
-  CALL handle_namelist_iostat(10, ios, ioMessage)
+  CALL handle_namelist_iostat(ios, ioMessage)
   close(10)
 
   ! Open, read and close the consistency check file.

--- a/offline/cable_plume_mip.F90
+++ b/offline/cable_plume_mip.F90
@@ -2,7 +2,7 @@ MODULE CABLE_PLUME_MIP
 
   USE netcdf
   USE CABLE_COMMON_MODULE, ONLY: IS_LEAPYEAR, LEAP_DAY, &
-       HANDLE_ERR, get_unit
+       HANDLE_ERR, get_unit, handle_iostat
 
   USE cable_IO_vars_module, ONLY: logn, land_x, land_y
 
@@ -85,14 +85,18 @@ CONTAINS
     REAL,DIMENSION(:)  ,ALLOCATABLE :: plume_lats, plume_lons
     INTEGER,DIMENSION(:,:),ALLOCATABLE :: landmask
 
+    ! I/O checker
+    INTEGER :: ios
+    CHARACTER(LEN=200) :: ioMessage
+
     namelist /plumenml/ BasePath, LandMaskFile, Run, Forcing, RCP, CO2, CO2file, &
          NDEP, NdepFILE, DT, DirectRead
 
     ! Read PLUME settings
 
-    call get_unit(iu)
-    open(iu, file="plume.nml", status='old', action='read')
-    read(iu, nml=plumenml)
+    open(NEWUNIT=iu, file="plume.nml", status='old', action='read')
+    read(iu, nml=plumenml, IOSTAT=ios, IOMSG=ioMessage)
+    CALL handle_iostat(ios, ioMessage)
     close(iu)
 
     PLUME%BasePath     = BasePath

--- a/offline/cable_site.F90
+++ b/offline/cable_site.F90
@@ -27,9 +27,10 @@ MODULE CABLE_site
 
 
   USE CABLE_COMMON_MODULE, ONLY: &   ! Selected cable_common.f90 routines:
-      HANDLE_ERR,  &                 ! Print error status info returned by netcdf file operations
+      HANDLE_ERR, &                 ! Print error status info returned by netcdf file operations
       GET_UNIT, &                       ! Finds an unused unit number for file opens
-      CurYear !  current year of multiannual run
+      CurYear, & !  current year of multiannual run
+      handle_iostat
 
   USE cable_IO_vars_module, ONLY: &  ! Selected cable_iovars.F90 variables:
       logn
@@ -86,6 +87,10 @@ CONTAINS
     REAL :: spinCO2 ! ppm (pre-industrial)
     REAL :: spinNdep  ! kgNha-1y-1 (pre-industrial)
     REAL :: spinPdep  ! kgPha-1y-1 (pre-industrial)
+
+    ! I/O checker
+    INTEGER :: ios
+    CHARACTER(LEN=200) :: ioMessage
  
     ! Flag for errors
 
@@ -94,8 +99,9 @@ CONTAINS
 
     ! Read site namelist settings
     CALL GET_UNIT(nmlunit)  ! CABLE routine finds spare unit number
-    OPEN (nmlunit,FILE="site.nml",STATUS='OLD',ACTION='READ')
-    READ (nmlunit,NML=siteNML)
+    OPEN (NEWUNIT=nmlunit,FILE="site.nml",STATUS='OLD',ACTION='READ')
+    READ (nmlunit, NML=siteNML, IOSTAT=ios, IOMSG=ioMessage)
+    CALL handle_iostat(ios, ioMessage)
     CLOSE(nmlunit)
 
     ! Assign namelist settings to corresponding CRU defined-type elements


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

Add a routine to handle namelist errors, that returns a much more informative error message than the baseline namelist error message. Utilises the new ```IOMSG``` specifier and the routine detailed [here](https://degenerateconic.com/namelist-error-checking.html).

Fixes #(431)

Edit: Turns out that this namelist checking routine relies on undefined behaviour. The problems I was seeing was the result of a "regression" in Intel Fortran 2023, see [this thread](https://community.intel.com/t5/Intel-Fortran-Compiler/Regression-with-quot-backspace-quot-in-2023-0/m-p/1448175). The comment from Steve Lionel in the accepted answer is important:

> The standard says, "If an error condition occurs during execution of an input/output statement, the position of the file becomes indeterminate."

This means that the so-called regression was not really a regression, just a change in already undefined behaviour. This use of ```BACKSPACE``` to return the incriminating line relies on undefined behaviour that may change at any time. Based on this, I decided against including this part of the routine, and just throwing back the ```IOMSG``` returned by the ```READ``` call.

## Type of change

- Quality of life change

## Checklist

- [ ] The new content is accessible and located in the appropriate section.
- [ ] I have checked that links are valid and point to the intended content.
- [ ] I have checked my code/text and corrected any misspellings

Please add a reviewer when ready for review.
