### PR TITLE
Offline driver refactor continued

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,7 +227,7 @@ else()
         src/offline/cable_abort.F90
         src/offline/cable_checks.F90
         src/offline/cable_cru_TRENDY.F90
-        src/offline/cable_driver_init.F90
+        src/offline/cable_driver_common.F90
         src/offline/cable_initialise.F90
         src/offline/cable_input.F90
         src/offline/cable_metutils.F90

--- a/src/offline/cable_driver_common.F90
+++ b/src/offline/cable_driver_common.F90
@@ -332,9 +332,11 @@ CONTAINS
   END SUBROUTINE cable_driver_init_cru
 
   SUBROUTINE prepareFiles(ncciy)
+    !* Select the correct files given the year for filenames following the gswp format
+    
     USE cable_IO_vars_module, ONLY: logn,gswpfile
     IMPLICIT NONE
-    INTEGER, INTENT(IN) :: ncciy
+    INTEGER, INTENT(IN) :: ncciy !! Year to select met. forcing data.
 
     WRITE(logn,*) 'CABLE offline global run using gswp forcing for ', ncciy
     PRINT *,      'CABLE offline global run using gswp forcing for ', ncciy
@@ -351,8 +353,11 @@ CONTAINS
   END SUBROUTINE prepareFiles
 
   SUBROUTINE renameFiles(logn,inFile,ncciy,inName)
+    !! Replace the year in the filename with the value of ncciy.
+
     IMPLICIT NONE
-    INTEGER, INTENT(IN) :: logn,ncciy
+    INTEGER, INTENT(IN) :: logn !! Log file unit number
+    INTEGER, INTENT(IN) :: ncciy !! Year to use in replacement in filenames
     INTEGER:: nn
     CHARACTER(LEN=200), INTENT(INOUT) :: inFile
     CHARACTER(LEN=*),  INTENT(IN)    :: inName
@@ -366,11 +371,11 @@ CONTAINS
   END SUBROUTINE renameFiles
 
   !==============================================================================
-  ! subroutine for reading LU input data, zeroing biomass in empty secondary forest tiles
-  ! and tranferring LUC-based age weights for secondary forest to POP structure
+  ! subroutine for 
   SUBROUTINE LUCdriver( casabiome,casapool, &
     casaflux,POP,LUC_EXPT, POPLUC, veg )
-
+      !* Reading LU input data, zeroing biomass in empty secondary forest tiles
+      ! and tranferring LUC-based age weights for secondary forest to POP structure
     USE cable_def_types_mod , ONLY: veg_parameter_type, mland
     USE cable_carbon_module
     USE cable_common_module, ONLY: CABLE_USER, CurYear

--- a/src/offline/cable_driver_common.F90
+++ b/src/offline/cable_driver_common.F90
@@ -2,8 +2,8 @@
 ! Copyright (c) 2015, Commonwealth Scientific and Industrial Research Organisation 
 ! (CSIRO) ABN 41 687 119 230.
 
-MODULE cable_driver_init_mod
-  !! Module for CABLE offline driver initialisation.
+MODULE cable_driver_common_mod
+  !! Module for CABLE offline driver common routines.
   USE cable_common_module, ONLY : &
     filename,                     &
     calcsoilalbedo,               &
@@ -102,6 +102,9 @@ MODULE cable_driver_init_mod
   PUBLIC :: cable_driver_init_cru
   PUBLIC :: cable_driver_init_site
   PUBLIC :: cable_driver_init_default
+  PUBLIC :: prepareFiles
+  PUBLIC :: renameFiles
+  PUBLIC :: LUCdriver
 
 CONTAINS
 
@@ -328,4 +331,127 @@ CONTAINS
 
   END SUBROUTINE cable_driver_init_cru
 
-END MODULE cable_driver_init_mod
+  SUBROUTINE prepareFiles(ncciy)
+    USE cable_IO_vars_module, ONLY: logn,gswpfile
+    IMPLICIT NONE
+    INTEGER, INTENT(IN) :: ncciy
+
+    WRITE(logn,*) 'CABLE offline global run using gswp forcing for ', ncciy
+    PRINT *,      'CABLE offline global run using gswp forcing for ', ncciy
+
+    CALL renameFiles(logn,gswpfile%rainf,ncciy,'rainf')
+    CALL renameFiles(logn,gswpfile%snowf,ncciy,'snowf')
+    CALL renameFiles(logn,gswpfile%LWdown,ncciy,'LWdown')
+    CALL renameFiles(logn,gswpfile%SWdown,ncciy,'SWdown')
+    CALL renameFiles(logn,gswpfile%PSurf,ncciy,'PSurf')
+    CALL renameFiles(logn,gswpfile%Qair,ncciy,'Qair')
+    CALL renameFiles(logn,gswpfile%Tair,ncciy,'Tair')
+    CALL renameFiles(logn,gswpfile%wind,ncciy,'wind')
+
+  END SUBROUTINE prepareFiles
+
+  SUBROUTINE renameFiles(logn,inFile,ncciy,inName)
+    IMPLICIT NONE
+    INTEGER, INTENT(IN) :: logn,ncciy
+    INTEGER:: nn
+    CHARACTER(LEN=200), INTENT(INOUT) :: inFile
+    CHARACTER(LEN=*),  INTENT(IN)    :: inName
+    INTEGER :: idummy
+
+    nn = INDEX(inFile,'19')
+    READ(inFile(nn:nn+3),'(i4)') idummy
+    WRITE(inFile(nn:nn+3),'(i4.4)') ncciy
+    WRITE(logn,*) TRIM(inName), ' global data from ', TRIM(inFile)
+
+  END SUBROUTINE renameFiles
+
+  !==============================================================================
+  ! subroutine for reading LU input data, zeroing biomass in empty secondary forest tiles
+  ! and tranferring LUC-based age weights for secondary forest to POP structure
+  SUBROUTINE LUCdriver( casabiome,casapool, &
+    casaflux,POP,LUC_EXPT, POPLUC, veg )
+
+    USE cable_def_types_mod , ONLY: veg_parameter_type, mland
+    USE cable_carbon_module
+    USE cable_common_module, ONLY: CABLE_USER, CurYear
+    USE casa_ncdf_module, ONLY: is_casa_time
+    USE cable_IO_vars_module, ONLY: logn, landpt, patch
+    USE casadimension
+    USE casaparm
+    USE casavariable
+    USE POP_Types,  ONLY: POP_TYPE
+    USE POPMODULE,            ONLY: POPStep, POP_init_single
+    USE TypeDef,              ONLY: i4b, dp
+    USE CABLE_LUC_EXPT, ONLY: LUC_EXPT_TYPE, read_LUH2,&
+      ptos,ptog,stog,gtos,grassfrac, pharv, smharv, syharv
+    USE POPLUC_Types
+    USE POPLUC_Module, ONLY: POPLUCStep, POPLUC_weights_Transfer, WRITE_LUC_OUTPUT_NC, &
+      POP_LUC_CASA_transfer,  WRITE_LUC_RESTART_NC, READ_LUC_RESTART_NC
+
+    IMPLICIT NONE
+
+    TYPE (casa_biome),            INTENT(INOUT) :: casabiome
+    TYPE (casa_pool),             INTENT(INOUT) :: casapool
+    TYPE (casa_flux),             INTENT(INOUT) :: casaflux
+    TYPE (POP_TYPE), INTENT(INOUT)     :: POP
+    TYPE (LUC_EXPT_TYPE), INTENT(INOUT) :: LUC_EXPT
+    TYPE(POPLUC_TYPE), INTENT(INOUT) :: POPLUC
+    TYPE (veg_parameter_type),    INTENT(IN) :: veg  ! vegetation parameters
+
+    INTEGER ::  k, j, l, yyyy
+
+    WRITE(*,*) 'cablecasa_LUC', CurYear
+    yyyy = CurYear
+
+    LUC_EXPT%CTSTEP = yyyy -  LUC_EXPT%FirstYear + 1
+
+    CALL READ_LUH2(LUC_EXPT)
+
+    DO k=1,mland
+      POPLUC%ptos(k) = LUC_EXPT%INPUT(ptos)%VAL(k)
+      POPLUC%ptog(k) = LUC_EXPT%INPUT(ptog)%VAL(k)
+      POPLUC%stop(k) = 0.0
+      POPLUC%stog(k) = LUC_EXPT%INPUT(stog)%VAL(k)
+      POPLUC%gtop(k) = 0.0
+      POPLUC%gtos(k) = LUC_EXPT%INPUT(gtos)%VAL(k)
+      POPLUC%pharv(k) = LUC_EXPT%INPUT(pharv)%VAL(k)
+      POPLUC%smharv(k) = LUC_EXPT%INPUT(smharv)%VAL(k)
+      POPLUC%syharv(k) = LUC_EXPT%INPUT(syharv)%VAL(k)
+      POPLUC%thisyear = yyyy
+    ENDDO
+
+    ! zero secondary forest tiles in POP where secondary forest area is zero
+    DO k=1,mland
+      IF ((POPLUC%frac_primf(k)-POPLUC%frac_forest(k))==0.0 &
+           .AND. (.NOT.LUC_EXPT%prim_only(k))) THEN
+        j = landpt(k)%cstart+1
+        DO l=1,SIZE(POP%Iwood)
+          IF( POP%Iwood(l) == j) THEN
+            CALL POP_init_single(POP,veg%disturbance_interval,l)
+            EXIT
+          ENDIF
+        ENDDO
+
+        casapool%cplant(j,leaf) = 0.01
+        casapool%nplant(j,leaf)= casabiome%ratioNCplantmin(veg%iveg(j),leaf)* casapool%cplant(j,leaf)
+        casapool%pplant(j,leaf)= casabiome%ratioPCplantmin(veg%iveg(j),leaf)* casapool%cplant(j,leaf)
+
+        casapool%cplant(j,froot) = 0.01
+        casapool%nplant(j,froot)= casabiome%ratioNCplantmin(veg%iveg(j),froot)* casapool%cplant(j,froot)
+        casapool%pplant(j,froot)= casabiome%ratioPCplantmin(veg%iveg(j),froot)* casapool%cplant(j,froot)
+
+        casapool%cplant(j,wood) = 0.01
+        casapool%nplant(j,wood)= casabiome%ratioNCplantmin(veg%iveg(j),wood)* casapool%cplant(j,wood)
+        casapool%pplant(j,wood)= casabiome%ratioPCplantmin(veg%iveg(j),wood)* casapool%cplant(j,wood)
+        casaflux%frac_sapwood(j) = 1.0
+
+      ENDIF
+    ENDDO
+
+    CALL POPLUCStep(POPLUC,yyyy)
+
+    CALL POPLUC_weights_transfer(POPLUC,POP,LUC_EXPT)
+
+  END SUBROUTINE LUCdriver
+
+END MODULE cable_driver_common_mod

--- a/src/offline/cable_mpimaster.F90
+++ b/src/offline/cable_mpimaster.F90
@@ -432,10 +432,8 @@ CONTAINS
                   TRIM(cable_user%RunIden)//'_cable_out.nc'
               ENDIF
             ENDIF
-            IF (YYYY.EQ.CABLE_USER%YEARSTART) THEN
-              CALL nullify_write() ! nullify pointers
-              CALL open_output_file( dels, soil, veg, bgc, rough, met)
-            ENDIF
+            CALL nullify_write() ! nullify pointers
+            CALL open_output_file( dels, soil, veg, bgc, rough, met)
           ENDIF
 
           ssnow%otss_0 = ssnow%tgg(:,1)

--- a/src/offline/cable_mpimaster.F90
+++ b/src/offline/cable_mpimaster.F90
@@ -332,463 +332,463 @@ CONTAINS
     ! outer loop - spinup loop no. ktau_tot :
     ktau     = 0
     SPINLOOP:DO
-       YEARLOOP: DO YYYY= CABLE_USER%YearStart,  CABLE_USER%YearEnd
+      YEARLOOP: DO YYYY= CABLE_USER%YearStart,  CABLE_USER%YearEnd
 
-          CurYear = YYYY
+        CurYear = YYYY
 
+        LOY = 365
+        IF ( leaps .AND. IS_LEAPYEAR( YYYY ) ) THEN
+          LOY = 366
+        ENDIF
+
+        IF ( TRIM(cable_user%MetType) .EQ. 'plum' ) THEN
+          kend = NINT(24.0*3600.0/dels) * LOY
+        ELSE IF ( TRIM(cable_user%MetType) .EQ. 'cru' ) THEN
           LOY = 365
-          IF ( leaps .AND. IS_LEAPYEAR( YYYY ) ) THEN
-             LOY = 366
+          kend = NINT(24.0*3600.0/dels) * LOY
+        ELSE IF (TRIM(cable_user%MetType) .EQ. 'gswp') THEN
+          ncciy = CurYear
+          WRITE(*,*) 'Looking for global offline run info.'
+          CALL prepareFiles(ncciy)
+          CALL open_met_file( dels, koffset, kend, spinup, CTFRZ )
+
+        ELSE IF (TRIM(cable_user%MetType) .EQ. 'gswp3') THEN
+          ncciy = CurYear
+          WRITE(*,*) 'Looking for global offline run info.'
+          CALL open_met_file( dels, koffset, kend, spinup, CTFRZ )
+
+
+        ELSE IF ( globalMetfile%l_gpcc ) THEN
+          ncciy = CurYear
+          WRITE(*,*) 'Looking for global offline run info.'
+          CALL open_met_file( dels, koffset, kend, spinup, CTFRZ )
+
+        ENDIF
+
+        !ccc Set calendar attribute: dependant on the value of `leaps`
+        ! that is set in the MetType if conditions above.
+        calendar = "noleap"
+        IF ( leaps ) THEN
+          calendar = "standard"
+        ENDIF
+
+
+        ! somethings (e.g. CASA-CNP) only need to be done once per day
+        ktauday=INT(24.0*3600.0/dels)
+
+        ! Checks where parameters and initialisations should be loaded from.
+        ! If they can be found in either the met file or restart file, they will
+        ! load from there, with the met file taking precedence. Otherwise, they'll
+        ! be chosen from a coarse global grid of veg and soil types, based on
+        ! the lat/lon coordinates. Allocation of CABLE's main variables also here.
+        IF ( CALL1 ) THEN
+
+
+          IF (cable_user%POPLUC) THEN
+            CALL LUC_EXPT_INIT (LUC_EXPT)
           ENDIF
 
+
+          ! vh_js !
+          CALL load_parameters( met, air, ssnow, veg,climate,bgc, &
+               soil, canopy, rough, rad, sum_flux, &
+               bal, logn, vegparmnew, casabiome, casapool, &
+               casaflux, sum_casapool, sum_casaflux, &
+               casamet, casabal, phen, POP, spinup, &
+               CEMSOIL, CTFRZ, LUC_EXPT, POPLUC )
+
+          IF (CABLE_USER%POPLUC .AND. TRIM(CABLE_USER%POPLUC_RunType) .EQ. 'static') &
+            CABLE_USER%POPLUC= .FALSE.
+
+          ssnow%otss_0 = ssnow%tgg(:,1)
+          ssnow%otss = ssnow%tgg(:,1)
+          ssnow%tss = ssnow%tgg(:,1)
+          canopy%fes_cor = 0.
+          canopy%fhs_cor = 0.
+          met%ofsd = 0.1
+
+
+          IF (.NOT.spinup) spinConv=.TRUE.
+
+          ! MPI: above was standard serial code
+          ! now it's time to initialize the workers
+
+          ! MPI: bcast to workers so that they don't need to open the met
+          ! file themselves
+          CALL MPI_Bcast (dels, 1, MPI_REAL, 0, comm, ierr)
+
+        ENDIF
+
+        CALL MPI_Bcast (kend, 1, MPI_INTEGER, 0, comm, ierr)
+
+        IF ( CALL1 ) THEN
+          ! MPI: need to know extents before creating datatypes
+          CALL find_extents
+
+          ! MPI: calculate and broadcast landpoint decomposition to the workers
+          CALL master_decomp(comm, mland)
+
+          ! MPI: set up stuff for new irecv isend code that separates completion
+          ! from posting of requests
+          ! wnp is set in master_decomp above
+          ALLOCATE (inp_req(wnp))
+          ALLOCATE (inp_stats(MPI_STATUS_SIZE, wnp))
+          ALLOCATE (recv_req(wnp))
+          ALLOCATE (recv_stats(MPI_STATUS_SIZE, wnp))
+          CALL MPI_Comm_dup (comm, icomm, ierr)
+          CALL MPI_Comm_dup (comm, ocomm, ierr)
+
+
+
+          ! MPI: data set in load_parameter is now scattered out to the
+          ! workers
+
+          CALL master_cable_params(comm, met,air,ssnow,veg,bgc,soil,canopy,&
+                                   rough,rad,sum_flux,bal)
+
+
+          IF (cable_user%call_climate) THEN
+            CALL master_climate_types(comm, climate, ktauday)
+          ENDIF
+
+          ! MPI: mvtype and mstype send out here instead of inside master_casa_params
+          !      so that old CABLE carbon module can use them. (BP May 2013)
+          CALL MPI_Bcast (mvtype, 1, MPI_INTEGER, 0, comm, ierr)
+          CALL MPI_Bcast (mstype, 1, MPI_INTEGER, 0, comm, ierr)
+
+          ! MPI: casa parameters scattered only if cnp module is active
+          IF (icycle>0) THEN
+            ! MPI:
+            CALL master_casa_params (comm,casabiome,casapool,casaflux,casamet,&
+                                     casabal,phen)
+
+            IF ( CABLE_USER%CALL_POP ) CALL master_pop_types (comm,pop)
+          END IF
+
+          ! MPI: allocate read ahead buffers for input met and veg data
+          CALL alloc_cbm_var (imet, mp)
+          CALL alloc_cbm_var (iveg, mp)
+
+          ! MPI: create inp_t types to scatter input data to the workers
+          ! at the start of every timestep
+          !CALL master_intypes (comm,met,veg)
+          ! for read ahead use the new variables
+          CALL master_intypes (comm,imet,iveg)
+
+          ! MPI: create recv_t types to receive results from the workers
+          ! at the end of every timestep
+          CALL master_outtypes (comm,met,canopy,ssnow,rad,bal,air,soil,veg)
+
+          ! MPI: create type for receiving casa results
+          ! only if cnp module is active
+
+          IF (icycle>0) THEN
+            CALL master_casa_types (comm, casapool, casaflux, &
+                 casamet, casabal, phen)
+
+            IF ( CABLE_USER%CASA_DUMP_READ .OR. CABLE_USER%CASA_DUMP_WRITE ) &
+              CALL master_casa_dump_types( comm, casamet, casaflux, phen )
+            WRITE(*,*) 'cable_mpimaster, POPLUC: ' ,  CABLE_USER%POPLUC
+            IF ( CABLE_USER%POPLUC ) &
+              CALL master_casa_LUC_types( comm, casapool, casabal)
+
+          END IF
+
+          ! MPI: create type to send restart data back to the master
+          ! only if restart file is to be created
+          IF(output%restart) THEN
+            CALL master_restart_types (comm, canopy, air)
+          END IF
+
+          !  CALL zero_sum_casa(sum_casapool, sum_casaflux)
+          !  count_sum_casa = 0
+
+          ! CALL master_sumcasa_types(comm, sum_casapool, sum_casaflux)
+          IF( icycle>0 .AND. spincasa) THEN
+            PRINT *, 'EXT spincasacnp enabled with mloop= ', mloop, dels, kstart, kend
+            CALL master_spincasacnp(dels,kstart,kend,mloop,veg,soil,casabiome,casapool, &
+                 casaflux,casamet,casabal,phen,POP,climate,icomm, ocomm)
+            SPINconv = .FALSE.
+            CASAONLY                   = .TRUE.
+            ktau_gl = 0
+            ktau = 0
+
+          ELSEIF ( casaonly .AND. (.NOT. spincasa) .AND. cable_user%popluc) THEN
+            CALL master_CASAONLY_LUC(dels,kstart,kend,veg,casabiome,casapool, &
+                 casaflux,casamet,casabal,phen,POP,climate,LUC_EXPT, POPLUC, &
+                 icomm, ocomm)
+            SPINconv = .FALSE.
+            ktau_gl = 0
+            ktau = 0
+          ENDIF
+
+          ! MPI: mostly original serial code follows...
+        ENDIF ! CALL1
+
+
+        ! Open output file:
+        IF (.NOT.CASAONLY) THEN
+          IF ( TRIM(filename%out) .EQ. '' ) THEN
+            IF ( CABLE_USER%YEARSTART .GT. 0 ) THEN
+              WRITE( dum, FMT="(I4,'_',I4)")CABLE_USER%YEARSTART, &
+                CABLE_USER%YEAREND
+              filename%out = TRIM(filename%path)//'/'//&
+                TRIM(cable_user%RunIden)//'_'//&
+                TRIM(dum)//'_cable_out.nc'
+            ELSE
+              filename%out = TRIM(filename%path)//'/'//&
+                TRIM(cable_user%RunIden)//'_cable_out.nc'
+            ENDIF
+          ENDIF
+          IF (YYYY.EQ.CABLE_USER%YEARSTART) THEN
+            CALL nullify_write() ! nullify pointers
+            CALL open_output_file( dels, soil, veg, bgc, rough, met)
+          ENDIF
+        ENDIF
+
+
+        ! globally (WRT code) accessible kend through USE cable_common_module
+        ktau_gl = 0
+        kwidth_gl = INT(dels)
+        kend_gl = kend
+        knode_gl = 0
+
+        ! MPI: separate time step counters for reading and writing
+        ! (ugly, I know)
+        iktau = ktau_gl
+        oktau = ktau_gl
+
+        ! MPI: read ahead
+        iktau = iktau + 1
+
+        ! MPI: flip ktau_gl
+        !tmp_kgl = ktau_gl
+        ktau_gl = iktau
+
+        IF (.NOT.casaonly) THEN
           IF ( TRIM(cable_user%MetType) .EQ. 'plum' ) THEN
-             kend = NINT(24.0*3600.0/dels) * LOY
+            CALL PLUME_MIP_GET_MET(PLUME, iMET, YYYY, 1, kend, &
+                 (YYYY.EQ.CABLE_USER%YearEnd .AND. 1.EQ.kend))
+
           ELSE IF ( TRIM(cable_user%MetType) .EQ. 'cru' ) THEN
-             LOY = 365
-             kend = NINT(24.0*3600.0/dels) * LOY
-          ELSE IF (TRIM(cable_user%MetType) .EQ. 'gswp') THEN
-             ncciy = CurYear
-             WRITE(*,*) 'Looking for global offline run info.'
-             CALL prepareFiles(ncciy)
-             CALL open_met_file( dels, koffset, kend, spinup, CTFRZ )
 
-          ELSE IF (TRIM(cable_user%MetType) .EQ. 'gswp3') THEN
-             ncciy = CurYear
-             WRITE(*,*) 'Looking for global offline run info.'
-             CALL open_met_file( dels, koffset, kend, spinup, CTFRZ )
+            CALL CRU_GET_SUBDIURNAL_MET(CRU, imet, YYYY, 1, kend, &
+                 (YYYY.EQ.CABLE_USER%YearEnd))
 
-
-           ELSE IF ( globalMetfile%l_gpcc ) THEN
-             ncciy = CurYear
-             WRITE(*,*) 'Looking for global offline run info.'
-             CALL open_met_file( dels, koffset, kend, spinup, CTFRZ )
+          ELSE
+            CALL get_met_data( spinup, spinConv, imet, soil,                 &
+                 rad, iveg, kend, dels, CTFRZ, iktau+koffset,                &
+                 kstart+koffset )
 
           ENDIF
-
-          !ccc Set calendar attribute: dependant on the value of `leaps`
-          ! that is set in the MetType if conditions above.
-          calendar = "noleap"
-          IF ( leaps ) THEN
-             calendar = "standard"
-          ENDIF
+        ENDIF
 
 
-          ! somethings (e.g. CASA-CNP) only need to be done once per day
-          ktauday=INT(24.0*3600.0/dels)
+        !  IF ( CASAONLY .AND. IS_CASA_TIME("dread", yyyy, iktau, kstart, koffset, &
+        !       kend, ktauday, logn) ) THEN
+        !     WRITE(CYEAR,FMT="(I4)")CurYear + INT((ktau-kstart+koffset)/(LOY*ktauday))
+        !     ncfile  = TRIM(casafile%c2cdumppath)//'c2c_'//CYEAR//'_dump.nc'
+        !     casa_it = NINT( REAL(iktau / ktauday) )
+        !     CALL read_casa_dump( ncfile, casamet, casaflux,phen, casa_it, kend, .FALSE. )
+        !  ENDIF
 
-          ! Checks where parameters and initialisations should be loaded from.
-          ! If they can be found in either the met file or restart file, they will
-          ! load from there, with the met file taking precedence. Otherwise, they'll
-          ! be chosen from a coarse global grid of veg and soil types, based on
-          ! the lat/lon coordinates. Allocation of CABLE's main variables also here.
-          IF ( CALL1 ) THEN
+        canopy%oldcansto=canopy%cansto
 
-
-             IF (cable_user%POPLUC) THEN
-                CALL LUC_EXPT_INIT (LUC_EXPT)
-             ENDIF
-
-
-             ! vh_js !
-             CALL load_parameters( met, air, ssnow, veg,climate,bgc, &
-                  soil, canopy, rough, rad, sum_flux, &
-                  bal, logn, vegparmnew, casabiome, casapool, &
-                  casaflux, sum_casapool, sum_casaflux, &
-                  casamet, casabal, phen, POP, spinup, &
-                  CEMSOIL, CTFRZ, LUC_EXPT, POPLUC )
-
-             IF (CABLE_USER%POPLUC .AND. TRIM(CABLE_USER%POPLUC_RunType) .EQ. 'static') &
-                  CABLE_USER%POPLUC= .FALSE.
-
-             ssnow%otss_0 = ssnow%tgg(:,1)
-             ssnow%otss = ssnow%tgg(:,1)
-             ssnow%tss = ssnow%tgg(:,1)
-             canopy%fes_cor = 0.
-             canopy%fhs_cor = 0.
-             met%ofsd = 0.1
-
-
-             IF (.NOT.spinup) spinConv=.TRUE.
-
-             ! MPI: above was standard serial code
-             ! now it's time to initialize the workers
-
-             ! MPI: bcast to workers so that they don't need to open the met
-             ! file themselves
-             CALL MPI_Bcast (dels, 1, MPI_REAL, 0, comm, ierr)
-
-          ENDIF
-
-          CALL MPI_Bcast (kend, 1, MPI_INTEGER, 0, comm, ierr)
-
-          IF ( CALL1 ) THEN
-             ! MPI: need to know extents before creating datatypes
-             CALL find_extents
-
-             ! MPI: calculate and broadcast landpoint decomposition to the workers
-             CALL master_decomp(comm, mland)
-
-             ! MPI: set up stuff for new irecv isend code that separates completion
-             ! from posting of requests
-             ! wnp is set in master_decomp above
-             ALLOCATE (inp_req(wnp))
-             ALLOCATE (inp_stats(MPI_STATUS_SIZE, wnp))
-             ALLOCATE (recv_req(wnp))
-             ALLOCATE (recv_stats(MPI_STATUS_SIZE, wnp))
-             CALL MPI_Comm_dup (comm, icomm, ierr)
-             CALL MPI_Comm_dup (comm, ocomm, ierr)
+        ! Zero out lai where there is no vegetation acc. to veg. index
+        WHERE ( iveg%iveg(:) .GE. 14 ) iveg%vlai = 0.
 
 
 
