### PR TITLE
Point API link to Ford docs directly

### DIFF
--- a/documentation/docs/developer_guide/other_resources/api.md
+++ b/documentation/docs/developer_guide/other_resources/api.md
@@ -1,3 +1,0 @@
-The API documentation for CABLE is hosted [here][API].
-
-[API]: https://cable.readthedocs.io/en/latest/api/

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -114,3 +114,4 @@ nav:
       - Obsolete and deprecated features: developer_guide/other_resources/obsolete_and_deprecated_features/obsolete_and_deprecated_features.md
   - How-to:
     - Set up a sensitivity experiment: how-to/sensitivity_exp.md      
+  - API Reference: api

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -110,7 +110,7 @@ nav:
       - Build System: developer_guide/other_resources/build_system.md
       - Cheat Sheets: developer_guide/other_resources/cheat_sheets.md
       - CABLE's release process: developer_guide/other_resources/release_process.md
-      - API documentation: developer_guide/other_resources/api.md
+      - API documentation: api
       - Obsolete and deprecated features: developer_guide/other_resources/obsolete_and_deprecated_features/obsolete_and_deprecated_features.md
   - How-to:
     - Set up a sensitivity experiment: how-to/sensitivity_exp.md      


### PR DESCRIPTION
The `api.md` page (currently https://cable.readthedocs.io/en/latest/developer_guide/other_resources/api/) does not contain any useful information. This change points the API link under Developer Guide to the Ford documentation directly and removes `api.md`.

## Type of change

- [x] New or updated documentation

## Checklist

- [x] The new content is accessible and located in the appropriate section.
- [x] I have checked that links are valid and point to the intended content.
- [x] I have checked my code/text and corrected any misspellings


<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--442.org.readthedocs.build/en/442/

<!-- readthedocs-preview cable end -->