### PR TITLE
Add initialisation routine for offline drivers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,7 @@ target_link_libraries(cable_common_objlib PRIVATE PkgConfig::NETCDF)
 add_executable(
     cable
     src/offline/cable_driver.F90
+    src/offline/cable_driver_init.F90
     "$<TARGET_OBJECTS:cable_common_objlib>"
 )
 target_link_libraries(cable PRIVATE PkgConfig::NETCDF)
@@ -163,6 +164,7 @@ install(TARGETS cable RUNTIME)
 if(CABLE_MPI)
     add_executable(
         cable-mpi
+        src/offline/cable_driver_init.F90
         src/offline/cable_mpicommon.F90
         src/offline/cable_mpidrv.F90
         src/offline/cable_mpimaster.F90
@@ -170,6 +172,7 @@ if(CABLE_MPI)
         src/science/pop/pop_mpi.F90
         "$<TARGET_OBJECTS:cable_common_objlib>"
     )
+    target_compile_definitions(cable-mpi PRIVATE __MPI__)
     target_link_libraries(cable-mpi PRIVATE PkgConfig::NETCDF MPI::MPI_Fortran)
     install(TARGETS cable-mpi RUNTIME)
 endif()

--- a/src/offline/cable_driver.F90
+++ b/src/offline/cable_driver.F90
@@ -59,6 +59,7 @@
 !==============================================================================
 
 PROGRAM cable_offline_driver
+  USE cable_driver_init_mod
   USE cable_def_types_mod
   USE cable_IO_vars_module, ONLY: logn,gswpfile,ncciy,leaps,                  &
        verbose, fixedCO2,output,check,patchout,    &
@@ -306,6 +307,8 @@ integer,   dimension(:),       allocatable,  save  :: cstart,cend,nap
 real(r_2), dimension(:,:,:),   allocatable,  save  :: patchfrac_new
 
 ! END header
+
+  CALL cable_driver_init()
 
   cable_runtime%offline = .TRUE.
   !check to see if first argument passed to cable is

--- a/src/offline/cable_driver.F90
+++ b/src/offline/cable_driver.F90
@@ -73,8 +73,7 @@ PROGRAM cable_offline_driver
        IS_LEAPYEAR, calcsoilalbedo,              &
        kwidth_gl, gw_params
 
-  USE cable_namelist_util, ONLY : get_namelist_file_name,&
-       CABLE_NAMELIST,arg_not_namelist
+  USE cable_namelist_util, ONLY : CABLE_NAMELIST, arg_not_namelist
 ! physical constants
 USE cable_phys_constants_mod, ONLY : CTFRZ   => TFRZ
 USE cable_phys_constants_mod, ONLY : CEMLEAF => EMLEAF
@@ -311,10 +310,6 @@ real(r_2), dimension(:,:,:),   allocatable,  save  :: patchfrac_new
   CALL cable_driver_init()
 
   cable_runtime%offline = .TRUE.
-  !check to see if first argument passed to cable is
-  !the name of the namelist file
-  !if not use cable.nml
-  CALL get_namelist_file_name()
 
   WRITE(*,*) "THE NAME LIST IS ",CABLE_NAMELIST
   ! Open, read and close the namelist file.

--- a/src/offline/cable_driver_init.F90
+++ b/src/offline/cable_driver_init.F90
@@ -1,5 +1,6 @@
 MODULE cable_driver_init_mod
   !! Module for CABLE offline driver initialisation.
+  USE cable_namelist_util, ONLY : get_namelist_file_name
   IMPLICIT NONE
   PRIVATE
 
@@ -9,6 +10,11 @@ CONTAINS
 
   SUBROUTINE cable_driver_init()
     !! Model initialisation routine for the CABLE offline driver.
+
+    !check to see if first argument passed to cable is
+    !the name of the namelist file
+    !if not use cable.nml
+    CALL get_namelist_file_name()
 
 #ifdef __MPI__
     ! MPI specific initialisation