-             ! MPI: data set in load_parameter is now scattered out to the
-             ! workers
+        IF ( .NOT. CASAONLY ) THEN
+          ! MPI: scatter input data to the workers
 
-             CALL master_cable_params(comm, met,air,ssnow,veg,bgc,soil,canopy,&
-                  &                         rough,rad,sum_flux,bal)
+          CALL master_send_input (icomm, inp_ts, iktau)
 
+          !  CALL MPI_Waitall (wnp, inp_req, inp_stats, ierr)
+        ELSE
+          CALL master_send_input (icomm, casa_dump_ts, iktau)
+          CALL MPI_Waitall (wnp, inp_req, inp_stats, ierr)
+        ENDIF
 
-             IF (cable_user%call_climate) THEN
-                CALL master_climate_types(comm, climate, ktauday)
-             ENDIF
+        IF (spincasa.OR. casaonly) THEN
+          EXIT
+        ENDIF
+        !IF (.NOT.spincasa) THEN
+        ! time step loop over ktau
+        KTAULOOP:DO ktau=kstart, kend - 1
+          !         ! increment total timstep counter
+          !         ktau_tot = ktau_tot + 1
+          iktau = iktau + 1
+          oktau = oktau + 1
 
-             ! MPI: mvtype and mstype send out here instead of inside master_casa_params
-             !      so that old CABLE carbon module can use them. (BP May 2013)
-             CALL MPI_Bcast (mvtype, 1, MPI_INTEGER, 0, comm, ierr)
-             CALL MPI_Bcast (mstype, 1, MPI_INTEGER, 0, comm, ierr)
+          WRITE(logn,*) 'Progress -',REAL(ktau)/REAL(kend)*100.0
 
-             ! MPI: casa parameters scattered only if cnp module is active
-             IF (icycle>0) THEN
-                ! MPI:
-                CALL master_casa_params (comm,casabiome,casapool,casaflux,casamet,&
-                     &                        casabal,phen)
-
-                IF ( CABLE_USER%CALL_POP ) CALL master_pop_types (comm,pop)
-             END IF
-
-             ! MPI: allocate read ahead buffers for input met and veg data
-             CALL alloc_cbm_var (imet, mp)
-             CALL alloc_cbm_var (iveg, mp)
-
-             ! MPI: create inp_t types to scatter input data to the workers
-             ! at the start of every timestep
-             !CALL master_intypes (comm,met,veg)
-             ! for read ahead use the new variables
-             CALL master_intypes (comm,imet,iveg)
-
-             ! MPI: create recv_t types to receive results from the workers
-             ! at the end of every timestep
-             CALL master_outtypes (comm,met,canopy,ssnow,rad,bal,air,soil,veg)
-
-             ! MPI: create type for receiving casa results
-             ! only if cnp module is active
-
-             IF (icycle>0) THEN
-                CALL master_casa_types (comm, casapool, casaflux, &
-                     casamet, casabal, phen)
-
-                IF ( CABLE_USER%CASA_DUMP_READ .OR. CABLE_USER%CASA_DUMP_WRITE ) &
-                     CALL master_casa_dump_types( comm, casamet, casaflux, phen )
-                WRITE(*,*) 'cable_mpimaster, POPLUC: ' ,  CABLE_USER%POPLUC
-                IF ( CABLE_USER%POPLUC ) &
-                     CALL master_casa_LUC_types( comm, casapool, casabal)
-
-             END IF
-
-             ! MPI: create type to send restart data back to the master
-             ! only if restart file is to be created
-             IF(output%restart) THEN
-                CALL master_restart_types (comm, canopy, air)
-             END IF
-
-             !  CALL zero_sum_casa(sum_casapool, sum_casaflux)
-             !  count_sum_casa = 0
-
-             ! CALL master_sumcasa_types(comm, sum_casapool, sum_casaflux)
-             IF( icycle>0 .AND. spincasa) THEN
-                PRINT *, 'EXT spincasacnp enabled with mloop= ', mloop, dels, kstart, kend
-                CALL master_spincasacnp(dels,kstart,kend,mloop,veg,soil,casabiome,casapool, &
-                     casaflux,casamet,casabal,phen,POP,climate,icomm, ocomm)
-                SPINconv = .FALSE.
-                CASAONLY                   = .TRUE.
-                ktau_gl = 0
-                ktau = 0
-
-             ELSEIF ( casaonly .AND. (.NOT. spincasa) .AND. cable_user%popluc) THEN
-                CALL master_CASAONLY_LUC(dels,kstart,kend,veg,casabiome,casapool, &
-                     casaflux,casamet,casabal,phen,POP,climate,LUC_EXPT, POPLUC, &
-                     icomm, ocomm)
-                SPINconv = .FALSE.
-                ktau_gl = 0
-                ktau = 0
-             ENDIF
-
-             ! MPI: mostly original serial code follows...
-          ENDIF ! CALL1
-
-
-          ! Open output file:
-          IF (.NOT.CASAONLY) THEN
-             IF ( TRIM(filename%out) .EQ. '' ) THEN
-                IF ( CABLE_USER%YEARSTART .GT. 0 ) THEN
-                   WRITE( dum, FMT="(I4,'_',I4)")CABLE_USER%YEARSTART, &
-                        CABLE_USER%YEAREND
-                   filename%out = TRIM(filename%path)//'/'//&
-                        TRIM(cable_user%RunIden)//'_'//&
-                        TRIM(dum)//'_cable_out.nc'
-                ELSE
-                   filename%out = TRIM(filename%path)//'/'//&
-                        TRIM(cable_user%RunIden)//'_cable_out.nc'
-                ENDIF
-             ENDIF
-             IF (YYYY.EQ.CABLE_USER%YEARSTART) THEN
-                CALL nullify_write() ! nullify pointers
-                CALL open_output_file( dels, soil, veg, bgc, rough, met)
-             ENDIF
-          ENDIF
-
+          met%year = imet%year
+          met%doy = imet%doy
 
           ! globally (WRT code) accessible kend through USE cable_common_module
-          ktau_gl = 0
-          kwidth_gl = INT(dels)
-          kend_gl = kend
-          knode_gl = 0
-
-          ! MPI: separate time step counters for reading and writing
-          ! (ugly, I know)
-          iktau = ktau_gl
-          oktau = ktau_gl
-
-          ! MPI: read ahead
-          iktau = iktau + 1
-
-          ! MPI: flip ktau_gl
-          !tmp_kgl = ktau_gl
+          ktau_tot= ktau_tot + 1
           ktau_gl = iktau
 
-          IF (.NOT.casaonly) THEN
-             IF ( TRIM(cable_user%MetType) .EQ. 'plum' ) THEN
-                CALL PLUME_MIP_GET_MET(PLUME, iMET, YYYY, 1, kend, &
-                     (YYYY.EQ.CABLE_USER%YearEnd .AND. 1.EQ.kend))
+          ! some things (e.g. CASA-CNP) only need to be done once per day
+          idoy =INT( MOD((REAL(ktau+koffset)/REAL(ktauday)),REAL(LOY)))
+          IF ( idoy .EQ. 0 ) idoy = LOY
 
-             ELSE IF ( TRIM(cable_user%MetType) .EQ. 'cru' ) THEN
+          ! needed for CASA-CNP
+          nyear =INT((kend-kstart+1)/(LOY*ktauday))
 
-                CALL CRU_GET_SUBDIURNAL_MET(CRU, imet, YYYY, 1, kend, &
-                     (YYYY.EQ.CABLE_USER%YearEnd))
+          ! Get met data and LAI, set time variables.
+          ! Rainfall input may be augmented for spinup purposes:
+          !          met%ofsd = met%fsd(:,1) + met%fsd(:,2)
+          IF ( TRIM(cable_user%MetType) .EQ. 'plum' ) THEN
+            CALL PLUME_MIP_GET_MET(PLUME, iMET, YYYY, iktau, kend, &
+                 (YYYY.EQ.CABLE_USER%YearEnd .AND. iktau.EQ.kend))
 
-             ELSE
-                CALL get_met_data( spinup, spinConv, imet, soil,                 &
-                     rad, iveg, kend, dels, CTFRZ, iktau+koffset,                &
-                     kstart+koffset )
+          ELSE IF ( TRIM(cable_user%MetType) .EQ. 'cru' ) THEN
+            CALL CRU_GET_SUBDIURNAL_MET(CRU, imet, YYYY, iktau, kend, &
+                 (YYYY.EQ.CABLE_USER%YearEnd) )
+          ELSE
 
-             ENDIF
+            CALL get_met_data( spinup, spinConv, imet, soil,                 &
+                 rad, iveg, kend, dels, CTFRZ, iktau+koffset,                &
+                 kstart+koffset )
+
+          ENDIF
+          IF ( (TRIM(cable_user%MetType) .NE. 'gswp') .AND. &
+               (TRIM(cable_user%MetType) .NE. 'gswp3') ) CurYear = met%year(1)
+
+!$        IF ( CASAONLY .AND. IS_CASA_TIME("dread", yyyy, iktau, kstart, koffset, &
+!$              kend, ktauday, logn) )  THEN
+!$          ! CLN READ FROM FILE INSTEAD !
+!$          WRITE(CYEAR,FMT="(I4)")CurYear + INT((ktau-kstart+koffset)/(LOY*ktauday))
+!$          ncfile  = TRIM(casafile%c2cdumppath)//'c2c_'//CYEAR//'_dump.nc'
+!$          casa_it = NINT( REAL(iktau / ktauday) )
+!$          CALL read_casa_dump( ncfile, casamet, casaflux, casa_it, kend, .FALSE. )
+!$        ENDIF
+
+
+!$        ! At first time step of year, set tile area according to updated LU areas
+!$        IF (ktau == 1 .and. CABLE_USER%POPLUC) THEN
+!$          CALL POPLUC_set_patchfrac(POPLUC,LUC_EXPT)
+!$        ENDIF
+
+
+          IF ( .NOT. CASAONLY ) THEN
+
+            IF ( icycle > 0 ) THEN
+              ! receive casa update from worker
+              CALL master_receive (ocomm, oktau, casa_ts)
+
+              CALL MPI_Waitall (wnp, recv_req, recv_stats, ierr)
+              ! receive casa dump requirements from worker
+              IF ( ((.NOT.spinup).OR.(spinup.AND.spinConv)) .AND.   &
+                    ( IS_CASA_TIME("dwrit", yyyy, oktau, kstart, &
+                    koffset, kend, ktauday, logn) ) ) THEN
+                CALL master_receive ( ocomm, oktau, casa_dump_ts )
+
+                ! CALL MPI_Waitall (wnp, recv_req, recv_stats, ierr)
+              ENDIF
+            ENDIF
+
+            ! MPI: receive this time step's results from the workers
+            CALL master_receive (ocomm, oktau, recv_ts)
+            ! CALL MPI_Waitall (wnp, recv_req, recv_stats, ierr)
+
+
+            ! MPI: scatter input data to the workers
+            CALL master_send_input (icomm, inp_ts, iktau)
+            !  CALL MPI_Waitall (wnp, inp_req, inp_stats, ierr)
+
+!$          IF ( ((.NOT.spinup).OR.(spinup.AND.spinConv)) .AND.   &
+!$                ( IS_CASA_TIME("dwrit", yyyy, oktau, kstart, &
+!$                               koffset, kend, ktauday, logn) ) ) THEN
+!$            WRITE(CYEAR,FMT="(I4)") CurYear + INT((ktau-kstart)/(LOY*ktauday))
+!$            ncfile = TRIM(casafile%c2cdumppath)//'c2c_'//CYEAR//'_dump.nc'
+!$            CALL write_casa_dump( ncfile, casamet , casaflux, idoy, &
+!$                kend/ktauday )
+!$
+!$          ENDIF
+
+            IF (((.NOT.spinup).OR.(spinup.AND.spinConv)).AND. &
+                  MOD((ktau-kstart+1),ktauday)==0) THEN
+              IF ( CABLE_USER%CASA_DUMP_WRITE )  THEN
+
+
+                !CLN CHECK FOR LEAP YEAR
+                WRITE(CYEAR,FMT="(I4)") CurYear + INT((ktau-kstart)/(LOY*ktauday))
+                ncfile = TRIM(casafile%c2cdumppath)//'c2c_'//CYEAR//'_dump.nc'
+                CALL write_casa_dump( ncfile, casamet , casaflux, phen, climate, idoy, &
+                     kend/ktauday )
+
+              ENDIF
+            ENDIF
+
+          ELSE IF ( MOD((ktau-kstart+1+koffset),ktauday)==0 ) THEN
+
+            CALL master_send_input (icomm, casa_dump_ts, iktau )
+            !    CALL MPI_Waitall (wnp, inp_req, inp_stats, ierr)
+
           ENDIF
 
+          !             CALL MPI_Waitall (wnp, recv_req, recv_stats, ierr)
+          !             CALL MPI_Waitall (wnp, inp_req, inp_stats, ierr)
 
-          !  IF ( CASAONLY .AND. IS_CASA_TIME("dread", yyyy, iktau, kstart, koffset, &
-          !       kend, ktauday, logn) ) THEN
-          !     WRITE(CYEAR,FMT="(I4)")CurYear + INT((ktau-kstart+koffset)/(LOY*ktauday))
-          !     ncfile  = TRIM(casafile%c2cdumppath)//'c2c_'//CYEAR//'_dump.nc'
-          !     casa_it = NINT( REAL(iktau / ktauday) )
-          !     CALL read_casa_dump( ncfile, casamet, casaflux,phen, casa_it, kend, .FALSE. )
-          !  ENDIF
-
+          met%ofsd = met%fsd(:,1) + met%fsd(:,2)
           canopy%oldcansto=canopy%cansto
 
           ! Zero out lai where there is no vegetation acc. to veg. index
           WHERE ( iveg%iveg(:) .GE. 14 ) iveg%vlai = 0.
 
+          ! Write time step's output to file if either: we're not spinning up
+          ! or we're spinning up and the spinup has converged:
+          ! MPI: TODO: pull mass and energy balance calculation from write_output
+          ! and refactor into worker code
+
+          ktau_gl = oktau
+
+          IF ((.NOT.spinup).OR.(spinup.AND.spinConv)) THEN
+            IF (icycle >0) THEN
+              IF ( IS_CASA_TIME("write", yyyy, oktau, kstart, &
+                                koffset, kend, ktauday, logn) ) THEN
+                ctime = ctime +1
 
 
-          IF ( .NOT. CASAONLY ) THEN
-             ! MPI: scatter input data to the workers
+                CALL WRITE_CASA_OUTPUT_NC (veg, casamet, casapool, casabal, casaflux, &
+                     CASAONLY, ctime, &
+                     ( ktau.EQ.kend .AND. YYYY .EQ.cable_user%YearEnd ) )
+              ENDIF
+            ENDIF
 
-             CALL master_send_input (icomm, inp_ts, iktau)
 
-             !  CALL MPI_Waitall (wnp, inp_req, inp_stats, ierr)
-          ELSE
-             CALL master_send_input (icomm, casa_dump_ts, iktau)
-             CALL MPI_Waitall (wnp, inp_req, inp_stats, ierr)
+            IF ( (.NOT. CASAONLY).AND. spinConv  ) THEN
+
+              IF ( TRIM(cable_user%MetType) .EQ. 'plum'       &
+                   .OR. TRIM(cable_user%MetType) .EQ. 'cru'   &
+                   .OR. TRIM(cable_user%MetType) .EQ. 'gswp'  &
+                   .OR. TRIM(cable_user%MetType) .EQ. 'gswp3') THEN
+                CALL write_output( dels, ktau_tot, met, canopy, casaflux, casapool, &
+                     casamet,ssnow,         &
+                     rad, bal, air, soil, veg, CSBOLTZ,     &
+                     CEMLEAF, CEMSOIL )
+              ELSE
+                CALL write_output( dels, ktau, met, canopy, casaflux, casapool, &
+                     casamet, ssnow,   &
+                     rad, bal, air, soil, veg, CSBOLTZ, CEMLEAF, CEMSOIL )
+
+              ENDIF
+            END IF
           ENDIF
 
-          IF (spincasa.OR. casaonly) THEN
-             EXIT
-          ENDIF
-          !IF (.NOT.spincasa) THEN
-          ! time step loop over ktau
-          KTAULOOP:DO ktau=kstart, kend - 1
-             !         ! increment total timstep counter
-             !         ktau_tot = ktau_tot + 1
-             iktau = iktau + 1
-             oktau = oktau + 1
+          !---------------------------------------------------------------------!
+          ! Check this run against standard for quasi-bitwise reproducability   !
+          ! Check triggered by cable_user%consistency_check=.TRUE. in cable.nml !
+          !---------------------------------------------------------------------!
+          IF(cable_user%consistency_check) THEN
 
-             WRITE(logn,*) 'Progress -',REAL(ktau)/REAL(kend)*100.0
-
-             met%year = imet%year
-             met%doy = imet%doy
-
-             ! globally (WRT code) accessible kend through USE cable_common_module
-             ktau_tot= ktau_tot + 1
-             ktau_gl = iktau
-
-             ! some things (e.g. CASA-CNP) only need to be done once per day
-             idoy =INT( MOD((REAL(ktau+koffset)/REAL(ktauday)),REAL(LOY)))
-             IF ( idoy .EQ. 0 ) idoy = LOY
-
-             ! needed for CASA-CNP
-             nyear =INT((kend-kstart+1)/(LOY*ktauday))
-
-             ! Get met data and LAI, set time variables.
-             ! Rainfall input may be augmented for spinup purposes:
-             !          met%ofsd = met%fsd(:,1) + met%fsd(:,2)
-             IF ( TRIM(cable_user%MetType) .EQ. 'plum' ) THEN
-                CALL PLUME_MIP_GET_MET(PLUME, iMET, YYYY, iktau, kend, &
-                     (YYYY.EQ.CABLE_USER%YearEnd .AND. iktau.EQ.kend))
-
-             ELSE IF ( TRIM(cable_user%MetType) .EQ. 'cru' ) THEN
-                CALL CRU_GET_SUBDIURNAL_MET(CRU, imet, YYYY, iktau, kend, &
-                     (YYYY.EQ.CABLE_USER%YearEnd) )
-             ELSE
-
-                CALL get_met_data( spinup, spinConv, imet, soil,                 &
-                     rad, iveg, kend, dels, CTFRZ, iktau+koffset,                &
-                     kstart+koffset )
-
-             ENDIF
-             IF ( (TRIM(cable_user%MetType) .NE. 'gswp') .AND. &
-                  (TRIM(cable_user%MetType) .NE. 'gswp3') ) CurYear = met%year(1)
-
-!$             IF ( CASAONLY .AND. IS_CASA_TIME("dread", yyyy, iktau, kstart, koffset, &
-!$                  kend, ktauday, logn) )  THEN
-!$                ! CLN READ FROM FILE INSTEAD !
-!$                WRITE(CYEAR,FMT="(I4)")CurYear + INT((ktau-kstart+koffset)/(LOY*ktauday))
-!$                ncfile  = TRIM(casafile%c2cdumppath)//'c2c_'//CYEAR//'_dump.nc'
-!$                casa_it = NINT( REAL(iktau / ktauday) )
-!$                CALL read_casa_dump( ncfile, casamet, casaflux, casa_it, kend, .FALSE. )
-!$             ENDIF
-
-
-!$             ! At first time step of year, set tile area according to updated LU areas
-!$             IF (ktau == 1 .and. CABLE_USER%POPLUC) THEN
-!$               CALL POPLUC_set_patchfrac(POPLUC,LUC_EXPT)
-!$            ENDIF
-
-
-             IF ( .NOT. CASAONLY ) THEN
-
-                IF ( icycle > 0 ) THEN
-                   ! receive casa update from worker
-                   CALL master_receive (ocomm, oktau, casa_ts)
-
-                   CALL MPI_Waitall (wnp, recv_req, recv_stats, ierr)
-                   ! receive casa dump requirements from worker
-                   IF ( ((.NOT.spinup).OR.(spinup.AND.spinConv)) .AND.   &
-                        ( IS_CASA_TIME("dwrit", yyyy, oktau, kstart, &
-                        koffset, kend, ktauday, logn) ) ) THEN
-                      CALL master_receive ( ocomm, oktau, casa_dump_ts )
-
-                      ! CALL MPI_Waitall (wnp, recv_req, recv_stats, ierr)
-                   ENDIF
-                ENDIF
-
-                ! MPI: receive this time step's results from the workers
-                CALL master_receive (ocomm, oktau, recv_ts)
-                ! CALL MPI_Waitall (wnp, recv_req, recv_stats, ierr)
-
-
-                ! MPI: scatter input data to the workers
-                CALL master_send_input (icomm, inp_ts, iktau)
-                !  CALL MPI_Waitall (wnp, inp_req, inp_stats, ierr)
-
-!$                IF ( ((.NOT.spinup).OR.(spinup.AND.spinConv)) .AND.   &
-!$                     ( IS_CASA_TIME("dwrit", yyyy, oktau, kstart, &
-!$                        koffset, kend, ktauday, logn) ) ) THEN
-!$                   WRITE(CYEAR,FMT="(I4)") CurYear + INT((ktau-kstart)/(LOY*ktauday))
-!$                   ncfile = TRIM(casafile%c2cdumppath)//'c2c_'//CYEAR//'_dump.nc'
-!$                   CALL write_casa_dump( ncfile, casamet , casaflux, idoy, &
-!$                        kend/ktauday )
-!$
-!$                ENDIF
-
-                IF (((.NOT.spinup).OR.(spinup.AND.spinConv)).AND. &
-                     MOD((ktau-kstart+1),ktauday)==0) THEN
-                   IF ( CABLE_USER%CASA_DUMP_WRITE )  THEN
-
-
-                      !CLN CHECK FOR LEAP YEAR
-                      WRITE(CYEAR,FMT="(I4)") CurYear + INT((ktau-kstart)/(LOY*ktauday))
-                      ncfile = TRIM(casafile%c2cdumppath)//'c2c_'//CYEAR//'_dump.nc'
-                      CALL write_casa_dump( ncfile, casamet , casaflux, phen, climate, idoy, &
-                           kend/ktauday )
-
-                   ENDIF
-                ENDIF
-
-             ELSE IF ( MOD((ktau-kstart+1+koffset),ktauday)==0 ) THEN
-
-                CALL master_send_input (icomm, casa_dump_ts, iktau )
-                !    CALL MPI_Waitall (wnp, inp_req, inp_stats, ierr)
-
-             ENDIF
-
-             !             CALL MPI_Waitall (wnp, recv_req, recv_stats, ierr)
-             !             CALL MPI_Waitall (wnp, inp_req, inp_stats, ierr)
-
-             met%ofsd = met%fsd(:,1) + met%fsd(:,2)
-             canopy%oldcansto=canopy%cansto
-
-             ! Zero out lai where there is no vegetation acc. to veg. index
-             WHERE ( iveg%iveg(:) .GE. 14 ) iveg%vlai = 0.
-
-             ! Write time step's output to file if either: we're not spinning up
-             ! or we're spinning up and the spinup has converged:
-             ! MPI: TODO: pull mass and energy balance calculation from write_output
-             ! and refactor into worker code
-
-             ktau_gl = oktau
-
-             IF((.NOT.spinup).OR.(spinup.AND.spinConv)) THEN
-                IF(icycle >0) THEN
-                   IF ( IS_CASA_TIME("write", yyyy, oktau, kstart, &
-                        koffset, kend, ktauday, logn) ) THEN
-                      ctime = ctime +1
-
-
-                      CALL WRITE_CASA_OUTPUT_NC (veg, casamet, casapool, casabal, casaflux, &
-                           CASAONLY, ctime, &
-                           ( ktau.EQ.kend .AND. YYYY .EQ.cable_user%YearEnd ) )
-                   ENDIF
-                ENDIF
-
-
-                IF ( (.NOT. CASAONLY).AND. spinConv  ) THEN
-
-                   IF ( TRIM(cable_user%MetType) .EQ. 'plum'       &
-                        .OR. TRIM(cable_user%MetType) .EQ. 'cru'   &
-                        .OR. TRIM(cable_user%MetType) .EQ. 'gswp'  &
-                        .OR. TRIM(cable_user%MetType) .EQ. 'gswp3') THEN
-                      CALL write_output( dels, ktau_tot, met, canopy, casaflux, casapool, &
-                           casamet,ssnow,         &
-                           rad, bal, air, soil, veg, CSBOLTZ,     &
-                           CEMLEAF, CEMSOIL )
-                   ELSE
-                      CALL write_output( dels, ktau, met, canopy, casaflux, casapool, &
-                           casamet, ssnow,   &
-                           rad, bal, air, soil, veg, CSBOLTZ, CEMLEAF, CEMSOIL )
-
-                   ENDIF
-                END IF
-             ENDIF
-
-             !---------------------------------------------------------------------!
-             ! Check this run against standard for quasi-bitwise reproducability   !
-             ! Check triggered by cable_user%consistency_check=.TRUE. in cable.nml !
-             !---------------------------------------------------------------------!
-             IF(cable_user%consistency_check) THEN
-
-                count_bal = count_bal +1;
-                new_sumbal = new_sumbal + SUM(bal%wbal)/mp +  SUM(bal%ebal)/mp
-                new_sumfpn = new_sumfpn + SUM(canopy%fpn)/mp
-                new_sumfe = new_sumfe + SUM(canopy%fe)/mp
+            count_bal = count_bal +1;
+            new_sumbal = new_sumbal + SUM(bal%wbal)/mp +  SUM(bal%ebal)/mp
+            new_sumfpn = new_sumfpn + SUM(canopy%fpn)/mp
+            new_sumfe = new_sumfe + SUM(canopy%fe)/mp
 !$                    if (ktau == kend-1) PRINT*, "time-space-averaged energy & water balances"
 !$                    if (ktau == kend-1) PRINT*,"Ebal_tot[Wm-2], Wbal_tot[mm]", &
 !$                         sum(bal%ebal_tot)/mp/count_bal, sum(bal%wbal_tot)/mp/count_bal
@@ -796,458 +796,458 @@ CONTAINS
 !$                    if (ktau == kend-1) PRINT*, "sum_fe[Wm-2], sum_fpn[umol/m2/s]",  &
 !$                         new_sumfe/count_bal, new_sumfpn/count_bal
 
-                ! check for Nans in biophysical outputs and abort if there are any
-                IF (ANY( canopy%fe.NE. canopy%fe)) THEN
-                   DO kk=1,mp
+            ! check for Nans in biophysical outputs and abort if there are any
+            IF (ANY( canopy%fe.NE. canopy%fe)) THEN
+              DO kk=1,mp
 
-                      IF (canopy%fe(kk).NE. canopy%fe(kk)) THEN
-                         WRITE(*,*) 'Nan in evap flux,', kk, patch(kk)%latitude, patch(kk)%longitude
-                         WRITE(*,*) 'fe nan', kk, ktau,met%qv(kk), met%precip(kk),met%precip_sn(kk), &
-                              met%fld(kk), met%fsd(kk,:), met%tk(kk), met%ua(kk), &
-                              ssnow%potev(kk), met%pmb(kk), &
-                              canopy%ga(kk), ssnow%tgg(kk,:), canopy%fwsoil(kk), &
-                              rad%fvlai(kk,:) ,  rad%fvlai(kk,1), &
-                              rad%fvlai(kk,2), canopy%vlaiw(kk)
+                IF (canopy%fe(kk).NE. canopy%fe(kk)) THEN
+                  WRITE(*,*) 'Nan in evap flux,', kk, patch(kk)%latitude, patch(kk)%longitude
+                  WRITE(*,*) 'fe nan', kk, ktau,met%qv(kk), met%precip(kk),met%precip_sn(kk), &
+                    met%fld(kk), met%fsd(kk,:), met%tk(kk), met%ua(kk), &
+                    ssnow%potev(kk), met%pmb(kk), &
+                    canopy%ga(kk), ssnow%tgg(kk,:), canopy%fwsoil(kk), &
+                    rad%fvlai(kk,:) ,  rad%fvlai(kk,1), &
+                    rad%fvlai(kk,2), canopy%vlaiw(kk)
 
