### PR TITLE
reconcile with dev-access-esm1.6 - interface code

### DIFF
--- a/src/coupled/ESM1.5/CABLEfilesFromESM1.5/allocate_soil_params_cbl.F90
+++ b/src/coupled/ESM1.5/CABLEfilesFromESM1.5/allocate_soil_params_cbl.F90
@@ -12,7 +12,7 @@ CONTAINS
 
 SUBROUTINE allocate_soil_parameter_type(var, mp)
 
-USE cable_params_mod,           ONLY: soil_parameter_type
+USE cable_soil_type_mod,        ONLY: soil_parameter_type
 USE cable_other_constants_mod,  ONLY: nrb
 
 !-----------------------------------------------------------------------------

--- a/src/coupled/ESM1.5/CABLEfilesFromESM1.5/allocate_veg_params_cbl.F90
+++ b/src/coupled/ESM1.5/CABLEfilesFromESM1.5/allocate_veg_params_cbl.F90
@@ -12,7 +12,7 @@ CONTAINS
 
 SUBROUTINE allocate_veg_parameter_type(var, mp)
 
-USE cable_params_mod,           ONLY: veg_parameter_type
+USE cable_veg_type_mod,         ONLY: veg_parameter_type
 USE cable_other_constants_mod,  ONLY: nrb !used as ambiguosly AND inconsistently as # rad. bands
 USE cable_other_constants_mod,  ONLY: nscs ! number of soil carbon stores
 USE cable_other_constants_mod,  ONLY: nvcs ! number of vegetation carbon stores

--- a/src/coupled/ESM1.5/CABLEfilesFromESM1.5/cable_cbm.F90
+++ b/src/coupled/ESM1.5/CABLEfilesFromESM1.5/cable_cbm.F90
@@ -1,66 +1,82 @@
 MODULE cable_cbm_module
    
-   USE cable_canopy_module
+USE cable_canopy_module
   
-   IMPLICIT NONE
+IMPLICIT NONE
   
-   PRIVATE
-   PUBLIC cbm 
+PRIVATE
+PUBLIC cbm 
 
 CONTAINS
 
-   SUBROUTINE cbm( dels, air, bgc, canopy, met,                                &
-                   bal, rad, rough, soil,                                      &
-                   ssnow, sum_flux, veg, climate )
+SUBROUTINE cbm( dels, air, bgc, canopy, met, bal, rad, rough, soil,            &
+                ssnow, sum_flux, veg, climate )
     
+!subrs:
+USE cbl_albedo_mod,            ONLY: albedo
 USE cbl_init_radiation_module, ONLY: init_radiation
-USE cbl_albedo_mod, ONLY: albedo
-USE cbl_masks_mod, ONLY: fveg_mask,  fsunlit_mask,  fsunlit_veg_mask
+USE cbl_masks_mod,             ONLY: fveg_mask, fsunlit_mask,  fsunlit_veg_mask
 USE cbl_soil_snow_main_module, ONLY: soil_snow
-USE snow_aging_mod, ONLY : snow_aging 
+USE snow_aging_mod,            ONLY: snow_aging
+USE cable_roughness_module,    ONLY: ruff_resist
+USE cable_air_module,          ONLY: define_air
+USE cable_canopy_module,       ONLY: define_canopy
 
-!jhan:pass these !data
+!data
+USE casadimension,             ONLY: icycle 
+USE cable_phys_constants_mod,  ONLY: GRAV, CAPP 
+  USE cable_common_module
+  USE cable_carbon_module
+
+!jhan:mp must come from here until revise the mp that is also set
+USE cable_def_types_mod, ONLY: met_type, radiation_type, veg_parameter_type,  &
+                               soil_parameter_type, roughness_type,           &
+                               canopy_type, soil_snow_type, balances_type,    &
+                               air_type, bgc_pool_type, sum_flux_type,        &
+                               climate_type, mp, nrb  
+                                   
+! data: scalars
 USE cable_other_constants_mod, ONLY: Ccoszen_tols => coszen_tols
-USE cable_other_constants_mod,  ONLY : Crad_thresh => rad_thresh
+USE cable_other_constants_mod, ONLY: Crad_thresh => rad_thresh
 USE cable_other_constants_mod, ONLY: clai_thresh => lai_thresh
 USE cable_other_constants_mod, ONLY: cgauss_w => gauss_w
 USE cable_math_constants_mod,  ONLY: cpi => pi
 USE cable_math_constants_mod,  ONLY: cpi180 => pi180
+USE cable_phys_constants_mod,  ONLY: tfrz            
+USE grid_constants_mod_cbl,    ONLY: ICE_SoilType!
 USE cable_surface_types_mod,   ONLY: lakes_cable
-USE grid_constants_mod_cbl,    ONLY: ICE_SoilType
+USE cable_phys_constants_mod,  ONLY: cEMLEAF=> EMLEAF
+USE cable_phys_constants_mod,  ONLY: cEMSOIL=> EMSOIL
+USE cable_phys_constants_mod,  ONLY: cSBOLTZ=> SBOLTZ
 
+! CABLE model variables
+TYPE (air_type),       INTENT(INOUT) :: air
+TYPE (bgc_pool_type),  INTENT(INOUT) :: bgc
+TYPE (canopy_type),    INTENT(INOUT) :: canopy
+TYPE (met_type),       INTENT(INOUT) :: met
+TYPE (balances_type),  INTENT(INOUT) :: bal
+TYPE (radiation_type), INTENT(INOUT) :: rad
+TYPE (roughness_type), INTENT(INOUT) :: rough
+TYPE (soil_snow_type), INTENT(INOUT) :: ssnow
+TYPE (sum_flux_type),  INTENT(INOUT) :: sum_flux
+TYPE(climate_type),    INTENT(INOUT) :: climate
+ 
+TYPE (soil_parameter_type), INTENT(INOUT)   :: soil 
+TYPE (veg_parameter_type),  INTENT(INOUT)    :: veg  
 
