### PR TITLE
Fix to groundwater parameter initialisations that can impact the soil conductivity

### DIFF
--- a/src/offline/cable_mpicommon.F90
+++ b/src/offline/cable_mpicommon.F90
@@ -29,7 +29,7 @@ MODULE cable_mpicommon
 
   ! base number of input fields: must correspond to CALLS to 
   ! MPI_address (field ) in *_mpimaster/ *_mpiworker
-  INTEGER, PARAMETER :: nparam = 330
+  INTEGER, PARAMETER :: nparam = 340
    
   ! MPI: extra params sent only if nsoilparmnew is true
   INTEGER, PARAMETER :: nsoilnew = 1

--- a/src/offline/cable_mpimaster.F90
+++ b/src/offline/cable_mpimaster.F90
@@ -3183,6 +3183,66 @@ CONTAINS
             &                             types(bidx), ierr)
        blen(bidx) = 1
 
+       bidx = bidx + 1
+       CALL MPI_Get_address (soil%zse_vec(off,1), displs(bidx), ierr)
+       CALL MPI_Type_create_hvector (ms, r2len, r2stride, MPI_BYTE, &
+            &                             types(bidx), ierr)
+       blen(bidx) = 1
+
+       bidx = bidx + 1
+       CALL MPI_Get_address (soil%css_vec(off,1), displs(bidx), ierr)
+       CALL MPI_Type_create_hvector (ms, r2len, r2stride, MPI_BYTE, &
+            &                             types(bidx), ierr)
+       blen(bidx) = 1
+
+       bidx = bidx + 1
+       CALL MPI_Get_address (soil%cnsd_vec(off,1), displs(bidx), ierr)
+       CALL MPI_Type_create_hvector (ms, r2len, r2stride, MPI_BYTE, &
+            &                             types(bidx), ierr)
+       blen(bidx) = 1
+
+       bidx = bidx + 1
+       CALL MPI_Get_address (soil%clay_vec(off,1), displs(bidx), ierr)
+       CALL MPI_Type_create_hvector (ms, r2len, r2stride, MPI_BYTE, &
+            &                             types(bidx), ierr)
+       blen(bidx) = 1
+
+       bidx = bidx + 1
+       CALL MPI_Get_address (soil%sand_vec(off,1), displs(bidx), ierr)
+       CALL MPI_Type_create_hvector (ms, r2len, r2stride, MPI_BYTE, &
+            &                             types(bidx), ierr)
+       blen(bidx) = 1
+
+       bidx = bidx + 1
+       CALL MPI_Get_address (soil%silt_vec(off,1), displs(bidx), ierr)
+       CALL MPI_Type_create_hvector (ms, r2len, r2stride, MPI_BYTE, &
+            &                             types(bidx), ierr)
+       blen(bidx) = 1
+
+       bidx = bidx + 1
+       CALL MPI_Get_address (soil%org_vec(off,1), displs(bidx), ierr)
+       CALL MPI_Type_create_hvector (ms, r2len, r2stride, MPI_BYTE, &
+            &                             types(bidx), ierr)
+       blen(bidx) = 1
+
+       bidx = bidx + 1
+       CALL MPI_Get_address (soil%rhosoil_vec(off,1), displs(bidx), ierr)
+       CALL MPI_Type_create_hvector (ms, r2len, r2stride, MPI_BYTE, &
+            &                             types(bidx), ierr)
+       blen(bidx) = 1
+
+       bidx = bidx + 1
+       CALL MPI_Get_address (soil%smpc_vec(off,1), displs(bidx), ierr)
+       CALL MPI_Type_create_hvector (ms, r2len, r2stride, MPI_BYTE, &
+            &                             types(bidx), ierr)
+       blen(bidx) = 1
+
+       bidx = bidx + 1
+       CALL MPI_Get_address (soil%wbc_vec(off,1), displs(bidx), ierr)
+       CALL MPI_Type_create_hvector (ms, r2len, r2stride, MPI_BYTE, &
+            &                             types(bidx), ierr)
+       blen(bidx) = 1
+
 
        !1D
        bidx = bidx + 1

--- a/src/offline/cable_mpiworker.F90
+++ b/src/offline/cable_mpiworker.F90
@@ -2263,6 +2263,46 @@ CONTAINS
     bidx = bidx + 1
     CALL MPI_Get_address (soil%sfc_vec, displs(bidx), ierr)
     blen(bidx) = ms * r2len