-                         CALL MPI_Abort(comm, 0, ierr)
-                      ENDIF
-
-                   ENDDO
-
-                ENDIF
-                IF(ktau==(kend-1)) THEN
-
-                   nkend = nkend+1
-                   IF( ABS(new_sumbal-trunk_sumbal) < 1.e-7) THEN
-
-                      PRINT *, ""
-                      PRINT *, &
-                           "NB. Offline-parallel runs spinup cycles:", nkend
-                      PRINT *, &
-                           "Internal check shows this version reproduces the trunk sumbal"
-
-                   ELSE
-
-                      PRINT *, ""
-                      PRINT *, &
-                           "NB. Offline-parallel runs spinup cycles:", nkend
-                      PRINT *, &
-                           "Internal check shows in this version new_sumbal != trunk sumbal"
-                      PRINT *, "The difference is: ", new_sumbal - trunk_sumbal
-                      PRINT *, &
-                           "Writing new_sumbal to the file:", TRIM(filename%new_sumbal)
-
-                      !CLN                      OPEN( 12, FILE = filename%new_sumbal )
-                      !CLN                      WRITE( 12, '(F20.7)' ) new_sumbal  ! written by previous trunk version
-                      !CLN                      CLOSE(12)
-
-                   ENDIF
-
+                  CALL MPI_Abort(comm, 0, ierr)
                 ENDIF
 
-             ENDIF
+              ENDDO
 
-             CALL1 = .FALSE.
+            ENDIF
+            IF(ktau==(kend-1)) THEN
 
-             !WRITE(*,*) " ktauloop end ", ktau, CurYear
+              nkend = nkend+1
+              IF( ABS(new_sumbal-trunk_sumbal) < 1.e-7) THEN
 
+                PRINT *, ""
+                PRINT *, &
+                      "NB. Offline-parallel runs spinup cycles:", nkend
+                PRINT *, &
+                      "Internal check shows this version reproduces the trunk sumbal"
 
-          END DO KTAULOOP ! END Do loop over timestep ktau
+              ELSE
+
+                PRINT *, ""
+                PRINT *, &
+                      "NB. Offline-parallel runs spinup cycles:", nkend
+                PRINT *, &
+                      "Internal check shows in this version new_sumbal != trunk sumbal"
+                PRINT *, "The difference is: ", new_sumbal - trunk_sumbal
+                PRINT *, &
+                      "Writing new_sumbal to the file:", TRIM(filename%new_sumbal)
+
+                !CLN                      OPEN( 12, FILE = filename%new_sumbal )
+                !CLN                      WRITE( 12, '(F20.7)' ) new_sumbal  ! written by previous trunk version
+                !CLN                      CLOSE(12)
+
+              ENDIF
+
+            ENDIF
+
+          ENDIF
 
           CALL1 = .FALSE.
 
-
-          ! MPI: read ahead tail to receive (last step and write)
-          met%year = imet%year
-          met%doy  = imet%doy
-          oktau    = oktau + 1
-          ktau_tot = ktau_tot + 1
-          ktau_gl  = oktau
-
-          IF ( .NOT. CASAONLY ) THEN
-
-             IF ( icycle >0 ) THEN
-
-                CALL master_receive (ocomm, oktau, casa_ts)
-
-                IF ( ((.NOT.spinup).OR.(spinup.AND.spinConv)) .AND. &
-                     ( IS_CASA_TIME("dwrit", yyyy, oktau, kstart, &
-                     koffset, kend, ktauday, logn) ) ) THEN
-                   CALL master_receive ( ocomm, oktau, casa_dump_ts )
-
-                ENDIF
-
-             ENDIF
+          !WRITE(*,*) " ktauloop end ", ktau, CurYear
 
 
-             CALL master_receive (ocomm, oktau, recv_ts)
+        END DO KTAULOOP ! END Do loop over timestep ktau
 
-          ENDIF
-
-          met%ofsd = met%fsd(:,1) + met%fsd(:,2)
-          canopy%oldcansto=canopy%cansto
-
-          IF ( (TRIM(cable_user%MetType) .EQ. "gswp") .OR. (TRIM(cable_user%MetType) .EQ. "gswp3") ) &
-               CALL close_met_file
-
-          IF (icycle>0 .AND.   cable_user%CALL_POP)  THEN
-             WRITE(*,*)  'b4 annual calcs'
-
-             IF (CABLE_USER%POPLUC) THEN
+        CALL1 = .FALSE.
 
 
-                ! master receives casa updates required for LUC calculations here
-                CALL master_receive (ocomm, 0, casa_LUC_ts)
+        ! MPI: read ahead tail to receive (last step and write)
+        met%year = imet%year
+        met%doy  = imet%doy
+        oktau    = oktau + 1
+        ktau_tot = ktau_tot + 1
+        ktau_gl  = oktau
 
-                ! Dynamic LUC
-                CALL LUCdriver( casabiome,casapool,casaflux,POP,LUC_EXPT, POPLUC, veg )
+        IF ( .NOT. CASAONLY ) THEN
 
+          IF ( icycle >0 ) THEN
 
-                ! transfer POP updates to workers
-                off = 1
-                DO rank = 1, wnp
-                   IF ( rank .GT. 1 ) off = off + wland(rank-1)%npop_iwood
-                   cnt = wland(rank)%npop_iwood
-                   CALL MPI_Send( POP%pop_grid(off), cnt, pop_ts, rank, 0, icomm, ierr )
-                END DO
-             ENDIF
+            CALL master_receive (ocomm, oktau, casa_ts)
 
-             ! one annual time-step of POP (worker calls POP here)
-             !CALL POPdriver(casaflux,casabal,veg, POP)
-             CALL master_receive_pop(POP, ocomm)
+            IF ( ((.NOT.spinup).OR.(spinup.AND.spinConv)) .AND. &
+                 ( IS_CASA_TIME("dwrit", yyyy, oktau, kstart, &
+                 koffset, kend, ktauday, logn) ) ) THEN
+              CALL master_receive ( ocomm, oktau, casa_dump_ts )
 
-             IF (CABLE_USER%POPLUC) THEN
-                ! Dynamic LUC: update casa pools according to LUC transitions
-                CALL POP_LUC_CASA_transfer(POPLUC,POP,LUC_EXPT,casapool,casabal,casaflux,ktauday)
-                ! Dynamic LUC: write output
-                IF (output%grid(1:3) == 'lan') THEN
-                   CALL WRITE_LUC_OUTPUT_NC( POPLUC, YYYY, ( YYYY.EQ.cable_user%YearEnd ))
-                ELSE
-                   CALL WRITE_LUC_OUTPUT_GRID_NC( POPLUC, YYYY, ( YYYY.EQ.cable_user%YearEnd ))
-                   !CALL WRITE_LUC_OUTPUT_NC( POPLUC, YYYY, ( YYYY.EQ.cable_user%YearEnd ))
-                ENDIF
-
-             ENDIF
-
-             IF (CABLE_USER%POPLUC) &
-                                ! send updates for CASA pools, resulting from LUC
-                  CALL master_send_input (icomm, casa_LUC_ts, nyear)
-
+            ENDIF
 
           ENDIF
-          WRITE(*,*) 'after annual calcs'
 
 
-          ! WRITE OUTPUT
-          IF((.NOT.spinup).OR.(spinup.AND.spinConv)) THEN
-             IF(icycle >0) THEN
-                ctime = ctime +1
-                CALL WRITE_CASA_OUTPUT_NC (veg, casamet, casapool, casabal, casaflux, &
-                     CASAONLY, ctime, ( ktau.EQ.kend .AND. YYYY .EQ.               &
-                     cable_user%YearEnd ) )
-                IF ( cable_user%CALL_POP ) THEN
+          CALL master_receive (ocomm, oktau, recv_ts)
 
-                   ! CALL master_receive_pop(POP, ocomm)
-                   ! CALL MPI_Waitall (wnp, recv_req, recv_stats, ierr)
-                   IF ( TRIM(cable_user%POP_out).EQ.'epi' ) THEN
-                      CALL POP_IO( pop, casamet, CurYear, 'WRITE_EPI', &
-                           (CurYear.EQ.CABLE_USER%YearEnd) )
-                   ENDIF
+        ENDIF
 
+        met%ofsd = met%fsd(:,1) + met%fsd(:,2)
+        canopy%oldcansto=canopy%cansto
 
-                ENDIF
-             END IF
+        IF ( (TRIM(cable_user%MetType) .EQ. "gswp") .OR. (TRIM(cable_user%MetType) .EQ. "gswp3") ) &
+          CALL close_met_file
 
-!$             IF ( CABLE_USER%CASA_DUMP_WRITE )  THEN
-!$                !CLN CHECK FOR LEAP YEAR
-!$                WRITE(CYEAR,FMT="(I4)") CurYear + INT((ktau-kstart)/(LOY*ktauday))
-!$                ncfile = TRIM(casafile%c2cdumppath)//'c2c_'//CYEAR//'_dump.nc'
-!$                CALL write_casa_dump( ncfile, casamet , casaflux, idoy, &
-!$                     kend/ktauday )
-!$
-!$             ENDIF
+        IF (icycle>0 .AND.   cable_user%CALL_POP)  THEN
+          WRITE(*,*)  'b4 annual calcs'
 
-             IF (((.NOT.spinup).OR.(spinup.AND.spinConv)).AND. &
-                  MOD((ktau-kstart+1),ktauday)==0) THEN
-                IF ( CABLE_USER%CASA_DUMP_WRITE )  THEN
-                   !CLN CHECK FOR LEAP YEAR
-                   WRITE(CYEAR,FMT="(I4)") CurYear + INT((ktau-kstart)/(LOY*ktauday))
-                   ncfile = TRIM(casafile%c2cdumppath)//'c2c_'//CYEAR//'_dump.nc'
-
-                   CALL write_casa_dump( ncfile, casamet , casaflux, phen, climate, LOY, &
-                        kend/ktauday )
-
-                ENDIF
-             ENDIF
-
-             IF ( (.NOT. CASAONLY) .AND. spinConv ) THEN
-                IF ( TRIM(cable_user%MetType) .EQ. 'plum' &
-                     .OR. TRIM(cable_user%MetType) .EQ. 'cru'   &
-                     .OR. TRIM(cable_user%MetType) .EQ. 'gswp' &
-                     .OR. TRIM(cable_user%MetType) .EQ. 'gswp3') THEN
-
-                   CALL write_output( dels, ktau_tot, met, canopy, casaflux, casapool, &
-                        casamet, ssnow,         &
-                        rad, bal, air, soil, veg, CSBOLTZ,     &
-                        CEMLEAF, CEMSOIL )
-                ELSE
-                   CALL write_output( dels, ktau, met, canopy, casaflux, casapool, casamet, &
-                        ssnow,   &
-                        rad, bal, air, soil, veg, CSBOLTZ, CEMLEAF, CEMSOIL )
-
-                ENDIF
-             END IF
-
-             IF(cable_user%consistency_check) THEN
-
-                count_bal = count_bal +1;
-                new_sumbal = new_sumbal + SUM(bal%wbal)/mp +  SUM(bal%ebal)/mp
-                new_sumfpn = new_sumfpn + SUM(canopy%fpn)/mp
-                new_sumfe = new_sumfe + SUM(canopy%fe)/mp
-                IF (ktau == kend) PRINT*
-                IF (ktau == kend) PRINT*, "time-space-averaged energy & water balances"
-                IF (ktau == kend) PRINT*,"Ebal_tot[Wm-2], Wbal_tot[mm per timestep]", &
-                     SUM(bal%ebal_tot)/mp/count_bal, SUM(bal%wbal_tot)/mp/count_bal
-                IF (ktau == kend) PRINT*, "time-space-averaged latent heat and &
-                     net photosynthesis"
-                IF (ktau == kend) PRINT*, "sum_fe[Wm-2], sum_fpn[umol/m2/s]",  &
-                     new_sumfe/count_bal, new_sumfpn/count_bal
-                IF (ktau == kend) WRITE(logn,*)
-                IF (ktau == kend) WRITE(logn,*)  "time-space-averaged energy & water balances"
-                IF (ktau == kend) WRITE(logn,*) "Ebal_tot[Wm-2], Wbal_tot[mm per timestep]", &
-                     SUM(bal%ebal_tot)/mp/count_bal, SUM(bal%wbal_tot)/mp/count_bal
-                IF (ktau == kend) WRITE(logn,*)  "time-space-averaged latent heat and &
-                     net photosynthesis"
-                IF (ktau == kend) WRITE(logn,*)  "sum_fe[Wm-2], sum_fpn[umol/m2/s]",  &
-                     new_sumfe/count_bal, new_sumfpn/count_bal
-
-
-
-             ENDIF
-
-
-
-          END IF
-          ! set tile area according to updated LU areas
           IF (CABLE_USER%POPLUC) THEN
-             CALL POPLUC_set_patchfrac(POPLUC,LUC_EXPT)
+
+
+            ! master receives casa updates required for LUC calculations here
+            CALL master_receive (ocomm, 0, casa_LUC_ts)
+
+            ! Dynamic LUC
+            CALL LUCdriver( casabiome,casapool,casaflux,POP,LUC_EXPT, POPLUC, veg )
+
+
+            ! transfer POP updates to workers
+            off = 1
+            DO rank = 1, wnp
+              IF ( rank .GT. 1 ) off = off + wland(rank-1)%npop_iwood
+              cnt = wland(rank)%npop_iwood
+              CALL MPI_Send( POP%pop_grid(off), cnt, pop_ts, rank, 0, icomm, ierr )
+            END DO
+          ENDIF
+
+          ! one annual time-step of POP (worker calls POP here)
+          !CALL POPdriver(casaflux,casabal,veg, POP)
+          CALL master_receive_pop(POP, ocomm)
+
+          IF (CABLE_USER%POPLUC) THEN
+            ! Dynamic LUC: update casa pools according to LUC transitions
+            CALL POP_LUC_CASA_transfer(POPLUC,POP,LUC_EXPT,casapool,casabal,casaflux,ktauday)
+            ! Dynamic LUC: write output
+            IF (output%grid(1:3) == 'lan') THEN
+              CALL WRITE_LUC_OUTPUT_NC( POPLUC, YYYY, ( YYYY.EQ.cable_user%YearEnd ))
+            ELSE
+              CALL WRITE_LUC_OUTPUT_GRID_NC( POPLUC, YYYY, ( YYYY.EQ.cable_user%YearEnd ))
+              !CALL WRITE_LUC_OUTPUT_NC( POPLUC, YYYY, ( YYYY.EQ.cable_user%YearEnd ))
+            ENDIF
+
+          ENDIF
+
+          IF (CABLE_USER%POPLUC) &
+            ! send updates for CASA pools, resulting from LUC
+            CALL master_send_input (icomm, casa_LUC_ts, nyear)
+
+
+        ENDIF
+        WRITE(*,*) 'after annual calcs'
+
+
+        ! WRITE OUTPUT
+        IF((.NOT.spinup).OR.(spinup.AND.spinConv)) THEN
+          IF(icycle >0) THEN
+            ctime = ctime +1
+            CALL WRITE_CASA_OUTPUT_NC (veg, casamet, casapool, casabal, casaflux, &
+                 CASAONLY, ctime, ( ktau.EQ.kend .AND. YYYY .EQ.               &
+                 cable_user%YearEnd ) )
+            IF ( cable_user%CALL_POP ) THEN
+
+              ! CALL master_receive_pop(POP, ocomm)
+              ! CALL MPI_Waitall (wnp, recv_req, recv_stats, ierr)
+              IF ( TRIM(cable_user%POP_out).EQ.'epi' ) THEN
+                CALL POP_IO( pop, casamet, CurYear, 'WRITE_EPI', &
+                     (CurYear.EQ.CABLE_USER%YearEnd) )
+              ENDIF
+
+
+            ENDIF
+          END IF
+
+!$        IF ( CABLE_USER%CASA_DUMP_WRITE )  THEN
+!$          !CLN CHECK FOR LEAP YEAR
+!$          WRITE(CYEAR,FMT="(I4)") CurYear + INT((ktau-kstart)/(LOY*ktauday))
+!$          ncfile = TRIM(casafile%c2cdumppath)//'c2c_'//CYEAR//'_dump.nc'
+!$          CALL write_casa_dump( ncfile, casamet , casaflux, idoy, &
+!$               kend/ktauday )
+!$
+!$        ENDIF
+
+          IF (((.NOT.spinup).OR.(spinup.AND.spinConv)).AND. &
+               MOD((ktau-kstart+1),ktauday)==0) THEN
+            IF ( CABLE_USER%CASA_DUMP_WRITE )  THEN
+              !CLN CHECK FOR LEAP YEAR
+              WRITE(CYEAR,FMT="(I4)") CurYear + INT((ktau-kstart)/(LOY*ktauday))
+              ncfile = TRIM(casafile%c2cdumppath)//'c2c_'//CYEAR//'_dump.nc'
+
+              CALL write_casa_dump( ncfile, casamet , casaflux, phen, climate, LOY, &
+                   kend/ktauday )
+
+            ENDIF
+          ENDIF
+
+          IF ( (.NOT. CASAONLY) .AND. spinConv ) THEN
+            IF ( TRIM(cable_user%MetType) .EQ. 'plum' &
+                 .OR. TRIM(cable_user%MetType) .EQ. 'cru'   &
+                 .OR. TRIM(cable_user%MetType) .EQ. 'gswp' &
+                 .OR. TRIM(cable_user%MetType) .EQ. 'gswp3') THEN
+
+              CALL write_output( dels, ktau_tot, met, canopy, casaflux, casapool, &
+                   casamet, ssnow,         &
+                   rad, bal, air, soil, veg, CSBOLTZ,     &
+                   CEMLEAF, CEMSOIL )
+            ELSE
+              CALL write_output( dels, ktau, met, canopy, casaflux, casapool, casamet, &
+                   ssnow,   &
+                   rad, bal, air, soil, veg, CSBOLTZ, CEMLEAF, CEMSOIL )
+
+            ENDIF
+          END IF
+
+          IF(cable_user%consistency_check) THEN
+
+            count_bal = count_bal +1;
+            new_sumbal = new_sumbal + SUM(bal%wbal)/mp +  SUM(bal%ebal)/mp
+            new_sumfpn = new_sumfpn + SUM(canopy%fpn)/mp
+            new_sumfe = new_sumfe + SUM(canopy%fe)/mp
+            IF (ktau == kend) PRINT*
+            IF (ktau == kend) PRINT*, "time-space-averaged energy & water balances"
+            IF (ktau == kend) PRINT*,"Ebal_tot[Wm-2], Wbal_tot[mm per timestep]", &
+              SUM(bal%ebal_tot)/mp/count_bal, SUM(bal%wbal_tot)/mp/count_bal
+            IF (ktau == kend) PRINT*, "time-space-averaged latent heat and &
+              net photosynthesis"
+            IF (ktau == kend) PRINT*, "sum_fe[Wm-2], sum_fpn[umol/m2/s]",  &
+              new_sumfe/count_bal, new_sumfpn/count_bal
+            IF (ktau == kend) WRITE(logn,*)
+            IF (ktau == kend) WRITE(logn,*)  "time-space-averaged energy & water balances"
+            IF (ktau == kend) WRITE(logn,*) "Ebal_tot[Wm-2], Wbal_tot[mm per timestep]", &
+              SUM(bal%ebal_tot)/mp/count_bal, SUM(bal%wbal_tot)/mp/count_bal
+            IF (ktau == kend) WRITE(logn,*)  "time-space-averaged latent heat and &
+              net photosynthesis"
+            IF (ktau == kend) WRITE(logn,*)  "sum_fe[Wm-2], sum_fpn[umol/m2/s]",  &
+              new_sumfe/count_bal, new_sumfpn/count_bal
+
+
+
           ENDIF
 
 
-       END DO YEARLOOP
 
-       IF (spincasa.OR.casaonly) THEN
-          EXIT
-       ENDIF
-
-       ! jhan this is insufficient testing. condition for
-       ! spinup=.false. & we want CASA_dump.nc (spinConv=.true.)
-       ! see if spinup (if conducting one) has converged:
-       IF(spinup.AND..NOT.spinConv.AND. .NOT. CASAONLY) THEN
-
-          ! Write to screen and log file:
-          WRITE(*,'(A18,I3,A24)') ' Spinning up: run ',INT(ktau_tot/kend),      &
-               ' of data set complete...'
-          WRITE(logn,'(A18,I3,A24)') ' Spinning up: run ',INT(ktau_tot/kend),   &
-               ' of data set complete...'
-
-          ! IF not 1st run through whole dataset:
-          IF( INT( ktau_tot/kend ) > 1 ) THEN
-
-             ! evaluate spinup
-             IF( ANY( ABS(ssnow%wb-soilMtemp)>delsoilM).OR.                     &
-                  ANY(ABS(ssnow%tgg-soilTtemp)>delsoilT) .OR. &
-                  MAXVAL(ABS(ssnow%GWwb-GWtemp),dim=1)>delgwM)  THEN
-
-                ! No complete convergence yet
-                !               PRINT *, 'ssnow%wb : ', ssnow%wb
-                !               PRINT *, 'soilMtemp: ', soilMtemp
-                !               PRINT *, 'ssnow%tgg: ', ssnow%tgg
-                !               PRINT *, 'soilTtemp: ', soilTtemp
-                maxdiff = MAXLOC(ABS(ssnow%wb-soilMtemp))
-                PRINT *, 'Example location of moisture non-convergence: ',maxdiff
-                PRINT *, 'ssnow%wb : ', ssnow%wb(maxdiff(1),maxdiff(2))
-                PRINT *, 'soilMtemp: ', soilMtemp(maxdiff(1),maxdiff(2))
-                maxdiff = MAXLOC(ABS(ssnow%tgg-soilTtemp))
-                PRINT *, 'Example location of temperature non-convergence: ',maxdiff
-                PRINT *, 'ssnow%tgg: ', ssnow%tgg(maxdiff(1),maxdiff(2))
-                PRINT *, 'soilTtemp: ', soilTtemp(maxdiff(1),maxdiff(2))
-
-                IF (cable_user%gw_model) THEN
-                   maxdiff(1) = MAXLOC(ABS(ssnow%GWwb-GWtemp),dim=1)
-                   PRINT *,'ssnow%GWwb: ', ssnow%GWwb(maxdiff(1))
-                   PRINT *, 'GWtemp: ', GWtemp(maxdiff(1))
-                ENDIF
+        END IF
+        ! set tile area according to updated LU areas
+        IF (CABLE_USER%POPLUC) THEN
+          CALL POPLUC_set_patchfrac(POPLUC,LUC_EXPT)
+        ENDIF
 
 
-             ELSE ! spinup has converged
+      END DO YEARLOOP
 
-                spinConv = .TRUE.
-                ! Write to screen and log file:
-                WRITE(*,'(A33)') ' Spinup has converged - final run'
-                WRITE(logn,'(A52)')                                             &
-                     ' Spinup has converged - final run - writing all data'
-                WRITE(logn,'(A37,F8.5,A28)')                                    &
-                     ' Criteria: Change in soil moisture < ',             &
-                     delsoilM, ' in any layer over whole run'
-                WRITE(logn,'(A40,F8.5,A28)' )                                   &
-                     '           Change in soil temperature < ',          &
+      IF (spincasa.OR.casaonly) THEN
+        EXIT
+      ENDIF
+
+      ! jhan this is insufficient testing. condition for
+      ! spinup=.false. & we want CASA_dump.nc (spinConv=.true.)
+      ! see if spinup (if conducting one) has converged:
+      IF(spinup.AND..NOT.spinConv.AND. .NOT. CASAONLY) THEN
+
+        ! Write to screen and log file:
+        WRITE(*,'(A18,I3,A24)') ' Spinning up: run ',INT(ktau_tot/kend),      &
+             ' of data set complete...'
+        WRITE(logn,'(A18,I3,A24)') ' Spinning up: run ',INT(ktau_tot/kend),   &
+             ' of data set complete...'
+
+        ! IF not 1st run through whole dataset:
+        IF( INT( ktau_tot/kend ) > 1 ) THEN
+
+          ! evaluate spinup
+          IF (ANY( ABS(ssnow%wb-soilMtemp)>delsoilM).OR.                     &
+              ANY(ABS(ssnow%tgg-soilTtemp)>delsoilT) .OR. &
+              MAXVAL(ABS(ssnow%GWwb-GWtemp),dim=1)>delgwM)  THEN
+
+            ! No complete convergence yet
+            !               PRINT *, 'ssnow%wb : ', ssnow%wb
+            !               PRINT *, 'soilMtemp: ', soilMtemp
+            !               PRINT *, 'ssnow%tgg: ', ssnow%tgg
+            !               PRINT *, 'soilTtemp: ', soilTtemp
+            maxdiff = MAXLOC(ABS(ssnow%wb-soilMtemp))
+            PRINT *, 'Example location of moisture non-convergence: ',maxdiff
+            PRINT *, 'ssnow%wb : ', ssnow%wb(maxdiff(1),maxdiff(2))
+            PRINT *, 'soilMtemp: ', soilMtemp(maxdiff(1),maxdiff(2))
+            maxdiff = MAXLOC(ABS(ssnow%tgg-soilTtemp))
+            PRINT *, 'Example location of temperature non-convergence: ',maxdiff
+            PRINT *, 'ssnow%tgg: ', ssnow%tgg(maxdiff(1),maxdiff(2))
+            PRINT *, 'soilTtemp: ', soilTtemp(maxdiff(1),maxdiff(2))
+
+            IF (cable_user%gw_model) THEN
+              maxdiff(1) = MAXLOC(ABS(ssnow%GWwb-GWtemp),dim=1)
+              PRINT *,'ssnow%GWwb: ', ssnow%GWwb(maxdiff(1))
+              PRINT *, 'GWtemp: ', GWtemp(maxdiff(1))
+            ENDIF
+
+
+          ELSE ! spinup has converged
+
+            spinConv = .TRUE.
+            ! Write to screen and log file:
+            WRITE(*,'(A33)') ' Spinup has converged - final run'
+            WRITE(logn,'(A52)')                                             &
+                 ' Spinup has converged - final run - writing all data'
+            WRITE(logn,'(A37,F8.5,A28)')                                    &
+                 ' Criteria: Change in soil moisture < ',             &
+                 delsoilM, ' in any layer over whole run'
+            WRITE(logn,'(A40,F8.5,A28)' )                                   &
+                 '           Change in soil temperature < ',          &
                      delsoilT, ' in any layer over whole run'
-             END IF
-
-          ELSE ! allocate variables for storage
-
-             IF (.NOT.ALLOCATED(soilMtemp)) ALLOCATE(  soilMtemp(mp,ms) )
-             IF (.NOT.ALLOCATED(soilTtemp)) ALLOCATE(  soilTtemp(mp,ms) )
-             IF (.NOT.ALLOCATED(GWtemp))    ALLOCATE(  GWtemp(mp) )
-
           END IF
 
