### PR TITLE
Compile with GFortran following Fortran 2008 Standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
     )
 endif()
 
-set(CABLE_GNU_Fortran_FLAGS -cpp -ffree-form -ffixed-line-length-132 -std=f08 -D__GFORTRAN__ -D__gFortran__ -D__NETCDF3__)
+set(CABLE_GNU_Fortran_FLAGS -cpp -ffree-form -ffixed-line-length-132 -std=f2008 -D__GFORTRAN__ -D__gFortran__ -D__NETCDF3__)
 set(CABLE_GNU_Fortran_FLAGS_DEBUG -O -g -pedantic-errors -Wall -W -Wno-maybe-uninitialized -fbacktrace -ffpe-trap=zero,overflow,underflow -finit-real=nan)
 set(CABLE_GNU_Fortran_FLAGS_RELEASE -O3 -Wno-aggressive-loop-optimizations)
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")

--- a/core/biogeophys/cable_common.F90
+++ b/core/biogeophys/cable_common.F90
@@ -711,9 +711,8 @@ CONTAINS
 
     IF (ios /= 0) THEN
       ! Read of namelist failed
-      WRITE(ERROR_UNIT, FMT='(A)') ioMessage
-
-      STOP ios
+      WRITE(ERROR_UNIT, FMT='(I8,A)') ios, ioMessage
+      STOP
     END IF
 
   END SUBROUTINE handle_iostat
@@ -912,9 +911,6 @@ CONTAINS
   ! get svn revision number and status
   SUBROUTINE report_version_no( logn )
 
-#ifdef __NAG__
-    USE F90_UNIX_ENV, only: getenv
-#endif
     INTEGER, INTENT(IN) :: logn
     ! set from environment variable $HOME
     CHARACTER(LEN=200) ::                                                       &
@@ -927,7 +923,7 @@ CONTAINS
 
     INTEGER :: revunit
 
-    CALL getenv("HOME", myhome)
+    CALL get_environment_variable("HOME", myhome)
     fcablerev = TRIM(myhome)//TRIM("/.cable_rev")
 
     OPEN(NEWUNIT=revunit, FILE=TRIM(fcablerev), STATUS='old', ACTION='READ', IOSTAT=ioerror)

--- a/core/biogeophys/mo_utils.f90
+++ b/core/biogeophys/mo_utils.f90
@@ -16,6 +16,8 @@ MODULE mo_utils
   !          Matthias Cuntz,              Jun 2016 - cumsum, arange, linspace, imaxloc/iminloc
   !          Matthias Cuntz,              Jun 2016 - copy toupper of mo_string_utils into module
   !          Matthias Cuntz,              Jan 2017 - isin, isinloc
+  !          Matthias Cuntz,              Jan 2025 - remove isnan. Use version of user hkvzjal at
+  !              https://fortran-lang.discourse.group/t/challenge-testing-inf-and-nan-with-gfortran-13-ofast/6481/30
 
   ! License
   ! -------
@@ -1596,41 +1598,29 @@ CONTAINS
 
   ELEMENTAL PURE FUNCTION is_nan_dp(a)
 
-#ifndef __GFORTRAN__
-  use, intrinsic :: ieee_arithmetic, only: isnan => ieee_is_nan
-#endif
-
     IMPLICIT NONE
 
     REAL(dp), INTENT(IN) :: a
     LOGICAL              :: is_nan_dp
 
-    ! isnan introduced in gfortran rev 4.2
-#ifdef __GFORTRAN41__
-    is_nan_dp = a /= a
-#else
-    is_nan_dp = isnan(a)
-#endif
+    integer, parameter :: mp = selected_real_kind(precision(a)+1) ! a more precise kind
+    real(mp), parameter :: huge_mp = real(huge(a), mp)*2
+
+    is_nan_dp = .not. (abs(a) > huge_mp) .and. .not. (abs(a) < huge_mp)
 
   END FUNCTION is_nan_dp
 
   ELEMENTAL PURE FUNCTION is_nan_sp(a)
