### PR TITLE
Add NEWUNIT to some OPEN statements

### DIFF
--- a/core/biogeochem/casa_inout.F90
+++ b/core/biogeochem/casa_inout.F90
@@ -523,7 +523,7 @@ contains
     fall(:,:)    = 367
     phendoy1(:,:)= 2
 
-    OPEN(phenunit, file=casafile%phen)
+    OPEN(NEWUNIT=phenunit, file=casafile%phen)
     READ(phenunit, *)
     READ(phenunit, *) (ivtx(nx), nx=1, npheno) ! fixed at 10, as only 10 of 17 IGBP PFT
     ! have seasonal leaf phenology
@@ -913,7 +913,7 @@ contains
 
     write(*,*) 'Within casa_poolout, mp = ', mp
     nout=103
-    OPEN(nout,file=casafile%cnpepool)
+    OPEN(NEWUNIT=nout,file=casafile%cnpepool)
     write(*,*) 'Opened file ', casafile%cnpepool
 
     casabal%sumcbal = MIN(9999.0_r_2, MAX(-9999.0_r_2, casabal%sumcbal))
@@ -1065,7 +1065,7 @@ contains
     !  csoilinput   = csoilinput   * xyear
 
     write(*,*) 'writing CNP fluxes out to file ', casafile%cnpflux
-    OPEN(nout,file=casafile%cnpflux)
+    OPEN(NEWUNIT=nout,file=casafile%cnpflux)
     DO npt =1,mp
        SELECT CASE(icycle)
        CASE(1)

--- a/core/biogeophys/cable_common.F90
+++ b/core/biogeophys/cable_common.F90
@@ -510,7 +510,7 @@ CONTAINS
     vegin%dleaf = SQRT(vegin%width * vegin%length)
 
     !================= Read in soil type specifications: ============
-    OPEN(soilunit, FILE=trim(filename%soil), STATUS='old', ACTION='READ', IOSTAT=ioerror)
+    OPEN(NEWUNIT=soilunit, FILE=trim(filename%soil), STATUS='old', ACTION='READ', IOSTAT=ioerror)
 
     IF(ioerror/=0) then
        write(*,*) 'CABLE_log: Cannot open soil type definitions.'
@@ -930,7 +930,7 @@ CONTAINS
     CALL getenv("HOME", myhome)
     fcablerev = TRIM(myhome)//TRIM("/.cable_rev")
 
-    OPEN(revunit, FILE=TRIM(fcablerev), STATUS='old', ACTION='READ', IOSTAT=ioerror)
+    OPEN(NEWUNIT=revunit, FILE=TRIM(fcablerev), STATUS='old', ACTION='READ', IOSTAT=ioerror)
 
     IF(ioerror==0) then
        ! get svn revision number (see WRITE comments)


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

Somehow I missed a few ```NEWUNIT``` specifiers in ```OPEN``` statements. It wasn't picked up during compilation, threw a runtime error.

Fixes #502 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## Checklist

Did a BIOS run to make sure things were working smoothly.
