### PR TITLE
Add logn back to the cable nml

### DIFF
--- a/offline/cable_driver.F90
+++ b/offline/cable_driver.F90
@@ -294,6 +294,7 @@ PROGRAM cable_offline_driver
        patchout, &
        check, &
        verbose, &
+       logn, &
        leaps, &
        fixedCO2, &
        spincasainput, &


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

Add the ```logn``` variable back into the namelist. This was an unintentional consequence of merged PR #460- existing configurations that have the now superfluous ```logn``` in the cable namelist will fail. The variable won't do anything, but needs to remain until configurations are updated.

Fixes #492 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix
