### PR TITLE
Use NEWUNIT in almost all active OPEN statements

### DIFF
--- a/core/biogeochem/casa_inout.F90
+++ b/core/biogeochem/casa_inout.F90
@@ -178,21 +178,23 @@ contains
     REAL(r_2), DIMENSION(mvtype)       :: la_to_sa, vcmax_scalar, disturbance_interval
     REAL(r_2), DIMENSION(mvtype)       :: DAMM_EnzPool, DAMM_KMO2,DAMM_KMcp, DAMM_Ea, DAMM_alpha
     REAL(r_2), DIMENSION(mso)          :: xxkplab,xxkpsorb,xxkpocc
+    
+    INTEGER :: biomeunit
 
 
-    OPEN(101,file=casafile%cnpbiome)
+    OPEN(NEWUNIT=biomeunit,file=casafile%cnpbiome)
     DO i=1,3
-       READ(101,*)
+       READ(biomeunit,*)
     ENDDO
 
     DO nv=1,mvtype
-       READ(101,*) nv0,casabiome%ivt2(nv)
+       READ(biomeunit,*) nv0,casabiome%ivt2(nv)
     ENDDO
 
-    READ(101,*)
-    READ(101,*)
+    READ(biomeunit,*)
+    READ(biomeunit,*)
     DO nv=1,mvtype
-       READ(101,*) nv1,casabiome%kroot(nv),casabiome%rootdepth(nv),      &
+       READ(biomeunit,*) nv1,casabiome%kroot(nv),casabiome%rootdepth(nv),      &
             casabiome%kuptake(nv),casabiome%krootlen(nv),         &
             casabiome%kminN(nv), casabiome%kuplabP(nv),           &
             xfherbivore(nv),leafage(nv),woodage(nv),frootage(nv), &
@@ -203,19 +205,19 @@ contains
        !             micage(nv),slowage(nv),passage(nv)
     ENDDO
 
-    READ(101,*)
-    READ(101,*)
+    READ(biomeunit,*)
+    READ(biomeunit,*)
     DO nv=1,mvtype
-       READ(101,*) nv2, &
+       READ(biomeunit,*) nv2, &
             casabiome%fracnpptoP(nv,leaf),casabiome%fracnpptoP(nv,wood), &
             casabiome%fracnpptoP(nv,froot),casabiome%rmplant(nv,leaf),   &
             casabiome%rmplant(nv,wood),casabiome%rmplant(nv,froot)
     ENDDO
 
-    READ(101,*)
-    READ(101,*)
+    READ(biomeunit,*)
+    READ(biomeunit,*)
     DO nv=1,mvtype
-       READ(101,*) nv2, ratioCNplant(nv,leaf),ratioCNplant(nv,wood),   &
+       READ(biomeunit,*) nv2, ratioCNplant(nv,leaf),ratioCNplant(nv,wood),   &
             ratioCNplant(nv,froot),                                         &
             casabiome%ftransNPtoL(nv,leaf), casabiome%ftransNPtoL(nv,wood), &
             casabiome%ftransNPtoL(nv,froot),                                &
@@ -229,50 +231,50 @@ contains
             casabiome%glaimax(nv),casabiome%glaimin(nv)
     ENDDO
 
-    READ(101,*)
-    READ(101,*)
+    READ(biomeunit,*)
+    READ(biomeunit,*)
     DO nv=1,mvtype
-       READ(101,*) nv3, cleaf(nv),cwood(nv),cfroot(nv),cmet(nv),   &
+       READ(biomeunit,*) nv3, cleaf(nv),cwood(nv),cfroot(nv),cmet(nv),   &
             cstr(nv),ccwd(nv), cmic(nv), cslow(nv),cpass(nv)
     ENDDO
 
-    READ(101,*)
-    READ(101,*)
+    READ(biomeunit,*)
+    READ(biomeunit,*)
     DO nv=1,mvtype
-       READ(101,*) nv4, &
+       READ(biomeunit,*) nv4, &
             phen%TKshed(nv),xxkleafcoldmax(nv),casabiome%xkleafcoldexp(nv), &
             xxkleafdrymax(nv),casabiome%xkleafdryexp(nv)
     ENDDO
