### PR TITLE
move snow aging call to avoid need for osnowd in restart

### DIFF
--- a/src/coupled/ACCESS-CM2/cable_cbm.F90
+++ b/src/coupled/ACCESS-CM2/cable_cbm.F90
@@ -146,8 +146,9 @@ CALL init_radiation( rad%extkb, rad%extkd,                                     &
                    ) !reducedLAIdue2snow 
 
 !Ticket 331 refactored albedo code for JAC
-CALL snow_aging(ssnow%snage,mp,dels,ssnow%snowd,ssnow%osnowd,ssnow%tggsn(:,1),&
-         ssnow%tgg(:,1),ssnow%isflag,veg%iveg,soil%isoilm) 
+!#539 - move snow_aging
+!CALL snow_aging(ssnow%snage,mp,dels,ssnow%snowd,ssnow%osnowd,ssnow%tggsn(:,1),&
+!         ssnow%tgg(:,1),ssnow%isflag,veg%iveg,soil%isoilm) 
 
 IF( cable_runtime%um_explicit ) THEN
 
@@ -202,6 +203,9 @@ IF( cable_runtime%um_implicit ) THEN
    ELSE
        CALL soil_snow(dels, soil, ssnow, canopy, met, bal,veg)
     ENDIF
+    !#539 move call to snow aging
+    CALL snow_aging(ssnow%snage,mp,dels,ssnow%snowd,ssnow%osnowd,ssnow%tggsn(:,1),&
+         ssnow%tgg(:,1),ssnow%isflag,veg%iveg,soil%isoilm) 
  ENDIF
 
 ssnow%deltss = ssnow%tss-ssnow%otss