-          IF (cable_user%max_spins .GT. 0) THEN
-             IF (INT( ktau_tot/kend ) .GT. cable_user%max_spins ) THEN
-                spinConv = .TRUE.
-                ! Write to screen and log file:
-                WRITE(*,*) ' Spinup exceeded max ',cable_user%max_spins,' cycles '
-                WRITE(*,*) ' Forcing the final run without spin up convergence '
-                WRITE(logn,*) ' Spinup exceeded max ',cable_user%max_spins,' cycles '
-                WRITE(logn,*) ' Forcing the final run without spin up convergence '
-             END IF
+        ELSE ! allocate variables for storage
+
+          IF (.NOT.ALLOCATED(soilMtemp)) ALLOCATE(  soilMtemp(mp,ms) )
+          IF (.NOT.ALLOCATED(soilTtemp)) ALLOCATE(  soilTtemp(mp,ms) )
+          IF (.NOT.ALLOCATED(GWtemp))    ALLOCATE(  GWtemp(mp) )
+
+        END IF
+
+        IF (cable_user%max_spins .GT. 0) THEN
+          IF (INT( ktau_tot/kend ) .GT. cable_user%max_spins ) THEN
+            spinConv = .TRUE.
+            ! Write to screen and log file:
+            WRITE(*,*) ' Spinup exceeded max ',cable_user%max_spins,' cycles '
+            WRITE(*,*) ' Forcing the final run without spin up convergence '
+            WRITE(logn,*) ' Spinup exceeded max ',cable_user%max_spins,' cycles '
+            WRITE(logn,*) ' Forcing the final run without spin up convergence '
           END IF
+        END IF
 
-          IF ( YYYY.GT. CABLE_USER%YearEnd ) THEN
-             ! store soil moisture and temperature
-             soilTtemp = ssnow%tgg
-             soilMtemp = REAL(ssnow%wb)
-          END IF
-          ! MPI:
-          loop_exit = .FALSE.
+        IF ( YYYY.GT. CABLE_USER%YearEnd ) THEN
+          ! store soil moisture and temperature
+          soilTtemp = ssnow%tgg
+          soilMtemp = REAL(ssnow%wb)
+        END IF
+        ! MPI:
+        loop_exit = .FALSE.
 
-       ELSE
+      ELSE
 
-          ! if not spinning up, or spin up has converged, exit:
-          ! EXIT
-          ! MPI:
-          loop_exit = .TRUE.
+        ! if not spinning up, or spin up has converged, exit:
+        ! EXIT
+        ! MPI:
+        loop_exit = .TRUE.
 
-       END IF
+      END IF
 
-       ! MPI: let the workers know whether it's time to quit
-       CALL MPI_Bcast (loop_exit, 1, MPI_LOGICAL, 0, comm, ierr)
+      ! MPI: let the workers know whether it's time to quit
+      CALL MPI_Bcast (loop_exit, 1, MPI_LOGICAL, 0, comm, ierr)
 
-       IF (loop_exit) THEN
-          EXIT
-       END IF
+      IF (loop_exit) THEN
+        EXIT
+      END IF
 
     END DO SPINLOOP
 
     IF (icycle > 0 .AND. (.NOT.spincasa).AND. (.NOT.casaonly)) THEN
-       ! MPI: gather casa results from all the workers
+      ! MPI: gather casa results from all the workers
 
-       CALL master_receive (ocomm, ktau_gl, casa_ts)
+      CALL master_receive (ocomm, ktau_gl, casa_ts)
 
-       !CALL MPI_Waitall (wnp, recv_req, recv_stats, ierr)
+      !CALL MPI_Waitall (wnp, recv_req, recv_stats, ierr)
 
-!$       CALL casa_poolout( ktau, veg, soil, casabiome,                           &
-!$            casapool, casaflux, casamet, casabal, phen )
-       CALL casa_fluxout( nyear, veg, soil, casabal, casamet)
+!$     CALL casa_poolout( ktau, veg, soil, casabiome,                           &
+!$          casapool, casaflux, casamet, casabal, phen )
+      CALL casa_fluxout( nyear, veg, soil, casabal, casamet)
 
-       if(.not.l_landuse) then
-           CALL write_casa_restart_nc ( casamet, casapool,casaflux,phen,CASAONLY )
-       endif
+      if(.not.l_landuse) then
+        CALL write_casa_restart_nc ( casamet, casapool,casaflux,phen,CASAONLY )
+      endif
 
-       !CALL write_casa_restart_nc ( casamet, casapool, met, CASAONLY )
+      !CALL write_casa_restart_nc ( casamet, casapool, met, CASAONLY )
 
 
-       IF (.not.l_landuse.and.CABLE_USER%CALL_POP .AND.POP%np.GT.0 ) THEN
-          IF ( CASAONLY .OR. cable_user%POP_fromZero &
-               .OR.TRIM(cable_user%POP_out).EQ.'ini' ) THEN
-             CALL POP_IO( pop, casamet, CurYear+1, 'WRITE_INI', .TRUE.)
+      IF (.not.l_landuse.and.CABLE_USER%CALL_POP .AND.POP%np.GT.0 ) THEN
+        IF ( CASAONLY .OR. cable_user%POP_fromZero &
+             .OR.TRIM(cable_user%POP_out).EQ.'ini' ) THEN
+          CALL POP_IO( pop, casamet, CurYear+1, 'WRITE_INI', .TRUE.)
 
-          ELSE
-             CALL POP_IO( pop, casamet, CurYear+1, 'WRITE_RST', .TRUE.)
-          ENDIF
-       END IF
-       IF (.not.l_landuse.and.cable_user%POPLUC .AND. .NOT. CASAONLY ) THEN
-          CALL WRITE_LUC_RESTART_NC ( POPLUC, YYYY )
-       ENDIF
+        ELSE
+          CALL POP_IO( pop, casamet, CurYear+1, 'WRITE_RST', .TRUE.)
+        ENDIF
+      END IF
+      IF (.not.l_landuse.and.cable_user%POPLUC .AND. .NOT. CASAONLY ) THEN
+        CALL WRITE_LUC_RESTART_NC ( POPLUC, YYYY )
+      ENDIF
 
 
     END IF
 
     ! Write restart file if requested:
     IF(output%restart .AND. (.NOT. CASAONLY)) THEN
-       ! MPI: TODO: receive variables that are required by create_restart
-       ! but not write_output
-       !CALL receive_restart (comm,ktau,dels,soil,veg,ssnow, &
-       !       &              canopy,rough,rad,bgc,bal)
-       ! gol124: how about call master_receive (comm, ktau, restart_ts)
-       ! instead of a separate receive_restart sub?
-       CALL master_receive (comm, ktau_gl, restart_ts)
+      ! MPI: TODO: receive variables that are required by create_restart
+      ! but not write_output
+      !CALL receive_restart (comm,ktau,dels,soil,veg,ssnow, &
+      !       &              canopy,rough,rad,bgc,bal)
+      ! gol124: how about call master_receive (comm, ktau, restart_ts)
+      ! instead of a separate receive_restart sub?
+      CALL master_receive (comm, ktau_gl, restart_ts)
 
-       !       CALL MPI_Waitall (wnp, recv_req, recv_stats, ierr)
+      !       CALL MPI_Waitall (wnp, recv_req, recv_stats, ierr)
 
-       if(.not.l_landuse) then
-       CALL create_restart( logn, dels, ktau, soil, veg, ssnow,                 &
-            canopy, rough, rad, bgc, bal, met  )
-       endif 
+      if(.not.l_landuse) then
+        CALL create_restart( logn, dels, ktau, soil, veg, ssnow,                 &
+             canopy, rough, rad, bgc, bal, met  )
+      endif
 
-       IF (cable_user%CALL_climate) THEN
-          CALL master_receive (comm, ktau_gl, climate_ts)
+      IF (cable_user%CALL_climate) THEN
+        CALL master_receive (comm, ktau_gl, climate_ts)
 
-          !CALL MPI_Waitall (wnp, recv_req, recv_stats, ierr)
+        !CALL MPI_Waitall (wnp, recv_req, recv_stats, ierr)
 
 
-          CALL WRITE_CLIMATE_RESTART_NC ( climate, ktauday )
-       END IF
+        CALL WRITE_CLIMATE_RESTART_NC ( climate, ktauday )
+      END IF
 
     END IF
 
 
     IF(l_landuse.and. .not. CASAONLY) then
-       mlon = maxval(landpt(1:mland)%ilon)
-       mlat = maxval(landpt(1:mland)%ilat)
-       allocate(luc_atransit(mland,mvmax,mvmax))
-       allocate(luc_fharvw(mland,mharvw))
-       allocate(luc_xluh2cable(mland,mvmax,mstate))
-       allocate(landmask(mlon,mlat))
-       allocate(arealand(mland))
-       allocate(patchfrac_new(mlon,mlat,mvmax))
-       allocate(cstart(mland),cend(mland),nap(mland))
+      mlon = maxval(landpt(1:mland)%ilon)
+      mlat = maxval(landpt(1:mland)%ilat)
+      allocate(luc_atransit(mland,mvmax,mvmax))
+      allocate(luc_fharvw(mland,mharvw))
+      allocate(luc_xluh2cable(mland,mvmax,mstate))
+      allocate(landmask(mlon,mlat))
+      allocate(arealand(mland))
+      allocate(patchfrac_new(mlon,mlat,mvmax))
+      allocate(cstart(mland),cend(mland),nap(mland))
 
-       do m=1,mland
-          cstart(m) = landpt(m)%cstart
-          cend(m)   = landpt(m)%cend
-          nap(m)    = landpt(m)%nap
-       enddo
+      do m=1,mland
+        cstart(m) = landpt(m)%cstart
+        cend(m)   = landpt(m)%cend
+        nap(m)    = landpt(m)%nap
+      enddo
 
-       call landuse_data(mlon,mlat,landmask,arealand,luc_atransit,luc_fharvw,luc_xluh2cable)
+      call landuse_data(mlon,mlat,landmask,arealand,luc_atransit,luc_fharvw,luc_xluh2cable)
 
-       call  landuse_driver(mlon,mlat,landmask,arealand,ssnow,soil,veg,bal,canopy,  &
+      call  landuse_driver(mlon,mlat,landmask,arealand,ssnow,soil,veg,bal,canopy,  &
                            phen,casapool,casabal,casamet,casabiome,casaflux,bgc,rad, &
                            cstart,cend,nap,lucmp)
 
-       print *, 'writing new gridinfo: landuse'
-       print *, 'new patch information. mland= ',mland
+      print *, 'writing new gridinfo: landuse'
+      print *, 'new patch information. mland= ',mland
 
-       do m=1,mland
-          do np=cstart(m),cend(m)
-             ivt=lucmp%iveg(np)
-             if(ivt<1.or.ivt>mvmax) then
-                print *, 'landuse: error in vegtype',m,np,ivt
-                stop
-             endif      
-             patchfrac_new(landpt(m)%ilon,landpt(m)%ilat,ivt) = lucmp%patchfrac(np)
-          enddo
-       enddo    
+      do m=1,mland
+        do np=cstart(m),cend(m)
+          ivt=lucmp%iveg(np)
+          if(ivt<1.or.ivt>mvmax) then
+            print *, 'landuse: error in vegtype',m,np,ivt
+            stop
+          endif
+          patchfrac_new(landpt(m)%ilon,landpt(m)%ilat,ivt) = lucmp%patchfrac(np)
+        enddo
+      enddo
 
-       call create_new_gridinfo(filename%type,filename%gridnew,mlon,mlat,landmask,patchfrac_new)                   
+      call create_new_gridinfo(filename%type,filename%gridnew,mlon,mlat,landmask,patchfrac_new)
 
-       call WRITE_LANDUSE_CASA_RESTART_NC(cend(mland), lucmp, CASAONLY )
+      call WRITE_LANDUSE_CASA_RESTART_NC(cend(mland), lucmp, CASAONLY )
 
-       call create_landuse_cable_restart(logn, dels, ktau, soil, cend(mland),lucmp,cstart,cend,nap, met)
+      call create_landuse_cable_restart(logn, dels, ktau, soil, cend(mland),lucmp,cstart,cend,nap, met)
 
-       call landuse_deallocate_mp(cend(mland),ms,msn,nrb,mplant,mlitter,msoil,mwood,lucmp)
-     ENDIF
+      call landuse_deallocate_mp(cend(mland),ms,msn,nrb,mplant,mlitter,msoil,mwood,lucmp)
+    ENDIF
 
 
 
@@ -1258,11 +1258,11 @@ CONTAINS
          TRIM(cable_user%MetType) .NE. "cru") CALL close_met_file
     IF  (.NOT. CASAONLY) THEN
        ! Close output file and deallocate main variables:
-       CALL close_output_file( bal, air, bgc, canopy, met,                         &
-            rad, rough, soil, ssnow,                            &
-            sum_flux, veg )
+      CALL close_output_file( bal, air, bgc, canopy, met,                         &
+           rad, rough, soil, ssnow,                            &
+           sum_flux, veg )
 
-       ! WRITE(logn,*) bal%wbal_tot, bal%ebal_tot, bal%ebal_tot_cncheck
+      ! WRITE(logn,*) bal%wbal_tot, bal%ebal_tot, bal%ebal_tot_cncheck
     ENDIF
 
     ! Close log file

--- a/src/offline/cable_mpimaster.F90
+++ b/src/offline/cable_mpimaster.F90
@@ -342,7 +342,7 @@ CONTAINS
         CurYear = YYYY
 
         !ccc Set calendar attribute: dependant on the value of `leaps`
-        ! that is set in the MetType if conditions above.
+        ! dependant on the MetType and set during initialisation.
         calendar = "noleap"
         LOY = 365
         IF ( leaps ) THEN

--- a/src/offline/cable_mpimaster.F90
+++ b/src/offline/cable_mpimaster.F90
@@ -75,16 +75,19 @@
 !==============================================================================
 MODULE cable_mpimaster
 
-  USE cable_driver_init_mod, ONLY : &
-    vegparmnew,                     &
-    spinup,                         &
-    spincasa,                       &
-    CASAONLY,                       &
-    l_landuse,                      &
-    delsoilM,                       &
-    delsoilT,                       &
-    delgwM,                         &
-    LALLOC
+  USE cable_driver_common_mod, ONLY : &
+    vegparmnew,                       &
+    spinup,                           &
+    spincasa,                         &
+    CASAONLY,                         &
+    l_landuse,                        &
+    delsoilM,                         &
+    delsoilT,                         &
+    delgwM,                           &
+    LALLOC,                           &
+    prepareFiles,                     &
+    renameFiles,                      &
+    LUCdriver
   USE cable_mpicommon
   USE casa_cable
   USE casa_inout_module
@@ -1276,81 +1279,6 @@ CONTAINS
     RETURN
 
   END SUBROUTINE mpidrv_master
-
-
-  SUBROUTINE prepareFiles(ncciy)
-    USE cable_IO_vars_module, ONLY: logn,gswpfile
-    IMPLICIT NONE
-    INTEGER, INTENT(IN) :: ncciy
-
-    WRITE(logn,*) 'CABLE offline global run using gswp forcing for ', ncciy
-    PRINT *,      'CABLE offline global run using gswp forcing for ', ncciy
-
-    CALL renameFiles(logn,gswpfile%rainf,ncciy,'rainf')
-    CALL renameFiles(logn,gswpfile%snowf,ncciy,'snowf')
-    CALL renameFiles(logn,gswpfile%LWdown,ncciy,'LWdown')
-    CALL renameFiles(logn,gswpfile%SWdown,ncciy,'SWdown')
-    CALL renameFiles(logn,gswpfile%PSurf,ncciy,'PSurf')
-    CALL renameFiles(logn,gswpfile%Qair,ncciy,'Qair')
-    CALL renameFiles(logn,gswpfile%Tair,ncciy,'Tair')
-    CALL renameFiles(logn,gswpfile%wind,ncciy,'wind')
-
-  END SUBROUTINE prepareFiles
-
-  SUBROUTINE renameFiles(logn,inFile,ncciy,inName)
-    IMPLICIT NONE
-    INTEGER, INTENT(IN) :: logn,ncciy
-    INTEGER:: nn
-    CHARACTER(LEN=200), INTENT(INOUT) :: inFile
-    CHARACTER(LEN=*),  INTENT(IN)    :: inName
-    INTEGER :: idummy
-
-    nn = INDEX(inFile,'19')
-    READ(inFile(nn:nn+3),'(i4)') idummy
-    WRITE(inFile(nn:nn+3),'(i4.4)') ncciy
-    WRITE(logn,*) TRIM(inName), ' global data from ', TRIM(inFile)
-
-  END SUBROUTINE renameFiles
-  !CLNSUBROUTINE prepareFiles(ncciy)
-  !CLN  USE cable_IO_vars_module, ONLY: logn,gswpfile
-  !CLN  IMPLICIT NONE
-  !CLN  INTEGER, INTENT(IN) :: ncciy
-  !CLN
-  !CLN  WRITE(logn,*) 'CABLE offline global run using gswp forcing for ', ncciy
-  !CLN  PRINT *,      'CABLE offline global run using gswp forcing for ', ncciy
-  !CLN
-  !CLN  CALL renameFiles(logn,gswpfile%rainf,16,ncciy,'rainf')
-  !CLN  CALL renameFiles(logn,gswpfile%snowf,16,ncciy,'snowf')
-  !CLN  CALL renameFiles(logn,gswpfile%LWdown,16,ncciy,'LWdown')
-  !CLN  CALL renameFiles(logn,gswpfile%SWdown,16,ncciy,'SWdown')
-  !CLN  CALL renameFiles(logn,gswpfile%PSurf,16,ncciy,'PSurf')
-  !CLN  CALL renameFiles(logn,gswpfile%Qair,14,ncciy,'Qair')
-  !CLN  CALL renameFiles(logn,gswpfile%Tair,14,ncciy,'Tair')
-  !CLN  CALL renameFiles(logn,gswpfile%wind,15,ncciy,'wind')
-  !CLN
-  !CLNEND SUBROUTINE prepareFiles
-  !CLN
-  !CLN
-  !CLNSUBROUTINE renameFiles(logn,inFile,nn,ncciy,inName)
-  !CLN  IMPLICIT NONE
-  !CLN  INTEGER, INTENT(IN) :: logn
-  !CLN  INTEGER, INTENT(IN) :: nn
-  !CLN  INTEGER, INTENT(IN) :: ncciy
-  !CLN  CHARACTER(LEN=99), INTENT(INOUT) :: inFile
-  !CLN  CHARACTER(LEN=*),  INTENT(IN)    :: inName
-  !CLN  INTEGER :: idummy
-  !CLN
-  !CLN  READ(inFile(nn:nn+3),'(i4)') idummy
-  !CLN  IF (idummy < 1983 .OR. idummy > 1995) THEN
-  !CLN    PRINT *, 'Check position of the year number in input gswp file', inFile
-  !CLN    STOP
-  !CLN  ELSE
-  !CLN    WRITE(inFile(nn:nn+3),'(i4.4)') ncciy
-  !CLN    WRITE(logn,*) TRIM(inName), ' global data from ', TRIM(inFile)
-  !CLN  ENDIF
-  !CLN
-  !CLNEND SUBROUTINE renameFiles
-
 
   ! ============== PRIVATE SUBROUTINES USED ONLY BY THE MPI MASTER ===============
 
@@ -8401,104 +8329,5 @@ CONTAINS
 
 
   END SUBROUTINE master_CASAONLY_LUC
-
-  !============================================================================
-  ! subroutine for reading LU input data, zeroing biomass in empty secondary forest tiles
-  ! and tranferring LUC-based age weights for secondary forest to POP structure
-
-
-  SUBROUTINE LUCdriver( casabiome,casapool, &
-       casaflux,POP,LUC_EXPT, POPLUC, veg )
-
-
-    USE cable_def_types_mod , ONLY: veg_parameter_type, mland
-    USE cable_carbon_module
-    USE cable_common_module, ONLY: CurYear
-    USE casa_ncdf_module, ONLY: is_casa_time
-    USE cable_IO_vars_module, ONLY: landpt
-    USE casadimension
-    USE casaparm
-    USE casavariable
-    USE POP_Types,  ONLY: POP_TYPE
-    USE POPMODULE,            ONLY: POPStep, POP_init_single
-    USE TypeDef,              ONLY: i4b, dp
-    USE CABLE_LUC_EXPT, ONLY: LUC_EXPT_TYPE, read_LUH2,&
-         ptos,ptog,stog,gtos,grassfrac, pharv, smharv, syharv
-    USE POPLUC_Types
-    USE POPLUC_Module, ONLY: POPLUCStep, POPLUC_weights_Transfer, WRITE_LUC_OUTPUT_NC, &
-         POP_LUC_CASA_transfer,  WRITE_LUC_RESTART_NC, READ_LUC_RESTART_NC
-
-    USE casa_cable
-
-    IMPLICIT NONE
-
-    TYPE (casa_biome),            INTENT(INOUT) :: casabiome
-    TYPE (casa_pool),             INTENT(INOUT) :: casapool
-    TYPE (casa_flux),             INTENT(INOUT) :: casaflux
-    TYPE (POP_TYPE), INTENT(INOUT)     :: POP
-    TYPE (LUC_EXPT_TYPE), INTENT(INOUT) :: LUC_EXPT
-    TYPE(POPLUC_TYPE), INTENT(INOUT) :: POPLUC
-    TYPE (veg_parameter_type),    INTENT(IN) :: veg  ! vegetation parameters
-
-    INTEGER ::  k, j, l, yyyy
-
-
-
-    WRITE(*,*) 'cablecasa_LUC', CurYear
-    yyyy = CurYear
-
-
-
-    LUC_EXPT%CTSTEP = yyyy -  LUC_EXPT%FirstYear + 1
-
-    CALL READ_LUH2(LUC_EXPT)
-
-    DO k=1,mland
-       POPLUC%ptos(k) = LUC_EXPT%INPUT(ptos)%VAL(k)
-       POPLUC%ptog(k) = LUC_EXPT%INPUT(ptog)%VAL(k)
-       POPLUC%stop(k) = 0.0
-       POPLUC%stog(k) = LUC_EXPT%INPUT(stog)%VAL(k)
-       POPLUC%gtop(k) = 0.0
-       POPLUC%gtos(k) = LUC_EXPT%INPUT(gtos)%VAL(k)
-       POPLUC%pharv(k) = LUC_EXPT%INPUT(pharv)%VAL(k)
-       POPLUC%smharv(k) = LUC_EXPT%INPUT(smharv)%VAL(k)
-       POPLUC%syharv(k) = LUC_EXPT%INPUT(syharv)%VAL(k)
-       POPLUC%thisyear = yyyy
-    ENDDO
-
-    ! zero secondary forest tiles in POP where secondary forest area is zero
-    DO k=1,mland
-       IF ((POPLUC%frac_primf(k)-POPLUC%frac_forest(k))==0.0 &
-            .AND. (.NOT.LUC_EXPT%prim_only(k))) THEN
-          j = landpt(k)%cstart+1
-          DO l=1,SIZE(POP%Iwood)
-             IF( POP%Iwood(l) == j) THEN
-                CALL POP_init_single(POP,veg%disturbance_interval,l)
-                EXIT
-             ENDIF
-          ENDDO
-
-          casapool%cplant(j,leaf) = 0.01
-          casapool%nplant(j,leaf)= casabiome%ratioNCplantmin(veg%iveg(j),leaf)* casapool%cplant(j,leaf)
-          casapool%pplant(j,leaf)= casabiome%ratioPCplantmin(veg%iveg(j),leaf)* casapool%cplant(j,leaf)
-
-          casapool%cplant(j,froot) = 0.01
-          casapool%nplant(j,froot)= casabiome%ratioNCplantmin(veg%iveg(j),froot)* casapool%cplant(j,froot)
-          casapool%pplant(j,froot)= casabiome%ratioPCplantmin(veg%iveg(j),froot)* casapool%cplant(j,froot)
-
-          casapool%cplant(j,wood) = 0.01
-          casapool%nplant(j,wood)= casabiome%ratioNCplantmin(veg%iveg(j),wood)* casapool%cplant(j,wood)
-          casapool%pplant(j,wood)= casabiome%ratioPCplantmin(veg%iveg(j),wood)* casapool%cplant(j,wood)
-          casaflux%frac_sapwood(j) = 1.0
-
-       ENDIF
-    ENDDO
-
-    CALL POPLUCStep(POPLUC,yyyy)
-
-    CALL POPLUC_weights_transfer(POPLUC,POP,LUC_EXPT)
-
-  END SUBROUTINE LUCdriver
-  !============================================================================
 
 END MODULE cable_mpimaster

--- a/src/offline/cable_mpiworker.F90
+++ b/src/offline/cable_mpiworker.F90
@@ -65,15 +65,15 @@
 !==============================================================================
 MODULE cable_mpiworker
 
-  USE cable_driver_init_mod, ONLY : &
-    vegparmnew,                     &
-    spinup,                         &
-    spincasa,                       &
-    CASAONLY,                       &
-    l_laiFeedbk,                    &
-    l_vcmaxFeedbk,                  &
-    delsoilM,                       &
-    delsoilT,                       &
+  USE cable_driver_common_mod, ONLY : &
+    vegparmnew,                       &
+    spinup,                           &
+    spincasa,                         &
+    CASAONLY,                         &
+    l_laiFeedbk,                      &
+    l_vcmaxFeedbk,                    &
+    delsoilM,                         &
+    delsoilT,                         &
     LALLOC
   USE cable_mpicommon
   USE cable_common_module,  ONLY: cable_user

--- a/src/offline/cable_mpiworker.F90
+++ b/src/offline/cable_mpiworker.F90
@@ -266,338 +266,338 @@ CONTAINS
     !                      C%TFRZ )
 
     SPINLOOP:DO
-       YEAR: DO YYYY= CABLE_USER%YearStart,  CABLE_USER%YearEnd
-          CurYear = YYYY
+      YEAR: DO YYYY= CABLE_USER%YearStart,  CABLE_USER%YearEnd
+        CurYear = YYYY
 
-          IF ( leaps .AND. IS_LEAPYEAR( YYYY ) ) THEN
-             LOY = 366
-          ELSE
-             LOY = 365
+        IF ( leaps .AND. IS_LEAPYEAR( YYYY ) ) THEN
+          LOY = 366
+        ELSE
+          LOY = 365
+        ENDIF
+
+        IF ( CALL1 ) THEN
+
+          IF (.NOT.spinup) spinConv=.TRUE.
+
+          ! MPI: bcast to workers so that they don't need to open the met
+          ! file themselves
+          CALL MPI_Bcast (dels, 1, MPI_REAL, 0, comm, ierr)
+        ENDIF
+
+        ! MPI: receive from master ending time fields
+        CALL MPI_Bcast (kend, 1, MPI_INTEGER, 0, comm, ierr)
+
+
+        IF ( CALL1 ) THEN
+          ! MPI: need to know extents before creating datatypes
+          CALL find_extents
+
+          ! MPI: receive decomposition info from the master
+          CALL worker_decomp(comm)
+
+          ! MPI: in overlap version sends and receives occur on separate comms
+          CALL MPI_Comm_dup (comm, icomm, ierr)
+          CALL MPI_Comm_dup (comm, ocomm, ierr)
+
+          ! MPI: data set in load_parameter is now received from
+          ! the master
+
+          CALL worker_cable_params(comm, met,air,ssnow,veg,bgc,soil,canopy,&
+               &                        rough,rad,sum_flux,bal)
+
+          !mrd561 debug
+          WRITE(logn,*) ' ssat_vec min',MINVAL(soil%ssat_vec),MINLOC(soil%ssat_vec)
+          WRITE(logn,*) ' sfc_vec min',MINVAL(soil%sfc_vec),MINLOC(soil%sfc_vec)
+          WRITE(logn,*) ' wb min',MINVAL(ssnow%wb),MINLOC(ssnow%wb)
+          CALL flush(logn)
+
+          IF (check%ranges /= NO_CHECK) THEN
+            WRITE (logn, *) "Checking parameter ranges"
+            CALL constant_check_range(soil, veg, 0, met)
+          END IF
+
+          IF (cable_user%call_climate) THEN
+            CALL worker_climate_types(comm, climate, ktauday )
           ENDIF
 