-    !  READ(101,*)
-    !  READ(101,*)
+    !  READ(biomeunit,*)
+    !  READ(biomeunit,*)
     !  DO nv=1,mvtype
-    !    READ(101,*) nv5, &
+    !    READ(biomeunit,*) nv5, &
     !         xxkleafcoldmax(nv),casabiome%xkleafcoldexp(nv),   &
     !         xxkleafdrymax(nv),casabiome%xkleafdryexp(nv)
     !  ENDDO
 
-    READ(101,*)
-    READ(101,*)
+    READ(biomeunit,*)
+    READ(biomeunit,*)
     DO nv=1,mvtype
-       READ(101,*) nv6, &
+       READ(biomeunit,*) nv6, &
             casabiome%ratioNCplantmin(nv,leaf),casabiome%ratioNCplantmax(nv,leaf), &
             casabiome%ratioNCplantmin(nv,wood),casabiome%ratioNCplantmax(nv,wood), &
             casabiome%ratioNCplantmin(nv,froot),casabiome%ratioNCplantmax(nv,froot), &
             xfNminloss(nv), xfNminleach(nv),xnfixrate(nv)
     ENDDO
 
-    READ(101,*)
-    READ(101,*)
+    READ(biomeunit,*)
+    READ(biomeunit,*)
     DO nv=1,mvtype
-       READ(101,*) nv7,nleaf(nv),nwood(nv),nfroot(nv), &
+       READ(biomeunit,*) nv7,nleaf(nv),nwood(nv),nfroot(nv), &
             nmet(nv),nstr(nv), ncwd(nv), &
             nmic(nv),nslow(nv),npass(nv),xnsoilmin(nv)
     ENDDO
 
-    READ(101,*)
-    READ(101,*)
+    READ(biomeunit,*)
+    READ(biomeunit,*)
     DO nv=1,mvtype
-       READ(101,*) nv8,xratioNPleafmin,xratioNPleafmax,      &
+       READ(biomeunit,*) nv8,xratioNPleafmin,xratioNPleafmax,      &
             xratioNPwoodmin,xratioNPwoodmax,                      &
             xratioNPfrootmin,xratioNPfrootmax,                    &
             casabiome%ftransPPtoL(nv,leaf), casabiome%ftransPPtoL(nv,wood), &
@@ -294,44 +296,44 @@ contains
 
     ENDDO
 
-    READ(101,*)
-    READ(101,*)
+    READ(biomeunit,*)
+    READ(biomeunit,*)
     DO iso=1,mso
-       READ(101,*) nv9,xkmlabp(iso),xpsorbmax(iso),xfPleach(iso), &
+       READ(biomeunit,*) nv9,xkmlabp(iso),xpsorbmax(iso),xfPleach(iso), &
             ratioNPsoil(iso,mic),ratioNPsoil(iso,slow),ratioNPsoil(iso,pass), &
             xxkplab(iso),xxkpsorb(iso),xxkpocc(iso)
     ENDDO
-    READ(101,*)
-    READ(101,*)
+    READ(biomeunit,*)
+    READ(biomeunit,*)
     DO nv=1,mvtype
-       READ(101,*) nv10, &
+       READ(biomeunit,*) nv10, &
             xpleaf(nv),xpwood(nv),xpfroot(nv),xpmet(nv),xpstr(nv),xpcwd(nv), &
             xpmic(nv),xpslow(nv),xppass(nv),xplab(nv),xpsorb(nv),xpocc(nv)
     ENDDO
 
-    READ(101,*)
-    READ(101,*)
+    READ(biomeunit,*)
+    READ(biomeunit,*)
     DO nv=1,mvtype
-       READ(101,*) nv11, &
+       READ(biomeunit,*) nv11, &
             xxnpmax(nv),xq10soil(nv),xxkoptlitter(nv),xxkoptsoil(nv),xprodptase(nv), &
             xcostnpup(nv),xmaxfinelitter(nv),xmaxcwd(nv),xnintercept(nv),xnslope(nv)
     ENDDO
 
-    READ(101,*)
-    READ(101,*)
+    READ(biomeunit,*)
+    READ(biomeunit,*)
     DO nv=1,mvtype
-       READ(101,*) nv12, &
+       READ(biomeunit,*) nv12, &
             la_to_sa(nv),disturbance_interval(nv),vcmax_scalar(nv)
     ENDDO
 
-    READ(101,*)
-    READ(101,*)
+    READ(biomeunit,*)
+    READ(biomeunit,*)
     DO nv=1,mvtype
-       READ(101,*) nv13, &
+       READ(biomeunit,*) nv13, &
             DAMM_EnzPool(nv), DAMM_KMO2(nv),DAMM_KMcp(nv), DAMM_Ea(nv), DAMM_alpha(nv)
     ENDDO
 
-    CLOSE(101)
+    CLOSE(biomeunit)
 
     fracroot   = 0.0_r_2
     depthsoila = 0.0_r_2
@@ -514,17 +516,19 @@ contains
     INTEGER, DIMENSION(npheno)     :: ivtx
     REAL(r_2), DIMENSION(271)      :: xlat
 
+    INTEGER :: phenunit
+
     ! initilize for evergreen PFTs
     greenup(:,:) = -50
     fall(:,:)    = 367
     phendoy1(:,:)= 2
 
-    OPEN(101, file=casafile%phen)
-    READ(101, *)
-    READ(101, *) (ivtx(nx), nx=1, npheno) ! fixed at 10, as only 10 of 17 IGBP PFT
+    OPEN(phenunit, file=casafile%phen)
+    READ(phenunit, *)
+    READ(phenunit, *) (ivtx(nx), nx=1, npheno) ! fixed at 10, as only 10 of 17 IGBP PFT
     ! have seasonal leaf phenology
     DO ilat=271,1,-1
-       READ(101,*) xlat(ilat), (greenupx(nx), nx=1, npheno), &
+       READ(phenunit,*) xlat(ilat), (greenupx(nx), nx=1, npheno), &
             (fallx(nx), nx=1, npheno), (xphendoy1(nx), nx=1, npheno)
        DO nx=1, npheno
           greenup(ilat,ivtx(nx)) = greenupx(nx)
@@ -533,7 +537,7 @@ contains
        ENDDO
     ENDDO
 
-    CLOSE(101)
+    CLOSE(phenunit)
 
     DO np=1,mp
        ilat = nint((casamet%lat(np)+55.25)/0.5)+1

--- a/core/biogeophys/cable_common.F90
+++ b/core/biogeophys/cable_common.F90
@@ -331,8 +331,9 @@ CONTAINS
     integer :: ierr
 #endif
 
+    INTEGER :: vegunit, soilunit
     !================= Read in vegetation type specifications: ============
-    OPEN(40, FILE=trim(filename%veg), STATUS='old', ACTION='READ', IOSTAT=ioerror)
+    OPEN(NEWUNIT=vegunit, FILE=trim(filename%veg), STATUS='old', ACTION='READ', IOSTAT=ioerror)
 
     IF(ioerror/=0) then
        write(*,*) 'CABLE_log: Cannot open veg type definitions.'
@@ -345,17 +346,17 @@ CONTAINS
 
     IF (vegparmnew) THEN
        ! assume using IGBP/CSIRO vegetation types
-       READ(40,*) comments
-       READ(40,*) mvtype
+       READ(vegunit,*) comments
+       READ(vegunit,*) mvtype
        IF (present(classification)) WRITE(classification,'(a4)') comments(1:4)
     ELSE
        ! assume using CASA vegetation types
        !classification = 'CASA'
-       READ(40,*)
-       READ(40,*)
-       READ(40,*) mvtype ! read # vegetation types
-       READ(40,*)
-       READ(40,*)
+       READ(vegunit,*)
+       READ(vegunit,*)
+       READ(vegunit,*) mvtype ! read # vegetation types
+       READ(vegunit,*)
+       READ(vegunit,*)
        comments = 'CASA'
     END IF
 
@@ -398,7 +399,7 @@ CONTAINS
        ! Read in parameter values for each vegetation type:
        DO a = 1,mvtype
 
