### PR TITLE
Initialise `ssnow` variables in mpiworker

### DIFF
--- a/src/offline/cable_mpiworker.F90
+++ b/src/offline/cable_mpiworker.F90
@@ -377,6 +377,7 @@ CONTAINS
           ssnow%otss     = ssnow%tgg(:,1)
           ssnow%rtevap_sat(:) = 0.0
           ssnow%rtevap_unsat(:) = 0.0
+          ssnow%qrecharge(:) = 0.0
           canopy%fes_cor = 0.
           canopy%fhs_cor = 0.
           met%ofsd = 0.1

--- a/src/offline/cable_mpiworker.F90
+++ b/src/offline/cable_mpiworker.F90
@@ -375,6 +375,8 @@ CONTAINS
 
           ssnow%otss_0   = ssnow%tgg(:,1)
           ssnow%otss     = ssnow%tgg(:,1)
+          ssnow%rtevap_sat(:) = 0.0
+          ssnow%rtevap_unsat(:) = 0.0
           canopy%fes_cor = 0.
           canopy%fhs_cor = 0.
           met%ofsd = 0.1


### PR DESCRIPTION
Variables `ssnow%rtevap_sat`, `ssnow%rtevap_unsat` and  `ssnow%qrecharge` are uninitialised in all MPI worker processes and crashes the model when runtime memory checks are enabled (see #397 for more details). These variables are specifically initialised (to zero) in cable_parameters.F90 for the serial case (and for the MPI master process). Rather than communicating the initialised variables from master to worker, this change initialises the variables in the worker directly.

Although we plan to deprecate the MPI drivers in the future, this change will still be useful when comparing the behaviour of MPI vs serial during development.

Fixes #397

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## Checklist

- [x] I have checked my code/text and corrected any misspellings

<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--471.org.readthedocs.build/en/471/

<!-- readthedocs-preview cable end -->