-          IF ( CALL1 ) THEN
+          ! MPI: mvtype and mstype send out here instead of inside worker_casa_params
+          !      so that old CABLE carbon module can use them. (BP May 2013)
+          CALL MPI_Bcast (mvtype, 1, MPI_INTEGER, 0, comm, ierr)
+          CALL MPI_Bcast (mstype, 1, MPI_INTEGER, 0, comm, ierr)
 
-             IF (.NOT.spinup) spinConv=.TRUE.
+          ! MPI: casa parameters received only if cnp module is active
+          IF (icycle>0) THEN
 
-             ! MPI: bcast to workers so that they don't need to open the met
-             ! file themselves
-             CALL MPI_Bcast (dels, 1, MPI_REAL, 0, comm, ierr)
+            CALL worker_casa_params (comm,casabiome,casapool,casaflux,casamet,&
+                 &                        casabal,phen)
+
+            ! MPI: POP restart received only if pop module AND casa are active
+            IF ( CABLE_USER%CALL_POP ) CALL worker_pop_types (comm,veg,pop)
+
+          END IF
+
+          ! MPI: create inp_t type to receive input data from the master
+          ! at the start of every timestep
+          CALL worker_intype (comm,met,veg)
+
+          ! MPI: casa parameters received only if cnp module is active
+          ! MPI: create send_t type to send the results to the master
+          ! at the end of every timestep
+          CALL worker_outtype (comm,met,canopy,ssnow,rad,bal,air,soil,veg)
+
+          ! MPI: casa parameters received only if cnp module is active
+          ! MPI: create type to send casa results back to the master
+          ! only if cnp module is active
+          IF (icycle>0) THEN
+            CALL worker_casa_type (comm, casapool,casaflux, &
+                 casamet,casabal, phen)
+
+            IF ( CABLE_USER%CASA_DUMP_READ .OR. CABLE_USER%CASA_DUMP_WRITE ) &
+                 CALL worker_casa_dump_types(comm, casamet, casaflux, phen)
+            WRITE(logn,*) 'cable_mpiworker, POPLUC: ',  CABLE_USER%POPLUC
+            WRITE(*,*) 'cable_mpiworker, POPLUC: ',  CABLE_USER%POPLUC
+            CALL flush(logn)
+            IF ( CABLE_USER%POPLUC ) &
+                 CALL worker_casa_LUC_types( comm, casapool, casabal)
+
+
+            ! MPI: casa parameters received only if cnp module is active
+          END IF
+
+          ! MPI: create type to send restart data back to the master
+          ! only if restart file is to be created
+          IF(output%restart) THEN
+
+            CALL worker_restart_type (comm, canopy, air)
+
+          END IF
+
+          ! Open output file:
+          ! MPI: only the master writes to the files
+          !CALL open_output_file( dels, soil, veg, bgc, rough )
+
+          ssnow%otss_0   = ssnow%tgg(:,1)
+          ssnow%otss     = ssnow%tgg(:,1)
+          canopy%fes_cor = 0.
+          canopy%fhs_cor = 0.
+          met%ofsd = 0.1
+
+          ! CALL worker_sumcasa_types(comm, sum_casapool, sum_casaflux)
+
+
+          !count_sum_casa = 0
+
+
+          IF( icycle>0 .AND. spincasa) THEN
+            WRITE(logn,*) 'EXT spincasacnp enabled with mloop= ', mloop
+            CALL worker_spincasacnp(dels,kstart,kend,mloop,veg,soil,casabiome,casapool, &
+                 casaflux,casamet,casabal,phen,POP,climate,LALLOC, icomm, ocomm)
+            SPINconv = .FALSE.
+            CASAONLY                   = .TRUE.
+            ktau_gl = 0
+            ktau = 0
+
+          ELSEIF ( casaonly .AND. (.NOT. spincasa) .AND. cable_user%popluc) THEN
+            CALL worker_CASAONLY_LUC(dels,kstart,kend,veg,soil,casabiome,casapool, &
+                 casaflux,casamet,casabal,phen,POP,climate,LALLOC, &
+                 icomm, ocomm)
+            SPINconv = .FALSE.
+            ktau_gl = 0
+            ktau = 0
           ENDIF
 
-          ! MPI: receive from master ending time fields
-          CALL MPI_Bcast (kend, 1, MPI_INTEGER, 0, comm, ierr)
-
-
-          IF ( CALL1 ) THEN
-             ! MPI: need to know extents before creating datatypes
-             CALL find_extents
-
-             ! MPI: receive decomposition info from the master
-             CALL worker_decomp(comm)
-
-             ! MPI: in overlap version sends and receives occur on separate comms
-             CALL MPI_Comm_dup (comm, icomm, ierr)
-             CALL MPI_Comm_dup (comm, ocomm, ierr)
-
-             ! MPI: data set in load_parameter is now received from
-             ! the master
-
-             CALL worker_cable_params(comm, met,air,ssnow,veg,bgc,soil,canopy,&
-                  &                        rough,rad,sum_flux,bal)
-
-             !mrd561 debug
-             WRITE(logn,*) ' ssat_vec min',MINVAL(soil%ssat_vec),MINLOC(soil%ssat_vec)
-             WRITE(logn,*) ' sfc_vec min',MINVAL(soil%sfc_vec),MINLOC(soil%sfc_vec)
-             WRITE(logn,*) ' wb min',MINVAL(ssnow%wb),MINLOC(ssnow%wb)
-             CALL flush(logn)
-
-             IF (check%ranges /= NO_CHECK) THEN
-               WRITE (logn, *) "Checking parameter ranges"
-               CALL constant_check_range(soil, veg, 0, met)
-             END IF
-
-             IF (cable_user%call_climate) THEN
-                CALL worker_climate_types(comm, climate, ktauday )
-             ENDIF
-
-             ! MPI: mvtype and mstype send out here instead of inside worker_casa_params
-             !      so that old CABLE carbon module can use them. (BP May 2013)
-             CALL MPI_Bcast (mvtype, 1, MPI_INTEGER, 0, comm, ierr)
-             CALL MPI_Bcast (mstype, 1, MPI_INTEGER, 0, comm, ierr)
-
-             ! MPI: casa parameters received only if cnp module is active
-             IF (icycle>0) THEN
-
-                CALL worker_casa_params (comm,casabiome,casapool,casaflux,casamet,&
-                     &                        casabal,phen)
-
-                ! MPI: POP restart received only if pop module AND casa are active
-                IF ( CABLE_USER%CALL_POP ) CALL worker_pop_types (comm,veg,pop)
-
-             END IF
-
-             ! MPI: create inp_t type to receive input data from the master
-             ! at the start of every timestep
-             CALL worker_intype (comm,met,veg)
-
-             ! MPI: casa parameters received only if cnp module is active
-             ! MPI: create send_t type to send the results to the master
-             ! at the end of every timestep
-             CALL worker_outtype (comm,met,canopy,ssnow,rad,bal,air,soil,veg)
-
-             ! MPI: casa parameters received only if cnp module is active
-             ! MPI: create type to send casa results back to the master
-             ! only if cnp module is active
-             IF (icycle>0) THEN
-                CALL worker_casa_type (comm, casapool,casaflux, &
-                     casamet,casabal, phen)
-
-                IF ( CABLE_USER%CASA_DUMP_READ .OR. CABLE_USER%CASA_DUMP_WRITE ) &
-                     CALL worker_casa_dump_types(comm, casamet, casaflux, phen)
-                WRITE(logn,*) 'cable_mpiworker, POPLUC: ',  CABLE_USER%POPLUC
-                WRITE(*,*) 'cable_mpiworker, POPLUC: ',  CABLE_USER%POPLUC
-                CALL flush(logn)
-                IF ( CABLE_USER%POPLUC ) &
-                     CALL worker_casa_LUC_types( comm, casapool, casabal)
-
-
-                ! MPI: casa parameters received only if cnp module is active
-             END IF
-
-             ! MPI: create type to send restart data back to the master
-             ! only if restart file is to be created
-             IF(output%restart) THEN
-
-                CALL worker_restart_type (comm, canopy, air)
-
-             END IF
-
-             ! Open output file:
-             ! MPI: only the master writes to the files
-             !CALL open_output_file( dels, soil, veg, bgc, rough )
-
-             ssnow%otss_0   = ssnow%tgg(:,1)
-             ssnow%otss     = ssnow%tgg(:,1)
-             canopy%fes_cor = 0.
-             canopy%fhs_cor = 0.
-             met%ofsd = 0.1
-
-             ! CALL worker_sumcasa_types(comm, sum_casapool, sum_casaflux)
-
-
-             !count_sum_casa = 0
-
-
-             IF( icycle>0 .AND. spincasa) THEN
-                WRITE(logn,*) 'EXT spincasacnp enabled with mloop= ', mloop
-                CALL worker_spincasacnp(dels,kstart,kend,mloop,veg,soil,casabiome,casapool, &
-                     casaflux,casamet,casabal,phen,POP,climate,LALLOC, icomm, ocomm)
-                SPINconv = .FALSE.
-                CASAONLY                   = .TRUE.
-                ktau_gl = 0
-                ktau = 0
-
-             ELSEIF ( casaonly .AND. (.NOT. spincasa) .AND. cable_user%popluc) THEN
-                CALL worker_CASAONLY_LUC(dels,kstart,kend,veg,soil,casabiome,casapool, &
-                     casaflux,casamet,casabal,phen,POP,climate,LALLOC, &
-                     icomm, ocomm)
-                SPINconv = .FALSE.
-                ktau_gl = 0
-                ktau = 0
-             ENDIF
-
-          ELSE
-             IF (icycle.GT.0) THEN
-                ! re-initalise annual flux sums
-                casabal%FCgppyear =0.0
-                casabal%FCrpyear  =0.0
-                casabal%FCnppyear =0.0
-                casabal%FCrsyear  =0.0
-                casabal%FCneeyear =0.0
-             ENDIF
-
-          ENDIF !CALL1
-
-
-          ! globally (WRT code) accessible kend through USE cable_common_module
-          ktau_gl  = 0
-          kwidth_gl = INT(dels)
-          kend_gl  = kend
-          knode_gl = 0
-
-          IF (spincasa .OR. casaonly) THEN
-             EXIT
+        ELSE
+          IF (icycle.GT.0) THEN
+            ! re-initalise annual flux sums
+            casabal%FCgppyear =0.0
+            casabal%FCrpyear  =0.0
+            casabal%FCnppyear =0.0
+            casabal%FCrsyear  =0.0
+            casabal%FCneeyear =0.0
           ENDIF
 
-  if( .NOT. allocated(heat_cap_lower_limit) ) then
-    allocate( heat_cap_lower_limit(mp,ms) ) 
-    heat_cap_lower_limit = 0.01
-  end if
+        ENDIF !CALL1
 
-  call spec_init_soil_snow(dels, soil, ssnow, canopy, met, bal, veg, heat_cap_lower_limit)
+
+        ! globally (WRT code) accessible kend through USE cable_common_module
+        ktau_gl  = 0
+        kwidth_gl = INT(dels)
+        kend_gl  = kend
+        knode_gl = 0
+
+        IF (spincasa .OR. casaonly) THEN
+          EXIT
+        ENDIF
+
+        if( .NOT. allocated(heat_cap_lower_limit) ) then
+          allocate( heat_cap_lower_limit(mp,ms) )
+          heat_cap_lower_limit = 0.01
+        end if
+
+        call spec_init_soil_snow(dels, soil, ssnow, canopy, met, bal, veg, heat_cap_lower_limit)
 
   
-          ! IF (.NOT.spincasa) THEN
-          ! time step loop over ktau
-          KTAULOOP:DO ktau=kstart, kend
+        ! IF (.NOT.spincasa) THEN
+        ! time step loop over ktau
+        KTAULOOP:DO ktau=kstart, kend
 
-             ! increment total timstep counter
-             ktau_tot = ktau_tot + 1
+          ! increment total timstep counter
+          ktau_tot = ktau_tot + 1
 
-             WRITE(logn,*) 'ktau -',ktau_tot
-             CALL flush(logn)
+          WRITE(logn,*) 'ktau -',ktau_tot
+          CALL flush(logn)
 
-             ! globally (WRT code) accessible kend through USE cable_common_module
-             ktau_gl = ktau_gl + 1
+          ! globally (WRT code) accessible kend through USE cable_common_module
+          ktau_gl = ktau_gl + 1
 
-             ! somethings (e.g. CASA-CNP) only need to be done once per day
-             ktauday=INT(24.0*3600.0/dels)
-!$             idoy = mod(ktau/ktauday,365)
-!$             IF(idoy==0) idoy=365
+          ! somethings (e.g. CASA-CNP) only need to be done once per day
+          ktauday=INT(24.0*3600.0/dels)
+!$        idoy = mod(ktau/ktauday,365)
+!$        IF(idoy==0) idoy=365
 !$
-!$             ! needed for CASA-CNP
-!$             nyear =INT((kend-kstart+1)/(365*ktauday))
+!$          ! needed for CASA-CNP
+!$          nyear =INT((kend-kstart+1)/(365*ktauday))
 
-             ! some things (e.g. CASA-CNP) only need to be done once per day
-             idoy =INT( MOD((REAL(ktau+koffset)/REAL(ktauday)),REAL(LOY)))
-             IF ( idoy .EQ. 0 ) idoy = LOY
+          ! some things (e.g. CASA-CNP) only need to be done once per day
+          idoy =INT( MOD((REAL(ktau+koffset)/REAL(ktauday)),REAL(LOY)))
+          IF ( idoy .EQ. 0 ) idoy = LOY
 
-             ! needed for CASA-CNP
-             nyear =INT((kend-kstart+1)/(LOY*ktauday))
-
-
+          ! needed for CASA-CNP
+          nyear =INT((kend-kstart+1)/(LOY*ktauday))
 
 
-             canopy%oldcansto=canopy%cansto
-
-             ! Get met data and LAI, set time variables.
-             ! Rainfall input may be augmented for spinup purposes:
-             met%ofsd = met%fsd(:,1) + met%fsd(:,2)
-             ! MPI: input file read on the master only
-             !CALL get_met_data( spinup, spinConv, met, soil,                    &
-             !                   rad, veg, kend, dels, C%TFRZ, ktau )
-
-             ! MPI: receive input data for this step from the master
-             IF ( .NOT. CASAONLY ) THEN
-
-                CALL MPI_Recv (MPI_BOTTOM, 1, inp_t, 0, ktau_gl, icomm, stat, ierr)
-
-                ! MPI: receive casa_dump_data for this step from the master
-             ELSEIF ( IS_CASA_TIME("dread", yyyy, ktau, kstart, koffset, &
-                  kend, ktauday, logn) ) THEN
-                CALL MPI_Recv (MPI_BOTTOM, 1, casa_dump_t, 0, ktau_gl, icomm, stat, ierr)
-             END IF
-
-             ! MPI: some fields need explicit init, because we don't transfer
-             ! them for better performance
-             ! in the serial version this is done in get_met_data
-             ! after input has been read from the file
-             met%tvair = met%tk
-             met%tvrad = met%tk
-
-             ! Feedback prognostic vcmax and daily LAI from casaCNP to CABLE
-             IF (l_vcmaxFeedbk) CALL casa_feedback( ktau, veg, casabiome,    &
-                  casapool, casamet )
-
-             IF (l_laiFeedbk) veg%vlai(:) = REAL(casamet%glai(:))
-
-             IF (cable_user%CALL_climate) &
-                  CALL cable_climate(ktau_tot,kstart,kend,ktauday,idoy,LOY,met, &
-                  climate, canopy, air, rad, dels, mp)
 
 
-   IF (.NOT. allocated(c1)) ALLOCATE( c1(mp,nrb), rhoch(mp,nrb), xk(mp,nrb) )
-             ! CALL land surface scheme for this timestep, all grid points:
-   CALL cbm( ktau, dels, air, bgc, canopy, met, bal,                             &
-             rad, rough, soil, ssnow, sum_flux, veg, climate, xk, c1, rhoch )
+          canopy%oldcansto=canopy%cansto
 
-             ssnow%smelt  = ssnow%smelt*dels
-             ssnow%rnof1  = ssnow%rnof1*dels
-             ssnow%rnof2  = ssnow%rnof2*dels
-             ssnow%runoff = ssnow%runoff*dels
+          ! Get met data and LAI, set time variables.
+          ! Rainfall input may be augmented for spinup purposes:
+          met%ofsd = met%fsd(:,1) + met%fsd(:,2)
+          ! MPI: input file read on the master only
+          !CALL get_met_data( spinup, spinConv, met, soil,                    &
+          !                   rad, veg, kend, dels, C%TFRZ, ktau )
 
+          ! MPI: receive input data for this step from the master
+          IF ( .NOT. CASAONLY ) THEN
 
-             !jhan this is insufficient testing. condition for
-             !spinup=.false. & we want CASA_dump.nc (spinConv=.true.)
+            CALL MPI_Recv (MPI_BOTTOM, 1, inp_t, 0, ktau_gl, icomm, stat, ierr)
 
-             IF(icycle >0) THEN
+            ! MPI: receive casa_dump_data for this step from the master
+          ELSEIF ( IS_CASA_TIME("dread", yyyy, ktau, kstart, koffset, &
+                   kend, ktauday, logn) ) THEN
+            CALL MPI_Recv (MPI_BOTTOM, 1, casa_dump_t, 0, ktau_gl, icomm, stat, ierr)
+          END IF
 
-                CALL bgcdriver( ktau, kstart, kend, dels, met,          &
-                     ssnow, canopy, veg, soil,climate, casabiome,       &
-                     casapool, casaflux, casamet, casabal,              &
-                     phen, pop, spinConv, spinup, ktauday, idoy, loy,   &
-                     .FALSE., .FALSE., LALLOC )
+          ! MPI: some fields need explicit init, because we don't transfer
+          ! them for better performance
+          ! in the serial version this is done in get_met_data
+          ! after input has been read from the file
+          met%tvair = met%tk
+          met%tvrad = met%tk
 
-                ! IF(MOD((ktau-kstart+1),ktauday)==0) THEN
-                CALL MPI_Send (MPI_BOTTOM,1, casa_t,0,ktau_gl,ocomm,ierr)
+          ! Feedback prognostic vcmax and daily LAI from casaCNP to CABLE
+          IF (l_vcmaxFeedbk) CALL casa_feedback( ktau, veg, casabiome,    &
+              casapool, casamet )
 
-                !  ENDIF
+          IF (l_laiFeedbk) veg%vlai(:) = REAL(casamet%glai(:))
 
-                IF ( IS_CASA_TIME("write", yyyy, ktau, kstart, &
-                     koffset, kend, ktauday, logn) ) THEN
-                   ! write(logn,*) 'IN IS_CASA', casapool%cplant(:,1)
-                   !      CALL MPI_Send (MPI_BOTTOM,1, casa_t,0,ktau_gl,ocomm,ierr)
-                ENDIF
-
-
-                ! MPI: send the results back to the master
-                IF( ((.NOT.spinup).OR.(spinup.AND.spinConv)) .AND. &
-                     IS_CASA_TIME("dwrit", yyyy, ktau, kstart, &
-                     koffset, kend, ktauday, logn))  &
-                     CALL MPI_Send (MPI_BOTTOM, 1, casa_dump_t, 0, ktau_gl, ocomm, ierr)
-
-             ENDIF
-
-             ! sumcflux is pulled out of subroutine cbm
-             ! so that casaCNP can be called before adding the fluxes (Feb 2008, YP)
-             CALL sumcflux( ktau, kstart, kend, dels, bgc,              &
-                  canopy, soil, ssnow, sum_flux, veg,                   &
-                  met, casaflux, l_vcmaxFeedbk )
-
-             ! MPI: send the results back to the master
-             CALL MPI_Send (MPI_BOTTOM, 1, send_t, 0, ktau_gl, ocomm, ierr)
-
-             ! Write time step's output to file if either: we're not spinning up
-             ! or we're spinning up and the spinup has converged:
-             ! MPI: writing done only by the master
-             !IF((.NOT.spinup).OR.(spinup.AND.spinConv))                         &
-             !   CALL write_output( dels, ktau, met, canopy, ssnow,                    &
-             !                      rad, bal, air, soil, veg, C%SBOLTZ, &
-             !                      C%EMLEAF, C%EMSOIL )
+          IF (cable_user%CALL_climate) &
+              CALL cable_climate(ktau_tot,kstart,kend,ktauday,idoy,LOY,met, &
+              climate, canopy, air, rad, dels, mp)
 
 
-             CALL1 = .FALSE.
+          IF (.NOT. allocated(c1)) ALLOCATE( c1(mp,nrb), rhoch(mp,nrb), xk(mp,nrb) )
+          ! CALL land surface scheme for this timestep, all grid points:
+          CALL cbm( ktau, dels, air, bgc, canopy, met, bal,                             &
+                    rad, rough, soil, ssnow, sum_flux, veg, climate, xk, c1, rhoch )
 
-          END DO KTAULOOP ! END Do loop over timestep ktau
-          ! ELSE
+          ssnow%smelt  = ssnow%smelt*dels
+          ssnow%rnof1  = ssnow%rnof1*dels
+          ssnow%rnof2  = ssnow%rnof2*dels
+          ssnow%runoff = ssnow%runoff*dels
+
+
+          !jhan this is insufficient testing. condition for
+          !spinup=.false. & we want CASA_dump.nc (spinConv=.true.)
+
+          IF(icycle >0) THEN
+
+            CALL bgcdriver( ktau, kstart, kend, dels, met,          &
+                 ssnow, canopy, veg, soil,climate, casabiome,       &
+                 casapool, casaflux, casamet, casabal,              &
+                 phen, pop, spinConv, spinup, ktauday, idoy, loy,   &
+                 .FALSE., .FALSE., LALLOC )
+
+            ! IF(MOD((ktau-kstart+1),ktauday)==0) THEN
+            CALL MPI_Send (MPI_BOTTOM,1, casa_t,0,ktau_gl,ocomm,ierr)
+
+            !  ENDIF
+
+            IF ( IS_CASA_TIME("write", yyyy, ktau, kstart, &
+                 koffset, kend, ktauday, logn) ) THEN
+              ! write(logn,*) 'IN IS_CASA', casapool%cplant(:,1)
+              !      CALL MPI_Send (MPI_BOTTOM,1, casa_t,0,ktau_gl,ocomm,ierr)
+            ENDIF
+
+
+            ! MPI: send the results back to the master
+            IF( ((.NOT.spinup).OR.(spinup.AND.spinConv)) .AND. &
+                IS_CASA_TIME("dwrit", yyyy, ktau, kstart, &
+                koffset, kend, ktauday, logn))  &
+                CALL MPI_Send (MPI_BOTTOM, 1, casa_dump_t, 0, ktau_gl, ocomm, ierr)
+
+          ENDIF
+
+          ! sumcflux is pulled out of subroutine cbm
+          ! so that casaCNP can be called before adding the fluxes (Feb 2008, YP)
+          CALL sumcflux( ktau, kstart, kend, dels, bgc,              &
+               canopy, soil, ssnow, sum_flux, veg,                   &
+               met, casaflux, l_vcmaxFeedbk )
+
+          ! MPI: send the results back to the master
+          CALL MPI_Send (MPI_BOTTOM, 1, send_t, 0, ktau_gl, ocomm, ierr)
+
+          ! Write time step's output to file if either: we're not spinning up
+          ! or we're spinning up and the spinup has converged:
+          ! MPI: writing done only by the master
+          !IF((.NOT.spinup).OR.(spinup.AND.spinConv))                         &
+          !   CALL write_output( dels, ktau, met, canopy, ssnow,                    &
+          !                      rad, bal, air, soil, veg, C%SBOLTZ, &
+          !                      C%EMLEAF, C%EMSOIL )
+
 
           CALL1 = .FALSE.
-          ! ENDIF
+
+        END DO KTAULOOP ! END Do loop over timestep ktau
+        ! ELSE
+
+        CALL1 = .FALSE.
+        ! ENDIF
 
 
-          CALL flush(logn)
-          IF (icycle >0 .AND.   cable_user%CALL_POP) THEN
+        CALL flush(logn)
+        IF (icycle >0 .AND.   cable_user%CALL_POP) THEN
 
-             IF (CABLE_USER%POPLUC) THEN
+          IF (CABLE_USER%POPLUC) THEN
 
-                WRITE(logn,*) 'before MPI_Send casa_LUC'
-                ! worker sends casa updates required for LUC calculations here
-                CALL MPI_Send (MPI_BOTTOM, 1, casa_LUC_t, 0, 0, ocomm, ierr)
-                WRITE(logn,*) 'after MPI_Send casa_LUC'
-                ! master calls LUCDriver here
-                ! worker receives casa and POP updates
-                CALL MPI_Recv( POP%pop_grid(1), POP%np, pop_t, 0, 0, icomm, stat, ierr )
-
-             ENDIF
-             ! one annual time-step of POP
-             CALL POPdriver(casaflux,casabal,veg, POP)
-
-             CALL worker_send_pop (POP, ocomm)
-
-             IF (CABLE_USER%POPLUC) &
-                  CALL MPI_Recv (MPI_BOTTOM, 1, casa_LUC_t, 0, nyear, icomm, stat, ierr)
+            WRITE(logn,*) 'before MPI_Send casa_LUC'
+            ! worker sends casa updates required for LUC calculations here
+            CALL MPI_Send (MPI_BOTTOM, 1, casa_LUC_t, 0, 0, ocomm, ierr)
+            WRITE(logn,*) 'after MPI_Send casa_LUC'
+            ! master calls LUCDriver here
+            ! worker receives casa and POP updates
+            CALL MPI_Recv( POP%pop_grid(1), POP%np, pop_t, 0, 0, icomm, stat, ierr )
 
           ENDIF
+          ! one annual time-step of POP
+          CALL POPdriver(casaflux,casabal,veg, POP)
+
+          CALL worker_send_pop (POP, ocomm)
+
+          IF (CABLE_USER%POPLUC) &
+            CALL MPI_Recv (MPI_BOTTOM, 1, casa_LUC_t, 0, nyear, icomm, stat, ierr)
+
+        ENDIF
 
 
 
@@ -613,106 +613,106 @@ CONTAINS
 
 
 
-          IF ( ((.NOT.spinup).OR.(spinup.AND.spinConv)).AND. &
-               CABLE_USER%CALL_POP) THEN
+        IF ( ((.NOT.spinup).OR.(spinup.AND.spinConv)).AND. &
+             CABLE_USER%CALL_POP) THEN
 
-             !CALL worker_send_pop (POP, ocomm)
+          !CALL worker_send_pop (POP, ocomm)
 
-          ENDIF
-
-
-       END DO YEAR
+        ENDIF
 
 
-       IF (spincasa .OR. casaonly) THEN
-          EXIT
-       ENDIF
-       !jhan this is insufficient testing. condition for
-       !spinup=.false. & we want CASA_dump.nc (spinConv=.true.)
-       ! see if spinup (if conducting one) has converged:
-       !IF(spinup.AND..NOT.spinConv) THEN
-       !
-       !   ! Write to screen and log file:
-       !   WRITE(*,'(A18,I3,A24)') ' Spinning up: run ',INT(ktau_tot/kend),      &
-       !         ' of data set complete...'
-       !   WRITE(logn,'(A18,I3,A24)') ' Spinning up: run ',INT(ktau_tot/kend),   &
-       !         ' of data set complete...'
-       !
-       !   ! IF not 1st run through whole dataset:
-       !   IF( INT( ktau_tot/kend ) > 1 ) THEN
-       !
-       !      ! evaluate spinup
-       !      IF( ANY( ABS(ssnow%wb-soilMtemp)>delsoilM).OR.                     &
-       !          ANY(ABS(ssnow%tgg-soilTtemp)>delsoilT) ) THEN
-       !
-       !         ! No complete convergence yet
-       !         PRINT *, 'ssnow%wb : ', ssnow%wb
-       !         PRINT *, 'soilMtemp: ', soilMtemp
-       !         PRINT *, 'ssnow%tgg: ', ssnow%tgg
-       !         PRINT *, 'soilTtemp: ', soilTtemp
-       !
-       !      ELSE ! spinup has converged
-       !
-       !         spinConv = .TRUE.
-       !         ! Write to screen and log file:
-       !         WRITE(*,'(A33)') ' Spinup has converged - final run'
-       !         WRITE(logn,'(A52)')                                             &
-       !                    ' Spinup has converged - final run - writing all data'
-       !         WRITE(logn,'(A37,F8.5,A28)')                                    &
-       !                    ' Criteria: Change in soil moisture < ',             &
-       !                    delsoilM, ' in any layer over whole run'
-       !         WRITE(logn,'(A40,F8.5,A28)' )                                   &
-       !                    '           Change in soil temperature < ',          &
-       !                    delsoilT, ' in any layer over whole run'
-       !      END IF
+      END DO YEAR
 
-       !   ELSE ! allocate variables for storage
-       !
-       !     ALLOCATE( soilMtemp(mp,ms), soilTtemp(mp,ms) )
-       !
-       !   END IF
-       !
-       !   ! store soil moisture and temperature
-       !   soilTtemp = ssnow%tgg
-       !   soilMtemp = REAL(ssnow%wb)
 
-       !ELSE
+      IF (spincasa .OR. casaonly) THEN
+        EXIT
+      ENDIF
+      !jhan this is insufficient testing. condition for
+      !spinup=.false. & we want CASA_dump.nc (spinConv=.true.)
+      ! see if spinup (if conducting one) has converged:
+      !IF(spinup.AND..NOT.spinConv) THEN
+      !
+      !   ! Write to screen and log file:
+      !   WRITE(*,'(A18,I3,A24)') ' Spinning up: run ',INT(ktau_tot/kend),      &
+      !         ' of data set complete...'
+      !   WRITE(logn,'(A18,I3,A24)') ' Spinning up: run ',INT(ktau_tot/kend),   &
+      !         ' of data set complete...'
+      !
+      !   ! IF not 1st run through whole dataset:
+      !   IF( INT( ktau_tot/kend ) > 1 ) THEN
+      !
+      !      ! evaluate spinup
+      !      IF( ANY( ABS(ssnow%wb-soilMtemp)>delsoilM).OR.                     &
+      !          ANY(ABS(ssnow%tgg-soilTtemp)>delsoilT) ) THEN
+      !
+      !         ! No complete convergence yet
+      !         PRINT *, 'ssnow%wb : ', ssnow%wb
+      !         PRINT *, 'soilMtemp: ', soilMtemp
+      !         PRINT *, 'ssnow%tgg: ', ssnow%tgg
+      !         PRINT *, 'soilTtemp: ', soilTtemp
+      !
+      !      ELSE ! spinup has converged
+      !
+      !         spinConv = .TRUE.
+      !         ! Write to screen and log file:
+      !         WRITE(*,'(A33)') ' Spinup has converged - final run'
+      !         WRITE(logn,'(A52)')                                             &
+      !                    ' Spinup has converged - final run - writing all data'
+      !         WRITE(logn,'(A37,F8.5,A28)')                                    &
+      !                    ' Criteria: Change in soil moisture < ',             &
+      !                    delsoilM, ' in any layer over whole run'
+      !         WRITE(logn,'(A40,F8.5,A28)' )                                   &
+      !                    '           Change in soil temperature < ',          &
+      !                    delsoilT, ' in any layer over whole run'
+      !      END IF
 
-       !   ! if not spinning up, or spin up has converged, exit:
-       !   EXIT
-       !
-       !END IF
+      !   ELSE ! allocate variables for storage
+      !
+      !     ALLOCATE( soilMtemp(mp,ms), soilTtemp(mp,ms) )
+      !
+      !   END IF
+      !
+      !   ! store soil moisture and temperature
+      !   soilTtemp = ssnow%tgg
+      !   soilMtemp = REAL(ssnow%wb)
 
-       ! MPI: learn from the master whether it's time to quit
-       CALL MPI_Bcast (loop_exit, 1, MPI_LOGICAL, 0, comm, ierr)
+      !ELSE
 
-       IF (loop_exit) THEN
-          EXIT
-       END IF
+      !   ! if not spinning up, or spin up has converged, exit:
+      !   EXIT
+      !
+      !END IF
+
+      ! MPI: learn from the master whether it's time to quit
+      CALL MPI_Bcast (loop_exit, 1, MPI_LOGICAL, 0, comm, ierr)
+
+      IF (loop_exit) THEN
+        EXIT
+      END IF
 
     END DO SPINLOOP
 
     IF (icycle > 0 .AND. (.NOT.spincasa).AND. (.NOT.casaonly)) THEN
 
-       ! MPI: send casa results back to the master
-       CALL MPI_Send (MPI_BOTTOM, 1, casa_t, 0, ktau_gl, ocomm, ierr)
+      ! MPI: send casa results back to the master
+      CALL MPI_Send (MPI_BOTTOM, 1, casa_t, 0, ktau_gl, ocomm, ierr)
 
-       ! MPI: output file written by master only
-       !CALL casa_poolout( ktau, veg, soil, casabiome,                           &
-       !                   casapool, casaflux, casamet, casabal, phen )
-       ! MPI: output file written by master only
-       !CALL casa_fluxout( nyear, veg, soil, casabal, casamet)
+      ! MPI: output file written by master only
+      !CALL casa_poolout( ktau, veg, soil, casabiome,                           &
+      !                   casapool, casaflux, casamet, casabal, phen )
+      ! MPI: output file written by master only
+      !CALL casa_fluxout( nyear, veg, soil, casabal, casamet)
 
     END IF
 
     ! Write restart file if requested:
     IF(output%restart .AND. (.NOT. CASAONLY)) THEN
-       ! MPI: send variables that are required by create_restart
-       CALL MPI_Send (MPI_BOTTOM, 1, restart_t, 0, ktau_gl, comm, ierr)
-       ! MPI: output file written by master only
+      ! MPI: send variables that are required by create_restart
+      CALL MPI_Send (MPI_BOTTOM, 1, restart_t, 0, ktau_gl, comm, ierr)
+      ! MPI: output file written by master only
 
-       IF (cable_user%CALL_climate) &
-            CALL MPI_Send (MPI_BOTTOM, 1, climate_t, 0, ktau_gl, comm, ierr)
+      IF (cable_user%CALL_climate) &
+          CALL MPI_Send (MPI_BOTTOM, 1, climate_t, 0, ktau_gl, comm, ierr)
     END IF
 
     ! MPI: cleanup

--- a/src/offline/cable_mpiworker.F90
+++ b/src/offline/cable_mpiworker.F90
@@ -275,6 +275,9 @@ CONTAINS
           LOY = 365
         ENDIF
 
+        ! MPI: receive from master ending time fields
+        CALL MPI_Bcast (kend, 1, MPI_INTEGER, 0, comm, ierr)
+
         IF ( CALL1 ) THEN
 
           IF (.NOT.spinup) spinConv=.TRUE.
@@ -282,13 +285,7 @@ CONTAINS
           ! MPI: bcast to workers so that they don't need to open the met
           ! file themselves
           CALL MPI_Bcast (dels, 1, MPI_REAL, 0, comm, ierr)
-        ENDIF
 
-        ! MPI: receive from master ending time fields
-        CALL MPI_Bcast (kend, 1, MPI_INTEGER, 0, comm, ierr)
-
-
-        IF ( CALL1 ) THEN
           ! MPI: need to know extents before creating datatypes
           CALL find_extents
 

--- a/src/offline/cable_offline_driver.F90
+++ b/src/offline/cable_offline_driver.F90
@@ -4,7 +4,13 @@
 PROGRAM cable_offline_driver
   USE iso_fortran_env, ONLY : error_unit
   USE cable_mpi_mod, ONLY : mpi_grp_t, mpi_mod_init, mpi_mod_end
-  USE cable_driver_common_mod
+  USE cable_driver_common_mod, ONLY: &
+      cable_driver_init,             &
+      cable_driver_init_gswp,        &
+      cable_driver_init_plume,       &
+      cable_driver_init_cru,         &
+      cable_driver_init_site,        &
+      cable_driver_init_default
   USE cable_serial
   USE cable_mpimaster
   USE cable_mpiworker

--- a/src/offline/cable_offline_driver.F90
+++ b/src/offline/cable_offline_driver.F90
@@ -4,7 +4,7 @@
 PROGRAM cable_offline_driver
   USE iso_fortran_env, ONLY : error_unit
   USE cable_mpi_mod, ONLY : mpi_grp_t, mpi_mod_init, mpi_mod_end
-  USE cable_driver_init_mod
+  USE cable_driver_common_mod
   USE cable_serial
   USE cable_mpimaster
   USE cable_mpiworker

--- a/src/offline/cable_serial.F90
+++ b/src/offline/cable_serial.F90
@@ -274,740 +274,741 @@ SUBROUTINE serialdrv(trunk_sumbal, NRRRR, dels, koffset, kend, GSWP_MID, PLUME, 
   ! outer loop - spinup loop no. ktau_tot :
   SPINLOOP:DO WHILE ( SPINon )
 
-     NREP: DO RRRR = 1, NRRRR
+    NREP: DO RRRR = 1, NRRRR
 
-        YEAR: DO YYYY= CABLE_USER%YearStart,  CABLE_USER%YearEnd
-           CurYear = YYYY
+      YEAR: DO YYYY= CABLE_USER%YearStart,  CABLE_USER%YearEnd
 
-           !ccc Set "calendar" for netcdf time attribute and 
-           ! number of days in the year
-           calendar = "noleap"
-           LOY = 365
-           IF ( leaps ) THEN
-              calendar = "standard"
-           END IF
-           IF ( IS_LEAPYEAR( YYYY ) ) THEN
-            LOY = 366
-           END IF
+        CurYear = YYYY
 
-           ! Check for gswp run
-           IF ( TRIM(cable_user%MetType) .EQ. 'gswp' ) THEN
-              ncciy = CurYear
+        !ccc Set "calendar" for netcdf time attribute and
+        ! number of days in the year
+        calendar = "noleap"
+        LOY = 365
+        IF ( leaps ) THEN
+          calendar = "standard"
+        END IF
+        IF ( IS_LEAPYEAR( YYYY ) ) THEN
+          LOY = 366
+        END IF
 
-              CALL prepareFiles(ncciy)
-              IF ( RRRR .EQ. 1 ) THEN
-                 CALL open_met_file( dels, koffset, kend, spinup, CTFRZ )
-                 IF (leaps.AND.is_leapyear(YYYY).AND.kend.EQ.2920) THEN
-                    STOP 'LEAP YEAR INCOMPATIBILITY WITH INPUT MET !'
-                 ENDIF
-                 IF ( NRRRR .GT. 1 ) THEN
-                    GSWP_MID(1,YYYY) = ncid_rain
-                    GSWP_MID(2,YYYY) = ncid_snow
-                    GSWP_MID(3,YYYY) = ncid_lw
-                    GSWP_MID(4,YYYY) = ncid_sw
-                    GSWP_MID(5,YYYY) = ncid_ps
-                    GSWP_MID(6,YYYY) = ncid_qa
-                    GSWP_MID(7,YYYY) = ncid_ta
-                    GSWP_MID(8,YYYY) = ncid_wd
-                 ENDIF
+        ! Check for gswp run
+        IF ( TRIM(cable_user%MetType) .EQ. 'gswp' ) THEN
+          ncciy = CurYear
+
+          CALL prepareFiles(ncciy)
+          IF ( RRRR .EQ. 1 ) THEN
+            CALL open_met_file( dels, koffset, kend, spinup, CTFRZ )
+            IF (leaps.AND.is_leapyear(YYYY).AND.kend.EQ.2920) THEN
+              STOP 'LEAP YEAR INCOMPATIBILITY WITH INPUT MET !'
+            ENDIF
+            IF ( NRRRR .GT. 1 ) THEN
+              GSWP_MID(1,YYYY) = ncid_rain
+              GSWP_MID(2,YYYY) = ncid_snow
+              GSWP_MID(3,YYYY) = ncid_lw
+              GSWP_MID(4,YYYY) = ncid_sw
+              GSWP_MID(5,YYYY) = ncid_ps
+              GSWP_MID(6,YYYY) = ncid_qa
+              GSWP_MID(7,YYYY) = ncid_ta
+              GSWP_MID(8,YYYY) = ncid_wd
+            ENDIF
+          ELSE
+            ncid_rain = GSWP_MID(1,YYYY)
+            ncid_snow = GSWP_MID(2,YYYY)
+            ncid_lw   = GSWP_MID(3,YYYY)
+            ncid_sw   = GSWP_MID(4,YYYY)
+            ncid_ps   = GSWP_MID(5,YYYY)
+            ncid_qa   = GSWP_MID(6,YYYY)
+            ncid_ta   = GSWP_MID(7,YYYY)
+            ncid_wd   = GSWP_MID(8,YYYY)
+            kend      = ktauday * LOY
+          ENDIF
+
+        ELSE IF ( TRIM(cable_user%MetType) .EQ. 'plum' ) THEN
+          ! PLUME experiment setup using WATCH
+          IF ( .NOT. PLUME%LeapYears ) LOY = 365
+          kend = NINT(24.0*3600.0/dels) * LOY
+        ELSE IF ( TRIM(cable_user%MetType) .EQ. 'cru' ) THEN
+          ! TRENDY experiment using CRU-NCEP
+          LOY = 365
+          kend = NINT(24.0*3600.0/dels) * LOY
+        ELSE IF ( TRIM(cable_user%MetType) .EQ. 'site' ) THEN
+          ! site experiment eg AmazonFace (spinup or  transient run type)
+          kend = NINT(24.0*3600.0/dels) * LOY
+          ! get koffset to add to time-step of sitemet
+          IF (TRIM(site%RunType)=='historical') THEN
+            MetYear = CurYear
+          ELSEIF (TRIM(site%RunType)=='spinup' .OR. TRIM(site%RunType)=='transient') THEN
+            ! setting met year so we end the spin-up at the end of the site data-years.
+            MetYear = site%spinstartyear + &
+                MOD(CurYear- &
+                (site%spinstartyear-(site%spinendyear-site%spinstartyear +1)*100), &
+                (site%spinendyear-site%spinstartyear +1))
+          ENDIF
+          WRITE(*,*) 'MetYear: ', MetYear
+          WRITE(*,*) 'Simulation Year: ', CurYear
+          koffset_met = 0
+          IF (MetYear .GT. site%spinstartyear) THEN
+            DO Y = site%spinstartyear, MetYear-1
+              LOYtmp = 365
+              IF (IS_LEAPYEAR(Y)) LOYtmp = 366
+              koffset_met = koffset_met + INT( REAL(LOYtmp) * 86400./REAL(dels) )
+            ENDDO
+          ENDIF
+
+        ENDIF
+
+        ! somethings (e.g. CASA-CNP) only need to be done once per day
+        ktauday=INT(24.0*3600.0/dels)
+
+        ! Checks where parameters and initialisations should be loaded from.
+        ! If they can be found in either the met file or restart file, they will
+        ! load from there, with the met file taking precedence. Otherwise, they'll
+        ! be chosen from a coarse global grid of veg and soil types, based on
+        ! the lat/lon coordinates. Allocation of CABLE's main variables also here.
+        IF ( CALL1 ) THEN
+
+          IF (cable_user%POPLUC) THEN
+            CALL LUC_EXPT_INIT (LUC_EXPT)
+          ENDIF
+          ! vh_js !
+          CALL load_parameters( met, air, ssnow, veg,climate,bgc,           &
+               soil, canopy, rough, rad, sum_flux,                   &
+               bal, logn, vegparmnew, casabiome, casapool,           &
+               casaflux, sum_casapool, sum_casaflux, &
+               casamet, casabal, phen, POP, spinup,        &
+               CEMSOIL, CTFRZ, LUC_EXPT, POPLUC )
+
+          IF (check%ranges /= NO_CHECK) THEN
+            WRITE (*, *) "Checking parameter ranges"
+            CALL constant_check_range(soil, veg, 0, met)
+          END IF
+
+          IF ( CABLE_USER%POPLUC .AND. TRIM(CABLE_USER%POPLUC_RunType) .EQ. 'static') &
+               CABLE_USER%POPLUC= .FALSE.
+          ! Open output file:
+          IF (.NOT.CASAONLY) THEN
+            IF ( TRIM(filename%out) .EQ. '' ) THEN
+              IF ( CABLE_USER%YEARSTART .GT. 0 ) THEN
+                WRITE( dum, FMT="(I4,'_',I4)")CABLE_USER%YEARSTART, &
+                     CABLE_USER%YEAREND
+                filename%out = TRIM(filename%path)//'/'//&
+                    TRIM(cable_user%RunIden)//'_'//&
+                    TRIM(dum)//'_cable_out.nc'
               ELSE
-                 ncid_rain = GSWP_MID(1,YYYY)
-                 ncid_snow = GSWP_MID(2,YYYY)
-                 ncid_lw   = GSWP_MID(3,YYYY)
-                 ncid_sw   = GSWP_MID(4,YYYY)
-                 ncid_ps   = GSWP_MID(5,YYYY)
-                 ncid_qa   = GSWP_MID(6,YYYY)
-                 ncid_ta   = GSWP_MID(7,YYYY)
-                 ncid_wd   = GSWP_MID(8,YYYY)
-                 kend      = ktauday * LOY
+                filename%out = TRIM(filename%path)//'/'//&
+                    TRIM(cable_user%RunIden)//'_cable_out.nc'
               ENDIF
+            ENDIF
+            IF (RRRR.EQ.1) THEN
+              CALL nullify_write() ! nullify pointers
+              CALL open_output_file( dels, soil, veg, bgc, rough, met)
+            ENDIF
+          ENDIF
 
-           ELSE IF ( TRIM(cable_user%MetType) .EQ. 'plum' ) THEN
-              ! PLUME experiment setup using WATCH
-              IF ( .NOT. PLUME%LeapYears ) LOY = 365
-              kend = NINT(24.0*3600.0/dels) * LOY
-           ELSE IF ( TRIM(cable_user%MetType) .EQ. 'cru' ) THEN
-              ! TRENDY experiment using CRU-NCEP
+          ssnow%otss_0 = ssnow%tgg(:,1)
+          ssnow%otss = ssnow%tgg(:,1)
+          ssnow%tss = ssnow%tgg(:,1)
+          canopy%fes_cor = 0.
+          canopy%fhs_cor = 0.
+          met%ofsd = 0.1
+
+
+          CALL zero_sum_casa(sum_casapool, sum_casaflux)
+          count_sum_casa = 0
+
+          IF (cable_user%call_climate) CALL climate_init ( climate, mp, ktauday )
+          IF (cable_user%call_climate .AND.(.NOT.cable_user%climate_fromzero)) &
+              CALL READ_CLIMATE_RESTART_NC (climate, ktauday)
+
+          spinConv = .FALSE. ! initialise spinup convergence variable
+          IF (.NOT.spinup)  spinConv=.TRUE.
+          IF( icycle>0 .AND. spincasa) THEN
+            PRINT *, 'EXT spincasacnp enabled with mloop= ', mloop
+            CALL spincasacnp(dels,kstart,kend,mloop,veg,soil,casabiome,casapool, &
+                  casaflux,casamet,casabal,phen,POP,climate,LALLOC)
+            SPINon = .FALSE.
+            SPINconv = .FALSE.
+
+          ELSEIF ( casaonly .AND. (.NOT. spincasa) ) THEN !.AND. cable_user%popluc) THEN
+
+            CALL CASAONLY_LUC(dels,kstart,kend,veg,soil,casabiome,casapool, &
+                 casaflux,casamet,casabal,phen,POP,climate,LALLOC, LUC_EXPT, POPLUC, &
+                 sum_casapool, sum_casaflux)
+            SPINon = .FALSE.
+            SPINconv = .FALSE.
+            ktau = kend
+
+          ENDIF
+
+
+
+        ENDIF ! CALL 1
+
+        ! globally (WRT code) accessible kend through USE cable_common_module
+        kwidth_gl = INT(dels)
+        kend_gl  = kend
+        knode_gl = 0
+
+        IF (casaonly) THEN
+          EXIT
+        ENDIF
+
+        if( .NOT. allocated(heat_cap_lower_limit) ) then
+          allocate( heat_cap_lower_limit(mp,ms) )
+          heat_cap_lower_limit = 0.01
+        end if
+
+        call spec_init_soil_snow(dels, soil, ssnow, canopy, met, bal, veg, heat_cap_lower_limit)
+
+        ! time step loop over ktau
+        DO ktau=kstart, kend
+
+          WRITE(logn,*) 'Progress -',REAL(ktau)/REAL(kend)*100.0
+
+          ! increment total timstep counter
+          ktau_tot = ktau_tot + 1
+
+          ! globally (WRT code) accessible kend through USE cable_common_module
+          ktau_gl = ktau_tot
+
+          idoy =INT( MOD(REAL(CEILING(REAL((ktau+koffset)/ktauday))),REAL(LOY)))
+          IF ( idoy .EQ. 0 ) idoy = LOY
+
+          ! needed for CASA-CNP
+          nyear     =INT((kend+koffset)/(LOY*ktauday))
+
+          ! Get met data and LAI, set time variables.
+          ! Rainfall input may be augmented for spinup purposes:
+          IF ( TRIM(cable_user%MetType) .EQ. 'plum' ) THEN
+
+            IF (( .NOT. CASAONLY ) .OR. (CASAONLY.AND.CALL1))  THEN
+              CALL PLUME_MIP_GET_MET(PLUME, MET, YYYY, ktau, kend, &
+                   (YYYY.EQ.CABLE_USER%YearEnd .AND. ktau.EQ.kend))
+
+            ENDIF
+
+          ELSE IF ( TRIM(cable_user%MetType) .EQ. 'cru' ) THEN
+            IF (( .NOT. CASAONLY ).OR. (CASAONLY.AND.CALL1))  THEN
+              CALL CRU_GET_SUBDIURNAL_MET(CRU, met, &
+                   YYYY, ktau, kend, &
+                   YYYY.EQ.CABLE_USER%YearEnd)
+            ENDIF
+          ELSE
+            IF (TRIM(cable_user%MetType) .EQ. 'site') &
+                CALL get_met_data( spinup, spinConv, met, soil,            &
+                rad, veg, kend, dels, CTFRZ, ktau+koffset_met,             &
+                kstart+koffset_met )
+            IF (TRIM(cable_user%MetType) .EQ. '') &
+                CALL get_met_data( spinup, spinConv, met, soil,            &
+                rad, veg, kend, dels, CTFRZ, ktau+koffset,                 &
+                kstart+koffset )
+
+            IF (TRIM(cable_user%MetType) .EQ. 'site' ) THEN
+              CALL site_get_CO2_Ndep(site)
+
+              ! Two options: (i) if we have sub-annual varying CO2, then
+              ! these data should be put into the met file and in site.nml
+              ! CO2 should be set to -9999; or (ii) if we only have annual
+              ! CO2 numbers then these should be read from the site csv file
+              WHERE (met%ca .EQ. fixedCO2/1000000.0)
+                met%ca = site%CO2 / 1.e+6
+              END WHERE
+
+              met%Ndep = site%Ndep  *1000./10000./365. ! kg ha-1 y-1 > g m-2 d-1
+              met%Pdep = site%Pdep  *1000./10000./365. ! kg ha-1 y-1 > g m-2 d-1
+              met%fsd = MAX(met%fsd,0.0)
+            ENDIF
+
+
+          ENDIF
+
+          IF (TRIM(cable_user%MetType).EQ.'' ) THEN
+            CurYear = met%year(1)
+            IF ( leaps .AND. IS_LEAPYEAR( CurYear ) ) THEN
+              LOY = 366
+            ELSE
               LOY = 365
-              kend = NINT(24.0*3600.0/dels) * LOY
-           ELSE IF ( TRIM(cable_user%MetType) .EQ. 'site' ) THEN
-              ! site experiment eg AmazonFace (spinup or  transient run type)
-              kend = NINT(24.0*3600.0/dels) * LOY
-              ! get koffset to add to time-step of sitemet
-              IF (TRIM(site%RunType)=='historical') THEN
-                 MetYear = CurYear
-              ELSEIF (TRIM(site%RunType)=='spinup' .OR. TRIM(site%RunType)=='transient') THEN
-                 ! setting met year so we end the spin-up at the end of the site data-years.
-                 MetYear = site%spinstartyear + &
-                      MOD(CurYear- &
-                      (site%spinstartyear-(site%spinendyear-site%spinstartyear +1)*100), &
-                      (site%spinendyear-site%spinstartyear +1))
+            ENDIF
+          ENDIF
+          met%ofsd = met%fsd(:,1) + met%fsd(:,2)
+          canopy%oldcansto=canopy%cansto
+          ! Zero out lai where there is no vegetation acc. to veg. index
+          WHERE ( veg%iveg(:) .GE. 14 ) veg%vlai = 0.
+
+          ! At first time step of year, set tile area according to updated LU areas
+          ! and zero casa fluxes
+          IF (ktau == 1) THEN
+            IF (icycle>1) CALL casa_cnpflux(casaflux,casapool,casabal,.TRUE.)
+            IF ( CABLE_USER%POPLUC) CALL POPLUC_set_patchfrac(POPLUC,LUC_EXPT)
+          ENDIF
+
+          IF ( .NOT. CASAONLY ) THEN
+
+            ! Feedback prognostic vcmax and daily LAI from casaCNP to CABLE
+            IF (l_vcmaxFeedbk) CALL casa_feedback( ktau, veg, casabiome,    &
+                casapool, casamet )
+
+            IF (l_laiFeedbk.AND.icycle>0) veg%vlai(:) = casamet%glai(:)
+
+            IF (.NOT. allocated(c1)) ALLOCATE( c1(mp,nrb), rhoch(mp,nrb), xk(mp,nrb) )
+            ! Call land surface scheme for this timestep, all grid points:
+            CALL cbm( ktau, dels, air, bgc, canopy, met, bal,                             &
+                 rad, rough, soil, ssnow, sum_flux, veg, climate, xk, c1, rhoch )
+
+            IF (cable_user%CALL_climate) &
+              CALL cable_climate(ktau_tot,kstart,kend,ktauday,idoy,LOY,met, &
+                   climate, canopy, air, rad, dels, mp)
+
+
+            ssnow%smelt = ssnow%smelt*dels
+            ssnow%rnof1 = ssnow%rnof1*dels
+            ssnow%rnof2 = ssnow%rnof2*dels
+            ssnow%runoff = ssnow%runoff*dels
+
+
+
+
+
+          ELSE IF ( IS_CASA_TIME("dread", yyyy, ktau, kstart, &
+                koffset, kend, ktauday, logn) ) THEN                ! CLN READ FROM FILE INSTEAD !
+            WRITE(CYEAR,FMT="(I4)")CurYear + INT((ktau-kstart+koffset)/(LOY*ktauday))
+            ncfile  = TRIM(casafile%c2cdumppath)//'c2c_'//CYEAR//'_dump.nc'
+            casa_it = NINT( REAL(ktau / ktauday) )
+
+            CALL read_casa_dump( ncfile, casamet, casaflux,phen, climate, casa_it, kend, .FALSE. )
+          ENDIF
+
+          !jhan this is insufficient testing. condition for
+          !spinup=.false. & we want CASA_dump.nc (spinConv=.true.)
+          IF(icycle >0 .OR.  CABLE_USER%CASA_DUMP_WRITE ) THEN
+            ! vh_js !
+
+            CALL bgcdriver( ktau, kstart, kend, dels, met,                &
+                 ssnow, canopy, veg, soil, climate, casabiome,                     &
+                 casapool, casaflux, casamet, casabal,                    &
+                 phen, pop, spinConv, spinup, ktauday, idoy, loy,         &
+                 CABLE_USER%CASA_DUMP_READ, CABLE_USER%CASA_DUMP_WRITE,   &
+                 LALLOC )
+
+            IF(MOD((ktau-kstart+1),ktauday)==0) THEN
+
+              !mpidiff
+              ! update time-aggregates of casa pools and fluxes
+              CALL update_sum_casa(sum_casapool, sum_casaflux, casapool, casaflux, &
+                   & .TRUE. , .FALSE., 1)
+              count_sum_casa = count_sum_casa + 1
+            ENDIF
+
+
+            IF( ((MOD((ktau-kstart+1),ktauday)==0) .AND.  &
+                  MOD((ktau-kstart+1)/ktauday,LOY)==0) )THEN ! end of year
+              IF (CABLE_USER%POPLUC) THEN
+                ! Dynamic LUC
+                CALL LUCdriver( casabiome,casapool,casaflux,POP,     &
+                     LUC_EXPT, POPLUC, veg )
               ENDIF