-          READ(40,*) jveg, vegtypetmp, vegnametmp
+          READ(vegunit,*) jveg, vegtypetmp, vegnametmp
 
           IF ( jveg .GT. mvtype ) then
              write(*,*) 'jveg out of range in parameter file'
@@ -411,80 +412,80 @@ CONTAINS
 
           veg_desc(jveg) = vegnametmp
 
-          READ(40,*) vegin%hc(jveg), vegin%xfang(jveg), vegin%width(jveg),   &
+          READ(vegunit,*) vegin%hc(jveg), vegin%xfang(jveg), vegin%width(jveg),   &
                vegin%length(jveg), vegin%frac4(jveg)
           ! only refl(1:2) and taul(1:2) used
-          READ(40,*) vegin%refl(1:3,jveg) ! rhowood not used ! BP may2011
-          READ(40,*) vegin%taul(1:3,jveg) ! tauwood not used ! BP may2011
-          READ(40,*) notused, notused, notused, vegin%xalbnir(jveg)
-          READ(40,*) notused, vegin%wai(jveg), vegin%canst1(jveg),           &
+          READ(vegunit,*) vegin%refl(1:3,jveg) ! rhowood not used ! BP may2011
+          READ(vegunit,*) vegin%taul(1:3,jveg) ! tauwood not used ! BP may2011
+          READ(vegunit,*) notused, notused, notused, vegin%xalbnir(jveg)
+          READ(vegunit,*) notused, vegin%wai(jveg), vegin%canst1(jveg),           &
                vegin%shelrb(jveg), vegin%vegcf(jveg), vegin%extkn(jveg)
 
-          READ(40,*) vegin%vcmax(jveg), vegin%rp20(jveg),                    &
+          READ(vegunit,*) vegin%vcmax(jveg), vegin%rp20(jveg),                    &
                vegin%rpcoef(jveg),                                     &
                vegin%rs20(jveg)
-          READ(40,*) vegin%tminvj(jveg), vegin%tmaxvj(jveg),                 &
+          READ(vegunit,*) vegin%tminvj(jveg), vegin%tmaxvj(jveg),                 &
                vegin%vbeta(jveg), vegin%rootbeta(jveg),                      &
                vegin%zr(jveg), vegin%clitt(jveg)
-          READ(40,*) vegin%cplant(1:3,jveg), vegin%csoil(1:2,jveg)
+          READ(vegunit,*) vegin%cplant(1:3,jveg), vegin%csoil(1:2,jveg)
           ! rates not currently set to vary with veg type
-          READ(40,*) vegin%ratecp(1:3,jveg), vegin%ratecs(1:2,jveg)
-          READ(40,*) vegin%a1gs(jveg), vegin%d0gs(jveg), vegin%alpha(jveg), vegin%convex(jveg), vegin%cfrd(jveg)
-          READ(40,*) vegin%gswmin(jveg), vegin%conkc0(jveg), vegin%conko0(jveg), vegin%ekc(jveg), vegin%eko(jveg)
-          READ(40,*) vegin%g0(jveg), vegin%g1(jveg)      ! Ticket #56
-          READ(40,*) vegin%gamma(jveg), vegin%gmmax(jveg)
+          READ(vegunit,*) vegin%ratecp(1:3,jveg), vegin%ratecs(1:2,jveg)
+          READ(vegunit,*) vegin%a1gs(jveg), vegin%d0gs(jveg), vegin%alpha(jveg), vegin%convex(jveg), vegin%cfrd(jveg)
+          READ(vegunit,*) vegin%gswmin(jveg), vegin%conkc0(jveg), vegin%conko0(jveg), vegin%ekc(jveg), vegin%eko(jveg)
+          READ(vegunit,*) vegin%g0(jveg), vegin%g1(jveg)      ! Ticket #56
+          READ(vegunit,*) vegin%gamma(jveg), vegin%gmmax(jveg)
        END DO
 
     ELSE
 
        DO a = 1,mvtype
-          READ(40,'(8X,A70)') veg_desc(a) ! Read description of each veg type
+          READ(vegunit,'(8X,A70)') veg_desc(a) ! Read description of each veg type
        END DO
 
-       READ(40,*); READ(40,*)
-       READ(40,*) vegin%canst1
-       READ(40,*) vegin%width
-       READ(40,*) vegin%length
-       READ(40,*) vegin%vcmax
-       READ(40,*) vegin%hc
-       READ(40,*) vegin%xfang
-       READ(40,*) vegin%rp20
-       READ(40,*) vegin%rpcoef
-       READ(40,*) vegin%rs20
-       READ(40,*) vegin%shelrb
-       READ(40,*) vegin%frac4
-       READ(40,*) vegin%wai
-       READ(40,*) vegin%vegcf
-       READ(40,*) vegin%extkn
-       READ(40,*) vegin%tminvj
-       READ(40,*) vegin%tmaxvj
-       READ(40,*) vegin%vbeta
-       READ(40,*) vegin%xalbnir
-       READ(40,*) vegin%rootbeta
-       READ(40,*) vegin%cplant(1,:)
-       READ(40,*) vegin%cplant(2,:)
-       READ(40,*) vegin%cplant(3,:)
-       READ(40,*) vegin%csoil(1,:)
-       READ(40,*) vegin%csoil(2,:)
-       READ(40,*)
-       READ(40,*) vegin%ratecp(:,1)
-       READ(40,*) vegin%a1gs
-       READ(40,*) vegin%d0gs
-       READ(40,*) vegin%alpha
-       READ(40,*) vegin%convex
-       READ(40,*) vegin%cfrd
-       READ(40,*) vegin%gswmin
-       READ(40,*) vegin%conkc0
-       READ(40,*) vegin%conko0
-       READ(40,*) vegin%ekc
-       READ(40,*) vegin%eko
+       READ(vegunit,*); READ(vegunit,*)
+       READ(vegunit,*) vegin%canst1
+       READ(vegunit,*) vegin%width
+       READ(vegunit,*) vegin%length
+       READ(vegunit,*) vegin%vcmax
+       READ(vegunit,*) vegin%hc
+       READ(vegunit,*) vegin%xfang
+       READ(vegunit,*) vegin%rp20
+       READ(vegunit,*) vegin%rpcoef
+       READ(vegunit,*) vegin%rs20
+       READ(vegunit,*) vegin%shelrb
+       READ(vegunit,*) vegin%frac4
+       READ(vegunit,*) vegin%wai
+       READ(vegunit,*) vegin%vegcf
+       READ(vegunit,*) vegin%extkn
+       READ(vegunit,*) vegin%tminvj
+       READ(vegunit,*) vegin%tmaxvj
+       READ(vegunit,*) vegin%vbeta
+       READ(vegunit,*) vegin%xalbnir
+       READ(vegunit,*) vegin%rootbeta
+       READ(vegunit,*) vegin%cplant(1,:)
+       READ(vegunit,*) vegin%cplant(2,:)
+       READ(vegunit,*) vegin%cplant(3,:)
+       READ(vegunit,*) vegin%csoil(1,:)
+       READ(vegunit,*) vegin%csoil(2,:)
+       READ(vegunit,*)
+       READ(vegunit,*) vegin%ratecp(:,1)
+       READ(vegunit,*) vegin%a1gs
+       READ(vegunit,*) vegin%d0gs
+       READ(vegunit,*) vegin%alpha
+       READ(vegunit,*) vegin%convex
+       READ(vegunit,*) vegin%cfrd
+       READ(vegunit,*) vegin%gswmin
+       READ(vegunit,*) vegin%conkc0
+       READ(vegunit,*) vegin%conko0
+       READ(vegunit,*) vegin%ekc
+       READ(vegunit,*) vegin%eko
 
        ! Set ratecp to be the same for all veg types:
        vegin%ratecp(1,:)=vegin%ratecp(1,1)
        vegin%ratecp(2,:)=vegin%ratecp(2,1)
        vegin%ratecp(3,:)=vegin%ratecp(3,1)