--- a/src/offline/cable_driver_init.F90
+++ b/src/offline/cable_driver_init.F90
@@ -1,0 +1,21 @@
+MODULE cable_driver_init_mod
+  !! Module for CABLE offline driver initialisation.
+  IMPLICIT NONE
+  PRIVATE
+
+  PUBLIC :: cable_driver_init
+
+CONTAINS
+
+  SUBROUTINE cable_driver_init()
+    !! Model initialisation routine for the CABLE offline driver.
+
+#ifdef __MPI__
+    ! MPI specific initialisation
+#else
+    ! Serial specific initialisation
+#endif
+
+  END SUBROUTINE cable_driver_init
+
+END MODULE cable_driver_init_mod

--- a/src/offline/cable_driver_init.F90
+++ b/src/offline/cable_driver_init.F90
@@ -1,12 +1,80 @@
 MODULE cable_driver_init_mod
   !! Module for CABLE offline driver initialisation.
-  USE cable_namelist_util, ONLY : get_namelist_file_name
+  USE cable_common_module, ONLY : &
+    filename,                     &
+    calcsoilalbedo,               &
+    redistrb,                     &
+    wiltParam,                    &
+    satuParam,                    &
+    cable_user,                   &
+    gw_params
+  USE cable_IO_vars_module, ONLY : &
+    soilparmnew,                   &
+    output,                        &
+    patchout,                      &
+    check,                         &
+    verbose,                       &
+    leaps,                         &
+    logn,                          &
+    fixedCO2,                      &
+    ncciy,                         &
+    gswpfile,                      &
+    globalMetfile
+  USE casadimension, ONLY : icycle
+  USE casavariable, ONLY : casafile
+  USE cable_namelist_util, ONLY : &
+    get_namelist_file_name,       &
+    CABLE_NAMELIST
 #ifdef __MPI__
   USE mpi
   USE cable_mpicommon, ONLY : comm, rank
 #endif
   IMPLICIT NONE
   PRIVATE
+
+  LOGICAL, SAVE, PUBLIC :: vegparmnew    = .FALSE. ! using new format input file (BP dec 2007)
+  LOGICAL, SAVE, PUBLIC :: spinup        = .FALSE. ! model spinup to soil state equilibrium?
+  LOGICAL, SAVE, PUBLIC :: spincasa      = .FALSE. ! TRUE: CASA-CNP Will spin mloop times, FALSE: no spin up
+  LOGICAL, SAVE, PUBLIC :: l_casacnp     = .FALSE. ! using CASA-CNP with CABLE
+  LOGICAL, SAVE, PUBLIC :: l_landuse     = .FALSE. ! using CASA-CNP with CABLE
+  LOGICAL, SAVE, PUBLIC :: l_laiFeedbk   = .FALSE. ! using prognostic LAI
+  LOGICAL, SAVE, PUBLIC :: l_vcmaxFeedbk = .FALSE. ! using prognostic Vcmax
+
+  REAL, SAVE, PUBLIC :: delsoilM ! allowed variation in soil moisture for spin up
+  REAL, SAVE, PUBLIC :: delsoilT ! allowed variation in soil temperature for spin up
+  REAL, SAVE, PUBLIC :: delgwM = 1e-4
+
+  NAMELIST /CABLE/  &
+    filename,       & ! TYPE, containing input filenames
+    vegparmnew,     & ! use new soil param. method
+    soilparmnew,    & ! use new soil param. method
+    calcsoilalbedo, & ! albedo considers soil color Ticket #27
+    spinup,         & ! spinup model (soil) to steady state
+    delsoilM,       &
+    delsoilT,       &
+    delgwM,         &
+    output,         &
+    patchout,       &
+    check,          &
+    verbose,        &
+    leaps,          &
+    logn,           &
+    fixedCO2,       &
+    spincasa,       &
+    l_casacnp,      &
+    l_landuse,      &
+    l_laiFeedbk,    &
+    l_vcmaxFeedbk,  &
+    icycle,         &
+    casafile,       &
+    ncciy,          &
+    gswpfile,       &
+    globalMetfile,  &
+    redistrb,       &
+    wiltParam,      &
+    satuParam,      &
+    cable_user,     & ! additional USER switches
+    gw_params
 
   PUBLIC :: cable_driver_init
 
@@ -22,6 +90,14 @@ CONTAINS
     !the name of the namelist file
     !if not use cable.nml
     CALL get_namelist_file_name()
