### PR TITLE
reconcile ESM16: CABLE and CABLE:main

### DIFF
--- a/src/science/canopy/cable_canopy.F90
+++ b/src/science/canopy/cable_canopy.F90
@@ -166,10 +166,8 @@ REAL :: soil_conductance(mp)
 REAL :: Surf_conductance(mp)
 ! END header
 
-    ! Not sure that this is appropriate for JULES standalone - HaC either
-    IF( .NOT. cable_runtime%um ) THEN
-      canopy%cansto =  canopy%oldcansto
-    ENDIF  
+canopy%cansto =  canopy%oldcansto
+
     ALLOCATE( cansat(mp), gbhu(mp,mf))
     ALLOCATE( dsx(mp), fwsoil(mp), tlfx(mp), tlfy(mp) )
     ALLOCATE( ecy(mp), hcy(mp), rny(mp))

--- a/src/science/soilsnow/cbl_surfbv.F90
+++ b/src/science/soilsnow/cbl_surfbv.F90
@@ -14,8 +14,6 @@ USE smoisturev_mod,          ONLY: smoisturev
 USE cable_surface_types_mod, ONLY: lakes_cable
 USE cable_common_module
 
-USE cable_common_module
-
 IMPLICIT NONE
 
     REAL, INTENT(IN) :: dels ! integration time step (s)


### PR DESCRIPTION
# CABLE

## Description

Reconcile ESM16: CABLE and CABLE:main excludes #497  and divergent casa-cnp/. Super quick

Fixes #500 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix
- [ ] New or updated documentation

## Checklist

- [x] The new content is accessible and located in the appropriate section.
- [x] I have checked that links are valid and point to the intended content.
- [x] I have checked my code/text and corrected any misspellings

Please add a reviewer when ready for review.


<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--501.org.readthedocs.build/en/501/

<!-- readthedocs-preview cable end -->