--- a/src/coupled/AM3/control/cable/CM3/cbl_cbm_mod.F90
+++ b/src/coupled/AM3/control/cable/CM3/cbl_cbm_mod.F90
@@ -13,7 +13,7 @@ SUBROUTINE cbm_expl( mp, nrb, ktau,dels, air, bgc, canopy, met,                &
 USE cbl_albedo_mod,            ONLY: albedo
 USE cbl_init_radiation_module, ONLY: init_radiation
 USE cbl_masks_mod,             ONLY: fveg_mask, fsunlit_mask,  fsunlit_veg_mask
-USE snow_aging_mod,            ONLY: snow_aging
+!USE snow_aging_mod,            ONLY: snow_aging  !539 no longer needed
 USE cable_roughness_module,    ONLY: ruff_resist
 USE cable_air_module,          ONLY: define_air
 USE cable_canopy_module,       ONLY: define_canopy
@@ -110,8 +110,9 @@ CALL init_radiation( rad%extkb, rad%extkd,                                     &
                    ) !reducedLAIdue2snow 
 
 !Ticket 331 refactored albedo code for JAC
-CALL snow_aging(ssnow%snage,mp,dels,ssnow%snowd,ssnow%osnowd,ssnow%tggsn(:,1), &
-                ssnow%tgg(:,1),ssnow%isflag,veg%iveg,soil%isoilm) 
+!#539 - move snow aging. 
+!CALL snow_aging(ssnow%snage,mp,dels,ssnow%snowd,ssnow%osnowd,ssnow%tggsn(:,1), &
+!                ssnow%tgg(:,1),ssnow%isflag,veg%iveg,soil%isoilm) 
 
 !explicit ONLY
 CALL Albedo( ssnow%AlbSoilsn, soil%AlbSoil,                                &
@@ -302,6 +303,10 @@ CALL define_canopy(bal,rad,rough,air,met,dels,ssnow,soil,veg, canopy,climate, su
 
 CALL soil_snow(dels, soil, ssnow, canopy, met, bal,veg)
 ssnow%deltss = ssnow%tss-ssnow%otss
+
+!#539 - move snow aging. 
+CALL snow_aging(ssnow%snage,mp,dels,ssnow%snowd,ssnow%osnowd,ssnow%tggsn(:,1), &
+                ssnow%tgg(:,1),ssnow%isflag,veg%iveg,soil%isoilm) 
 
 ! reset tss & wetfac to value corresponding to beginning of timestep 
 IF( cycleno .NE. numcycles ) THEN

--- a/src/coupled/AM3/control/cable/CM3/cbl_cbm_mod.F90
+++ b/src/coupled/AM3/control/cable/CM3/cbl_cbm_mod.F90
@@ -109,11 +109,6 @@ CALL init_radiation( rad%extkb, rad%extkd,                                     &
                      canopy%vlaiw                                              &
                    ) !reducedLAIdue2snow 
 
-!Ticket 331 refactored albedo code for JAC
-!#539 - move snow aging. 
-!CALL snow_aging(ssnow%snage,mp,dels,ssnow%snowd,ssnow%osnowd,ssnow%tggsn(:,1), &
-!                ssnow%tgg(:,1),ssnow%isflag,veg%iveg,soil%isoilm) 
-
 !explicit ONLY
 CALL Albedo( ssnow%AlbSoilsn, soil%AlbSoil,                                &
              !AlbSnow, AlbSoil,              
@@ -304,7 +299,7 @@ CALL define_canopy(bal,rad,rough,air,met,dels,ssnow,soil,veg, canopy,climate, su
 CALL soil_snow(dels, soil, ssnow, canopy, met, bal,veg)
 ssnow%deltss = ssnow%tss-ssnow%otss
 
-!#539 - move snow aging. 
+!Ticket 331 refactored albedo code for JAC, #539 - moved snow aging. 
 CALL snow_aging(ssnow%snage,mp,dels,ssnow%snowd,ssnow%osnowd,ssnow%tggsn(:,1), &
                 ssnow%tgg(:,1),ssnow%isflag,veg%iveg,soil%isoilm) 
 

--- a/src/coupled/ESM1.5/CABLEfilesFromESM1.5/cable_cbm.F90
+++ b/src/coupled/ESM1.5/CABLEfilesFromESM1.5/cable_cbm.F90
@@ -100,8 +100,9 @@ CALL init_radiation( rad%extkb, rad%extkd,                                     &
 IF( cable_runtime%um_explicit ) THEN
    
  !Ticket 331 refactored albedo code for JAC
- CALL snow_aging(ssnow%snage,mp,dels,ssnow%snowd,ssnow%osnowd,ssnow%tggsn(:,1),&
-         ssnow%tgg(:,1),ssnow%isflag,veg%iveg,soil%isoilm) 
+ !#539 move of snow_Aging routine  
+ !CALL snow_aging(ssnow%snage,mp,dels,ssnow%snowd,ssnow%osnowd,ssnow%tggsn(:,1),&
+ !        ssnow%tgg(:,1),ssnow%isflag,veg%iveg,soil%isoilm) 
          
 call Albedo( ssnow%AlbSoilsn, soil%AlbSoil,                                &
              mp, nrb, ICE_SoilType, lakes_cable, jls_radiation, veg_mask,       &
@@ -142,10 +143,16 @@ call Albedo( ssnow%AlbSoilsn, soil%AlbSoil,                                &
       
      IF( cable_runtime%um_implicit ) THEN
          CALL soil_snow(dels, soil, ssnow, canopy, met, bal,veg)
+         !#539 move of snow_Aging routine  
+         CALL snow_aging(ssnow%snage,mp,dels,ssnow%snowd,ssnow%osnowd,ssnow%tggsn(:,1),&
+                          ssnow%tgg(:,1),ssnow%isflag,veg%iveg,soil%isoilm) 
       ENDIF
 
    ELSE
       call soil_snow(dels, soil, ssnow, canopy, met, bal,veg)
+      !#539 move of snow_Aging routine  
+      CALL snow_aging(ssnow%snage,mp,dels,ssnow%snowd,ssnow%osnowd,ssnow%tggsn(:,1),&
+                       ssnow%tgg(:,1),ssnow%isflag,veg%iveg,soil%isoilm) 
    ENDIF
 
    ssnow%deltss = ssnow%tss-ssnow%otss

--- a/src/offline/cbl_model_driver_offline.F90
+++ b/src/offline/cbl_model_driver_offline.F90
@@ -149,8 +149,9 @@ CALL init_radiation( rad%extkb, rad%extkd,                                     &
                    ) !reducedLAIdue2snow 
 
 !Ticket 331 refactored albedo code for JAC
-CALL snow_aging(ssnow%snage,mp,dels,ssnow%snowd,ssnow%osnowd,ssnow%tggsn(:,1),&
-         ssnow%tgg(:,1),ssnow%isflag,veg%iveg,soil%isoilm) 
+!# Issue 539 - moving to after soil_snow
+!CALL snow_aging(ssnow%snage,mp,dels,ssnow%snowd,ssnow%osnowd,ssnow%tggsn(:,1),&
+!         ssnow%tgg(:,1),ssnow%isflag,veg%iveg,soil%isoilm) 
 
 call Albedo( ssnow%AlbSoilsn, soil%AlbSoil,                                &
              !AlbSnow, AlbSoil,              
@@ -182,11 +183,17 @@ call Albedo( ssnow%AlbSoilsn, soil%AlbSoil,                                &
 ssnow%otss_0 = ssnow%otss  ! vh should be before call to canopy?
 ssnow%otss = ssnow%tss
 
+!Evaluate the energy balance - includes updating canopy water storage
 CALL define_canopy(bal,rad,rough,air,met,dels,ssnow,soil,veg, canopy,climate, sunlit_veg_mask,  canopy%vlaiw)
-    
+
+!update the various biophysics state variables
 ssnow%owetfac = ssnow%wetfac
 
 CALL soil_snow(dels, soil, ssnow, canopy, met, bal,veg)
+
+!#539 - move snow_aging now after soil_snow - uses this timestep snow amount
+CALL snow_aging(ssnow%snage,mp,dels,ssnow%snowd,ssnow%osnowd,ssnow%tggsn(:,1),&
+         ssnow%tgg(:,1),ssnow%isflag,veg%iveg,soil%isoilm) 
 
 ssnow%deltss = ssnow%tss-ssnow%otss
 


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description
As per #539 it would be useful (for coupled applications) if there was no need for `%osnowd` in the restart file.
The current need stems from the call to `snow_aging()` prior to the first setting of `%osnowd` as part of the time stepping.
Moving the call to `snow_aging` to after the call to `soil_snow` (or `sli_main`) avoids this as both `osnowd` and `snowd` are evaluated in those routines.

This change will not be bitwise reproducible - but is likely scientifically of no impact. 

There are partner changes that are needed in the coupled routines (particularly CM2 and AM3) which will be included in this issue - but have not been tested.

Once accepted we may also be able to review/remove the need for `osnowd` in the offline restart and MPI sections.

Fixes #539 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix
- [ ] New or updated documentation
- [x] Minor change in science algorithm sequencing 

## Checklist

- [x] The new content is accessible and located in the appropriate section
- [ ] I have checked that links are valid and point to the intended content
- [ ] I have checked my code/text and corrected any misspellings

## Testing

- [ ] Are the changes bitwise-compatible with the main branch? If working on an optional feature, are the results bitwise-compatible when this feature is off? If yes, copy benchcab output showing successful completion of the bitwise compatibility tests or equivalent results below this line.

- [x] Are the changes non bitwise-compatible with the main branch because of a bug fix or a feature being newly implemented or improved? If yes, add the link to the modelevaluation.org analysis versus the main branch or equivalent results below this line.

Please add a reviewer when ready for review.


<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--545.org.readthedocs.build/en/545/

<!-- readthedocs-preview cable end -->