+
+#ifndef __MPI__
+    WRITE(*,*) "THE NAME LIST IS ", CABLE_NAMELIST
+#endif
+    ! Open, read and close the namelist file.
+    OPEN(10, FILE=CABLE_NAMELIST, STATUS="OLD", ACTION="READ")
+    READ(10, NML=CABLE)
+    CLOSE(10)
 
 #ifdef __MPI__
     CALL MPI_Init(ierr)

--- a/src/offline/cable_driver_init.F90
+++ b/src/offline/cable_driver_init.F90
@@ -1,6 +1,10 @@
 MODULE cable_driver_init_mod
   !! Module for CABLE offline driver initialisation.
   USE cable_namelist_util, ONLY : get_namelist_file_name
+#ifdef __MPI__
+  USE mpi
+  USE cable_mpicommon, ONLY : comm, rank
+#endif
   IMPLICIT NONE
   PRIVATE
 
@@ -10,6 +14,9 @@ CONTAINS
 
   SUBROUTINE cable_driver_init()
     !! Model initialisation routine for the CABLE offline driver.
+#ifdef __MPI__
+    INTEGER :: np, ierr
+#endif
 
     !check to see if first argument passed to cable is
     !the name of the namelist file
@@ -17,9 +24,16 @@ CONTAINS
     CALL get_namelist_file_name()
 
 #ifdef __MPI__
-    ! MPI specific initialisation
-#else
-    ! Serial specific initialisation
+    CALL MPI_Init(ierr)
+    CALL MPI_Comm_dup(MPI_COMM_WORLD, comm, ierr)
+    CALL MPI_Comm_size(comm, np, ierr)
+
+    IF (np < 2) THEN
+      WRITE (*,*) 'This program needs at least 2 processes to run!'
+      CALL MPI_Abort(comm, 0, ierr)
+    END IF
+
+    CALL MPI_Comm_rank(comm, rank, ierr)
 #endif
 
   END SUBROUTINE cable_driver_init

--- a/src/offline/cable_driver_init.F90
+++ b/src/offline/cable_driver_init.F90
@@ -1,3 +1,7 @@
+! CSIRO Open Source Software License Agreement (variation of the BSD / MIT License)
+! Copyright (c) 2015, Commonwealth Scientific and Industrial Research Organisation 
+! (CSIRO) ABN 41 687 119 230.
+
 MODULE cable_driver_init_mod
   !! Module for CABLE offline driver initialisation.
   USE cable_common_module, ONLY : &

--- a/src/offline/cable_mpicommon.F90
+++ b/src/offline/cable_mpicommon.F90
@@ -27,6 +27,13 @@ MODULE cable_mpicommon
 
   PUBLIC
 
+  ! MPI commicator and rank are declared as global variables (see
+  ! cable_driver_init_mod for their initialisation). This is done so that the comm
+  ! and rank variables are only accessible in cable_driver_init_mod when MPI
+  ! compilation is enabled.
+  ! TODO(Sean): revise which module to declare these variables in
+  INTEGER :: comm, rank
+
   ! base number of input fields: must correspond to CALLS to 
   ! MPI_address (field ) in *_mpimaster/ *_mpiworker
   INTEGER, PARAMETER :: nparam = 330

--- a/src/offline/cable_mpidrv.F90
+++ b/src/offline/cable_mpidrv.F90
@@ -22,27 +22,16 @@ PROGRAM mpi_driver
   USE mpi
   USE cable_driver_init_mod
 
-  USE cable_mpicommon
+  USE cable_mpicommon, ONLY : comm, rank
   USE cable_mpimaster
   USE cable_mpiworker
 
   IMPLICIT NONE
 
-  INTEGER :: comm, np, rank, ierr
+  INTEGER :: ierr
   REAL    :: etime ! Declare the type of etime()
 
   CALL cable_driver_init()
-
-  CALL MPI_Init (ierr)
-  CALL MPI_Comm_dup (MPI_COMM_WORLD, comm, ierr)
-  CALL MPI_Comm_size (comm, np, ierr)
-
-  IF (np < 2) THEN
-     WRITE (*,*) 'This program needs at least 2 processes to run!'
-     CALL MPI_Abort (comm, 0, ierr)
-  END IF
-
-  CALL MPI_Comm_rank (comm, rank, ierr)
 
   IF (rank == 0) THEN
      CALL mpidrv_master (comm)

--- a/src/offline/cable_mpidrv.F90
+++ b/src/offline/cable_mpidrv.F90
@@ -25,7 +25,6 @@ PROGRAM mpi_driver
   USE cable_mpicommon
   USE cable_mpimaster
   USE cable_mpiworker
-  USE cable_namelist_util, ONLY: get_namelist_file_name
 
   IMPLICIT NONE
 
@@ -37,11 +36,6 @@ PROGRAM mpi_driver
   CALL MPI_Init (ierr)
   CALL MPI_Comm_dup (MPI_COMM_WORLD, comm, ierr)
   CALL MPI_Comm_size (comm, np, ierr)
-
-  !check to see if first argument passed to cable is
-  !the name of the namelist file
-  !if not use cable.nml
-  CALL get_namelist_file_name()
 
   IF (np < 2) THEN
      WRITE (*,*) 'This program needs at least 2 processes to run!'

--- a/src/offline/cable_mpidrv.F90
+++ b/src/offline/cable_mpidrv.F90
@@ -20,6 +20,7 @@
 PROGRAM mpi_driver
 
   USE mpi
+  USE cable_driver_init_mod
 
   USE cable_mpicommon
   USE cable_mpimaster
@@ -31,7 +32,7 @@ PROGRAM mpi_driver
   INTEGER :: comm, np, rank, ierr
   REAL    :: etime ! Declare the type of etime()
 
-
+  CALL cable_driver_init()
 
   CALL MPI_Init (ierr)
   CALL MPI_Comm_dup (MPI_COMM_WORLD, comm, ierr)

--- a/src/offline/cable_mpimaster.F90
+++ b/src/offline/cable_mpimaster.F90
@@ -75,6 +75,17 @@
 !==============================================================================
 MODULE cable_mpimaster
 
+  USE cable_driver_init_mod, ONLY : &
+    vegparmnew,                     &
+    spinup,                         &
+    spincasa,                       &
+    l_casacnp,                      &
+    l_landuse,                      &
+    l_laiFeedbk,                    &
+    l_vcmaxFeedbk,                  &
+    delsoilM,                       &
+    delsoilT,                       &
+    delgwM
   USE cable_mpicommon
   USE casa_cable
   USE casa_inout_module
@@ -156,15 +167,15 @@ CONTAINS
 
     USE cable_def_types_mod
     USE cable_IO_vars_module, ONLY: logn,gswpfile,ncciy,leaps,globalMetfile, &
-         verbose, fixedCO2,output,check,patchout,    &
+         output,check,&
          patch_type,landpt,soilparmnew,&
          timeunits, exists, output, &
          calendar, set_group_output_values
     USE cable_common_module,  ONLY: ktau_gl, kend_gl, knode_gl, cable_user,     &
          cable_runtime, fileName,            &
-         redistrb, wiltParam, satuParam, CurYear,    &
+         CurYear,    &
          IS_LEAPYEAR, calcsoilalbedo,                &
-         kwidth_gl, gw_params
+         kwidth_gl
     USE casa_ncdf_module, ONLY: is_casa_time
     ! physical constants
     USE cable_phys_constants_mod, ONLY : CTFRZ   => TFRZ
@@ -273,24 +284,10 @@ CONTAINS
     CHARACTER             :: cyear*4
     CHARACTER             :: ncfile*99
 
-    ! declare vars for switches (default .FALSE.) etc declared thru namelist
     LOGICAL, SAVE           :: &
-         vegparmnew    = .FALSE., & ! using new format input file (BP dec 2007)
-         spinup        = .FALSE., & ! model spinup to soil state equilibrium?
          spinConv      = .FALSE., & ! has spinup converged?
-         spincasa      = .FALSE., & ! TRUE: CASA-CNP Will spin mloop times,
-         l_casacnp     = .FALSE., & ! using CASA-CNP with CABLE
-         l_landuse     = .FALSE., & ! using LANDUSE             
-         l_laiFeedbk   = .FALSE., & ! using prognostic LAI
-         l_vcmaxFeedbk = .FALSE., & ! using prognostic Vcmax
          CASAONLY      = .FALSE., & ! ONLY Run CASA-CNP
          CALL1         = .TRUE.