-   USE cable_common_module
-   USE cable_carbon_module
-   USE cable_def_types_mod
-   USE cable_roughness_module
-   USE cable_air_module
-   USE casadimension,            ONLY: icycle 
-   USE cable_phys_constants_mod, ONLY: GRAV, CAPP 
-
-   
-   ! CABLE model variables
-   TYPE (air_type),       INTENT(INOUT) :: air
-   TYPE (bgc_pool_type),  INTENT(INOUT) :: bgc
-   TYPE (canopy_type),    INTENT(INOUT) :: canopy
-   TYPE (met_type),       INTENT(INOUT) :: met
-   TYPE (balances_type),  INTENT(INOUT) :: bal
-   TYPE (radiation_type), INTENT(INOUT) :: rad
-   TYPE (roughness_type), INTENT(INOUT) :: rough
-   TYPE (soil_snow_type), INTENT(INOUT) :: ssnow
-   TYPE (sum_flux_type),  INTENT(INOUT) :: sum_flux
-   TYPE(climate_type),    INTENT(INOUT) :: climate
-    
-   TYPE (soil_parameter_type), INTENT(INOUT)   :: soil 
-   TYPE (veg_parameter_type),  INTENT(INOUT)    :: veg  
-
-   REAL, INTENT(IN)               :: dels ! time setp size (s)
+REAL, INTENT(IN)               :: dels ! time setp size (s)
     
 !co-efficients usoughout init_radiation ` called from _albedo as well
 REAL :: c1(mp,nrb)
 REAL :: rhoch(mp,nrb)
 REAL :: xk(mp,nrb)
+REAL :: veg_wt(mp)    
+REAL :: veg_trad(mp)      
+REAL :: soil_wt(mp)       
+REAL :: soil_trad(mp)     
+REAL :: trad_corr(mp)     
 
+! local vars
 LOGICAL :: veg_mask(mp), sunlit_mask(mp), sunlit_veg_mask(mp)
 LOGICAL :: jls_standalone = .FALSE.
 LOGICAL :: jls_radiation  = .FALSE.
@@ -75,7 +91,7 @@ IF( cable_runtime%um_explicit ) THEN
 ENDIF
       
 CALL define_air (met, air)
-   
+
 CALL fveg_mask( veg_mask, mp, Clai_thresh, canopy%vlaiw )
 CALL fsunlit_mask( sunlit_mask, mp, CRAD_THRESH,( met%fsd(:,1)+met%fsd(:,2) ) )
 CALL fsunlit_veg_mask( sunlit_veg_mask, veg_mask, sunlit_mask, mp )
@@ -99,11 +115,8 @@ CALL init_radiation( rad%extkb, rad%extkd,                                     &
  
 IF( cable_runtime%um_explicit ) THEN
    
- !Ticket 331 refactored albedo code for JAC
- CALL snow_aging(ssnow%snage,mp,dels,ssnow%snowd,ssnow%osnowd,ssnow%tggsn(:,1),&
-         ssnow%tgg(:,1),ssnow%isflag,veg%iveg,soil%isoilm) 
          
-call Albedo( ssnow%AlbSoilsn, soil%AlbSoil,                                &
+  CALL Albedo( ssnow%AlbSoilsn, soil%AlbSoil,                                &
              mp, nrb, ICE_SoilType, lakes_cable, jls_radiation, veg_mask,       &
              Ccoszen_tols, cgauss_w,                                        & 
              veg%iveg, soil%isoilm, veg%refl, veg%taul,                     & 
@@ -125,61 +138,112 @@ call Albedo( ssnow%AlbSoilsn, soil%AlbSoil,                                &
              !CanopyTransmit_beam, CanopyTransmit_dif, 
              rad%reffbm, rad%reffdf                                        &
            ) !EffSurfRefl_beam, EffSurfRefl_dif
-
-
          
-      ENDIF
+ENDIF
    
-   ! Calculate canopy variables:
-   CALL define_canopy(bal,rad,rough,air,met,dels,ssnow,soil,veg, canopy, climate, sunlit_veg_mask, canopy%vlaiw )
+! on 1st call tss, wetfac initialized in _um_init_soilsnow  
+! on subsequent calls it has the value as updated in soilsnow 
+IF( cable_runtime%um_explicit ) THEN
+  ssnow%otss = ssnow%tss
+  ssnow%owetfac = ssnow%wetfac
+  ! unfortunately for clarity here, define_canopy immediately sets
+  ! canopy%cansto = canopy%oldcansto, so we need this initialization
+  canopy%oldcansto = canopy%cansto
+ENDIF
 
-   ssnow%otss_0 = ssnow%otss
-   ssnow%otss = ssnow%tss
-   ! RML moved out of following IF after discussion with Eva
-   ssnow%owetfac = ssnow%wetfac
+! Calculate canopy variables:
+CALL define_canopy( bal, rad, rough, air, met, dels, ssnow, soil, veg, canopy, &
+                    climate, sunlit_veg_mask, canopy%vlaiw )
 
-   IF( cable_runtime%um ) THEN
-      
-     IF( cable_runtime%um_implicit ) THEN
-         CALL soil_snow(dels, soil, ssnow, canopy, met, bal,veg)
-      ENDIF
+IF( cable_runtime%um_explicit ) THEN
+  ! reset tss, wetfac, cansto to value corresponding to beginning of timestep 
+  ssnow%tss     = ssnow%otss
+  ssnow%wetfac  = ssnow%owetfac
+  canopy%cansto = canopy%oldcansto
+ENDIF
 
-   ELSE
-      call soil_snow(dels, soil, ssnow, canopy, met, bal,veg)
-   ENDIF
-
-   ssnow%deltss = ssnow%tss-ssnow%otss
-   ! correction required for energy balance in online simulations
-   IF( cable_runtime%um ) THEN
-   
-      canopy%fhs = canopy%fhs + ( ssnow%tss-ssnow%otss ) * ssnow%dfh_dtg
-      
-      canopy%fhs_cor = canopy%fhs_cor + ( ssnow%tss-ssnow%otss ) * ssnow%dfh_dtg
-      
-      canopy%fh = canopy%fhv + canopy%fhs
-
-   canopy%fes = canopy%fes + ( ssnow%tss-ssnow%otss ) *                        &
-                ( ssnow%dfe_ddq * ssnow%ddq_dtg )
-                !( ssnow%cls * ssnow%dfe_ddq * ssnow%ddq_dtg )
-   
-   canopy%fes_cor = canopy%fes_cor + ( ssnow%tss-ssnow%otss ) *                &
-                    ( ssnow%cls * ssnow%dfe_ddq * ssnow%ddq_dtg )
-
-   ENDIF
-
-   ! need to adjust fe after soilsnow
-   canopy%fev  = canopy%fevc + canopy%fevw
+IF( cable_runtime%um_implicit ) THEN
   
-   ! Calculate total latent heat flux:
-   canopy%fe = canopy%fev + canopy%fes
+  CALL soil_snow(dels, soil, ssnow, canopy, met, bal,veg)
+  !#539 move of snow_Aging routine  
+  CALL snow_aging(ssnow%snage,mp,dels,ssnow%snowd,ssnow%osnowd,ssnow%tggsn(:,1),&
+                   ssnow%tgg(:,1),ssnow%isflag,veg%iveg,soil%isoilm) 
+  
+  ssnow%deltss = ssnow%tss-ssnow%otss ! from ESM1.5 could substitute below
 
-   ! Calculate net radiation absorbed by soil + veg
-   canopy%rnet = canopy%fns + canopy%fnv
+  ! correction required for energy balance in online simulations
+  IF( cable_user%SOIL_STRUC=='default') THEN
+    
+    canopy%fhs = canopy%fhs + ( ssnow%tss-ssnow%otss ) * ssnow%dfh_dtg
+    canopy%fhs_cor = canopy%fhs_cor + ( ssnow%tss-ssnow%otss ) * ssnow%dfh_dtg
+    canopy%fh = canopy%fhv + canopy%fhs
+    
+    !INH rewritten in terms of %dfe_dtg - NB factor %cls was a bug
+    canopy%fes = canopy%fes + ( ssnow%tss-ssnow%otss ) * ssnow%dfe_dtg
+    !INH NB factor %cls in %fes_cor was a bug - see Ticket #135 #137
+    canopy%fes_cor = canopy%fes_cor + (ssnow%tss-ssnow%otss) * ssnow%dfe_dtg
+    
+    IF (cable_user%L_REV_CORR) THEN
+      
+      !INH need to add on corrections to all terms in the soil energy balance
+      canopy%fns_cor = canopy%fns_cor + (ssnow%tss-ssnow%otss)*ssnow%dfn_dtg
+  
+      !NB %fns_cor also added onto out%Rnet and out%LWnet in cable_output and
+      !cable_checks as the correction term needs to pass through the 
+      !canopy in entirity not be partially absorbed and %fns not used there 
+      !(as would be the case if rad%flws were changed)
+      canopy%fns = canopy%fns + ( ssnow%tss-ssnow%otss )*ssnow%dfn_dtg
+  
+      canopy%ga_cor = canopy%ga_cor + ( ssnow%tss-ssnow%otss )*canopy%dgdtg
+      canopy%ga = canopy%ga + ( ssnow%tss-ssnow%otss )*canopy%dgdtg
+  
+      !assign all the correction to %fes to %fess - none to %fesp
+      canopy%fess = canopy%fess + ( ssnow%tss-ssnow%otss ) * ssnow%dfe_dtg
+  
+    ENDIF
 
-   ! Calculate radiative/skin temperature:
-   rad%trad = ( ( 1.-rad%transd ) * canopy%tv**4 +                             &
-              rad%transd * ssnow%tss**4 )**0.25
+  ENDIF
 
+ENDIF
+
+! need to adjust fe after soilsnow
+canopy%fev  = canopy%fevc + canopy%fevw
+
+! Calculate total latent heat flux:
+canopy%fe = canopy%fev + canopy%fes
+
+! Calculate net radiation absorbed by soil + veg
+canopy%rnet = canopy%fns + canopy%fnv
+
+! Calculate radiative/skin temperature:
+!Jan 2018: UM assumes a single emissivity for the surface in the radiation scheme
+!To accommodate this a single value of is 1. is assumed in ACCESS
+! any leaf/soil emissivity /=1 must be incorporated into rad%trad.  
+! check that emissivities (pft and nvg) set = 1 within the UM i/o configuration
+! CM2 - further adapted to pass the correction term onto %trad correctly
+
+veg_wt    = 1.0 - rad%transd
+veg_trad  = Cemleaf * canopy%tv**4
+soil_wt   = rad%transd 
+soil_trad = Cemsoil * ssnow%tss**4
+
+rad%trad = ( veg_wt * veg_trad )  + ( soil_wt * soil_trad )
+rad%trad = rad%trad**0.25
+
+! In physical model only (i.e. without CASA-CNP)
+
+!! calculate canopy%frp
+!CALL plantcarb(veg,bgc,met,canopy)
+!
+!!calculate canopy%frs
+!CALL soilcarb(soil, ssnow, veg, bgc, met, canopy)
+!
+!CALL carbon_pl(dels, soil, ssnow, veg, canopy, bgc)
+!
+!canopy%fnpp = -1.0* canopy%fpn - canopy%frp
+!canopy%fnee = canopy%fpn + canopy%frs + canopy%frp
+ 
+RETURN
 END SUBROUTINE cbm
 
 END MODULE cable_cbm_module

--- a/src/coupled/ESM1.5/CABLEfilesFromESM1.5/cable_define_types.F90
+++ b/src/coupled/ESM1.5/CABLEfilesFromESM1.5/cable_define_types.F90
@@ -30,12 +30,12 @@
 
 MODULE cable_def_types_mod
 
+USE grid_constants_mod_cbl,   ONLY: ntype_max, nsoil_max  
 USE cable_canopy_type_mod,    ONLY: canopy_type
 USE cable_soil_snow_type_mod, ONLY: soil_snow_type
 USE cable_climate_type_mod,   ONLY: climate_type
-
-USE cable_params_mod,         ONLY: soil_parameter_type
-USE cable_params_mod,         ONLY: veg_parameter_type
+USE cable_soil_type_mod,      ONLY: soil_parameter_type
+USE cable_veg_type_mod,       ONLY: veg_parameter_type
 USE cable_other_constants_mod, ONLY: r_2
 
 !cbl3!USE cable_types_mod!!,          ONLY: mp, l_tile_pts
@@ -46,65 +46,64 @@ USE cable_other_constants_mod, ONLY: r_2
 !cbl3!USE cable_radiation_type_mod, ONLY: radiation_type
 !cbl3!USE cable_roughness_type_mod, ONLY: roughness_type
 !cbl3!USE cable_sum_flux_type_mod,  ONLY: sum_flux_type
-   IMPLICIT NONE
+IMPLICIT NONE
 
-   PUBLIC
+PUBLIC
    
-   !---CABLE default KINDs for representing INTEGER/REAL values   
-   !---at least 10-digit precision
+!---CABLE default KINDs for representing INTEGER/REAL values   
+!---at least 10-digit precision
    
-   INTEGER :: mp,    & ! # total no of patches/tiles 
-              mvtype,& ! total # vegetation types,   from input
-              mstype,& ! total # soil types,         from input
-              mland                           ! # land grid cells
+INTEGER :: mp,                 &     ! # total no of patches/tiles 
+  mvtype = ntype_max ,&     ! total # vegetation types
+  mstype = nsoil_max ,&     ! total # soil types
+  mland                     ! # land grid cells
    
-   INTEGER, PARAMETER ::                                                        &
-      n_tiles = 17,  & ! # possible no of different 
-      ncp = 3,       & ! # vegetation carbon stores
-      ncs = 2,       & ! # soil carbon stores
-      mf = 2,        & ! # leaves (sunlit, shaded)
-      nrb = 3,       & ! # radiation bands
-      msn = 3,       & ! max # snow layers
-      swb = 2,       & ! # shortwave bands 
-      niter = 4,     & ! number of iterations for za/L
-      ms = 6           ! # soil layers
-
+INTEGER, PARAMETER ::                                                        &
+  n_tiles = 17,  & ! # possible no of different 
+  ncp = 3,       & ! # vegetation carbon stores
+  ncs = 2,       & ! # soil carbon stores
+  mf = 2,        & ! # leaves (sunlit, shaded)
+  nrb = 3,       & ! # radiation bands
+  msn = 3,       & ! max # snow layers
+  swb = 2,       & ! # shortwave bands 
+  niter = 4,     & ! number of iterations for za/L
+  ms = 6           ! # soil layers
   
 ! .............................................................................
 
    ! Energy and water balance variables:
-   TYPE balances_type 
+TYPE balances_type 
 
-      REAL, DIMENSION(:), POINTER ::                                           &
-         drybal,           & ! energy balance for dry canopy
-         ebal,             & ! energy balance per time step (W/m^2)
-         ebal_tot,         & ! cumulative energy balance (W/m^2)
-         ebal_cncheck,     & ! energy balance consistency check (W/m^2)
-         ebal_tot_cncheck, & ! cumulative energy balance (W/m^2)
-         ebaltr,           & ! energy balance per time step (W/m^2)
-         ebal_tottr,       & ! cumulative energy balance (W/m^2)
-         evap_tot,         & ! cumulative evapotranspiration (mm/dels)
-         osnowd0,          & ! snow depth, first time step
-         precip_tot,       & ! cumulative precipitation (mm/dels)
-         rnoff_tot,        & ! cumulative runoff (mm/dels)
-         wbal,             & ! water balance per time step (mm/dels)
-         wbal_tot,         & ! cumulative water balance (mm/dels)
-         wbtot0,           & ! total soil water (mm), first time step
-         wetbal,           & ! energy balance for wet canopy
-         cansto0,          & ! canopy water storage (mm)
-         owbtot,           & ! total soil water (mm), first time step
-         evapc_tot,        & ! cumulative evapotranspiration (mm/dels)
-         evaps_tot,        & ! cumulative evapotranspiration (mm/dels)
-         rnof1_tot,        & ! cumulative runoff (mm/dels)
-         rnof2_tot,        & ! cumulative runoff (mm/dels)
-         snowdc_tot,       & ! cumulative runoff (mm/dels)
-         wbal_tot1,        & ! cumulative water balance (mm/dels)
-         delwc_tot,        & ! energy balance for wet canopy
-         qasrf_tot,        & ! heat advected to the snow by precip. 
-         qfsrf_tot,        & ! energy of snowpack phase changes 
-         qssrf_tot           ! energy of snowpack phase changes 
+  REAL, DIMENSION(:), POINTER ::                                               &
+    drybal,           & ! energy balance for dry canopy
+    ebal,             & ! energy balance per time step (W/m^2)
+    ebal_tot,         & ! cumulative energy balance (W/m^2)
+    ebal_cncheck,     & ! energy balance consistency check (W/m^2)
+    ebal_tot_cncheck, & ! cumulative energy balance (W/m^2)
+    ebaltr,           & ! energy balance per time step (W/m^2)
+    ebal_tottr,       & ! cumulative energy balance (W/m^2)
+    evap_tot,         & ! cumulative evapotranspiration (mm/dels)
+    osnowd0,          & ! snow depth, first time step
+    precip_tot,       & ! cumulative precipitation (mm/dels)
+    rnoff_tot,        & ! cumulative runoff (mm/dels)
+    wbal,             & ! water balance per time step (mm/dels)
+    wbal_tot,         & ! cumulative water balance (mm/dels)
+    wbtot0,           & ! total soil water (mm), first time step
+    wetbal,           & ! energy balance for wet canopy
+    cansto0,          & ! canopy water storage (mm)
+    owbtot,           & ! total soil water (mm), first time step
+    evapc_tot,        & ! cumulative evapotranspiration (mm/dels)
+    evaps_tot,        & ! cumulative evapotranspiration (mm/dels)
+    rnof1_tot,        & ! cumulative runoff (mm/dels)
+    rnof2_tot,        & ! cumulative runoff (mm/dels)
+    snowdc_tot,       & ! cumulative runoff (mm/dels)
+    wbal_tot1,        & ! cumulative water balance (mm/dels)
+    delwc_tot,        & ! energy balance for wet canopy
+    qasrf_tot,        & ! heat advected to the snow by precip. 
+    qfsrf_tot,        & ! energy of snowpack phase changes 
+    qssrf_tot           ! energy of snowpack phase changes 
 
-   END TYPE balances_type
+END TYPE balances_type
 
 ! .............................................................................
 

--- a/src/coupled/ESM1.5/CABLEfilesFromESM1.5/cable_explicit_driver.F90
+++ b/src/coupled/ESM1.5/CABLEfilesFromESM1.5/cable_explicit_driver.F90
@@ -35,7 +35,9 @@ SUBROUTINE cable_explicit_driver( row_length, rows, land_pts, ntiles,npft,     &
                                   sm_levels, timestep, latitude, longitude,    &
                                   land_index, tile_frac,  tile_pts, tile_index,&
                                   bexp, hcon, satcon, sathh, smvcst,           &
-                                  smvcwt,  smvccl, albsoil, snow_tile,         &
+                                  smvcwt,  smvccl, albsoil,                    & 
+                                  hcap, soil_clay, soil_silt, soil_sand,       &
+                                  snow_tile,                                   &
                                   snow_rho1l, snage_tile, isnow_flg3l,         &
                                   snow_rho3l, snow_cond, snow_depth3l,         &
                                   snow_tmp3l, snow_mass3l, sw_down, lw_down,   &
@@ -64,7 +66,7 @@ SUBROUTINE cable_explicit_driver( row_length, rows, land_pts, ntiles,npft,     &
                                   iday, endstep, timestep_number, mype )    
    
    !--- reads runtime and user switches and reports
-   USE cable_um_tech_mod, ONLY : cable_um_runtime_vars, air, bgc, canopy,      &
+   USE cable_um_tech_mod, ONLY : air, bgc, canopy,      &
                                  met, bal, rad, rough, soil, ssnow, sum_flux,  &
                                  veg, climate 
    
@@ -134,6 +136,11 @@ SUBROUTINE cable_explicit_driver( row_length, rows, land_pts, ntiles,npft,     &
       albsoil, &
       fland 
    
+REAL, INTENT(IN) :: soil_clay ( row_length, rows )
+REAL, INTENT(IN) :: soil_silt ( row_length, rows )
+REAL, INTENT(IN) :: soil_sand ( row_length, rows )
+REAL, INTENT(IN) :: hcap(land_pts)
+
    REAL, INTENT(INOUT), DIMENSION(row_length,rows) :: &
       sw_down,          & 
       cos_zenith_angle
@@ -293,22 +300,6 @@ SUBROUTINE cable_explicit_driver( row_length, rows, land_pts, ntiles,npft,     &
    !--- end INPUT ARGS FROM sf_exch() ----------------------------------------
    !-------------------------------------------------------------------------- 
    
-
-
-   !___ declare local vars 
-   
-   !___ location of namelist file defining runtime vars
-   CHARACTER(LEN=200), PARAMETER ::                                            & 
-      runtime_vars_file = 'cable.nml'
-
-
-   !___ 1st call in RUN (!=ktau_gl -see below) 
-   LOGICAL, SAVE :: first_cable_call = .TRUE.
- 
-integer :: j
-
-   
-
    !--- initialize cable_runtime% switches 
    cable_runtime%um = .TRUE.
    cable_runtime%esm15= .TRUE.
@@ -326,15 +317,6 @@ integer :: j
    !--- from cable_common_module
    cable_runtime%um_explicit = .TRUE.
 
-   
-   !--- user FLAGS, variables etc def. in cable.nml is read on 
-   !--- first time step of each run. these variables are read at 
-   !--- runtime and for the most part do not require a model rebuild.
-   IF(first_cable_call) THEN
-      CALL cable_um_runtime_vars(runtime_vars_file) 
-      first_cable_call = .FALSE.
-   ENDIF      
-   
   mtau = mod(ktau_gl,int(24.*3600./timestep))
   if (l_luc .and. iday==1 .and. mtau==1) then
    ! resdistr(frac,in,out) - Lestevens 10oct17
@@ -364,7 +346,9 @@ integer :: j
                            sm_levels, itimestep, latitude, longitude,          &
                            land_index, tile_frac, tile_pts, tile_index,        &
                            bexp, hcon, satcon, sathh, smvcst, smvcwt,          &
-                           smvccl, albsoil, snow_tile, snow_rho1l,             &
+                           smvccl, albsoil,                                    &
+                           hcap, soil_clay, soil_silt, soil_sand,              &
+                           snow_tile, snow_rho1l,                              &
                            snage_tile, isnow_flg3l, snow_rho3l, snow_cond,     &
                            snow_depth3l, snow_tmp3l, snow_mass3l, sw_down,     &
                            lw_down, cos_zenith_angle, surf_down_sw, ls_rain,   &

--- a/src/coupled/ESM1.5/CABLEfilesFromESM1.5/cable_hyd_driver.F90
+++ b/src/coupled/ESM1.5/CABLEfilesFromESM1.5/cable_hyd_driver.F90
@@ -65,7 +65,9 @@ SUBROUTINE cable_hyd_driver( SNOW_TILE, LYING_SNOW, SURF_ROFF, SUB_SURF_ROFF,  &
       
       SURF_CAB_ROFF  = UNPACK(ssnow%rnof2, um1%L_TILE_PTS, miss)
       SUB_SURF_ROFF  = SUM(um1%TILE_FRAC * SURF_CAB_ROFF,2)
-
+      
+      ! %through is /dels in UM app. for STASH output 
+      canopy%through = canopy%through / kwidth_gl
       TOT_TFALL_TILE = UNPACK(canopy%through, um1%L_TILE_PTS, miss)
       TOT_TFALL      = SUM(um1%TILE_FRAC * TOT_TFALL_TILE,2)
 

--- a/src/coupled/ESM1.5/CABLEfilesFromESM1.5/cable_rad_driver.F90
+++ b/src/coupled/ESM1.5/CABLEfilesFromESM1.5/cable_rad_driver.F90
@@ -55,8 +55,8 @@ USE cable_math_constants_mod,  ONLY: cpi180 => pi180
    USE cable_common_module, ONLY : cable_runtime, cable_user
    
 USE cbl_init_radiation_module, ONLY: Common_InitRad_Scalings
-USE grid_constants_mod_cbl,  ONLY: ICE_SoilType
-USE cable_surface_types_mod, ONLY: lakes_cable
+USE grid_constants_mod_cbl,    ONLY: ICE_SoilType
+USE cable_surface_types_mod,   ONLY: lakes_cable
 
    IMPLICIT NONE                     
 

--- a/src/coupled/ESM1.5/CABLEfilesFromESM1.5/cable_read_nml.F90
+++ b/src/coupled/ESM1.5/CABLEfilesFromESM1.5/cable_read_nml.F90
@@ -1,0 +1,164 @@
+!==============================================================================
+! This source code is part of the 
+! Australian Community Atmosphere Biosphere Land Exchange (CABLE) model.
+! This work is licensed under the CABLE Academic User Licence Agreement 
+! (the "Licence").
+! You may not use this file except in compliance with the Licence.
+! A copy of the Licence and registration form can be obtained from 
+! http://www.cawcr.gov.au/projects/access/cable
+! You need to register and read the Licence agreement before use.
+! Please contact cable_help@nf.nci.org.au for any questions on 
+! registration and the Licence.
+!
+! Unless required by applicable law or agreed to in writing, 
+! software distributed under the Licence is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the Licence for the specific language governing permissions and 
+! limitations under the Licence.
+! ==============================================================================
+!
+! Purpose: Routines to read CABLE namelist, check variables, allocate and 
+!          deallocate CABLE arrays
+!
+! Contact: Jhan.Srbinovsky@csiro.au
+!
+! History: Rewrite of code from v1.8 (ACCESS1.3)
+!          soil_snow_type now ssnow (instead of ssoil)
+!
+!
+! ==============================================================================
+
+MODULE cable_read_nml_mod
+   
+CHARACTER(LEN=*), PARAMETER :: runtime_vars_file="cable.nml"
+
+INTERFACE check_nmlvar 
+  MODULE PROCEDURE check_chvar, check_intvar, check_lgvar
+END INTERFACE check_nmlvar 
+ 
+CONTAINS
+
+SUBROUTINE cable_read_nml() 
+
+USE cable_common_module,    ONLY: cable_runtime, filename,                     & 
+                                  redistrb, l_casacnp, l_laiFeedbk,            &
+                                  l_vcmaxFeedbk, l_luc, l_thinforest
+USE cable_runtime_opts_mod, ONLY: wiltParam, satuParam, snmin, cable_user
+USE casavariable,           ONLY: casafile
+USE casadimension,          ONLY: icycle
+
+IMPLICIT NONE
+
+INTEGER :: funit=88813
+
+!--- namelist for CABLE runtime vars, switches 
+NAMELIST/CABLE/filename, l_thinforest, l_luc, l_laiFeedbk, l_vcmaxFeedbk,      &
+               icycle, casafile, cable_user, redistrb, wiltParam, satuParam,   &
+               snmin, l_casacnp
+
+!--- assume namelist exists. no iostatus check 
+OPEN(unit=funit,FILE= runtime_vars_file)
+  READ(funit,NML=CABLE)
+  PRINT *, '  '; PRINT *, 'CABLE_log:' 
+  PRINT *, '  Opened file - '
+  PRINT *, '  ', TRIM(runtime_vars_file)
+  PRINT *, '  for reading runtime vars.' 
+  PRINT *, 'End CABLE_log:'; PRINT *, '  '
+CLOSE(funit)
+
+!jh:revise list, include error traps 
+!--- check value of variable 
+CALL check_nmlvar('cable_user%DIAG_SOIL_RESP', cable_user%DIAG_SOIL_RESP)
+CALL check_nmlvar('cable_user%LEAF_RESPIRATION',                         &
+                  cable_user%LEAF_RESPIRATION)
+CALL check_nmlvar('cable_user%FWSOIL_SWITCH', cable_user%FWSOIL_SWITCH)
+CALL check_nmlvar('cable_user%RUN_DIAG_LEVEL', cable_user%RUN_DIAG_LEVEL)
+CALL check_nmlvar('cable_user%l_new_roughness_soil',                     &
+                   cable_user%l_new_roughness_soil)
+CALL check_nmlvar('cable_user%l_new_roughness_soil',                     &
+                   cable_user%l_new_roughness_soil)
+CALL check_nmlvar('cable_user%l_new_roughness_soil',                     &
+                         cable_user%l_new_roughness_soil)
+
+PRINT *, '  ' 
+PRINT *, 'CASA_log:'
+PRINT *, '  icycle =        ', icycle
+PRINT *, '  l_laiFeedbk =   ', l_laiFeedbk
+PRINT *, '  l_vcmaxFeedbk = ', l_vcmaxFeedbk
+PRINT *, '  l_luc =         ', l_luc
+PRINT *, 'End CASA_log:' 
+PRINT *, '  '
+
+IF (l_casacnp  .AND. (icycle == 0 .OR. icycle > 3)) THEN 
+  STOP 'CASA_log: icycle must be 1 to 3 when using casaCNP'
+END IF  
+IF ((.NOT. l_casacnp)  .AND. (icycle >= 1)) THEN
+  STOP 'CASA_log: icycle must be <=0 when not using casaCNP'
+END IF  
+IF ((l_laiFeedbk .OR. l_vcmaxFeedbk) .AND. (.NOT. l_casacnp)) THEN
+  STOP 'CASA_log: casaCNP required to get prognostic LAI or Vcmax'
+END IF  
+IF (l_vcmaxFeedbk .AND. icycle < 2) THEN
+  STOP 'CASA_log: icycle must be 2 to 3 to get prognostic Vcmax'
+END IF  
+
+RETURN
+END SUBROUTINE cable_read_nml
+
+!jhan: also add real, logical, int interfaces
+SUBROUTINE check_chvar(this_var, val_var)
+
+CHARACTER(LEN=*), INTENT(IN) :: this_var, val_var 
+
+PRINT *, '  ' 
+PRINT *, 'CABLE_log:' 
+PRINT *, '   run time variable - '
+PRINT *, '  ', TRIM(this_var) 
+PRINT *, '   defined as - '
+PRINT *, '  ', TRIM(val_var) 
+PRINT *, 'End CABLE_log:' 
+PRINT *, '  '
+
+RETURN
+END SUBROUTINE check_chvar
+
+SUBROUTINE check_intvar(this_var, val_var)
+
+CHARACTER(LEN=*), INTENT(IN) :: this_var
+INTEGER, INTENT(IN) :: val_var 
+
+PRINT *, '  ' 
+PRINT *, 'CABLE_log:' 
+PRINT *, '   run time variable - '
+PRINT *, '  ', TRIM(this_var) 
+PRINT *, '   defined as - '
+PRINT *, '  ', val_var
+PRINT *, 'End CABLE_log:'
+PRINT *, '  '
+
+RETURN
+END SUBROUTINE check_intvar
+
+SUBROUTINE check_lgvar(this_var, val_var)
+
+CHARACTER(LEN=*), INTENT(IN) :: this_var
+LOGICAL, INTENT(IN) :: val_var
+
+PRINT *, '  '
+PRINT *, 'CABLE_log:'
+PRINT *, '   run time variable - '
+PRINT *, '  ', TRIM(this_var)
+PRINT *, '   defined as - '
+PRINT *, '  ', val_var
+PRINT *, 'End CABLE_log:' 
+PRINT *, '  '
+
+RETURN
+END SUBROUTINE check_lgvar
+
+END MODULE cable_read_nml_mod
+
+
+
+
+

--- a/src/coupled/ESM1.5/CABLEfilesFromESM1.5/cable_um_tech.F90
+++ b/src/coupled/ESM1.5/CABLEfilesFromESM1.5/cable_um_tech.F90
@@ -79,10 +79,6 @@ USE cable_def_types_mod, ONLY : air_type, bgc_pool_type, met_type,             &
          laift(:,:)       ! hruffmax(:.:)
    END TYPE derived_veg_pars
 
-   INTERFACE check_nmlvar 
-      MODULE PROCEDURE check_chvar, check_intvar, check_lgvar
-   END INTERFACE check_nmlvar 
- 
       TYPE(derived_rad_bands), SAVE :: kblum_rad    
       TYPE(derived_veg_pars),  SAVE :: kblum_veg    
       TYPE(um_dimensions),     SAVE :: um1
@@ -91,128 +87,6 @@ USE cable_def_types_mod, ONLY : air_type, bgc_pool_type, met_type,             &
 
 CONTAINS
 
-!========================================================================
-!========================================================================
-!========================================================================
-
-SUBROUTINE cable_um_runtime_vars(runtime_vars_file) 
-   USE cable_common_module, ONLY : cable_runtime, cable_user, filename,        &
-                                   cable_user, knode_gl, redistrb, wiltParam,  &
-                                   satuParam, l_casacnp, l_laiFeedbk,          &
-                                   l_vcmaxFeedbk, l_luc, l_thinforest
-   USE casavariable, ONLY : casafile
-   USE casadimension, ONLY : icycle
-
-
-   CHARACTER(LEN=*), INTENT(IN) :: runtime_vars_file
-   INTEGER :: funit=88
-   
-   !--- namelist for CABLE runtime vars, files, switches 
-   NAMELIST/CABLE/filename, l_thinforest, l_luc, l_casacnp, l_laiFeedbk, &
-                  l_vcmaxFeedbk, icycle,   &
-                  casafile, cable_user, redistrb, wiltParam, satuParam
-
-      !--- assume namelist exists. no iostatus check 
-      OPEN(unit=funit,FILE= runtime_vars_file)
-         READ(funit,NML=CABLE)
-         IF( knode_gl==0)  THEN
-            PRINT *, '  '; PRINT *, 'CABLE_log:' 
-            PRINT *, '  Opened file - '
-            PRINT *, '  ', trim(runtime_vars_file)
-            PRINT *, '  for reading runtime vars.' 
-            PRINT *, 'End CABLE_log:'; PRINT *, '  '
-        ENDIF
-      CLOSE(funit)
-
-      if (knode_gl==0) then
-        print *, '  '; print *, 'CASA_log:'
-        print *, '  icycle =',icycle
-        print *, '  l_casacnp =',l_casacnp
-        print *, '  l_laiFeedbk =',l_laiFeedbk
-        print *, '  l_vcmaxFeedbk =',l_vcmaxFeedbk
-        print *, 'End CASA_log:'; print *, '  '
-      endif
-      IF (l_casacnp  .AND. (icycle == 0 .OR. icycle > 3)) &
-          STOP 'CASA_log: icycle must be 1 to 3 when using casaCNP'
-      IF ((.NOT. l_casacnp)  .AND. (icycle >= 1)) &
-          STOP 'CASA_log: icycle must be <=0 when not using casaCNP'
-      IF ((l_laiFeedbk .OR. l_vcmaxFeedbk) .AND. (.NOT. l_casacnp)) &
-          STOP 'CASA_log: casaCNP required to get prognostic LAI or Vcmax'
-      IF (l_vcmaxFeedbk .AND. icycle < 2) &
-          STOP 'CASA_log: icycle must be 2 to 3 to get prognostic Vcmax'
-   
-      !--- check value of variable 
-      CALL check_nmlvar('filename%veg', filename%veg)
-      CALL check_nmlvar('filename%soil', filename%soil)
-      CALL check_nmlvar('cable_user%DIAG_SOIL_RESP', cable_user%DIAG_SOIL_RESP)
-      CALL check_nmlvar('cable_user%LEAF_RESPIRATION',                         &
-                        cable_user%LEAF_RESPIRATION)
-      CALL check_nmlvar('cable_user%FWSOIL_SWITCH', cable_user%FWSOIL_SWITCH)
-      CALL check_nmlvar('cable_user%RUN_DIAG_LEVEL', cable_user%RUN_DIAG_LEVEL)
-      CALL check_nmlvar('cable_user%l_new_roughness_soil',                     &
-                         cable_user%l_new_roughness_soil)
-      CALL check_nmlvar('cable_user%l_new_roughness_soil',                     &
-                         cable_user%l_new_roughness_soil)
-      CALL check_nmlvar('cable_user%l_new_roughness_soil',                     &
-                         cable_user%l_new_roughness_soil)
-
-END SUBROUTINE cable_um_runtime_vars
-
-!jhan: also add real, logical, int interfaces
-SUBROUTINE check_chvar(this_var, val_var)
-   USE cable_common_module, ONLY : knode_gl
-
-   CHARACTER(LEN=*), INTENT(IN) :: this_var, val_var 
-   
-      IF (knode_gl==0) THEN
-         PRINT *, '  '; PRINT *, 'CABLE_log:' 
-         PRINT *, '   run time variable - '
-         PRINT *, '  ', trim(this_var) 
-         PRINT *, '   defined as - '
-         PRINT *, '  ', trim(val_var) 
-         PRINT *, 'End CABLE_log:'; PRINT *, '  '
-      ENDIf
-
-END SUBROUTINE check_chvar
-
-SUBROUTINE check_intvar(this_var, val_var)
-   USE cable_common_module, ONLY : knode_gl
-
-   CHARACTER(LEN=*), INTENT(IN) :: this_var
-   INTEGER, INTENT(IN) :: val_var 
-
-      IF (knode_gl==0) THEN
-         PRINT *, '  '; PRINT *, 'CABLE_log:' 
-         PRINT *, '   run time variable - '
-         PRINT *, '  ', trim(this_var) 
-         PRINT *, '   defined as - '
-         PRINT *, '  ', val_var
-         PRINT *, 'End CABLE_log:'; PRINT *, '  '
-      ENDIF
-
-END SUBROUTINE check_intvar
-
-SUBROUTINE check_lgvar(this_var, val_var)
-   USE cable_common_module, ONLY : knode_gl
-
-   CHARACTER(LEN=*), INTENT(IN) :: this_var
-   LOGICAL, INTENT(IN) :: val_var
-
-      IF (knode_gl==0) THEN
-         PRINT *, '  '; PRINT *, 'CABLE_log:'
-         PRINT *, '   run time variable - '
-         PRINT *, '  ', trim(this_var)
-         PRINT *, '   defined as - '
-         PRINT *, '  ', (val_var)
-         PRINT *, 'End CABLE_log:'; PRINT *, '  '
-      ENDIf
-
-END SUBROUTINE check_lgvar
-    
-!========================================================================= 
-!=========================================================================
-!========================================================================= 
- 
 SUBROUTINE alloc_um_interface_types( row_length, rows, land_pts, ntiles,       &
                                      sm_levels )
       USE cable_common_module, ONLY : cable_runtime, cable_user

--- a/src/coupled/ESM1.5/CABLEfilesFromESM1.5/cbl_LAI_canopy_height.F90
+++ b/src/coupled/ESM1.5/CABLEfilesFromESM1.5/cbl_LAI_canopy_height.F90
@@ -1,0 +1,106 @@
+module cbl_LAI_canopy_height_mod
+  !* This MODULE contains the SUBROUTINE [[limit_HGT_LAI]].  This routine
+  ! places limits on the values of the leaf area and canopy height to ensure
+  ! realism.
+
+contains
+
+subroutine limit_HGT_LAI( HGT_pft_temp, LAI_pft_cbl, HGT_pft_cbl, mp, land_pts, ntiles, &
+                          tile_pts, tile_index, tile_frac,L_tile_pts, &
+                          LAI_pft, HGT_pft, CLAI_thresh )
+  !*## Purpose
+  !
+  ! This SUBROUTINE checks that input values of leaf area and canopy height
+  ! lie between set values (defined by PFT) and overwrites if necessary.
+  ! These limits are needed to ensure that the canopy roughness properties of
+  ! the land point are well behaved (see [[ruff_resist]]).
+  !
+  ! The mapping from grid cells (land_pts,ntiles) to the (mp) structure
+  ! is also undertaken.
+  !
+  ! **This SUBROUTINE is active when CABLE is run within a coupled model
+  ! (i.e. ACCESS)** 
+  !
+  !## Method
+  !
+  ! The cell-level input (land_pts,ntile) variables for leaf area `LAI_pft` and
+  ! canopy height `HGT_pft` are checked for
+  !
+  ! - whether the land_pt has a non-zero fraction of that tile (if zero
+  !   fraction then LAI and canopy height are set to zero)
+  ! - whether the LAI lies above a minimum value `CLAI_thresh`
+  ! - whether the canopy height lies above a minimum value (which is PFT dependent)
+  ! - whether non-vegetated tiles have a non-zero canopy height.
+  !
+  ! Outputs are `LAI_pft_cbl` and `HGT_pft_cbl`
+  !
+  ! **WARNINGS**
+  !
+  ! - INTENT statements need to be added to the argument lists
+  ! - hardwired indexing is used throughout.  This SUBROUTINE assumes that
+  !     1. non-vegetated tiles take indexes 14 and onwards
+  !     2. tall vegetation occupies tile indexes 1-4
+  !     3. other vegetation (shrubs/grasses/crops/wetlands) occupy tile indexes
+  !     5-13
+  ! - the limits on canopy height are hardwired
+  !     1. canopy height for tall vegetation is limited to be greater than 1m
+  !     2. canopy height for other vegetation is limited to be greater than 0.1m
+
+implicit none
+real :: Clai_thresh                 !! The minimum LAI below which a tile is considered to be NOT vegetated (m\(^2\)m\(^{-2}\))
+integer :: land_pts, ntiles         !! number of land points, max number of tiles that can be carried in any land point (-)
+integer :: tile_pts(ntiles)         !! number of land_pts in the array that include an active tile of a particular tile type (-) 
+integer:: tile_index(land_pts,ntiles) !! specifies the tile types within each land point (-)
+real:: tile_frac(land_pts,ntiles)   !! fraction of cell assigned to each tile (-)
+logical :: L_tile_pts(land_pts,ntiles) !! switch to denote whether a tile is active (-)
+integer :: mp                       !! total number of tiles carried by land vector (-)
+real :: LAI_pft(land_pts, ntiles)   !! IN leaf area (m\(^2\)m\(^{-2}\))
+real :: HGT_pft(land_pts, ntiles)   !! IN canopy height (m)
+
+!return vars
+real :: HGT_pft_temp(land_pts,ntiles) !! OUT adjusted canopy height in (land_pts,ntile) form (m)
+real :: LAI_pft_cbl(mp)             !! OUT adjusted leaf area in (mp) form (m\(^2\)m\(^{-2}\))
+real :: HGT_pft_cbl(mp)             !! OUT adjusted canopy height in (mp) form (m)
+
+!local vars
+real :: LAI_pft_temp(land_pts,ntiles)
+integer :: i,j, N 
+
+!Retain init where tile_frac=0
+LAI_pft_temp = 0. 
+HGT_pft_temp = 0.
+
+DO N=1,NTILES
+  DO J=1,TILE_PTS(N)
+      
+    i = TILE_INDEX(j,N)  ! It must be landpt index
+
+    IF( TILE_FRAC(i,N) .gt. 0.0 ) THEN
+      
+       ! hard-wired vegetation type numbers need to be removed
+       IF(N < 5 ) THEN ! trees 
+        LAI_pft_temp(i,N) = max(CLAI_thresh,LAI_pft(i,N)) 
+          HGT_pft_temp(i,N) = max(1.,HGT_pft(i,N)) 
+      ELSE IF(N > 4 .AND. N < 14 ) THEN  ! shrubs/grass
+        LAI_pft_temp(i,N) = max(CLAI_thresh,LAI_pft(i,N)) 
+          HGT_pft_temp(i,N) = max(0.1, HGT_pft(i,N)) 
+      ELSE IF(N > 13 ) THEN ! non-vegetated
+        LAI_pft_temp(i,N) = 0.0
+        HGT_pft_temp(i,N) = 0.0
+       ENDIF
+
+    ENDIF
+
+   ENDDO
+ENDDO
+  
+  !surface_type = PACK(surface_type_temp, um1%L_TILE_PTS)
+  LAI_pft_cbl  = PACK(LAI_pft_temp, L_TILE_PTS)
+  HGT_pft_cbl  = PACK(HGT_pft_temp, L_TILE_PTS)
+
+End subroutine limit_HGT_LAI
+
+!==============================================================================
+ 
+End module cbl_LAI_canopy_height_mod
+

--- a/src/coupled/ESM1.5/CABLEfilesFromESM1.5/cbl_um_init_soil.F90
+++ b/src/coupled/ESM1.5/CABLEfilesFromESM1.5/cbl_um_init_soil.F90
@@ -1,0 +1,190 @@
+MODULE cbl_um_init_soil_mod
+   
+IMPLICIT NONE
+PUBLIC initialize_soil
+
+CONTAINS
+
+SUBROUTINE initialize_soil( bexp, hcon, satcon, sathh, smvcst, smvcwt,         &
+                        smvccl, albsoil,                             & 
+                        hcap, soil_clay, soil_silt, soil_sand,       &
+                        tsoil_tile, sthu, sthu_tile, dzsoil )
+                        
+! subrs
+USE cable_pack_mod,    ONLY: pack_landpts2mp_ICE, pack_landpts2mp, cable_pack_rr
+
+! data
+!USE params_io_mod_cbl,      ONLY: params_io_data_type
+USE cable_common_module,     ONLY : cable_user, gw_params
+USE cable_def_types_mod,     ONLY: soil_parameter_type, r_2
+USE cable_def_types_mod,     ONLY: ms, mstype, mp, r_2
+USE cable_um_tech_mod,       ONLY: um1, soil, veg, ssnow 
+USE cable_soil_params_mod,   ONLY: soilin
+USE grid_constants_mod_cbl,  ONLY: ICE_SoilType, nsoil_max 
+USE cable_surface_types_mod, ONLY: ICE_SurfaceType => ice_cable
+IMPLICIT NONE
+
+REAL, INTENT(IN), DIMENSION(um1%land_pts) :: &
+   bexp, &
+   hcon, &
+   satcon, & 
+   sathh, &
+   smvcst, &
+   smvcwt, &
+   smvccl, &
+   albsoil 
+
+REAL, INTENT(IN) :: soil_clay ( um1%row_length, um1%rows )
+REAL, INTENT(IN) :: soil_silt ( um1%row_length, um1%rows )
+REAL, INTENT(IN) :: soil_sand ( um1%row_length, um1%rows )
+REAL, INTENT(IN) :: hcap(um1%land_pts)
+
+REAL, INTENT(IN), DIMENSION(um1%land_pts, um1%sm_levels) :: sthu
+
+REAL, INTENT(IN), DIMENSION(um1%land_pts, um1%ntiles, um1%sm_levels) :: &
+   sthu_tile,     &
+   tsoil_tile
+
+REAL, INTENT(IN), DIMENSION(um1%sm_levels) :: dzsoil
+
+!___defs 1st call to CABLE in this run
+LOGICAL, SAVE :: first_call= .TRUE.
+INTEGER :: i,j,k,L,n
+REAL, ALLOCATABLE :: tempvar(:), tempvar2(:)
+LOGICAL, PARAMETER :: skip =.TRUE. 
+REAL, DIMENSION(mstype) :: dummy 
+!from AM3
+REAL    :: hcon_ICE(nsoil_max) 
+REAL    :: soilCnsd_real(mp) 
+REAL    :: sucs_sign_factor, hyds_unit_factor, sucs_min_magnitude
+
+soil%heat_cap_lower_limit = 0.01
+
+soil%isoilm(:)=2
+DO j=1,mp
+  IF (veg%iveg(j) == ICE_SurfaceType) THEN
+    soil%isoilm(j) = ICE_SoilType
+  END IF
+END DO
+
+soil%zse = dzsoil  !ESM!
+
+! distance between consecutive layer midpoints
+soil%zshh(1)    = 0.5 * soil%zse(1) 
+soil%zshh(ms+1) = 0.5 * soil%zse(ms)
+soil%zshh(2:ms) = 0.5 * (soil%zse(1:ms-1) + soil%zse(2:ms))
+
+ssnow%pudsto = 0.0; ssnow%pudsmx = 0.0!ESM!
+
+! albsoil ->  soil%albsoil
+CALL pack_landpts2mp( um1%ntiles, um1%land_pts, mp, um1%tile_pts, um1%tile_index,            &
+                      um1%L_tile_pts, albsoil, soil%albsoil(:,1) )
+  
+! bexp -> soil%bch: parameter b in Campbell equation 
+CALL pack_landpts2mp_ICE( um1%ntiles, um1%land_pts, mp, nsoil_max, ICE_soiltype,       &
+                          um1%tile_pts, um1%tile_index, um1%L_tile_pts, BEXP, soil%isoilm,  &
+                          soilin%bch, soil%bch )
+!--- Fix Init for soil% textures  needed for CASA-CNP
+CALL cable_pack_rr( soil%sand, soil_sand, mp, um1%l_tile_pts, um1%row_length,    &
+                    um1%rows, um1%ntiles, um1%land_pts, um1%land_index, um1%tile_pts, &  
+                    um1%tile_index )
+
+CALL cable_pack_rr( soil%clay, soil_clay, mp, um1%l_tile_pts, um1%row_length,    &
+                    um1%rows, um1%ntiles, um1%land_pts, um1%land_index, um1%tile_pts, &  
+                    um1%tile_index )
+
+CALL cable_pack_rr( soil%silt, soil_silt, mp, um1%l_tile_pts, um1%row_length,    &
+                    um1%rows, um1%ntiles, um1%land_pts, um1%land_index, um1%tile_pts, &  
+                    um1%tile_index )
+
+!jhan: where do these wweighting factors come from
+hcon_ICE(:) = ( soilin%sand(ICE_SoilType) * 0.3 )                         &
+             + ( soilin%clay(ICE_SoilType) * 0.25 )                       &
+             + ( soilin%silt(ICE_SoilType) * 0.265 )
+
+! hcon -> soil%cnsd
+CALL pack_landpts2mp_ICE( um1%ntiles, um1%land_pts, mp, nsoil_max, ICE_soiltype,       &
+                          um1%tile_pts, um1%tile_index, um1%L_tile_pts, hcon, soil%isoilm,  &
+                          hcon_ICE, soilCnsd_real )
+
+soil%cnsd = REAL( soilCnsd_real, r_2 )
+
+! CABLE soil parameters are in general PACKed from UM spatial fields
+! *EXCEPT* for permanent ice points where we overwrite with parametrs read from
+! cable_soil_params (pars%)
+
+! soil%hyds = hydraulic conductivity @saturation is PACKed from satcon[mm/s]
+! *EXCEPT* at permanent ice points where we overwrite with parametrs read from
+! pars%soilin_hyds[m/s] which are already in correct units. Dividing by 1000  
+! soil%hyds is correct for tiles 1:8. Would be 1000* too small, hence *1000 first 
+CALL pack_landpts2mp_ICE( um1%ntiles, um1%land_pts, mp, nsoil_max, ICE_soiltype,       &
+                          um1%tile_pts, um1%tile_index, um1%L_tile_pts, satcon, soil%isoilm,&
+                          soilin%hyds * 1000.0, soil%hyds )
+                          !pars%soilin_hyds * 1000.0, soil%hyds )
+soil%hyds    = soil%hyds / 1000.0
+
+! sathh -> soil%sucs
+CALL pack_landpts2mp_ICE( um1%ntiles, um1%land_pts, mp, nsoil_max, ICE_soiltype,       &
+                          um1%tile_pts, um1%tile_index, um1%L_tile_pts, sathh, soil%isoilm, &
+                          soilin%sucs, soil%sucs )
+
+! smvcst -> soil%ssat
+CALL pack_landpts2mp_ICE( um1%ntiles, um1%land_pts, mp, nsoil_max, ICE_soiltype,       &
+                          um1%tile_pts, um1%tile_index, um1%L_tile_pts, smvcst, soil%isoilm,&
+                          soilin%ssat, soil%ssat )
+
+! smvcwt -> soil%swilt
+CALL pack_landpts2mp_ICE( um1%ntiles, um1%land_pts, mp, nsoil_max, ICE_soiltype,       &
+                          um1%tile_pts, um1%tile_index, um1%L_tile_pts, smvcwt, soil%isoilm,&
+                          soilin%swilt, soil%swilt )
+
+! smvccl -> soil%sfc  
+CALL pack_landpts2mp_ICE( um1%ntiles, um1%land_pts, mp, nsoil_max, ICE_soiltype,       &
+                          um1%tile_pts, um1%tile_index, um1%L_tile_pts, smvccl, soil%isoilm,&
+                          soilin%sfc, soil%sfc )
+
+!--- (re)set values for CABLE
+soil%ibp2    =  NINT(soil%bch)+2
+soil%i2bp3   =  2*NINT(soil%bch)+3
+
+soil%ssat    = MAX( soil%ssat, soil%sfc + 0.01 )
+soil%sucs    = ABS( soil%sucs )
+sucs_min_magnitude = 106.0/1000.0 ! satcon in UM is in mm/s; Cable needs m/s
+soil%sucs          = MAX(sucs_min_magnitude,soil%sucs)
+soil%hsbh          = soil%hyds * ABS(soil%sucs) * soil%bch
+WHERE( soil%ssat > 0. ) 
+  soil%pwb_min =  (soil%swilt / soil%ssat )**soil%ibp2
+END WHERE
+
+! USED product (rhosoil*css) assumes css is specific heat capacity 
+! JULES hcap is already volumetric heat capacity - requires set rhosoil = 1.0
+soil%rhosoil = 1.0 
+! hcap ->  soil%css
+CALL pack_landpts2mp( um1%ntiles, um1%land_pts, mp, um1%tile_pts, um1%tile_index,            &
+                      um1%L_tile_pts, hcap, soil%css )
+
+!initializations require for cable_user%soil_thermal_fix and %Haverd2013 
+DO k=1,ms
+   soil%ssat_vec(:,k)      = real(soil%ssat(:)   ,r_2)    
+   soil%sucs_vec(:,k)      = real(soil%sucs(:)   ,r_2)   
+   soil%hyds_vec(:,k)      = real(soil%hyds(:)   ,r_2)  
+   soil%swilt_vec(:,k)     = real(soil%swilt(:)  ,r_2)  
+   soil%bch_vec(:,k)       = real(soil%bch(:)    ,r_2)
+   soil%sfc_vec(:,k)       = real(soil%sfc(:)    ,r_2)
+   soil%rhosoil_vec(:,k)   = real(soil%rhosoil(:),r_2)   
+   soil%cnsd_vec(:,k)      = real(soil%cnsd(:)   ,r_2)
+   soil%css_vec(:,k)       = real(soil%css(:)    ,r_2)
+   soil%sand_vec(:,k)      = real(soil%sand(:)   ,r_2)
+   soil%clay_vec(:,k)      = real(soil%clay(:)   ,r_2)
+   soil%silt_vec(:,k)      = real(soil%silt(:)   ,r_2)
+   soil%watr(:,k)          = 0.001_r_2
+END DO
+
+WHERE (soil%ssat_vec .LE. 0.0 .AND. soil%sfc_vec .GT. 0.0)
+  soil%ssat_vec = soil%sfc_vec + 0.05
+END WHERE
+
+RETURN
+END SUBROUTINE initialize_soil
+
+END MODULE cbl_um_init_soil_mod

--- a/src/coupled/ESM1.5/CABLEfilesFromESM1.5/cbl_um_init_soilsnow.F90
+++ b/src/coupled/ESM1.5/CABLEfilesFromESM1.5/cbl_um_init_soilsnow.F90
@@ -1,0 +1,197 @@
+MODULE cbl_um_init_soilsnow_mod
+   
+IMPLICIT NONE
+
+PUBLIC initialize_soilsnow
+
+CONTAINS
+
+! ESM1.5 args moderated by necessary AM3 USEs etc to support AM3 algorithm(s)
+! ESM1.5 algorithm(s) super indented 
+SUBROUTINE initialize_soilsnow( smvcst, tsoil_tile, sthf_tile, smcl_tile,      &
+                                snow_tile, snow_rho1l, snage_tile, isnow_flg3l,&
+                                snow_rho3l, snow_cond, snow_depth3l,           &
+                                snow_mass3l, snow_tmp3l, fland,                &
+                                sin_theta_latitude ) 
+
+! subrs
+USE cable_init_wetfac_mod,   ONLY: initialize_wetfac
+USE cable_um_init_subrs_mod, ONLY: um2cable_lp
+
+USE cable_def_types_mod, ONLY: mp, msn
+USE cable_um_tech_mod,   ONLY: um1, soil, ssnow, met, bal, veg
+USE cable_common_module, ONLY: cable_runtime, cable_user, frozen_limit
+
+USE cable_phys_constants_mod, ONLY: density_ice, density_liq
+USE cable_phys_constants_mod, ONLY: TFRZ
+USE cable_phys_constants_mod, ONLY: cgsnow, csice, cswat 
+USE grid_constants_mod_cbl,   ONLY: ICE_SoilType
+   
+   REAL, INTENT(IN), DIMENSION(um1%land_pts) :: smvcst
+   
+   REAL, INTENT(IN), DIMENSION(um1%land_pts, um1%ntiles, um1%sm_levels) ::    &
+      sthf_tile, &   !
+      smcl_tile, &   !
+      tsoil_tile     !
+
+   INTEGER, INTENT(IN), DIMENSION(um1%land_pts, um1%ntiles) :: isnow_flg3l 
+
+   REAL, INTENT(INOUT), DIMENSION(um1%land_pts, um1%ntiles) :: snow_tile
+
+   REAL, INTENT(IN), DIMENSION(um1%land_pts, um1%ntiles) ::                    &
+      snow_rho1l, &  !
+      snage_tile     !
+
+   REAL, INTENT(INOUT), DIMENSION(um1%land_pts, um1%ntiles,3) :: snow_cond
+
+   REAL, INTENT(IN), DIMENSION(um1%land_pts, um1%ntiles,3) ::                  & 
+      snow_rho3l,    & !
+      snow_depth3l,  & !
+      snow_mass3l,   & !
+      snow_tmp3l       !
+   
+   REAL, INTENT(IN), DIMENSION(um1%land_pts) :: fland 
+   
+   REAL, INTENT(IN), DIMENSION(um1%row_length, um1%rows) :: sin_theta_latitude
+   
+!local vars
+INTEGER :: i,j,k,L,n
+REAL    :: zsetot
+REAL    :: ice_vol_tmp(um1%land_pts, um1%ntiles, um1%sm_levels)
+REAL    :: wbtot_mp(mp, um1%sm_levels)
+REAL    :: wbice_mp(mp, um1%sm_levels)
+! from ESM1.5
+REAL    :: max_snow_depth=50000. 
+REAL    :: sfact(mp)
+REAL    :: fvar(um1%land_pts )
+LOGICAL :: skip =.TRUE. 
+
+ssnow%pudsto       = 0.0 
+ssnow%pudsmx       = 0.0
+ssnow%wbtot        = 0.0
+ssnow%totwblake    = 0.0  ! wb_lake integrated over river timestep
+ssnow%tggav        = 0.0
+ssnow%qhz          = 0.0
+ssnow%qhlev        = 0.0
+ssnow%qrecharge    = 0.0
+ssnow%rtevap_sat   = 0.0
+ssnow%rtevap_unsat = 0.0
+
+! identify module parameters here and recast (NOT ssnow% state variables)
+ssnow%t_snwlr      = 0.05
+ssnow%rtsoil       = 50.0
+ssnow%satfrac      = 0.5
+ssnow%wtd          = 1.0
+
+!from esm1.5 snow_tile    = MIN( max_snow_depth, snow_tile )
+ssnow%snowd  = PACK( snow_tile, um1%L_TILE_PTS)
+ssnow%snage  = PACK( snage_tile, um1%L_TILE_PTS)
+ssnow%ssdnn  = PACK( snow_rho1l, um1%L_TILE_PTS)  
+ssnow%isflag = PACK( isnow_flg3L, um1%L_TILE_PTS)  
+
+! over snow layers
+DO j=1, msn
+  ssnow%sdepth(:,j)= PACK( snow_depth3l(:,:,j), um1%L_TILE_PTS)
+  ssnow%smass(:,j) = PACK( snow_mass3l(:,:,j), um1%L_TILE_PTS)  
+  ssnow%ssdn(:,j)  = PACK( snow_rho3l(:,:,j), um1%L_TILE_PTS)  
+  ssnow%tggsn(:,j) = PACK( snow_tmp3l(:,:,j), um1%L_TILE_PTS)  
+  ssnow%sconds(:,J)= PACK(SNOW_COND(:,:,J), um1%L_TILE_PTS) ! rm-ed in AM3
+ENDDO 
+     
+! over soil layers
+DO j=1, um1%sm_levels
+  ssnow%tgg(:,j)   = PACK( tsoil_tile(:,:,j), um1%L_TILE_PTS)
+ENDDO 
+
+! AM3 this is broken into init/update
+! IF( first_call) THEN 
+        
+ssnow%osnowd = ssnow%snowd
+
+zsetot = sum(soil%zse)
+DO k = 1, um1%sm_levels
+  ssnow%tggav = ssnow%tggav  + soil%zse(k)*ssnow%tgg(:,k)/zsetot
+END DO
+
+!jhan:Ian: check this is indeed equiv to previous algorithm
+ice_vol_tmp(:,:,:)  = 0.0
+DO n=1,um1%ntiles                                                       
+  DO k=1,um1%tile_pts(n)                                           
+    i = um1%tile_index(k,n)                                      
+    DO j = 1, um1%sm_levels
+      ice_vol_tmp(i,n,j)  = sthf_tile(i,n,j) * smvcst(i)
+    ENDDO ! J
+  ENDDO
+ENDDO
+ 
+DO j = 1, um1%sm_levels
+  !liq volume  from (tot_mass - ice_mass) / (dz*rho_liq)
+  wbtot_mp(:,j)    = PACK( smcl_tile(:,:,j), um1%L_TILE_PTS)
+  
+  ssnow%wbice(:,J) = PACK( ice_vol_tmp(:,:,j), um1%L_TILE_PTS)
+  ssnow%wbice(:,J) = MAX ( 0.0 , ssnow%wbice(:,j) )
+  wbice_mp(:,j)    = ssnow%wbice(:,j) * ( soil%zse(j) * density_ice )
+  
+  ssnow%wbliq(:,j) = ( wbtot_mp(:,j) - wbice_mp(:,j) )  / ( soil%zse(j) * density_liq )
+  ssnow%wb(:,j)    = ssnow%wbice(:,j) + ssnow%wbliq(:,j) 
+END DO
+
+         ! from ESM1.5
+         DO N=1,um1%NTILES
+            DO K=1,um1%TILE_PTS(N)
+               L = um1%TILE_INDEX(K,N)
+               fvar(L) = real(L)
+            ENDDO
+         ENDDO
+         CALL um2cable_lp( fland, fland, ssnow%fland, soil%isoilm, skip )
+         CALL um2cable_lp( fvar, fvar, ssnow%ifland, soil%isoilm, skip )
+         
+         ssnow%owetfac = MAX( 0., MIN( 1.0,                                    &
+                         ( ssnow%wb(:,1) - soil%swilt ) /                      &
+                         ( soil%sfc - soil%swilt) ) )
+
+! wetfac initialized here as used to init owetfac on firstimestep in cbm
+! add to startdump? includes Temporay fix for accounting for reduction of 
+! soil evaporation due to freezing. Also includes specific lakes case  
+! Prevents divide by zero at glaciated points where both wb and wbice=0.
+CALL initialize_wetfac( mp, ssnow%wetfac, soil%swilt, soil%sfc,            &
+                        ssnow%wb(:,1), ssnow%wbice(:,1), ssnow%snowd,      &
+                        veg%iveg, met%tk, tfrz ) 
+
+         ! Temporay fix for accounting for reduction of soil evaporation 
+         ! due to freezing
+         WHERE( ssnow%wbice(:,1) > 0. )                                        &
+            ! Prevents divide by zero at glaciated points where both 
+            ! wb and wbice=0.
+            ssnow%owetfac = ssnow%owetfac * ( 1.0 - ssnow%wbice(:,1) /         &
+                            ssnow%wb(:,1) )**2
+      
+! initialized here on first call 
+ssnow%tss=(1-ssnow%isflag)*ssnow%tgg(:,1) + ssnow%isflag*ssnow%tggsn(:,1) 
+ 
+!jhan: do we want to do this before %owetfac is set 
+DO J = 1, um1%sm_levels
+  !should be removed!!!!!!!! This cannot conserve if there are any
+  !dynamics 
+  WHERE( soil%isoilm == ICE_SoilType)
+    ssnow%wb(:,j)    = 0.95 * soil%ssat
+    ssnow%wbice(:,j) = frozen_limit  * ssnow%wb(:,j)
+  ENDWHERE
+  
+  !no not force rho_water==rho_ice==1000.0
+  ssnow%wbtot = ssnow%wbtot + soil%zse(j) *                       &
+                             ( ssnow%wbliq(:,j) * density_liq +   &
+                               ssnow%wbice(:,j) * density_ice )                     
+ENDDO
+
+!initialize %gammz (see soil_snow)
+ssnow%gammzz(:,1) = MAX( (1.0 - soil%ssat) * soil%css * soil%rhosoil                                        &
+            & + (ssnow%wb(:,1) - ssnow%wbice(:,1) ) * cswat * density_liq                                     &
+            & + ssnow%wbice(:,1) * csice * density_ice, soil%css * soil%rhosoil ) * soil%zse(1) +   &
+            & (1. - ssnow%isflag) * cgsnow * ssnow%snowd
+     
+RETURN
+END SUBROUTINE initialize_soilsnow
+
+END MODULE cbl_um_init_soilsnow_mod
+

--- a/src/coupled/ESM1.5/CABLEfilesFromESM1.5/cbl_um_update_soilsnow.F90
+++ b/src/coupled/ESM1.5/CABLEfilesFromESM1.5/cbl_um_update_soilsnow.F90
@@ -1,0 +1,43 @@
+MODULE cbl_um_update_soilsnow_mod
+   
+IMPLICIT NONE
+
+CONTAINS
+
+SUBROUTINE update_soilsnow( mp, soil, ssnow, veg_iveg )
+                            
+
+USE cable_def_types_mod,       ONLY: soil_parameter_type
+USE cable_def_types_mod,       ONLY: soil_snow_type
+USE cable_phys_constants_mod,  ONLY: density_ice, density_liq
+USE cable_surface_types_mod,   ONLY: lakes_cable
+IMPLICIT NONE
+
+INTEGER, INTENT(IN) :: mp                ! # active land points
+INTEGER, INTENT(IN) :: veg_iveg(mp)
+!jhan:build fudge inOUT
+TYPE(soil_snow_type), INTENT(inOUT)     :: ssnow      ! 
+TYPE(soil_parameter_type), INTENT(IN) :: soil       ! soil parameters
+REAL :: wbtot1(mp), wbtot2(mp) 
+INTEGER :: j 
+
+ssnow%wb_lake = 0.0
+wbtot1        = 0.0
+wbtot2        = 0.0
+
+ssnow%wbliq = ssnow%wb - ssnow%wbice
+
+WHERE( veg_iveg == lakes_cable .AND. ssnow%wb(:,1) < soil%sfc ) 
+  wbtot1  = wbtot1 + REAL( ssnow%wb(:,1) ) * density_liq * soil%zse(1)
+  ssnow%wb(:,1) = soil%sfc
+  wbtot2  = wbtot2 + REAL( ssnow%wb(:,1) ) * density_liq * soil%zse(1)
+ENDWHERE
+  
+ssnow%wb_lake = MAX( wbtot2 - wbtot1, 0.)
+
+RETURN
+END SUBROUTINE update_soilsnow
+
+END MODULE cbl_um_update_soilsnow_mod
+
+

--- a/src/coupled/ESM1.5/cable_pft_params_mod.F90
+++ b/src/coupled/ESM1.5/cable_pft_params_mod.F90
@@ -1,0 +1,128 @@
+MODULE cable_pft_params_mod
+USE grid_constants_mod_cbl, ONLY: ntype_max
+
+IMPLICIT NONE 
+
+CHARACTER(LEN=*), PARAMETER :: nml_dir='./' 
+CHARACTER(LEN=*), PARAMETER :: filename="pft_params.nml"
+
+TYPE vegin_type
+
+CHARACTER(LEN=70) :: desc(ntype_max)         ! decriptions of veg type
+
+REAL ::                                                                        &
+   canst1(ntype_max),                                                          &
+   length(ntype_max),                                                          &
+   width(ntype_max),                                                           &
+   vcmax(ntype_max),                                                           &
+   ejmax(ntype_max),                                                           &
+   hc(ntype_max),                                                              &
+   xfang(ntype_max),                                                           &
+   rp20(ntype_max),                                                            &
+   rpcoef(ntype_max),                                                          &
+   rs20(ntype_max),                                                            &
+   wai(ntype_max),                                                             &
+   rootbeta(ntype_max),                                                        &
+   shelrb(ntype_max),                                                          &
+   vegcf(ntype_max),                                                           &
+   frac4(ntype_max),                                                           &
+   xalbnir(ntype_max),                                                         &
+   extkn(ntype_max),                                                           &
+   tminvj(ntype_max),                                                          &
+   tmaxvj(ntype_max),                                                          &
+   vbeta(ntype_max),                                                           &
+   a1gs(ntype_max),                                                            &
+   d0gs(ntype_max),                                                            &
+   alpha(ntype_max),                                                           &
+   convex(ntype_max),                                                          &
+   cfrd(ntype_max),                                                            &
+   gswmin(ntype_max),                                                          &
+   conkc0(ntype_max),                                                          &
+   conko0(ntype_max),                                                          &
+   ekc(ntype_max),                                                             &
+   eko(ntype_max),                                                             &
+   g0(ntype_max),                                                              &
+   g1(ntype_max),                                                              &
+   zr(ntype_max),                                                              &
+   clitt(ntype_max),                                                           &
+   froot1(ntype_max),                                                          &
+   froot2(ntype_max),                                                          &
+   froot3(ntype_max),                                                          &
+   froot4(ntype_max),                                                          &
+   froot5(ntype_max),                                                          &
+   froot6(ntype_max),                                                          &
+   csoil1(ntype_max),                                                          &
+   csoil2(ntype_max),                                                          &
+   ratecs1(ntype_max),                                                         &
+   ratecs2(ntype_max),                                                         &
+   cplant1(ntype_max),                                                         &
+   cplant2(ntype_max),                                                         &
+   cplant3(ntype_max),                                                         &
+   ratecp1(ntype_max),                                                         &
+   ratecp2(ntype_max),                                                         &
+   ratecp3(ntype_max),                                                         &
+   refl1(ntype_max),                                                           &
+   refl2(ntype_max),                                                           &
+   refl3(ntype_max),                                                           &
+   taul1(ntype_max),                                                           &
+   taul2(ntype_max),                                                           &
+   taul3(ntype_max),                                                           &
+   dleaf(ntype_max),                                                           &
+   lai(ntype_max)
+
+END TYPE vegin_type
+
+TYPE(vegin_type) :: vegin
+
+CHARACTER(LEN=70) :: veg_desc(ntype_max)         ! decriptions of veg type
+
+CONTAINS
+
+SUBROUTINE cable_read_pft_params( )
+
+IMPLICIT NONE
+
+INTEGER :: mvtype 
+INTEGER :: error
+INTEGER :: j
+
+INTEGER, PARAMETER          :: namelist_unit=711179
+CHARACTER(LEN=*), PARAMETER :: iomessage='error with your PFT params file' 
+CHARACTER(LEN=*), PARAMETER :: routinename='cable_pft_params'
+
+NAMELIST / cable_pftparm/ vegin
+
+mvtype = ntype_max    
+!-----------------------------------------------------------------------------
+! Read namelist
+!-----------------------------------------------------------------------------
+WRITE(6,*) "Reading CABLE_PFTPARM namelist ", TRIM(nml_dir) // '/' // filename
+
+OPEN( namelist_unit, FILE=(TRIM(nml_dir) // '/' // filename ),                 &
+      STATUS='old', POSITION='rewind', ACTION='read', IOSTAT  = ERROR )
+
+IF ( ERROR /= 0 ) THEN
+  WRITE (6,*) "Error opening  CABLE_PFTPARM namelist..."
+  STOP
+ENDIF
+
+READ(namelist_unit, NML = cable_pftparm, IOSTAT = ERROR )
+
+IF ( ERROR /= 0 ) THEN
+  WRITE (6,*) "Error reading  CABLE_PFTPARM namelist..."
+  STOP
+ENDIF
+                 
+CLOSE(namelist_unit, IOSTAT = ERROR)
+
+ 
+! new calculation dleaf since April 2012 (cable v1.8 did not use width)
+vegin%dleaf = SQRT(vegin%width * vegin%length)
+
+veg_desc = vegin%desc
+
+RETURN    
+END SUBROUTINE cable_read_pft_params
+
+END MODULE cable_pft_params_mod
+

--- a/src/coupled/ESM1.5/cable_soil_params_mod.F90
+++ b/src/coupled/ESM1.5/cable_soil_params_mod.F90
@@ -1,0 +1,79 @@
+MODULE cable_soil_params_mod
+
+USE grid_constants_mod_cbl, ONLY: nsoil_max   ! # of soil types [9]
+
+IMPLICIT NONE 
+
+CHARACTER(LEN=*), parameter :: nml_dir='./' 
+CHARACTER(LEN=*), PARAMETER :: filename="soil.nml"
+
+TYPE soilin_type
+
+  CHARACTER(LEN=70) ::  desc(nsoil_max) ! decriptns of soil type 
+
+  REAL, DIMENSION(nsoil_max) ::                                                &
+    silt,    & !
+    clay,    & !
+    sand,    & !
+    swilt,   & !
+    sfc,     & !
+    ssat,    & !
+    bch,     & !
+    hyds,    & !
+    sucs,    & !
+    rhosoil, & !
+    css,     & !
+    c3         ! IDK where this came from?
+
+END TYPE soilin_type
+
+TYPE(soilin_type) :: soilin
+
+CHARACTER(LEN=70), DIMENSION(nsoil_max) ::  soil_desc    
+
+CONTAINS
+
+SUBROUTINE cable_read_soil_params()
+
+IMPLICIT NONE
+
+INTEGER :: error
+INTEGER :: j
+
+INTEGER, PARAMETER          :: namelist_unit=711178
+CHARACTER(LEN=*), parameter :: iomessage='error with your soil params file'
+CHARACTER(LEN=*), PARAMETER :: routinename='cable_soil_params'
+
+NAMELIST / cable_soilparm / soilin
+
+!SOIL parameters are assigned as TYPE soilin% but later mapped to soil%
+
+!-----------------------------------------------------------------------------
+! Read namelist
+!-----------------------------------------------------------------------------
+WRITE(6,*) "Reading CABLE_SOILPARM namelist ", TRIM(nml_dir) // '/' // filename
+
+OPEN( namelist_unit, FILE=(TRIM(nml_dir) // '/' // filename ),                 &
+      STATUS='old', POSITION='rewind', ACTION='read', IOSTAT  = ERROR )
+
+IF ( ERROR /= 0 ) THEN
+  WRITE (6,*) "Error opening  CABLE_SOILPARM namelist..."
+  STOP
+ENDIF
+
+READ(namelist_unit, NML = cable_soilparm, IOSTAT = ERROR )
+                 
+IF ( ERROR /= 0 ) THEN
+  WRITE (6,*) "Error reading  CABLE_SOILPARM namelist..."
+  STOP
+ENDIF
+
+CLOSE(namelist_unit, IOSTAT = ERROR)
+
+soil_desc = soilin%desc
+
+RETURN
+END SUBROUTINE cable_read_soil_params
+
+END MODULE cable_soil_params_mod
+

--- a/src/coupled/ESM1.5/casa_um_inout.F90
+++ b/src/coupled/ESM1.5/casa_um_inout.F90
@@ -263,10 +263,6 @@ IMPLICIT NONE
   REAL   , INTENT(INOUT) ::THINNING(um1%land_pts,um1%ntiles)
   INTEGER :: idoy,mtau
 
-  print *, 'LUC1', l_luc
-  !l_luc = .TRUE.
-  print *, 'LUC2', l_luc
-
 !  PRINT *, 'initcasa,mp ', initcasa,mp
 
 ! Lest 6dec11 - moved from bgcdriver
@@ -292,19 +288,13 @@ IMPLICIT NONE
 
   IF (initcasa==1) THEN
      IF (l_luc .and. idoy == 1 .and. mtau == 1) THEN
-
-        print *, 'Lest LUC', mtau
         CALL casa_reinit_pk(casabiome,casamet,casapool,casabal,veg,phen, &
                           cpool_tile,npool_tile,ppool_tile,&
                           wood_hvest_c,wood_hvest_n,wood_hvest_p,&
                           wood_flux_c,wood_flux_n,wood_flux_p,&
                           wresp_c,wresp_n,wresp_p,thinning,&
                           GLAI,PHENPHASE,PREV_YR_SFRAC)
-        print *, 'TEST_LS reinit DONE'
-
      ELSE
-
-        print *, 'Lest No LUC', mtau
         ! CALL pack_cnppool(casamet,casapool,casabal,phen,um1,cpool_tile,npool_tile, &
         CALL pack_cnppool(casamet,casapool,casabal,phen,cpool_tile,npool_tile, &
                           ppool_tile,GLAI,PHENPHASE)
@@ -444,9 +434,9 @@ SUBROUTINE casa_reinit_pk(casabiome,casamet,casapool,casabal,veg,phen, &
    !REAL(r_2), DIMENSION(3) :: pool_frac, pool_time
    REAL,PARAMETER:: POOL_FRAC(3) =(/0.33, 0.33, 0.34/)
    REAL,PARAMETER:: POOL_TIME(3) =(/1.00, 0.10, 0.01/)
-   REAL(r_2) :: cplant_z(um1%land_pts,um1%ntiles,mplant)
-   REAL(r_2) :: nplant_z(um1%land_pts,um1%ntiles,mplant)
-   REAL(r_2) :: pplant_z(um1%land_pts,um1%ntiles,mplant)
+   REAL(r_2) :: cplant_z(um1%land_pts,um1%ntiles,mplant) ! Plant carbon pools after thinning.
+   REAL(r_2) :: nplant_z(um1%land_pts,um1%ntiles,mplant) ! Plant nitrogen pools after thinning.
+   REAL(r_2) :: pplant_z(um1%land_pts,um1%ntiles,mplant) ! Plant phosphorus pools after thinning.
 
    ! check if all of them are required
    INTEGER   :: g, p, k, y ! np
@@ -506,8 +496,6 @@ SUBROUTINE casa_reinit_pk(casabiome,casamet,casapool,casabal,veg,phen, &
   wresp_c = 0.
   wresp_n = 0.
   wresp_p = 0.
-
-  thinning = 0.
 
   ! assign "old" cnp pool values (from last dump file, initilization)
   clabile_x(:,:)   = cpool_tile(:,:,1)
@@ -595,8 +583,8 @@ SUBROUTINE casa_reinit_pk(casabiome,casamet,casapool,casabal,veg,phen, &
                                  frac_x(g,iceland), frac_y(g,iceland)
             STOP "Glacier fraction .ne. 1"
          ELSE
-            print *, 'Lest cycle', g,ifpre_x(g,iceland),ifpre_y(g,iceland),&
-                                 frac_x(g,iceland), frac_y(g,iceland)
+            !print *, 'Lest cycle', g,ifpre_x(g,iceland),ifpre_y(g,iceland),&
+            !                     frac_x(g,iceland), frac_y(g,iceland)
             cycle
          END IF
      ELSEIF (.not.ifpre_x(g,iceland) .and. .not.ifpre_y(g,iceland)) THEN
@@ -613,8 +601,6 @@ SUBROUTINE casa_reinit_pk(casabiome,casamet,casapool,casabal,veg,phen, &
          STOP "Glacier tiles not consistent"
      END IF
 
-     !write(6,*)"TEST_TZ just before call newplant"
-
      ! For none glacier tiles
      ! Re-calculate plant C, N, P pools
      CALL newplant(cplant_x(g,:,:),frac_x(g,:),ifpre_x(g,:), &
@@ -623,8 +609,6 @@ SUBROUTINE casa_reinit_pk(casabiome,casamet,casapool,casabal,veg,phen, &
                                    nplant_y(g,:,:),frac_y(g,:),ifpre_y(g,:),logn(g,:))
      IF (icycle > 2) CALL newplant(pplant_x(g,:,:),frac_x(g,:),ifpre_x(g,:), &
                                    pplant_y(g,:,:),frac_y(g,:),ifpre_y(g,:),logp(g,:))
-
-     write(6,*)"TEST_TZ just after call newplant"
 
 ! Lestevens 24 Nov 2017 - Implement Yingping's flux to state pools
      !DATA pool_frac/0.33,0.33,0.34/
@@ -672,38 +656,64 @@ SUBROUTINE casa_reinit_pk(casabiome,casamet,casapool,casabal,veg,phen, &
                      psoilocc_y(g,:),frac_y(g,:),ifpre_y(g,:))
      ENDIF
 
-
-     ! TEST Lestevens 6june18 - thinning forests after luc ----
-     IF (l_thinforest) THEN
+    !! Thinning forests after land-use change.
+    IF (l_thinforest) THEN
+      ! Initialize local arrays for CNP pools after thinning.
                       cplant_z(g,:,:) = cplant_y(g,:,:)
-      if (icycle > 1) nplant_z(g,:,:) = nplant_y(g,:,:)
-      if (icycle > 2) pplant_z(g,:,:) = pplant_y(g,:,:)
-      DO y=1,3 ! pools for whvest
-                        woodhvest_c(g,:,y) = woodhvest_c(g,:,y) + &
-                                   (1-thinning(g,:)) * pool_frac(y) * cplant_y(g,:,wood)
-        if (icycle > 1) woodhvest_n(g,:,y) = woodhvest_n(g,:,y) + &
-                                   (1-thinning(g,:)) * pool_frac(y) * nplant_y(g,:,wood)
-        if (icycle > 2) woodhvest_p(g,:,y) = woodhvest_p(g,:,y) + &
-                                   (1-thinning(g,:)) * pool_frac(y) * pplant_y(g,:,wood)
-      END DO
-      DO y=1,mplant
-                        cplant_z(g,:,y) = thinning(g,:) * cplant_y(g,:,y)
-        if (icycle > 1) nplant_z(g,:,y) = thinning(g,:) * nplant_y(g,:,y)
-        if (icycle > 2) pplant_z(g,:,y) = thinning(g,:) * pplant_y(g,:,y)
-      END DO
-      CALL newlitter_thin(casabiome,frac_y(g,:),ifpre_y(g,:),frac_y(g,:),ifpre_y(g,:), &
-                     cplant_y(g,:,:),nplant_y(g,:,:),pplant_y(g,:,:), &
-                     cplant_z(g,:,:),nplant_z(g,:,:),pplant_z(g,:,:), &
-                     clitter_y(g,:,:),nlitter_y(g,:,:),plitter_y(g,:,:), &
-                     clitter_y(g,:,:),nlitter_y(g,:,:),plitter_y(g,:,:),thinning(g,:))
-                      cplant_y(g,:,:) = cplant_z(g,:,:)
-      if (icycle > 1) nplant_y(g,:,:) = nplant_z(g,:,:)
-      if (icycle > 2) pplant_y(g,:,:) = pplant_z(g,:,:)
-     ENDIF
-     ! TEST Lestevens 6june18 - thinning forests after luc ----
+      IF (icycle > 1) nplant_z(g,:,:) = nplant_y(g,:,:)
+      IF (icycle > 2) pplant_z(g,:,:) = pplant_y(g,:,:)
 
-! Lestevens 24 Nov 2017 - Implement Yingping's flux to state pools
-! Lestevens 7 June 2018 - Moved to after thinning
+      DO k=1,mlogmax
+        IF (ifpre_y(g,k) .AND. thinning(g,k)<1.0) THEN
+          !! 1. Calculate CNP pools after thinning.
+          DO y=1,mplant
+                          cplant_z(g,k,y) = thinning(g,k)*cplant_y(g,k,y)
+            IF (icycle>1) nplant_z(g,k,y) = thinning(g,k)*nplant_y(g,k,y)
+            IF (icycle>2) pplant_z(g,k,y) = thinning(g,k)*pplant_y(g,k,y)
+          END DO
+
+          !! 2. Add the removed wood to the wood_flux variable.
+                        logc(g,k) = logc(g,k) &
+                            + (1 - thinning(g,k))*cplant_y(g,k,wood)
+          IF (icycle>1) logn(g,k) = logn(g,k) &
+                            + (1 - thinning(g,k))*nplant_y(g,k,wood)
+          IF (icycle>2) logp(g,k) = logp(g,k) &
+                            + (1 - thinning(g,k))*pplant_y(g,k,wood)
+
+          !! 3. Add the wood harvest from thinning to the product pools.
+          DO p=1,3 ! pools for whvest
+                          woodhvest_c(g,k,p) = woodhvest_c(g,k,p) &
+                           + (1 - thinning(g,k))*pool_frac(p)*cplant_y(g,k,wood)
+            IF (icycle>1) woodhvest_n(g,k,p) = woodhvest_n(g,k,p) &
+                           + (1 - thinning(g,k))*pool_frac(p)*nplant_y(g,k,wood)
+            IF (icycle>2) woodhvest_p(g,k,p) = woodhvest_p(g,k,p) &
+                           + (1 - thinning(g,k))*pool_frac(p)*pplant_y(g,k,wood)
+          END DO
+        END IF
+      END DO
+
+      !! 4. Redistribute the harvested plant mass to litter pools.
+       CALL newlitter_thin( &
+             casabiome, &
+             ifpre_y(g,:), &
+             cplant_y(g,:,:), &
+             nplant_y(g,:,:), &
+             pplant_y(g,:,:), &
+             cplant_z(g,:,:), &
+             nplant_z(g,:,:), &
+             pplant_z(g,:,:), &
+             clitter_y(g,:,:), &
+             nlitter_y(g,:,:), &
+             plitter_y(g,:,:), &
+             thinning(g,:))
+
+      ! Restore the new plant pools to output arrays.
+                    cplant_y(g,:,:) = cplant_z(g,:,:)
+      IF (icycle>1) nplant_y(g,:,:) = nplant_z(g,:,:)
+      IF (icycle>2) pplant_y(g,:,:) = pplant_z(g,:,:)
+    END IF ! End thinning forests after LUC.
+
+     ! Lestevens 24 Nov 2017 - Implement Yingping's flux to state pools
      !DATA pool_frac/0.33,0.33,0.34/
      !DATA pool_time/1.0 ,0.1 ,0.01/
      DO y = 1,3 ! pools NOT leaf/wood/root
@@ -714,34 +724,37 @@ SUBROUTINE casa_reinit_pk(casabiome,casamet,casapool,casabal,veg,phen, &
       IF (icycle > 1) woodhvest_n(g,:,y) = woodhvest_n(g,:,y) - wresp_n(g,:,y)
       IF (icycle > 2) woodhvest_p(g,:,y) = woodhvest_p(g,:,y) - wresp_p(g,:,y)
      END DO
-! Lestevens 24 Nov 2017 - Implement Yingping's flux to state pools
-
+     ! Lestevens 24 Nov 2017 - Implement Yingping's flux to state pools
 
      ! Balance check
      cbal = sum((sum(cplant_x(g,:,:),2) + sum(clitter_x(g,:,:),2)  &
-          + sum(csoil_x(g,:,:),2) + clabile_x(g,:)) * frac_x(g,:))  &
+          + sum(csoil_x(g,:,:),2) + clabile_x(g,:))*frac_x(g,:))  &
           - (sum((sum(cplant_y(g,:,:),2) + sum(clitter_y(g,:,:),2)  &
-          + sum(csoil_y(g,:,:),2) + clabile_y(g,:)) * frac_y(g,:)) + sum(logc(g,:)))
+          + sum(csoil_y(g,:,:),2) + clabile_y(g,:))*frac_y(g,:)) &
+          + sum(frac_y(g,:)*logc(g,:)))
 
      IF (icycle > 1) nbal = sum((sum(nplant_x(g,:,:),2) + sum(nlitter_x(g,:,:),2)  &
-                          + sum(nsoil_x(g,:,:),2) + nsoilmin_x(g,:)) * frac_x(g,:))  &
+                          + sum(nsoil_x(g,:,:),2) + nsoilmin_x(g,:))*frac_x(g,:))  &
                           - (sum((sum(nplant_y(g,:,:),2) + sum(nlitter_y(g,:,:),2)  &
-                          + sum(nsoil_y(g,:,:),2) + nsoilmin_y(g,:)) * frac_y(g,:)) + sum(logn(g,:)))
+                          + sum(nsoil_y(g,:,:),2) + nsoilmin_y(g,:))*frac_y(g,:)) &
+                          + sum(frac_y(g,:)*logn(g,:)))
 
      IF (icycle > 2) pbal = sum((sum(pplant_x(g,:,:),2) + sum(plitter_x(g,:,:),2)  &
                           + sum(psoil_x(g,:,:),2) + psoillab_x(g,:)  &
-                          + psoilsorb_x(g,:) + psoilocc_x(g,:)) * frac_x(g,:))  &
+                          + psoilsorb_x(g,:) + psoilocc_x(g,:))*frac_x(g,:))  &
                           - (sum((sum(pplant_y(g,:,:),2) + sum(plitter_y(g,:,:),2)  &
                           + sum(psoil_y(g,:,:),2) + psoillab_y(g,:) + psoilsorb_y(g,:)  &
-                          + psoilocc_y(g,:)) * frac_y(g,:)) + sum(logp(g,:)))
+                          + psoilocc_y(g,:))*frac_y(g,:)) + sum(frac_y(g,:)*logp(g,:)))
 
 
-     IF(abs(cbal)>1.e-3 .or.abs(nbal)>1.e-4 .or.abs(pbal)>1.e-4) THEN
-        print*, 'imbalance on grid:',g,cbal,nbal,pbal
+     IF(ABS(cbal)>1.0E-3 .or. ABS(nbal)>1.0E-4 .or. ABS(pbal)>1.0E-4) THEN
+       PRINT *, "WARNING: CNP conservation imbalance"
+       IF (ABS(cbal)>1.0E-3) PRINT *, 'C imbalance on grid at point',g,"of",cbal
+       IF (ABS(nbal)>1.0E-4) PRINT *, 'N imbalance on grid at point',g,"of",nbal
+       IF (ABS(pbal)>1.0E-4) PRINT *, 'P imbalance on grid at point',g,"of",pbal
      END IF
 
   END DO ! end main loop
-  !END DO ! end main loop
 
   ! write values back into cnp pool files
   cpool_tile(:,:,1)  = clabile_y(:,:)

--- a/src/coupled/ESM1.5/pack_mod_cbl.F90
+++ b/src/coupled/ESM1.5/pack_mod_cbl.F90
@@ -1,0 +1,164 @@
+!******************************COPYRIGHT********************************************
+! (c) CSIRO 2022.
+! All rights reserved.
+!
+! This routine has been licensed to the other JULES partners for use and
+! distribution under the JULES collaboration agreement, subject to the terms and
+! conditions set out therein.
+!
+! [Met Office Ref SC0237]
+!******************************COPYRIGHT********************************************
+
+MODULE cable_pack_mod
+
+!-----------------------------------------------------------------------------
+! Description:
+!   JULES met forcing vars needed by CABLE commonly have JULES dimensions
+!   (row_length,rows), which are no good for CABLE. These have to be
+!   re-packed in a single vector of active tiles. Hence we use
+!   conditional "mask" l_tile_pts(land_pts,ntiles) which is .true.
+!   if the land point is/has an active tile. A packing routine for
+!   land_point dimensioned JULES fields is to be included as required on the
+!   subsequent (e.g. explicit) CALLs to CABLE
+!
+! This MODULE is USEd by:
+!      cable_land_albedo_mod.F90
+!
+! This MODULE contains 1 public Subroutine:
+!      cable_pack_rr,
+!
+! Code Owner: Please refer to ModuleLeaders.txt
+! This file belongs in CABLE SCIENCE
+!
+! Code Description:
+!   Language: Fortran 90.
+!   This code is written to JULES coding standards v1.
+!-----------------------------------------------------------------------------
+
+IMPLICIT NONE
+PUBLIC :: cable_pack_rr, pack_landpts2mp_ICE, pack_landpts2mp
+PRIVATE
+
+CONTAINS
+
+SUBROUTINE cable_pack_rr( cable_var, jules_var, mp, l_tile_pts, row_length,    &
+                          rows, ntype, land_pts, land_index, surft_pts,        &
+                          surft_index )
+
+! Description:
+!   Nothing further to add to module description.
+
+IMPLICIT NONE
+
+INTEGER, INTENT(IN) :: mp, row_length, rows, ntype, land_pts
+REAL, INTENT(OUT)   :: cable_var(mp)
+LOGICAL, INTENT(IN) :: l_tile_pts(land_pts, ntype)
+INTEGER, INTENT(IN) :: land_index(land_pts)           !Index in (x,y) array
+INTEGER, INTENT(IN) :: surft_pts(ntype)              !# land points per PFT
+INTEGER, INTENT(IN) :: surft_index(land_pts,ntype)   !Index in land_pts array
+REAL, INTENT(IN)    :: jules_var(row_length, rows)
+!local vars
+REAL    :: fvar(land_pts, ntype)
+INTEGER :: n, k, l, j, i
+
+fvar(:, :) = 0.0
+DO n = 1, ntype
+  ! loop over number of points per tile
+  DO k = 1, surft_pts(n)
+    l = surft_index(k, n)
+    j = (land_index(l) - 1) / row_length + 1
+    i = land_index(l) - (j-1) * row_length
+    fvar(l, n) = jules_var(i, j)
+  END DO
+END DO
+cable_var =  PACK(fvar, l_tile_pts)
+
+RETURN
+END SUBROUTINE cable_pack_rr
+
+!--- UM met forcing vars needed by CABLE which have UM dimensions
+!---(land_points)[_lp], which is no good to cable. These have to be 
+!--- re-packed in a single vector of active tiles. Hence we use 
+!--- conditional "mask" l_tile_pts(land_pts,ntiles) which is .true.
+!--- if the land point is/has an active tile
+SUBROUTINE pack_landpts2mp_ICE( nsurft, land_pts, mp, nsoil_max, ICE_soiltype, &
+                                tile_pts, tile_index, L_tile_pts, umvar,       &
+                                soiltype, ICE_value, cablevar )
+  
+IMPLICIT NONE
+ 
+INTEGER, INTENT(IN) :: nsurft 
+INTEGER, INTENT(IN) :: land_pts
+INTEGER, INTENT(IN) :: mp 
+INTEGER, INTENT(IN) :: nsoil_max 
+INTEGER, INTENT(IN) :: ICE_soiltype
+INTEGER, INTENT(IN) :: soiltype(mp)
+INTEGER, INTENT(IN) :: tile_pts(nsurft)   
+INTEGER, INTENT(IN) :: tile_index(land_pts, nsurft)   
+LOGICAL, INTENT(IN) :: L_tile_pts(land_pts, nsurft)
+REAL, INTENT(IN)    :: umvar(land_pts)
+REAL, INTENT(IN)    :: ICE_value(nsoil_max)
+REAL, INTENT(INOUT) :: cablevar(mp)
+!local vars
+REAL :: fvar(land_pts, nsurft)   
+INTEGER :: n,k,l,i
+
+fvar(:,:) = 0.0
+DO n=1, nsurft
+
+  ! loop over number of points per nth tile
+  DO k=1,tile_pts(n)
+    ! land pt index of point 
+    L = tile_index(k,n)
+    ! at this point fvar=umvar, ELSE=0.0 
+    fvar(l,n) = umvar(l)
+  ENDDO
+
+ENDDO
+
+cablevar = PACK(fvar,L_tile_pts)
+
+DO i=1,mp
+  
+  IF(soiltype(i)==ICE_soiltype) THEN
+    cablevar(i) =  ICE_value(ICE_soiltype)
+  END IF
+    
+ENDDO        
+
+END SUBROUTINE pack_landpts2mp_ICE
+
+SUBROUTINE pack_landpts2mp( nsurft, land_pts, mp, tile_pts, tile_index,        &
+                            L_tile_pts, umvar, cablevar )
+  
+IMPLICIT NONE
+ 
+INTEGER, INTENT(IN) :: nsurft 
+INTEGER, INTENT(IN) :: land_pts
+INTEGER, INTENT(IN) :: mp 
+LOGICAL, INTENT(IN) :: L_tile_pts(land_pts, nsurft)   
+INTEGER, INTENT(IN) :: tile_pts(nsurft)   
+INTEGER, INTENT(IN) :: tile_index(land_pts, nsurft)   
+REAL, INTENT(IN)    :: umvar(land_pts) 
+REAL, INTENT(INOUT) :: cablevar(mp)
+!local vars
+REAL :: fvar(land_pts, nsurft)   
+INTEGER :: n,k,l
+ 
+fvar(:,:) = 0.0
+DO n=1, nsurft
+  ! loop over number of points per nth tile
+  DO k=1,tile_pts(n)
+    ! land pt index of point 
+    l = tile_index(k,n)
+    ! at this point fvar=umvar, ELSE=0.0 
+    fvar(l,n) = umvar(l)
+  ENDDO
+ENDDO
+
+cablevar = PACK(fvar,L_tile_pts)
+ 
+END SUBROUTINE pack_landpts2mp
+
+
+END MODULE cable_pack_mod

--- a/src/coupled/shared/cable_soil_type_mod.F90
+++ b/src/coupled/shared/cable_soil_type_mod.F90
@@ -1,0 +1,100 @@
+MODULE cable_soil_type_mod
+
+IMPLICIT NONE
+
+PUBLIC :: soil_parameter_type
+
+!-----------------------------------------------------------------------------
+! Description:
+!   Defines variable types and variables for CABLE standalone runs.
+!   Based on cable_def_types_mod.F90 from the CABLE trunk.
+!
+! Code Owner: Please refer to ModuleLeaders.txt
+! This file belongs in CABLE SCIENCE
+!-----------------------------------------------------------------------------
+
+! Soil parameters used:
+TYPE soil_parameter_type
+
+   INTEGER, DIMENSION(:), POINTER ::                                        &
+    isoilm     ! integer soil type
+
+   REAL, DIMENSION(:), POINTER ::                                           &
+     bch,     & ! parameter b in Campbell equation
+     c3,      & ! c3 drainage coeff (fraction)
+     clay,    & ! fraction of soil which is clay
+     css,     & ! soil specific heat capacity [kJ/kg/K]
+     hsbh,    & ! difsat * etasat (=hyds*abs(sucs)*bch)
+     hyds,    & ! hydraulic conductivity @ saturation [m/s], Ksat
+     i2bp3,   & ! par. one in K vis suction (=nint(bch)+2)
+     ibp2,    & ! par. two in K vis suction (fn of pbch)
+     rhosoil, & ! soil density [kg/m3]
+     sand,    & ! fraction of soil which is sand
+     sfc,     & ! vol H2O @ field capacity
+     silt,    & ! fraction of soil which is silt
+     ssat,    & ! vol H2O @ saturation
+     sucs,    & ! suction at saturation (m)
+     swilt,   & ! vol H2O @ wilting
+     zse,     & ! thickness of each soil layer (1=top) in m
+     zshh,    & ! distance between consecutive layer midpoints (m)
+                ! vars intro for Ticket #27
+     soilcol, & ! keep color for all patches/tiles
+     albsoilf   ! soil reflectance
+
+   REAL, DIMENSION(:,:), POINTER ::                                            &
+    heat_cap_lower_limit, &
+    zse_vec,              &
+    css_vec,              &
+    cnsd_vec
+
+   REAL, DIMENSION(:), POINTER ::                                              &
+     cnsd,    & ! thermal conductivity of dry soil [W/m/K]
+     pwb_min    ! working variable (swilt/ssat)**ibp2
+
+   REAL, DIMENSION(:,:), POINTER ::                                            &
+     albsoil    ! soil reflectance (2nd dim. BP 21Oct2009)
+   
+   ! parameters for GW module that vary with soil layer
+   REAL, DIMENSION(:,:), POINTER ::                                            &
+     sucs_vec,   & !psi at saturation in [mm]
+     hyds_vec,   & !saturated hydraulic conductivity  [mm/s]
+     bch_vec,    & !C and H B [none]
+     clay_vec,   & !fraction of soil that is clay [frac]
+     sand_vec,   & !fraction of soil that is sand [frac]
+     silt_vec,   & !fraction of soil that is silt [frac]
+     org_vec,    & !fration of soil made of organic soils [frac]
+     rhosoil_vec,& !soil density  [kg/m3]
+     ssat_vec,   & !volumetric water content at saturation [mm3/mm3]
+     watr,       & !residual water content of the soil [mm3/mm3]
+     sfc_vec,    & !field capcacity (hk = 1 mm/day)
+     swilt_vec     ! wilting point (hk = 0.02 mm/day)
+
+   REAL, DIMENSION(:), POINTER ::                                              &
+     drain_dens, & !  drainage density ( mean dist to rivers/streams )
+     elev,       & ! elevation above sea level
+     elev_std,   & ! elevation above sea level
+     slope,      & ! mean slope of grid cell
+     slope_std     ! stddev of grid cell slope
+
+   !MD parameters for GW module for the aquifer
+   REAL, DIMENSION(:), POINTER ::                                       &
+     GWsucs_vec, & ! head in the aquifer [mm]
+     GWhyds_vec, & ! saturated hydraulic conductivity of aquifer [mm/s]
+     GWbch_vec,  & ! clapp and horn b of the aquifer   [none]
+     GWssat_vec, & ! saturated water content of the aquifer [mm3/mm3]
+     GWwatr,     & ! residual water content of the aquifer [mm3/mm3]
+     GWz,        & ! node depth of the aquifer    [m]
+     GWdz,       & ! thickness of the aquifer   [m]
+     GWrhosoil_vec !density of the aquifer substrate [kg/m3]
+
+   ! Additional SLI parameters
+   INTEGER, POINTER :: nhorizons(:)   ! number of soil horizons
+   INTEGER, POINTER :: ishorizon(:,:) ! horizon number 1:nhorizons
+   REAL,    POINTER :: clitt(:)       ! litter (tC/ha)
+   REAL,    POINTER :: zeta(:)        ! macropore parameter
+   REAL,    POINTER :: fsatmax(:)     ! variably saturated area parameter
+
+END TYPE soil_parameter_type
+
+END MODULE cable_soil_type_mod
+

--- a/src/coupled/shared/cable_veg_type_mod.F90
+++ b/src/coupled/shared/cable_veg_type_mod.F90
@@ -1,0 +1,90 @@
+MODULE cable_veg_type_mod
+
+IMPLICIT NONE
+
+PUBLIC :: veg_parameter_type
+
+!-----------------------------------------------------------------------------
+! Description:
+!   Defines variable types and variables for CABLE standalone runs.
+!   Based on cable_def_types_mod.F90 from the CABLE trunk.
+!
+! Code Owner: Please refer to ModuleLeaders.txt
+! This file belongs in CABLE SCIENCE
+!-----------------------------------------------------------------------------
+
+! Vegetation parameters used:
+TYPE veg_parameter_type
+  
+  !jhan: surely %meth doesn't need to be 'mp' here
+  INTEGER, DIMENSION(:), POINTER ::                                        &
+    meth, & ! method for calculation of canopy fluxes and temp.
+    iveg, & ! vegetation type
+    iLU     ! land use type
+  
+  REAL, DIMENSION(:), POINTER ::                                           &
+    canst1,  & ! max intercepted water by canopy (mm/LAI)
+    dleaf,   & ! chararacteristc legnth of leaf (m)
+    ejmax,   & ! max pot. electron transp rate top leaf(mol/m2/s)
+    frac4,   & ! fraction of c4 plants
+    hc,      & ! roughness height of canopy (veg - snow)
+    vlai,    & ! leaf area index
+    xalbnir, &
+    rp20,    & ! plant respiration coefficient at 20 C
+    rpcoef,  & ! temperature coef nonleaf plant respiration (1/C)
+    rs20,    & ! soil respiration at 20 C [mol m-2 s-1]
+    shelrb,  & ! sheltering factor (dimensionless)
+    vegcf,   & ! kdcorbin, 08/10
+    tminvj,  & ! min temperature of the start of photosynthesis
+    toptvj,  & ! opt temperature of the start of photosynthesis
+    tmaxvj,  & ! max temperature of the start of photosynthesis
+    vbeta,   & !
+    vcmax,   & ! max RuBP carboxylation rate top leaf (mol/m2/s)
+    xfang,   & ! leaf angle PARAMETER
+    extkn,   & ! extinction coef for vertical
+    vlaimax, & ! extinction coef for vertical
+    wai,     & ! wood area index (stem+branches+twigs)
+    a1gs,    & ! a1 parameter in stomatal conductance model
+    d0gs,    & ! d0 in stomatal conductance model
+    alpha,   & ! initial slope of J-Q response curve
+    convex,  & ! convexity of J-Q response curve
+    cfrd,    & ! ratio of day respiration to vcmax
+    gswmin,  & ! minimal stomatal conductance
+    conkc0,  & ! Michaelis-menton constant for carboxylase
+    conko0,  & ! Michaelis-menton constant for oxygenase
+    ekc,     & ! activation energy for caroxylagse
+    eko,     & ! acvtivation enegery for oxygenase
+    g0,      & ! Belinda's stomatal model intercept, Ticket #56.
+    g1         ! Belinda's stomatal model slope, Ticket #56.
+
+  LOGICAL, DIMENSION(:), POINTER ::                                        &
+    deciduous ! flag used for phenology fix
+
+  REAL, DIMENSION(:,:), POINTER ::                                         &
+    refl,    &
+    taul,    &
+    froot      ! fraction of root in each soil layer
+
+  ! Additional  veg parameters:
+  REAL, DIMENSION(:), POINTER :: rootbeta ! parameter for estimating vertical 
+                                          ! root mass distribution (froot)
+  REAL, DIMENSION(:), POINTER :: gamma    ! parameter: root efficiency function
+                                          ! (Lai and Katul 2000)
+  REAL, DIMENSION(:), POINTER :: ZR       ! maximum rooting depth (cm)
+  REAL, DIMENSION(:), POINTER :: F10      ! fraction of roots in top 10 cm
+  REAL, DIMENSION(:), POINTER :: clitt    !
+
+  ! Additional POP veg param
+  INTEGER, DIMENSION(:,:), POINTER ::  disturbance_interval
+  REAL, DIMENSION(:,:),    POINTER ::  disturbance_intensity
+
+  REAL,  POINTER ::                                                            &
+    soil(:,:),                                                                 &
+    csoil(:,:),                                                                &
+    cplant(:,:),                                                               &
+    ratecs(:,:),                                                               &
+    ratecp(:,:)
+
+END TYPE veg_parameter_type
+
+END MODULE cable_veg_type_mod


### PR DESCRIPTION
# CABLE

## Description
Reconcile developments in ESM1.6 with CABLE:main

There are changes across utilities since directories as well BUT here it is only those in coupled/ that are considered.

Post shuffling these files around to facilitate building a library. What happens to them is irrelevant really. 

These modified and added files are from dev-access-esm1.6. 

## Testing

- [x] Are the changes bitwise-compatible with the main branch? If working on an optional feature, are the results bitwise-compatible when this feature is off? If yes, copy benchcab output showing successful completion of the bitwise compatibility tests or equivalent results below this line.

So - I haven't actually done the testing BUT considering none of these fits are even in the build they cant impact anything

<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--551.org.readthedocs.build/en/551/

<!-- readthedocs-preview cable end -->