-              WRITE(*,*) 'MetYear: ', MetYear
-              WRITE(*,*) 'Simulation Year: ', CurYear
-              koffset_met = 0
-              IF (MetYear .GT. site%spinstartyear) THEN
-                 DO Y = site%spinstartyear, MetYear-1
-                    LOYtmp = 365
-                    IF (IS_LEAPYEAR(Y)) LOYtmp = 366
-                    koffset_met = koffset_met + INT( REAL(LOYtmp) * 86400./REAL(dels) )
-                 ENDDO
+
+              ! one annual time-step of POP
+              CALL POPdriver(casaflux,casabal,veg, POP)
+
+              IF (CABLE_USER%POPLUC) THEN
+                ! Dynamic LUC: update casa pools according to LUC transitions
+                CALL POP_LUC_CASA_transfer(POPLUC,POP,LUC_EXPT,casapool,casabal,casaflux,ktauday)
+                ! Dynamic LUC: write output
+                CALL WRITE_LUC_OUTPUT_NC( POPLUC, YYYY, ( YYYY.EQ.cable_user%YearEnd ))
+
               ENDIF
+            ENDIF
 
-           ENDIF
-
-           ! somethings (e.g. CASA-CNP) only need to be done once per day
-           ktauday=INT(24.0*3600.0/dels)
-
-           ! Checks where parameters and initialisations should be loaded from.
-           ! If they can be found in either the met file or restart file, they will
-           ! load from there, with the met file taking precedence. Otherwise, they'll
-           ! be chosen from a coarse global grid of veg and soil types, based on
-           ! the lat/lon coordinates. Allocation of CABLE's main variables also here.
-           IF ( CALL1 ) THEN
-
-              IF (cable_user%POPLUC) THEN
-                 CALL LUC_EXPT_INIT (LUC_EXPT)
-              ENDIF
-              ! vh_js !
-              CALL load_parameters( met, air, ssnow, veg,climate,bgc,           &
-                   soil, canopy, rough, rad, sum_flux,                   &
-                   bal, logn, vegparmnew, casabiome, casapool,           &
-                   casaflux, sum_casapool, sum_casaflux, &
-                   casamet, casabal, phen, POP, spinup,        &
-                   CEMSOIL, CTFRZ, LUC_EXPT, POPLUC )
-
-              IF (check%ranges /= NO_CHECK) THEN
-                  WRITE (*, *) "Checking parameter ranges"
-                  CALL constant_check_range(soil, veg, 0, met)
-              END IF
-
-              IF ( CABLE_USER%POPLUC .AND. TRIM(CABLE_USER%POPLUC_RunType) .EQ. 'static') &
-                   CABLE_USER%POPLUC= .FALSE.
-              ! Open output file:
-              IF (.NOT.CASAONLY) THEN
-                 IF ( TRIM(filename%out) .EQ. '' ) THEN
-                    IF ( CABLE_USER%YEARSTART .GT. 0 ) THEN
-                       WRITE( dum, FMT="(I4,'_',I4)")CABLE_USER%YEARSTART, &
-                            CABLE_USER%YEAREND
-                       filename%out = TRIM(filename%path)//'/'//&
-                            TRIM(cable_user%RunIden)//'_'//&
-                            TRIM(dum)//'_cable_out.nc'
-                    ELSE
-                       filename%out = TRIM(filename%path)//'/'//&
-                            TRIM(cable_user%RunIden)//'_cable_out.nc'
-                    ENDIF
-                 ENDIF
-                 IF (RRRR.EQ.1) THEN
-                    CALL nullify_write() ! nullify pointers
-                    CALL open_output_file( dels, soil, veg, bgc, rough, met)
-                 ENDIF
-              ENDIF
-
-              ssnow%otss_0 = ssnow%tgg(:,1)
-              ssnow%otss = ssnow%tgg(:,1)
-              ssnow%tss = ssnow%tgg(:,1)
-              canopy%fes_cor = 0.
-              canopy%fhs_cor = 0.
-              met%ofsd = 0.1
+          ENDIF
+          ! WRITE CASA OUTPUT
+          IF(icycle >0) THEN
 
 
-              CALL zero_sum_casa(sum_casapool, sum_casaflux)
+            IF ( IS_CASA_TIME("write", yyyy, ktau, kstart, &
+                 koffset, kend, ktauday, logn) ) THEN
+              ctime = ctime +1
+              !mpidiff
+              CALL update_sum_casa(sum_casapool, sum_casaflux, casapool, casaflux, &
+                   .FALSE. , .TRUE. , count_sum_casa)
+              CALL WRITE_CASA_OUTPUT_NC (veg, casamet, sum_casapool, casabal, sum_casaflux, &
+                   CASAONLY, ctime, ( ktau.EQ.kend .AND. YYYY .EQ.               &
+                   cable_user%YearEnd.AND. RRRR .EQ.NRRRR ) )
+              !mpidiff
               count_sum_casa = 0
+              CALL zero_sum_casa(sum_casapool, sum_casaflux)
+            ENDIF
 
-              IF (cable_user%call_climate) CALL climate_init ( climate, mp, ktauday )
-              IF (cable_user%call_climate .AND.(.NOT.cable_user%climate_fromzero)) &
-                   CALL READ_CLIMATE_RESTART_NC (climate, ktauday)
 
-              spinConv = .FALSE. ! initialise spinup convergence variable
-              IF (.NOT.spinup)  spinConv=.TRUE.
-              IF( icycle>0 .AND. spincasa) THEN
-                 PRINT *, 'EXT spincasacnp enabled with mloop= ', mloop
-                 CALL spincasacnp(dels,kstart,kend,mloop,veg,soil,casabiome,casapool, &
-                      casaflux,casamet,casabal,phen,POP,climate,LALLOC)
-                 SPINon = .FALSE.
-                 SPINconv = .FALSE.
+            IF (((.NOT.spinup).OR.(spinup.AND.spinConv)).AND. &
+                 MOD((ktau-kstart+1),ktauday)==0) THEN
+              IF ( CABLE_USER%CASA_DUMP_WRITE )  THEN
 
-              ELSEIF ( casaonly .AND. (.NOT. spincasa) ) THEN !.AND. cable_user%popluc) THEN
+                IF (TRIM(cable_user%MetType).EQ.'' .OR. &
+                    TRIM(cable_user%MetType).EQ.'site' ) THEN
 
-                 CALL CASAONLY_LUC(dels,kstart,kend,veg,soil,casabiome,casapool, &
-                      casaflux,casamet,casabal,phen,POP,climate,LALLOC, LUC_EXPT, POPLUC, &
-                      sum_casapool, sum_casaflux)
-                 SPINon = .FALSE.
-                 SPINconv = .FALSE.
-                 ktau = kend
+                  WRITE(CYEAR,FMT="(I4)") CurYear
+                ELSE
+                  !CLN CHECK FOR LEAP YEAR
+                  WRITE(CYEAR,FMT="(I4)") CurYear + INT((ktau-kstart)/(LOY*ktauday))
+                ENDIF
+                ncfile = TRIM(casafile%c2cdumppath)//'c2c_'//CYEAR//'_dump.nc'
+
+                IF (TRIM(cable_user%MetType).EQ.'' ) THEN
+                  !jhan:assuming doy for mp=1 is same as ....
+                  CALL write_casa_dump( ncfile, casamet , casaflux, phen, climate,&
+                       INT(met%doy(1)), LOY )
+                ELSE
+                  CALL write_casa_dump( ncfile, casamet , casaflux, &
+                       phen, climate, idoy, kend/ktauday )
+                ENDIF
 
               ENDIF
+            ENDIF
+
+          ENDIF
 
 
+          IF ( .NOT. CASAONLY ) THEN
+            ! sumcflux is pulled out of subroutine cbm
+            ! so that casaCNP can be called before adding the fluxes
+            ! (Feb 2008, YP)
+            CALL sumcflux( ktau, kstart, kend, dels, bgc,              &
+                 canopy, soil, ssnow, sum_flux, veg,                   &
+                 met, casaflux, l_vcmaxFeedbk )
 
-           ENDIF ! CALL 1
 
-           ! globally (WRT code) accessible kend through USE cable_common_module
-           kwidth_gl = INT(dels)
-           kend_gl  = kend
-           knode_gl = 0
+          ENDIF
 
-           IF (casaonly) THEN
-              EXIT
-           ENDIF
+          ! Write timestep's output to file if either: we're not spinning up
+          ! or we're spinning up and the spinup has converged:
 
-  if( .NOT. allocated(heat_cap_lower_limit) ) then
-    allocate( heat_cap_lower_limit(mp,ms) ) 
-    heat_cap_lower_limit = 0.01
-  end if
+          IF ( (.NOT. CASAONLY) .AND. spinConv ) THEN
+            !mpidiff
+            IF ( TRIM(cable_user%MetType) .EQ. 'plum'  .OR.  &
+                 TRIM(cable_user%MetType) .EQ. 'cru'   .OR.  &
+                 TRIM(cable_user%MetType) .EQ. 'bios'  .OR.  &
+                 TRIM(cable_user%MetType) .EQ. 'gswp'  .OR.  &
+                 TRIM(cable_user%MetType) .EQ. 'site' ) THEN
 
-  call spec_init_soil_snow(dels, soil, ssnow, canopy, met, bal, veg, heat_cap_lower_limit)
 
-           ! time step loop over ktau
-           DO ktau=kstart, kend
+              CALL write_output( dels, ktau_tot, met, canopy, casaflux, casapool, casamet, &
+                   ssnow,   rad, bal, air, soil, veg, CSBOLTZ, CEMLEAF, CEMSOIL )
+            ELSE
+              CALL write_output( dels, ktau, met, canopy, casaflux, casapool, casamet, &
+                   ssnow,rad, bal, air, soil, veg, CSBOLTZ, CEMLEAF, CEMSOIL )
+            ENDIF
+          ENDIF
 
-              WRITE(logn,*) 'Progress -',REAL(ktau)/REAL(kend)*100.0
 
-              ! increment total timstep counter
-              ktau_tot = ktau_tot + 1
+          ! Check triggered by cable_user%consistency_check = .TRUE. in cable.nml
+          IF(cable_user%consistency_check) THEN
 
-              ! globally (WRT code) accessible kend through USE cable_common_module
-              ktau_gl = ktau_tot
+            count_bal = count_bal +1;
+            new_sumbal = new_sumbal + SUM(bal%wbal)/mp +  SUM(bal%ebal)/mp
+            new_sumfpn = new_sumfpn + SUM(canopy%fpn)/mp
+            new_sumfe = new_sumfe + SUM(canopy%fe)/mp
+            IF (ktau == kend) PRINT*
+            IF (ktau == kend) PRINT*, "time-space-averaged energy & water balances"
+            IF (ktau == kend) PRINT*,"Ebal_tot[Wm-2], Wbal_tot[mm per timestep]", &
+                 SUM(bal%ebal_tot)/mp/count_bal, SUM(bal%wbal_tot)/mp/count_bal
+            IF (ktau == kend) PRINT*, "time-space-averaged latent heat and net photosynthesis"
+            IF (ktau == kend) PRINT*, "sum_fe[Wm-2], sum_fpn[umol/m2/s]",  &
+                 new_sumfe/count_bal, new_sumfpn/count_bal
+            IF (ktau == kend) WRITE(logn,*)
+            IF (ktau == kend) WRITE(logn,*), "time-space-averaged energy & water balances"
+            IF (ktau == kend) WRITE(logn,*),"Ebal_tot[Wm-2], Wbal_tot[mm per timestep]", &
+                 SUM(bal%ebal_tot)/mp/count_bal, SUM(bal%wbal_tot)/mp/count_bal
+            IF (ktau == kend) WRITE(logn,*), "time-space-averaged latent heat and net photosynthesis"
+            IF (ktau == kend) WRITE(logn,*), "sum_fe[Wm-2], sum_fpn[umol/m2/s]",  &
+                 new_sumfe/count_bal, new_sumfpn/count_bal
 
-              idoy =INT( MOD(REAL(CEILING(REAL((ktau+koffset)/ktauday))),REAL(LOY)))
-              IF ( idoy .EQ. 0 ) idoy = LOY
 
-              ! needed for CASA-CNP
-              nyear     =INT((kend+koffset)/(LOY*ktauday))
+            ! vh ! commented code below detects Nans in evaporation flux and stops if there are any.
+!$          do kk=1,mp
+!$            if( canopy%fe(kk).NE.( canopy%fe(kk))) THEN
+!$              write(*,*) 'fe nan', kk, ktau,met%qv(kk), met%precip(kk),met%precip_sn(kk), &
+!$                   met%fld(kk), met%fsd(kk,:), met%tk(kk), met%ua(kk), ssnow%potev(kk), met%pmb(kk), &
+!$                   canopy%ga(kk), ssnow%tgg(kk,:), canopy%fwsoil(kk)
+!$
+!$
+!$              stop
+!$            endif
+!$            if ( casaflux%cnpp(kk).NE. casaflux%cnpp(kk)) then
+!$              write(*,*) 'npp nan', kk, ktau,  casaflux%cnpp(kk)
+!$              stop
+!$
+!$            endif
+!$
+!$
+!$            !if (canopy%fwsoil(kk).eq.0.0) then
+!$            !   write(*,*) 'zero fwsoil', ktau, canopy%fpn(kk)
+!$            !endif
+!$
+!$
+!$          enddo
 
-              ! Get met data and LAI, set time variables.
-              ! Rainfall input may be augmented for spinup purposes:
-              IF ( TRIM(cable_user%MetType) .EQ. 'plum' ) THEN
+            IF( ktau == kend ) THEN
+              nkend = nkend+1
 
-                 IF (( .NOT. CASAONLY ) .OR. (CASAONLY.AND.CALL1))  THEN
-                    CALL PLUME_MIP_GET_MET(PLUME, MET, YYYY, ktau, kend, &
-                         (YYYY.EQ.CABLE_USER%YearEnd .AND. ktau.EQ.kend))
+              IF( ABS(new_sumbal-trunk_sumbal) < 1.e-7) THEN
 
-                 ENDIF
+                PRINT *, ""
+                PRINT *, &
+                     "NB. Offline-serial runs spinup cycles:", nkend
+                PRINT *, &
+                     "Internal check shows this version reproduces the trunk sumbal"
 
-              ELSE IF ( TRIM(cable_user%MetType) .EQ. 'cru' ) THEN
-                 IF (( .NOT. CASAONLY ).OR. (CASAONLY.AND.CALL1))  THEN
-                    CALL CRU_GET_SUBDIURNAL_MET(CRU, met, &
-                         YYYY, ktau, kend, &
-                         YYYY.EQ.CABLE_USER%YearEnd)
-                 ENDIF
               ELSE
-                 IF (TRIM(cable_user%MetType) .EQ. 'site') &
-                      CALL get_met_data( spinup, spinConv, met, soil,            &
-                      rad, veg, kend, dels, CTFRZ, ktau+koffset_met,             &
-                      kstart+koffset_met )
-                 IF (TRIM(cable_user%MetType) .EQ. '') &
-                      CALL get_met_data( spinup, spinConv, met, soil,            &
-                      rad, veg, kend, dels, CTFRZ, ktau+koffset,                 &
-                      kstart+koffset )
 
-                 IF (TRIM(cable_user%MetType) .EQ. 'site' ) THEN
-                    CALL site_get_CO2_Ndep(site)
+                PRINT *, ""
+                PRINT *, &
+                     "NB. Offline-serial runs spinup cycles:", nkend
+                PRINT *, &
+                     "Internal check shows in this version new_sumbal != trunk sumbal"
+                PRINT *, &
+                     "Writing new_sumbal to the file:", TRIM(filename%new_sumbal)
 
-                    ! Two options: (i) if we have sub-annual varying CO2, then
-                    ! these data should be put into the met file and in site.nml
-                    ! CO2 should be set to -9999; or (ii) if we only have annual
-                    ! CO2 numbers then these should be read from the site csv file
-                    WHERE (met%ca .EQ. fixedCO2/1000000.0)
-                       met%ca = site%CO2 / 1.e+6
-                    END WHERE
-
-                    met%Ndep = site%Ndep  *1000./10000./365. ! kg ha-1 y-1 > g m-2 d-1
-                    met%Pdep = site%Pdep  *1000./10000./365. ! kg ha-1 y-1 > g m-2 d-1
-                    met%fsd = MAX(met%fsd,0.0)
-                 ENDIF
-
+                OPEN( 12, FILE = filename%new_sumbal )
+                WRITE( 12, '(F20.7)' ) new_sumbal  ! written by previous trunk version
+                CLOSE(12)
 
               ENDIF
+            ENDIF
 
-              IF (TRIM(cable_user%MetType).EQ.'' ) THEN
-                 CurYear = met%year(1)
-                 IF ( leaps .AND. IS_LEAPYEAR( CurYear ) ) THEN
-                    LOY = 366
-                 ELSE
-                    LOY = 365
-                 ENDIF
-              ENDIF
-              met%ofsd = met%fsd(:,1) + met%fsd(:,2)
-              canopy%oldcansto=canopy%cansto
-              ! Zero out lai where there is no vegetation acc. to veg. index
-              WHERE ( veg%iveg(:) .GE. 14 ) veg%vlai = 0.
+          ENDIF
 
-              ! At first time step of year, set tile area according to updated LU areas
-              ! and zero casa fluxes
-              IF (ktau == 1) THEN
-                 IF (icycle>1) CALL casa_cnpflux(casaflux,casapool,casabal,.TRUE.)
-                 IF ( CABLE_USER%POPLUC) CALL POPLUC_set_patchfrac(POPLUC,LUC_EXPT)
-              ENDIF
+          CALL1 = .FALSE.
 
-              IF ( .NOT. CASAONLY ) THEN
+        END DO ! END Do loop over timestep ktau
 
-                 ! Feedback prognostic vcmax and daily LAI from casaCNP to CABLE
-                 IF (l_vcmaxFeedbk) CALL casa_feedback( ktau, veg, casabiome,    &
-                      casapool, casamet )
+        CALL1 = .FALSE.
 
-                 IF (l_laiFeedbk.AND.icycle>0) veg%vlai(:) = casamet%glai(:)
+        !jhan this is insufficient testing. condition for
+        !spinup=.false. & we want CASA_dump.nc (spinConv=.true.)
+        ! see if spinup (if conducting one) has converged:
+        !IF(spinup.AND..NOT.spinConv) THEN
+        IF(spinup.AND.(.NOT.spinConv).AND.(.NOT.CASAONLY) ) THEN
 
-   IF (.NOT. allocated(c1)) ALLOCATE( c1(mp,nrb), rhoch(mp,nrb), xk(mp,nrb) )
-                 ! Call land surface scheme for this timestep, all grid points:
-   CALL cbm( ktau, dels, air, bgc, canopy, met, bal,                             &
-             rad, rough, soil, ssnow, sum_flux, veg, climate, xk, c1, rhoch )
-
-                 IF (cable_user%CALL_climate) &
-                      CALL cable_climate(ktau_tot,kstart,kend,ktauday,idoy,LOY,met, &
-                      climate, canopy, air, rad, dels, mp)
+          ! Write to screen and log file:
+          WRITE(*,'(A18,I3,A24)') ' Spinning up: run ',INT(ktau_tot/kend),&
+               ' of data set complete...'
+          WRITE(logn,'(A18,I3,A24)') ' Spinning up: run ',                &
+               INT(ktau_tot/kend), ' of data set complete...'
 
 
-                 ssnow%smelt = ssnow%smelt*dels
-                 ssnow%rnof1 = ssnow%rnof1*dels
-                 ssnow%rnof2 = ssnow%rnof2*dels
-                 ssnow%runoff = ssnow%runoff*dels
+          ! IF not 1st run through whole dataset:
+!$        IF( MOD( ktau_tot, kend ) .EQ. 0 .AND. ktau_Tot .GT. kend .AND. &
+!$             YYYY.EQ. CABLE_USER%YearEnd .OR. ( NRRRR .GT. 1 .AND. &
+!$             RRRR.EQ. NRRRR) ) THEN
 
+          IF( MOD( ktau_tot, kend ) .EQ. 0 .AND. ktau_Tot .GT. kend .AND. &
+               YYYY.EQ. CABLE_USER%YearEnd ) THEN
 
+            ! evaluate spinup
+            IF( ANY( ABS(ssnow%wb-soilMtemp)>delsoilM).OR.               &
+                 ANY( ABS(ssnow%tgg-soilTtemp)>delsoilT) .OR. &
+                 MAXVAL(ABS(ssnow%GWwb-GWtemp),dim=1) > delgwM) THEN
 
-
-
-              ELSE IF ( IS_CASA_TIME("dread", yyyy, ktau, kstart, &
-                   koffset, kend, ktauday, logn) ) THEN                ! CLN READ FROM FILE INSTEAD !
-                 WRITE(CYEAR,FMT="(I4)")CurYear + INT((ktau-kstart+koffset)/(LOY*ktauday))
-                 ncfile  = TRIM(casafile%c2cdumppath)//'c2c_'//CYEAR//'_dump.nc'
-                 casa_it = NINT( REAL(ktau / ktauday) )
-
-                 CALL read_casa_dump( ncfile, casamet, casaflux,phen, climate, casa_it, kend, .FALSE. )
+              ! No complete convergence yet
+              PRINT *, 'ssnow%wb : ', ssnow%wb
+              PRINT *, 'soilMtemp: ', soilMtemp
+              PRINT *, 'ssnow%tgg: ', ssnow%tgg
+              PRINT *, 'soilTtemp: ', soilTtemp
+              IF (cable_user%gw_model) THEN
+                PRINT *, 'ssnow%GWwb : ', ssnow%GWwb
+                PRINT *, 'GWtemp: ', GWtemp
               ENDIF
 
-              !jhan this is insufficient testing. condition for
-              !spinup=.false. & we want CASA_dump.nc (spinConv=.true.)
-              IF(icycle >0 .OR.  CABLE_USER%CASA_DUMP_WRITE ) THEN
-                 ! vh_js !
+            ELSE ! spinup has converged
 