-
-    REAL              :: &
-         delsoilM,         & ! allowed variation in soil moisture for spin up
-         delsoilT            ! allowed variation in soil temperature for spin up
-
-    REAL :: delgwM = 1e-4
 
     ! temporary storage for soil moisture/temp. in spin up mode
     REAL, ALLOCATABLE, DIMENSION(:,:)  :: &
@@ -327,38 +324,6 @@ CONTAINS
     INTEGER :: nkend=0
     INTEGER :: ioerror=0
 
-
-    ! switches etc defined thru namelist (by default cable.nml)
-    NAMELIST/CABLE/                  &
-         filename,         & ! TYPE, containing input filenames
-         vegparmnew,       & ! use new soil param. method
-         soilparmnew,      & ! use new soil param. method
-         calcsoilalbedo,   & ! ! vars intro for Ticket #27
-         spinup,           & ! spinup model (soil) to steady state
-         delsoilM,delsoilT,& !
-         output,           &
-         patchout,         &
-         check,            &
-         verbose,          &
-         leaps,            &
-         logn,             &
-         fixedCO2,         &
-         spincasa,         &
-         l_casacnp,        &
-         l_landuse,        &
-         l_laiFeedbk,      &
-         l_vcmaxFeedbk,    &
-         icycle,           &
-         casafile,         &
-         ncciy,            &
-         gswpfile,         &
-         globalMetfile,    &
-         redistrb,         &
-         wiltParam,        &
-         satuParam,        &
-         cable_user,       &  ! additional USER switches
-         gw_params        
- 
     INTEGER :: kk,m,np,ivt
     INTEGER :: LALLOC
     INTEGER, PARAMETER :: mloop = 30   ! CASA-CNP PreSpinup loops
@@ -377,11 +342,6 @@ CONTAINS
 
 
     ! END header
-
-    ! Open, read and close the namelist file.
-    OPEN( 10, FILE = CABLE_NAMELIST, STATUS="OLD", ACTION="READ" )
-    READ( 10, NML=CABLE )   !where NML=CABLE defined above
-    CLOSE(10)
 
     ! Open, read and close the consistency check file.
     ! Check triggered by cable_user%consistency_check = .TRUE. in cable.nml

--- a/src/offline/cable_mpimaster.F90
+++ b/src/offline/cable_mpimaster.F90
@@ -204,8 +204,7 @@ CONTAINS
          PLUME_MIP_INIT
     USE CABLE_CRU,            ONLY: CRU_TYPE, CRU_GET_SUBDIURNAL_MET, CRU_INIT
 
-    USE cable_namelist_util,  ONLY : get_namelist_file_name,&
-                                     CABLE_NAMELIST
+    USE cable_namelist_util,  ONLY : CABLE_NAMELIST
 
     USE landuse_constant,     ONLY: mstate,mvmax,mharvw
     USE landuse_variable

--- a/src/offline/cable_mpiworker.F90
+++ b/src/offline/cable_mpiworker.F90
@@ -151,9 +151,8 @@ CONTAINS
     ! PLUME-MIP only
     USE CABLE_PLUME_MIP,      ONLY: PLUME_MIP_TYPE
 
-    USE cable_namelist_util, ONLY : get_namelist_file_name,&
-         CABLE_NAMELIST
-    
+    USE cable_namelist_util, ONLY : CABLE_NAMELIST
+
     USE cbl_soil_snow_init_special_module
     IMPLICIT NONE
 


### PR DESCRIPTION
Whilst looking into merging the MPI master and worker drivers (#358), @micaeljtoliveira and I have identified that the model initialisation logic is duplicated across all drivers (serial and MPI master/worker). This change adds a preliminary initialisation routine to remove code duplication and improve code clarity across each of the drivers. The remaining initialisation code in the offline drivers will be moved to this routine in later pull requests to clean up the drivers further.

## Checklist

- [x] The new content is accessible and located in the appropriate section.
- [x] I have checked that links are valid and point to the intended content.
- [x] I have checked my code/text and corrected any misspellings


<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--440.org.readthedocs.build/en/440/

<!-- readthedocs-preview cable end -->