### PR TITLE
First pass at adding POP namelist

### DIFF
--- a/offline/cable_input.F90
+++ b/offline/cable_input.F90
@@ -2580,6 +2580,17 @@ SUBROUTINE load_parameters(met, air, ssnow, veg, bgc, soil, canopy, rough, rad, 
             ENDIF
          ENDDO
 
+         ! The parameters veg%disturbance_interval and veg%disturbance_intensity
+         ! are intended to part of the tunable parameters for POP. We don't want
+         ! to expose the veg type to the POP routines directly, but still have
+         ! them modifiable via namelist, so we call the namelist reading
+         ! routine here. Unfortunately, all the POP parameters exist in a POP
+         ! module, so we're going to do a bit of modifying module data and a bit
+         ! of modifying argument data. This is far from a perfect solution, but
+         ! an acceptable temporary one.
+         CALL read_POP_namelist(veg%disturbance_interval,&
+           veg%disturbance_intensity)
+
          CALL POP_init(POP, veg%disturbance_interval(Iwood,:), mp_POP, Iwood)
          IF (.NOT. (spinup .OR. CABLE_USER%POP_fromZero)) &
               CALL POP_IO(POP, casamet, cable_user%YearStart, "READ_RST", .TRUE.)


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

@juergenknauer @har917 

Making the POP parameters configurable via namelist. At the moment, I've made everything bar ```PI``` and ```EPS``` changable via the namelist, but discussions with @juergenknauer suggest that this probably isn't wise. Opening this PR now to prompt discussions. Some things that have been discussed:

* Some declared variables are unused: ```Q```, ```N_EXTENT```, ```NAGE_MAX```, ```NPATCH1D```, ```TIMEBASE_FACTOR```, ```AGEMAX```. Will be removed unless good arguments can be made otherwise.
* ```NLAYERS``` should be restricted to 1. Currently there is machinery for including multiple layers (although I can't find what these "layers" represent in Vanessa's original publication), but I think all layers will contain identical data. Will this be extended in future?
* How does the existing configuration interact with ```POPLUC``` and ```BLAZE```? What do we need to be careful of? It looks to me like it's quite self-contained, with the variables coming in from the "main" CABLE being ```veg%disturbance_frequency``` and ```veg%disturbance_intensity```, which I assume may also be set via ```BLAZE```?

Also, please ping anyone else that would have input on this that I haven't mentioned.

## Type of change

Please delete options that are not relevant.

- [] Enhancement