-                 CALL bgcdriver( ktau, kstart, kend, dels, met,                &
-                      ssnow, canopy, veg, soil, climate, casabiome,                     &
-                      casapool, casaflux, casamet, casabal,                    &
-                      phen, pop, spinConv, spinup, ktauday, idoy, loy,         &
-                      CABLE_USER%CASA_DUMP_READ, CABLE_USER%CASA_DUMP_WRITE,   &
-                      LALLOC )
-
-                 IF(MOD((ktau-kstart+1),ktauday)==0) THEN
-
-                    !mpidiff
-                    ! update time-aggregates of casa pools and fluxes
-                    CALL update_sum_casa(sum_casapool, sum_casaflux, casapool, casaflux, &
-                         & .TRUE. , .FALSE., 1)
-                    count_sum_casa = count_sum_casa + 1
-                 ENDIF
-
-
-                 IF( ((MOD((ktau-kstart+1),ktauday)==0) .AND.  &
-                      MOD((ktau-kstart+1)/ktauday,LOY)==0) )THEN ! end of year
-                    IF (CABLE_USER%POPLUC) THEN
-                       ! Dynamic LUC
-                       CALL LUCdriver( casabiome,casapool,casaflux,POP,     &
-                            LUC_EXPT, POPLUC, veg )
-                    ENDIF
-
-                    ! one annual time-step of POP
-                    CALL POPdriver(casaflux,casabal,veg, POP)
-
-                    IF (CABLE_USER%POPLUC) THEN
-                       ! Dynamic LUC: update casa pools according to LUC transitions
-                       CALL POP_LUC_CASA_transfer(POPLUC,POP,LUC_EXPT,casapool,casabal,casaflux,ktauday)
-                       ! Dynamic LUC: write output
-                       CALL WRITE_LUC_OUTPUT_NC( POPLUC, YYYY, ( YYYY.EQ.cable_user%YearEnd ))
-
-                    ENDIF
-                 ENDIF
-
-              ENDIF
-              ! WRITE CASA OUTPUT
-              IF(icycle >0) THEN
-
-
-                 IF ( IS_CASA_TIME("write", yyyy, ktau, kstart, &
-                      koffset, kend, ktauday, logn) ) THEN
-                    ctime = ctime +1
-                    !mpidiff
-                    CALL update_sum_casa(sum_casapool, sum_casaflux, casapool, casaflux, &
-                         .FALSE. , .TRUE. , count_sum_casa)
-                    CALL WRITE_CASA_OUTPUT_NC (veg, casamet, sum_casapool, casabal, sum_casaflux, &
-                         CASAONLY, ctime, ( ktau.EQ.kend .AND. YYYY .EQ.               &
-                         cable_user%YearEnd.AND. RRRR .EQ.NRRRR ) )
-                    !mpidiff
-                    count_sum_casa = 0
-                    CALL zero_sum_casa(sum_casapool, sum_casaflux)
-                 ENDIF
-
-
-                 IF (((.NOT.spinup).OR.(spinup.AND.spinConv)).AND. &
-                      MOD((ktau-kstart+1),ktauday)==0) THEN
-                    IF ( CABLE_USER%CASA_DUMP_WRITE )  THEN
-
-                       IF (TRIM(cable_user%MetType).EQ.'' .OR. &
-                            TRIM(cable_user%MetType).EQ.'site' ) THEN
-
-                          WRITE(CYEAR,FMT="(I4)") CurYear
-                       ELSE
-                          !CLN CHECK FOR LEAP YEAR
-                          WRITE(CYEAR,FMT="(I4)") CurYear + INT((ktau-kstart)/(LOY*ktauday))
-                       ENDIF
-                       ncfile = TRIM(casafile%c2cdumppath)//'c2c_'//CYEAR//'_dump.nc'
-
-                       IF (TRIM(cable_user%MetType).EQ.'' ) THEN
-                          !jhan:assuming doy for mp=1 is same as ....
-                          CALL write_casa_dump( ncfile, casamet , casaflux, phen, climate,&
-                               INT(met%doy(1)), LOY )
-                       ELSE
-                          CALL write_casa_dump( ncfile, casamet , casaflux, &
-                               phen, climate, idoy, kend/ktauday )
-                       ENDIF
-
-                    ENDIF
-                 ENDIF
-
-              ENDIF
-
-
-              IF ( .NOT. CASAONLY ) THEN
-                 ! sumcflux is pulled out of subroutine cbm
-                 ! so that casaCNP can be called before adding the fluxes
-                 ! (Feb 2008, YP)
-                 CALL sumcflux( ktau, kstart, kend, dels, bgc,              &
-                      canopy, soil, ssnow, sum_flux, veg,                   &
-                      met, casaflux, l_vcmaxFeedbk )
-
-
-              ENDIF
-
-              ! Write timestep's output to file if either: we're not spinning up
-              ! or we're spinning up and the spinup has converged:
-
-              IF ( (.NOT. CASAONLY) .AND. spinConv ) THEN
-                 !mpidiff
-                 IF ( TRIM(cable_user%MetType) .EQ. 'plum'  .OR.  &
-                      TRIM(cable_user%MetType) .EQ. 'cru'   .OR.  &
-                      TRIM(cable_user%MetType) .EQ. 'bios'  .OR.  &
-                      TRIM(cable_user%MetType) .EQ. 'gswp'  .OR.  &
-                      TRIM(cable_user%MetType) .EQ. 'site' ) THEN
-
-
-                    CALL write_output( dels, ktau_tot, met, canopy, casaflux, casapool, casamet, &
-                         ssnow,   rad, bal, air, soil, veg, CSBOLTZ, CEMLEAF, CEMSOIL )
-                 ELSE
-                    CALL write_output( dels, ktau, met, canopy, casaflux, casapool, casamet, &
-                         ssnow,rad, bal, air, soil, veg, CSBOLTZ, CEMLEAF, CEMSOIL )
-                 ENDIF
-              ENDIF
-
-
-              ! Check triggered by cable_user%consistency_check = .TRUE. in cable.nml
-              IF(cable_user%consistency_check) THEN
-
-                 count_bal = count_bal +1;
-                 new_sumbal = new_sumbal + SUM(bal%wbal)/mp +  SUM(bal%ebal)/mp
-                 new_sumfpn = new_sumfpn + SUM(canopy%fpn)/mp
-                 new_sumfe = new_sumfe + SUM(canopy%fe)/mp
-                 IF (ktau == kend) PRINT*
-                 IF (ktau == kend) PRINT*, "time-space-averaged energy & water balances"
-                 IF (ktau == kend) PRINT*,"Ebal_tot[Wm-2], Wbal_tot[mm per timestep]", &
-                      SUM(bal%ebal_tot)/mp/count_bal, SUM(bal%wbal_tot)/mp/count_bal
-                 IF (ktau == kend) PRINT*, "time-space-averaged latent heat and net photosynthesis"
-                 IF (ktau == kend) PRINT*, "sum_fe[Wm-2], sum_fpn[umol/m2/s]",  &
-                      new_sumfe/count_bal, new_sumfpn/count_bal
-                 IF (ktau == kend) WRITE(logn,*)
-                 IF (ktau == kend) WRITE(logn,*), "time-space-averaged energy & water balances"
-                 IF (ktau == kend) WRITE(logn,*),"Ebal_tot[Wm-2], Wbal_tot[mm per timestep]", &
-                      SUM(bal%ebal_tot)/mp/count_bal, SUM(bal%wbal_tot)/mp/count_bal
-                 IF (ktau == kend) WRITE(logn,*), "time-space-averaged latent heat and net photosynthesis"
-                 IF (ktau == kend) WRITE(logn,*), "sum_fe[Wm-2], sum_fpn[umol/m2/s]",  &
-                      new_sumfe/count_bal, new_sumfpn/count_bal
-
-
-                 ! vh ! commented code below detects Nans in evaporation flux and stops if there are any.
-!$            do kk=1,mp
-!$               if( canopy%fe(kk).NE.( canopy%fe(kk))) THEN
-!$                  write(*,*) 'fe nan', kk, ktau,met%qv(kk), met%precip(kk),met%precip_sn(kk), &
-!$                       met%fld(kk), met%fsd(kk,:), met%tk(kk), met%ua(kk), ssnow%potev(kk), met%pmb(kk), &
-!$                       canopy%ga(kk), ssnow%tgg(kk,:), canopy%fwsoil(kk)
-!$
-!$
-!$                  stop
-!$               endif
-!$               if ( casaflux%cnpp(kk).NE. casaflux%cnpp(kk)) then
-!$                  write(*,*) 'npp nan', kk, ktau,  casaflux%cnpp(kk)
-!$                  stop
-!$
-!$               endif
-!$
-!$
-!$               !if (canopy%fwsoil(kk).eq.0.0) then
-!$               !   write(*,*) 'zero fwsoil', ktau, canopy%fpn(kk)
-!$               !endif
-!$
-!$
-!$            enddo
-
-                 IF( ktau == kend ) THEN
-                    nkend = nkend+1
-
-                    IF( ABS(new_sumbal-trunk_sumbal) < 1.e-7) THEN
-
-                       PRINT *, ""
-                       PRINT *, &
-                            "NB. Offline-serial runs spinup cycles:", nkend
-                       PRINT *, &
-                            "Internal check shows this version reproduces the trunk sumbal"
-
-                    ELSE
-
-                       PRINT *, ""
-                       PRINT *, &
-                            "NB. Offline-serial runs spinup cycles:", nkend
-                       PRINT *, &
-                            "Internal check shows in this version new_sumbal != trunk sumbal"
-                       PRINT *, &
-                            "Writing new_sumbal to the file:", TRIM(filename%new_sumbal)
-
-                       OPEN( 12, FILE = filename%new_sumbal )
-                       WRITE( 12, '(F20.7)' ) new_sumbal  ! written by previous trunk version
-                       CLOSE(12)
-
-                    ENDIF
-                 ENDIF
-
-              ENDIF
-
-              CALL1 = .FALSE.
-
-           END DO ! END Do loop over timestep ktau
-
-           CALL1 = .FALSE.
-
-           !jhan this is insufficient testing. condition for
-           !spinup=.false. & we want CASA_dump.nc (spinConv=.true.)
-           ! see if spinup (if conducting one) has converged:
-           !IF(spinup.AND..NOT.spinConv) THEN
-           IF(spinup.AND.(.NOT.spinConv).AND.(.NOT.CASAONLY) ) THEN
-
+              spinConv = .TRUE.
               ! Write to screen and log file:
-              WRITE(*,'(A18,I3,A24)') ' Spinning up: run ',INT(ktau_tot/kend),&
-                   ' of data set complete...'
-              WRITE(logn,'(A18,I3,A24)') ' Spinning up: run ',                &
-                   INT(ktau_tot/kend), ' of data set complete...'
+              WRITE(*,'(A33)') ' Spinup has converged - final run'
+              WRITE(logn,'(A52)')                                       &
+                   ' Spinup has converged - final run - writing all data'
+              WRITE(logn,'(A37,F8.5,A28)')                              &
+                   ' Criteria: Change in soil moisture < ',             &
+                   delsoilM, ' in any layer over whole run'
+              WRITE(logn,'(A40,F8.5,A28)' )                             &
+                   '           Change in soil temperature < ',           &
+                   delsoilT, ' in any layer over whole run'
+            END IF
+
+          ELSE ! allocate variables for storage
+
+            IF (.NOT.ALLOCATED(soilMtemp)) ALLOCATE(  soilMtemp(mp,ms) )
+            IF (.NOT.ALLOCATED(soilTtemp)) ALLOCATE(  soilTtemp(mp,ms) )
+            IF (.NOT.ALLOCATED(GWtemp)   ) ALLOCATE(  GWtemp(mp)  )
+
+          END IF
+
+          IF (cable_user%max_spins .GT. 0) THEN
+            IF ((ktau_tot/kend .GE. cable_user%max_spins)) THEN
+              spinConv = .TRUE.
+              WRITE(logn,*) 'Past ',cable_user%max_spins,' spin cycles, running anyways'
+            END IF
+          END IF
+
+          ! store soil moisture and temperature
+          IF ( YYYY.EQ. CABLE_USER%YearEnd ) THEN
+            soilTtemp = ssnow%tgg
+            soilMtemp = REAL(ssnow%wb)
+            GWtemp = ssnow%GWwb
+          ENDIF
+
+        ELSE
+
+          ! if not spinning up, or spin up has converged, exit:
+          IF ( SpinOn ) THEN
+            PRINT*,"setting SPINON -> FALSE", YYYY, RRRR
+            SPINon = .FALSE.
+          END IF
+
+        END IF
 
 
-              ! IF not 1st run through whole dataset:
-!$            IF( MOD( ktau_tot, kend ) .EQ. 0 .AND. ktau_Tot .GT. kend .AND. &
-!$                 YYYY.EQ. CABLE_USER%YearEnd .OR. ( NRRRR .GT. 1 .AND. &
-!$                 RRRR.EQ. NRRRR) ) THEN
+        IF((.NOT.(spinup.OR.casaonly)).OR.(spinup.AND.spinConv)) THEN
+          IF (icycle > 0) THEN
+            CALL casa_fluxout( nyear, veg, soil, casabal, casamet)
+          END IF
 
-              IF( MOD( ktau_tot, kend ) .EQ. 0 .AND. ktau_Tot .GT. kend .AND. &
-                   YYYY.EQ. CABLE_USER%YearEnd ) THEN
+        ENDIF
 
-                 ! evaluate spinup
-                 IF( ANY( ABS(ssnow%wb-soilMtemp)>delsoilM).OR.               &
-                      ANY( ABS(ssnow%tgg-soilTtemp)>delsoilT) .OR. &
-                      MAXVAL(ABS(ssnow%GWwb-GWtemp),dim=1) > delgwM) THEN
+        IF ( .NOT. (spinup.OR.casaonly) .OR. spinconv ) THEN
+          IF ( NRRRR .GT. 1 ) THEN
+            RYEAR = YYYY + ( CABLE_USER%YearEnd - CABLE_USER%YearStart + 1 ) &
+                 * ( RRRR - 1 )
+          ELSE
+            RYEAR = YYYY
+          END IF
+          IF ( cable_user%CALL_POP.AND.POP%np.GT.0 ) THEN
 
-                    ! No complete convergence yet
-                    PRINT *, 'ssnow%wb : ', ssnow%wb
-                    PRINT *, 'soilMtemp: ', soilMtemp
-                    PRINT *, 'ssnow%tgg: ', ssnow%tgg
-                    PRINT *, 'soilTtemp: ', soilTtemp
-                    IF (cable_user%gw_model) THEN
-                       PRINT *, 'ssnow%GWwb : ', ssnow%GWwb
-                       PRINT *, 'GWtemp: ', GWtemp
-                    ENDIF
+            IF (TRIM(cable_user%POP_out).EQ.'epi') THEN
+              CALL POP_IO( pop, casamet, RYEAR, 'WRITE_EPI', &
+                   (YYYY.EQ.CABLE_USER%YearEnd .AND. RRRR.EQ.NRRRR) )
 
-                 ELSE ! spinup has converged
+            ENDIF
+          ENDIF
 
-                    spinConv = .TRUE.
-                    ! Write to screen and log file:
-                    WRITE(*,'(A33)') ' Spinup has converged - final run'
-                    WRITE(logn,'(A52)')                                       &
-                         ' Spinup has converged - final run - writing all data'
-                    WRITE(logn,'(A37,F8.5,A28)')                              &
-                         ' Criteria: Change in soil moisture < ',             &
-                         delsoilM, ' in any layer over whole run'
-                    WRITE(logn,'(A40,F8.5,A28)' )                             &
-                         '           Change in soil temperature < ',           &
-                         delsoilT, ' in any layer over whole run'
-                 END IF
+        ENDIF
+        ! Close met data input file:
 
-              ELSE ! allocate variables for storage
+        IF ( TRIM(cable_user%MetType) .EQ. "gswp" .AND. &
+             RRRR .EQ. NRRRR ) THEN
+          CALL close_met_file
+          IF ( YYYY .EQ. CABLE_USER%YearEnd .AND. &
+               NRRRR .GT. 1 ) DEALLOCATE ( GSWP_MID )
+        ENDIF
 
-                 IF (.NOT.ALLOCATED(soilMtemp)) ALLOCATE(  soilMtemp(mp,ms) )
-                 IF (.NOT.ALLOCATED(soilTtemp)) ALLOCATE(  soilTtemp(mp,ms) )
-                 IF (.NOT.ALLOCATED(GWtemp)   ) ALLOCATE(  GWtemp(mp)  )
+        IF ((icycle.GT.0).AND.(.NOT.casaonly)) THEN
+          ! re-initalise annual flux sums
+          casabal%FCgppyear=0.0
+          casabal%FCrpyear=0.0
+          casabal%FCnppyear=0
+          casabal%FCrsyear=0.0
+          casabal%FCneeyear=0.0
+        ENDIF
+        CALL CPU_TIME(etime)
+        PRINT *, 'Finished. ', etime, ' seconds needed for year'
 
-              END IF
-
-              IF (cable_user%max_spins .GT. 0) THEN
-                 IF ((ktau_tot/kend .GE. cable_user%max_spins)) THEN
-                    spinConv = .TRUE.
-                    WRITE(logn,*) 'Past ',cable_user%max_spins,' spin cycles, running anyways'
-                 END IF
-              END IF
-
-              ! store soil moisture and temperature
-              IF ( YYYY.EQ. CABLE_USER%YearEnd ) THEN
-                 soilTtemp = ssnow%tgg
-                 soilMtemp = REAL(ssnow%wb)
-                 GWtemp = ssnow%GWwb
-              ENDIF
-
-           ELSE
-
-              ! if not spinning up, or spin up has converged, exit:
-              IF ( SpinOn ) THEN
-                 PRINT*,"setting SPINON -> FALSE", YYYY, RRRR
-                 SPINon = .FALSE.
-              END IF
-
-           END IF
+      END DO YEAR
 
 
-           IF((.NOT.(spinup.OR.casaonly)).OR.(spinup.AND.spinConv)) THEN
-              IF (icycle > 0) THEN
-                 CALL casa_fluxout( nyear, veg, soil, casabal, casamet)
-              END IF
-
-           ENDIF
-
-           IF ( .NOT. (spinup.OR.casaonly) .OR. spinconv ) THEN
-              IF ( NRRRR .GT. 1 ) THEN
-                 RYEAR = YYYY + ( CABLE_USER%YearEnd - CABLE_USER%YearStart + 1 ) &
-                      * ( RRRR - 1 )
-              ELSE
-                 RYEAR = YYYY
-              END IF
-              IF ( cable_user%CALL_POP.AND.POP%np.GT.0 ) THEN
-
-                 IF (TRIM(cable_user%POP_out).EQ.'epi') THEN
-                    CALL POP_IO( pop, casamet, RYEAR, 'WRITE_EPI', &
-                         (YYYY.EQ.CABLE_USER%YearEnd .AND. RRRR.EQ.NRRRR) )
-
-                 ENDIF
-              ENDIF
-
-           ENDIF
-           ! Close met data input file:
-
-           IF ( TRIM(cable_user%MetType) .EQ. "gswp" .AND. &
-                RRRR .EQ. NRRRR ) THEN
-              CALL close_met_file
-              IF ( YYYY .EQ. CABLE_USER%YearEnd .AND. &
-                   NRRRR .GT. 1 ) DEALLOCATE ( GSWP_MID )
-           ENDIF
-
-           IF ((icycle.GT.0).AND.(.NOT.casaonly)) THEN
-              ! re-initalise annual flux sums
-              casabal%FCgppyear=0.0
-              casabal%FCrpyear=0.0
-              casabal%FCnppyear=0
-              casabal%FCrsyear=0.0
-              casabal%FCneeyear=0.0
-           ENDIF
-           CALL CPU_TIME(etime)
-           PRINT *, 'Finished. ', etime, ' seconds needed for year'
-
-        END DO YEAR
-
-
-     END DO NREP
+    END DO NREP
 
   END DO SPINLOOP
 
   l_landuse=.false.
 
   IF ( SpinConv .AND. .NOT. CASAONLY ) THEN
-     ! Close output file and deallocate main variables:
-     CALL close_output_file( bal, air, bgc, canopy, met,                      &
-          rad, rough, soil, ssnow,                                            &
-          sum_flux, veg )
+    ! Close output file and deallocate main variables:
+    CALL close_output_file( bal, air, bgc, canopy, met,                      &
+         rad, rough, soil, ssnow,                                            &
+         sum_flux, veg )
   ENDIF
 
   IF ( cable_user%CALL_POP.AND.POP%np.GT.0 ) THEN
-     !mpidiff
-     IF ( CASAONLY .OR. cable_user%pop_fromzero &
-          .OR.TRIM(cable_user%POP_out).EQ.'ini' ) THEN
-        CALL POP_IO( pop, casamet, RYEAR+1, 'WRITE_INI', .TRUE.)
-     ELSE
-        CALL POP_IO( pop, casamet, RYEAR+1, 'WRITE_RST', .TRUE.)
-     ENDIF
+    !mpidiff
+    IF ( CASAONLY .OR. cable_user%pop_fromzero &
+         .OR.TRIM(cable_user%POP_out).EQ.'ini' ) THEN
+      CALL POP_IO( pop, casamet, RYEAR+1, 'WRITE_INI', .TRUE.)
+    ELSE
+      CALL POP_IO( pop, casamet, RYEAR+1, 'WRITE_RST', .TRUE.)
+    ENDIF
   ENDIF
 
 
 
   IF (icycle > 0.and. .not.l_landuse) THEN
 
-     !CALL casa_poolout( ktau, veg, soil, casabiome,              &
-     ! casapool, casaflux, casamet, casabal, phen )
-     CALL write_casa_restart_nc ( casamet, casapool,casaflux,phen, CASAONLY )
+    !CALL casa_poolout( ktau, veg, soil, casabiome,              &
+    ! casapool, casaflux, casamet, casabal, phen )
+    CALL write_casa_restart_nc ( casamet, casapool,casaflux,phen, CASAONLY )
 
   END IF
 
   IF (l_landuse .AND. .NOT. CASAONLY ) THEN
-     mlon = maxval(landpt(1:mp)%ilon)
-     mlat = maxval(landpt(1:mp)%ilat)     
-     print *, 'before landuse: mlon mlat ', mlon,mlat
-     allocate(luc_atransit(mland,mvmax,mvmax)) 
-     allocate(luc_fharvw(mland,mharvw)) 
-     allocate(luc_xluh2cable(mland,mvmax,mstate))  
-     allocate(landmask(mlon,mlat))
-     allocate(arealand(mland))
-     allocate(patchfrac_new(mlon,mlat,mvmax))
-     allocate(cstart(mland),cend(mland),nap(mland))
+    mlon = maxval(landpt(1:mp)%ilon)
+    mlat = maxval(landpt(1:mp)%ilat)
+    print *, 'before landuse: mlon mlat ', mlon,mlat
+    allocate(luc_atransit(mland,mvmax,mvmax))
+    allocate(luc_fharvw(mland,mharvw))
+    allocate(luc_xluh2cable(mland,mvmax,mstate))
+    allocate(landmask(mlon,mlat))
+    allocate(arealand(mland))
+    allocate(patchfrac_new(mlon,mlat,mvmax))
+    allocate(cstart(mland),cend(mland),nap(mland))
 
-     do m=1,mland
-        cstart(m) = landpt(m)%cstart
-        cend(m)   = landpt(m)%cend
-        nap(m)    = landpt(m)%nap
-     enddo
+    do m=1,mland
+      cstart(m) = landpt(m)%cstart
+      cend(m)   = landpt(m)%cend
+      nap(m)    = landpt(m)%nap
+    enddo
 
-     call landuse_data(mlon,mlat,landmask,arealand,luc_atransit,luc_fharvw,luc_xluh2cable)      
-     call  landuse_driver(mlon,mlat,landmask,arealand,ssnow,soil,veg,bal,canopy,  &
-                          phen,casapool,casabal,casamet,casabiome,casaflux,bgc,rad, &
-                          cstart,cend,nap,lucmp)
+    call landuse_data(mlon,mlat,landmask,arealand,luc_atransit,luc_fharvw,luc_xluh2cable)
+    call  landuse_driver(mlon,mlat,landmask,arealand,ssnow,soil,veg,bal,canopy,  &
+                         phen,casapool,casabal,casamet,casabiome,casaflux,bgc,rad, &
+                         cstart,cend,nap,lucmp)
 
-     do m=1,mland
-        do np=cstart(m),cend(m)
-           ivt=lucmp%iveg(np)
-           if(ivt<1.or.ivt>mvmax) then
-             print *, 'landuse: error in vegtype',m,np,ivt
-             stop
-           endif
-           patchfrac_new(landpt(m)%ilon,landpt(m)%ilat,ivt) = lucmp%patchfrac(np)
-        enddo
-     enddo
+    do m=1,mland
+      do np=cstart(m),cend(m)
+        ivt=lucmp%iveg(np)
+        if(ivt<1.or.ivt>mvmax) then
+          print *, 'landuse: error in vegtype',m,np,ivt
+          stop
+        endif
+        patchfrac_new(landpt(m)%ilon,landpt(m)%ilat,ivt) = lucmp%patchfrac(np)
+      enddo
+    enddo
 
-      call create_new_gridinfo(filename%type,filename%gridnew,mlon,mlat,landmask,patchfrac_new)
+    call create_new_gridinfo(filename%type,filename%gridnew,mlon,mlat,landmask,patchfrac_new)
 
-      print *, 'writing casapools: land use'
-      call WRITE_LANDUSE_CASA_RESTART_NC(cend(mland), lucmp, CASAONLY )
+    print *, 'writing casapools: land use'
+    call WRITE_LANDUSE_CASA_RESTART_NC(cend(mland), lucmp, CASAONLY )
 
-      print *, 'writing cable restart: land use'
-      call create_landuse_cable_restart(logn, dels, ktau, soil, cend(mland),lucmp,cstart,cend,nap, met)
+    print *, 'writing cable restart: land use'
+    call create_landuse_cable_restart(logn, dels, ktau, soil, cend(mland),lucmp,cstart,cend,nap, met)
 
-      print *, 'deallocating'
-      call landuse_deallocate_mp(cend(mland),ms,msn,nrb,mplant,mlitter,msoil,mwood,lucmp)
+    print *, 'deallocating'
+    call landuse_deallocate_mp(cend(mland),ms,msn,nrb,mplant,mlitter,msoil,mwood,lucmp)
 
   ENDIF
 
   IF (cable_user%POPLUC .AND. .NOT. CASAONLY ) THEN
-     CALL WRITE_LUC_RESTART_NC ( POPLUC, YYYY )
+    CALL WRITE_LUC_RESTART_NC ( POPLUC, YYYY )
   ENDIF
 
   IF ( .NOT. CASAONLY.and. .not. l_landuse ) THEN
-     ! Write restart file if requested:
-     IF(output%restart)                                           &
-          CALL create_restart( logn, dels, ktau, soil, veg, ssnow,  &
-          canopy, rough, rad, bgc, bal, met )
-     !mpidiff
-     IF (cable_user%CALL_climate) &
-          CALL WRITE_CLIMATE_RESTART_NC ( climate, ktauday )
+    ! Write restart file if requested:
+    IF(output%restart)                                           &
+      CALL create_restart( logn, dels, ktau, soil, veg, ssnow,  &
+           canopy, rough, rad, bgc, bal, met )
+    !mpidiff
+    IF (cable_user%CALL_climate) &
+      CALL WRITE_CLIMATE_RESTART_NC ( climate, ktauday )
 
-     !--- LN ------------------------------------------[
+    !--- LN ------------------------------------------[
   ENDIF
 
 

--- a/src/offline/cable_serial.F90
+++ b/src/offline/cable_serial.F90
@@ -275,6 +275,7 @@ SUBROUTINE serialdrv(trunk_sumbal, NRRRR, dels, koffset, kend, GSWP_MID, PLUME, 
 
 
   ! outer loop - spinup loop no. ktau_tot :
+  ktau     = 0
   SPINLOOP:DO WHILE ( SPINon )
 
     NREP: DO RRRR = 1, NRRRR
@@ -290,7 +291,7 @@ SUBROUTINE serialdrv(trunk_sumbal, NRRRR, dels, koffset, kend, GSWP_MID, PLUME, 
         IF ( leaps ) THEN
           calendar = "standard"
         END IF
-        IF ( IS_LEAPYEAR( YYYY ) ) THEN
+        IF ( leaps .AND. IS_LEAPYEAR( YYYY ) ) THEN
           LOY = 366
         END IF
 
@@ -392,6 +393,7 @@ SUBROUTINE serialdrv(trunk_sumbal, NRRRR, dels, koffset, kend, GSWP_MID, PLUME, 
 
           IF ( CABLE_USER%POPLUC .AND. TRIM(CABLE_USER%POPLUC_RunType) .EQ. 'static') &
                CABLE_USER%POPLUC= .FALSE.
+
           ! Open output file:
           IF (.NOT.CASAONLY) THEN
             IF ( TRIM(filename%out) .EQ. '' ) THEN

--- a/src/offline/cable_serial.F90
+++ b/src/offline/cable_serial.F90
@@ -408,10 +408,8 @@ SUBROUTINE serialdrv(trunk_sumbal, NRRRR, dels, koffset, kend, GSWP_MID, PLUME, 
                     TRIM(cable_user%RunIden)//'_cable_out.nc'
               ENDIF
             ENDIF
-            IF (RRRR.EQ.1) THEN
-              CALL nullify_write() ! nullify pointers
-              CALL open_output_file( dels, soil, veg, bgc, rough, met)
-            ENDIF
+            CALL nullify_write() ! nullify pointers
+            CALL open_output_file( dels, soil, veg, bgc, rough, met)
           ENDIF
 
           ssnow%otss_0 = ssnow%tgg(:,1)


### PR DESCRIPTION
Several changes to make the MPI and serial versions of the offline driver more similar. This is mostly to help identifying the differences between the two versions so they can later be merged.

Also moved some common code between the two versions to the `cable_driver_init_mod`, which is renamed to `cable_driver_common_mod`.

## Type of change

- [X] Code refactor

## Checklist

- [X] The new content is accessible and located in the appropriate section.
- [X] I have checked that links are valid and point to the intended content.
- [X] I have checked my code/text and corrected any misspellings

## Testing
After rebasing on the head of main, benchcab's bitwise-comparisons succeed for the flux site tests:
```
2025-01-13 14:55:18,320 - INFO - benchcab.benchcab.py:391 - 0 failed, 168 passed
```

Please add a reviewer when ready for review.


<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--516.org.readthedocs.build/en/516/

<!-- readthedocs-preview cable end -->