-
-#ifndef __GFORTRAN__
-  use, intrinsic :: ieee_arithmetic, only: isnan => ieee_is_nan
-#endif
 
     IMPLICIT NONE
 
     REAL(sp), INTENT(IN) :: a
     LOGICAL              :: is_nan_sp
 
-    ! isnan introduced in gfortran rev 4.2
-#ifdef __GFORTRAN41__
-    is_nan_sp = a /= a
-#else
-    is_nan_sp = isnan(a)
-#endif
+    integer, parameter :: mp = selected_real_kind(precision(a)+1) ! a more precise kind
+    real(mp), parameter :: huge_mp = real(huge(a), mp)*2
+
+    is_nan_sp = .not. (abs(a) > huge_mp) .and. .not. (abs(a) < huge_mp)
 
   END FUNCTION is_nan_sp
 

--- a/offline/cable_cru_TRENDY.F90
+++ b/offline/cable_cru_TRENDY.F90
@@ -635,7 +635,7 @@ SUBROUTINE get_met_date(SimYear, SimDay, IsRecycled, RecycleStart,&
     WRITE(ERROR_UNIT,*) "Looking too far into the past/future. "//&
       "The get_met_date routine was only intended for nearby temporal "//&
       "searching, not more than a year in the future/past."
-    CALL EXIT(5)
+    STOP 5
   ELSEIF (SimDay < 1) THEN
     ! Go back to last year- set the day later, once we know whether the MetYear
     ! is a leapyear or not
@@ -1062,7 +1062,7 @@ SUBROUTINE prepare_temporal_dataset(FileName, TargetArray)
   OPEN(NEWUNIT=FileID, FILE = FileName, STATUS = "old", ACTION = "read", IOSTAT = ios)
   IF (ios < 0) THEN
     WRITE(ERROR_UNIT,*) "Open of temporal dataset file failed with status:", ios
-    CALL EXIT(5)
+    STOP 5
   END IF
 
   LineCounter = 0

--- a/offline/cable_input.F90
+++ b/offline/cable_input.F90
@@ -3005,7 +3005,7 @@ SUBROUTINE prepare_spatiotemporal_dataset(FileTemplate, Dataset)
   ! Check that both occurrences were found- this triggers if either remain 0
   IF ((IndxStartDate == 0) .OR. (IndxEndDate == 0)) THEN
     write(*,*) "File for "//CurrentFile//" does not match the template."
-    CALL EXIT(5)
+    STOP 5
   END IF
 
   ! Now we go and replace the <startdate> and <enddate> strings with "*" so
@@ -3047,7 +3047,7 @@ SUBROUTINE prepare_spatiotemporal_dataset(FileTemplate, Dataset)
       EXIT CountFiles
     ELSEIF (ios /= 0) THEN
       ! Read failed for some other reason
-      CALL EXIT(5)
+      STOP 5
     END IF
     ! Otherwise, we read a line, so increase the counter
     FileCounter = FileCounter + 1


### PR DESCRIPTION
# CABLE

## Description

Bug fixes to compile with GFortran > v13 following the Fortran 2008 Standard.

CABLE gets compiled with the option to follow the Fortran 2008 Standard now.
The compiler flag was wrong for GFortran in `CMakeLists.txt`. It was `-std=f08` as for the Intel compiler but should be `-std=f2008`.

There were several non-standard functions used in the code, that do not work anymore with the `-std=f2008` flag:
1. getenv() - replaced by the F2003 function get_environment_variable
3. call exit(5) - replaced by stop 5
4. stop variable - stop cannot be followed by a variable (apparently), put the error code into the message above the stop
5. isnan - this was a GNU extension. Replaced it with code from [here](https://fortran-lang.discourse.group/t/challenge-testing-inf-and-nan-with-gfortran-13-ofast/6481/30)

## Type of change

- [x] Bug fix
- [ ] New or updated documentation

## Checklist

- [x] The new content is accessible and located in the appropriate section.
- [x] I have checked that links are valid and point to the intended content.
- [x] I have checked my code/text and corrected any misspellings