+ 
+    bidx = bidx + 1
+    CALL MPI_Get_address (soil%zse_vec, displs(bidx), ierr)
+    blen(bidx) = ms * r2len
+ 
+    bidx = bidx + 1
+    CALL MPI_Get_address (soil%css_vec, displs(bidx), ierr)
+    blen(bidx) = ms * r2len
+ 
+    bidx = bidx + 1
+    CALL MPI_Get_address (soil%cnsd_vec, displs(bidx), ierr)
+    blen(bidx) = ms * r2len
+ 
+    bidx = bidx + 1
+    CALL MPI_Get_address (soil%clay_vec, displs(bidx), ierr)
+    blen(bidx) = ms * r2len
+ 
+    bidx = bidx + 1
+    CALL MPI_Get_address (soil%sand_vec, displs(bidx), ierr)
+    blen(bidx) = ms * r2len
+ 
+    bidx = bidx + 1
+    CALL MPI_Get_address (soil%silt_vec, displs(bidx), ierr)
+    blen(bidx) = ms * r2len
+ 
+    bidx = bidx + 1
+    CALL MPI_Get_address (soil%org_vec, displs(bidx), ierr)
+    blen(bidx) = ms * r2len
+ 
+    bidx = bidx + 1
+    CALL MPI_Get_address (soil%rhosoil_vec, displs(bidx), ierr)
+    blen(bidx) = ms * r2len
+ 
+    bidx = bidx + 1
+    CALL MPI_Get_address (soil%smpc_vec, displs(bidx), ierr)
+    blen(bidx) = ms * r2len
+ 
+    bidx = bidx + 1
+    CALL MPI_Get_address (soil%wbc_vec, displs(bidx), ierr)
+    blen(bidx) = ms * r2len
 
 
     !1d

--- a/src/offline/cable_parameters.F90
+++ b/src/offline/cable_parameters.F90
@@ -2161,12 +2161,6 @@ CONTAINS
 
        if ((gw_params%MaxSatFraction .lt. -9999.9) .and. (mp .eq. 1)) soil%slope(:) = 0.01
 
-    ELSE  !not gw model
-
-      !These are not used when gw_model == false
-      soil%watr = 0._r_2
-      soil%GWwatr = 0._r_2
-
    END IF
 
     IF (cable_user%soil_thermal_fix) then

--- a/src/offline/cable_parameters.F90
+++ b/src/offline/cable_parameters.F90
@@ -1380,6 +1380,11 @@ CONTAINS
                incnsd(landpt(e)%ilon, landpt(e)%ilat)
 
           !possibly heterogeneous soil properties
+          ! Set all heterogeneous soil properties to their equivalent uniform values.
+          ! These values can be overridden later on by input values in files.
+          ! `smpc_vec` and `wbc_vec` are only used in the ground water and have no
+          ! equivalent in the uniform parameters (non _vec). So we do not initialise
+          ! these variables when we are not using the ground water scheme.
           DO klev=1,ms
 
              soil%clay_vec(landpt(e)%cstart:landpt(e)%cend,klev) =                    &
@@ -1399,6 +1404,15 @@ CONTAINS
 
              soil%watr(landpt(e)%cstart:landpt(e)%cend,klev) =                    &
                   REAL(inWatr(landpt(e)%ilon, landpt(e)%ilat),r_2)
+
+             soil%zse_vec(landpt(e)%cstart:landpt(e)%cend,klev) =              &
+                  REAL(soil%zse(landpt(e)%cstart:landpt(e)%cend), r_2)
+
+             soil%css_vec(landpt(e)%cstart:landpt(e)%cend, klev) =             &
+                  REAL(incss(landpt(e)%ilon, landpt(e)%ilat), r_2)
+
+             soil%cnsd_vec(landpt(e)%cstart:landpt(e)%cend, klev) =            &
+                  REAL(incnsd(landpt(e)%ilon, landpt(e)%ilat), r_2)
 
           END DO
 


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

Fixes #490 

Working on the groundwater implementation, I have found that the function `total_soil_conductivity` depends on some GW parameters that aren't correctly implemented. This is to fix this.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## Testing
Since this requires MPI to test the impact, I haven't used modelevaluation.org to analyse the results. I have run benchcab with the spatial configuration for:
1. main with `cable_user%soil_thermal_fix = .TRUE`
1. main with `cable_user%soil_thermal_fix = .FALSE`
1. this branch with `cable_user%soil_thermal_fix = .TRUE`
2. this branch with `cable_user%soil_thermal_fix = .FALSE`

Case 3 - Case 1 allow to gauge the total effect of the change. Case 2 - Case 1 give a measure of the change compared to the initial fix to the soil conductivity. Case 4 - Case 2 shows whether there are any impacts beyond the soil conductivity (without explicitly finding these other sources). 

The comparison of case 4 and case 2 with `cdo diffn` shows there are no differences when `cable_user%soil_thermal_fix` is false.

The largest effect for this branch is found on the ground flux but the effect is limited (right plot) compared to the effect of `soil_thermal_fix` (left plot):
![ground_flux_effect](https://github.com/user-attachments/assets/0cd7e6e7-0ba2-4f91-86fd-45cccc08b75b)
These are time-mean values of the differences between the simulations.

Please add a reviewer when ready for review.


<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--491.org.readthedocs.build/en/491/

<!-- readthedocs-preview cable end -->