-       READ(40,*)
-       READ(40,*) vegin%ratecs(:,1)
+       READ(vegunit,*)
+       READ(vegunit,*) vegin%ratecs(:,1)
        vegin%ratecs(1,:)=vegin%ratecs(1,1)
        vegin%ratecs(2,:)=vegin%ratecs(2,1)
 
@@ -496,20 +497,20 @@ CONTAINS
        vegin%refl(2,:) = 0.425
        vegin%refl(3,:) = 0.0
 
-       READ(40,*) vegin%g0 ! Ticket #56
-       READ(40,*) vegin%g1 ! Ticket #56
+       READ(vegunit,*) vegin%g0 ! Ticket #56
+       READ(vegunit,*) vegin%g1 ! Ticket #56
 
     ENDIF
 
     WRITE(6,*)'CABLE_log:Closing veg params file: ',trim(filename%veg)
 
-    CLOSE(40)
+    CLOSE(vegunit)
 
     ! new calculation dleaf since April 2012 (cable v1.8 did not use width)
     vegin%dleaf = SQRT(vegin%width * vegin%length)
 
     !================= Read in soil type specifications: ============
-    OPEN(40, FILE=trim(filename%soil), STATUS='old', ACTION='READ', IOSTAT=ioerror)
+    OPEN(soilunit, FILE=trim(filename%soil), STATUS='old', ACTION='READ', IOSTAT=ioerror)
 
     IF(ioerror/=0) then
        write(*,*) 'CABLE_log: Cannot open soil type definitions.'
@@ -520,9 +521,9 @@ CONTAINS
 #endif
     ENDIF
 
-    READ(40,*); READ(40,*)
-    READ(40,*) mstype ! Number of soil types
-    READ(40,*); READ(40,*)
+    READ(soilunit,*); READ(soilunit,*)
+    READ(soilunit,*) mstype ! Number of soil types
+    READ(soilunit,*); READ(soilunit,*)
 
     ALLOCATE ( soil_desc(mstype) )
     ALLOCATE ( soilin%silt(mstype), soilin%clay(mstype), soilin%sand(mstype) )
@@ -531,23 +532,23 @@ CONTAINS
     ALLOCATE ( soilin%rhosoil(mstype), soilin%css(mstype) )
 
     DO a = 1,mstype
-       READ(40,'(8X,A70)') soil_desc(a) ! Read description of each soil type
+       READ(soilunit,'(8X,A70)') soil_desc(a) ! Read description of each soil type
     END DO
 
-    READ(40,*); READ(40,*)
-    READ(40,*) soilin%silt
-    READ(40,*) soilin%clay
-    READ(40,*) soilin%sand
-    READ(40,*) soilin%swilt
-    READ(40,*) soilin%sfc
-    READ(40,*) soilin%ssat
-    READ(40,*) soilin%bch
-    READ(40,*) soilin%hyds
-    READ(40,*) soilin%sucs
-    READ(40,*) soilin%rhosoil
-    READ(40,*) soilin%css
+    READ(soilunit,*); READ(soilunit,*)
+    READ(soilunit,*) soilin%silt
+    READ(soilunit,*) soilin%clay
+    READ(soilunit,*) soilin%sand
+    READ(soilunit,*) soilin%swilt
+    READ(soilunit,*) soilin%sfc
+    READ(soilunit,*) soilin%ssat
+    READ(soilunit,*) soilin%bch
+    READ(soilunit,*) soilin%hyds
+    READ(soilunit,*) soilin%sucs
+    READ(soilunit,*) soilin%rhosoil
+    READ(soilunit,*) soilin%css
 
-    CLOSE(40)
+    CLOSE(soilunit)
 
     ! ! MCtest
     ! !     sed -e 's|.*cable|\&cable|' -e 's|=[ ]\{1,100\}|=|' \
@@ -924,14 +925,16 @@ CONTAINS
 
     INTEGER :: icable_rev, ioerror
 
+    INTEGER :: revunit
+
     CALL getenv("HOME", myhome)
     fcablerev = TRIM(myhome)//TRIM("/.cable_rev")
 
-    OPEN(440, FILE=TRIM(fcablerev), STATUS='old', ACTION='READ', IOSTAT=ioerror)
+    OPEN(revunit, FILE=TRIM(fcablerev), STATUS='old', ACTION='READ', IOSTAT=ioerror)
 
     IF(ioerror==0) then
        ! get svn revision number (see WRITE comments)
-       READ(440,*) icable_rev
+       READ(revunit,*) icable_rev
     ELSE
        icable_rev = 0 !default initialization
        write(*,'(a)') "We'll keep running but the generated revision number in the log & file will be meaningless."
@@ -951,7 +954,7 @@ CONTAINS
     WRITE(logn,*) 'SVN STATUS indicates that you have (at least) the following'
     WRITE(logn,*) 'local changes: '
     IF(ioerror==0) then
-       READ(440,'(A)',IOSTAT=ioerror) icable_status
+       READ(revunit,'(A)',IOSTAT=ioerror) icable_status
        WRITE(logn,*) TRIM(icable_status)
        WRITE(logn,*) ''
     else
@@ -959,7 +962,7 @@ CONTAINS
        WRITE(logn,*) ''
     endif
 
-    CLOSE(440)
+    CLOSE(revunit)
 
   END SUBROUTINE report_version_no
 

--- a/core/biogeophys/cable_diag.F90
+++ b/core/biogeophys/cable_diag.F90
@@ -105,7 +105,7 @@ SUBROUTINE cable_diag_desc1( iDiag, filename, dimx, dimy, vname1 )
    character(len=*), intent(in) :: filename, vname1
    integer, save :: gopenstatus = 1
 
-     open(NEWUNIT=iDiag,file=filename//'.dat', status="replace", &
+     open(unit=iDiag,file=filename//'.dat', status="replace", &
           action="write", iostat=gopenstatus )
 
       if(gopenstatus==gok) then

--- a/core/biogeophys/cable_diag.F90
+++ b/core/biogeophys/cable_diag.F90
@@ -105,7 +105,7 @@ SUBROUTINE cable_diag_desc1( iDiag, filename, dimx, dimy, vname1 )
    character(len=*), intent(in) :: filename, vname1
    integer, save :: gopenstatus = 1
 
-     open(unit=iDiag,file=filename//'.dat', status="replace", &
+     open(NEWUNIT=iDiag,file=filename//'.dat', status="replace", &
           action="write", iostat=gopenstatus )
 
       if(gopenstatus==gok) then

--- a/core/blaze/simfire.F90
+++ b/core/blaze/simfire.F90
@@ -299,7 +299,7 @@ SUBROUTINE GET_POPDENS ( SF, YEAR )
         STOP -1
      END IF
 
-     OPEN(iu, FILE=TRIM(FNAME), ACTION="READ", STATUS="OLD")
+     OPEN(NEWUNIT=iu, FILE=TRIM(FNAME), ACTION="READ", STATUS="OLD")
      ! Skip header
      DO i = 1, 6
         READ(iu,*)
@@ -376,7 +376,7 @@ SUBROUTINE GET_POPDENS ( SF, YEAR )
            STOP -1
         ENDIF
 
-        OPEN(iu, FILE=TRIM(FNAME), ACTION="READ", STATUS="OLD")
+        OPEN(NEWUNIT=iu, FILE=TRIM(FNAME), ACTION="READ", STATUS="OLD")
         ! Skip header
         DO i = 1, 6
            READ(iu,*)

--- a/offline/cable_driver.F90
+++ b/offline/cable_driver.F90
@@ -279,6 +279,8 @@ PROGRAM cable_offline_driver
   !___ unique unit/file identifiers for cable_diag: arbitrarily 5 here
   integer :: iDiagZero=0
 
+  INTEGER :: Ftrunk_unit, Fnew_unit
+
   ! switches etc defined thru namelist (by default cable.nml)
   namelist /cablenml/ &
        filename, &       ! TYPE, containing input filenames

--- a/offline/cable_driver.F90
+++ b/offline/cable_driver.F90
@@ -293,7 +293,6 @@ PROGRAM cable_offline_driver
        check, &
        verbose, &
        leaps, &
-       logn, &
        fixedCO2, &
        spincasainput, &
        spincasa, &
@@ -344,15 +343,16 @@ PROGRAM cable_offline_driver
   ! Open, read and close the consistency check file.
   ! Check triggered by cable_user%consistency_check = .TRUE. in cable.nml
   if (cable_user%consistency_check) then
-     open(11, file=Ftrunk_sumbal, status='old', action='READ', iostat=ioerror)
+     open(NEWUNIT=Ftrunk_unit, file=Ftrunk_sumbal, status='old', action='READ',&
+       iostat=ioerror)
      if (ioerror==0) then
-        read(11,*) trunk_sumbal  ! written by previous trunk version
+        read(Ftrunk_unit,*) trunk_sumbal  ! written by previous trunk version
      end if
-     close(11)
+     close(Ftrunk_unit)
   end if
 
   ! Open log file:
-  open(logn, file=filename%log)
+  open(NEWUNIT=logn, file=filename%log)
 
   call report_version_no(logn)
 
@@ -483,9 +483,8 @@ PROGRAM cable_offline_driver
   ! Read atmospheric delta-13C values
   if (cable_user%c13o2) then
      ! get start and end year
-     call get_unit(iunit)
-     open(iunit, file=trim(cable_user%c13o2_delta_atm_file), status="old", &
-          action="read")
+     open(NEWUNIT=iunit, file=trim(cable_user%c13o2_delta_atm_file),&
+       status="old", action="read")
      read(iunit, fmt=*, iostat=ios) header
      read(iunit, fmt=*, iostat=ios) iyear
      c13o2_atm_syear = floor(iyear)
@@ -1285,9 +1284,9 @@ PROGRAM cable_offline_driver
                        write(*,*) "NB. Offline-serial runs spinup cycles:", nkend
                        write(*,*) "Internal check shows in this version new_sumbal != trunk sumbal"
                        write(*,*) "Writing new_sumbal to the file:", trim(Fnew_sumbal)
-                       open(12, file=Fnew_sumbal)
-                       write(12, '(F20.7)') new_sumbal  ! written by previous trunk version
-                       close(12)
+                       open(NEWUNIT=Fnew_unit, file=Fnew_sumbal)
+                       write(Fnew_unit, '(F20.7)') new_sumbal  ! written by previous trunk version
+                       close(Fnew_unit)
                     end if
                  end if
 

--- a/offline/cable_input.F90
+++ b/offline/cable_input.F90
@@ -2978,9 +2978,6 @@ SUBROUTINE prepare_spatiotemporal_dataset(FileTemplate, Dataset)
   ! Iterators
   INTEGER           :: FileIndx
 
-  ! Get a unique file ID here.
-  CALL get_unit(InputUnit)
-
   ! First thing we have to do is determine the location of the <startdate>
   ! and <enddate> strings in the supplied filenames. To do that, we compare
   ! substrings of the relevant length, with the substring moving along the
@@ -3028,7 +3025,7 @@ SUBROUTINE prepare_spatiotemporal_dataset(FileTemplate, Dataset)
   ! the year ranges for each file as described in the opening preamble to
   ! this subroutine.
 
-  OPEN(InputUnit, FILE = "__FileNameWithNoClashes__.txt", IOSTAT = ios)
+  OPEN(NEWUNIT=InputUnit, FILE = "__FileNameWithNoClashes__.txt", IOSTAT = ios)
 
   ! Now iterate through this temporary file and check how many files are in the
   ! dataset, so we can allocate memory in the SpatioTemporalDataset


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

Extend the use of the ```NEWUNIT=``` specifier for acquiring io units to the rest of the active ```OPEN``` calls in the code. There is one exception, in the calls found within ```core/biogeophys/cable_diag.F90```. The units are handled a bit strangely here, with one being defined dependent on the other. Looks like it might interact with the UM coupling in a specific way, so I've left it as is at the moment.

Fixes #455 

## Type of change

- Fortran standards update

## Checklist

- [ ] The new content is accessible and located in the appropriate section.
- [ ] I have checked that links are valid and point to the intended content.
- [ ] I have checked my code/text and corrected any misspellings
