### PR TITLE
Avoid using uninitialised trunk_sumbal

### DIFF
--- a/src/offline/cable_mpimaster_stub.F90
+++ b/src/offline/cable_mpimaster_stub.F90
@@ -13,10 +13,9 @@ MODULE cable_mpimaster
 
 CONTAINS
 
-  SUBROUTINE mpidrv_master(comm, trunk_sumbal, dels, koffset, kend, PLUME, CRU)
+  SUBROUTINE mpidrv_master(comm, dels, koffset, kend, PLUME, CRU)
     !! Stub for when MPI is not available
     INTEGER, INTENT(IN) :: comm
-    DOUBLE PRECISION, INTENT(IN) :: trunk_sumbal
     REAL, INTENT(INOUT) :: dels
     INTEGER, INTENT(INOUT) :: koffset
     INTEGER, INTENT(INOUT) :: kend

--- a/src/offline/cable_offline_driver.F90
+++ b/src/offline/cable_offline_driver.F90
@@ -23,8 +23,6 @@ PROGRAM cable_offline_driver
 
   REAL    :: etime ! Declare the type of etime()
   TYPE(mpi_grp_t) :: mpi_grp
-  DOUBLE PRECISION :: trunk_sumbal
-    !! Reference value for quasi-bitwise reproducibility checks.
   INTEGER :: NRRRR !! Number of repeated spin-up cycles
   REAL :: dels !! Time step size in seconds
   INTEGER :: koffset = 0 !! Timestep to start at
@@ -37,7 +35,7 @@ PROGRAM cable_offline_driver
   call mpi_mod_init()
   mpi_grp = mpi_grp_t()
 
-  CALL cable_driver_init(mpi_grp, trunk_sumbal, NRRRR)
+  CALL cable_driver_init(mpi_grp, NRRRR)
 
   SELECT CASE(TRIM(cable_user%MetType))
   CASE('gswp')
@@ -59,10 +57,10 @@ PROGRAM cable_offline_driver
   END SELECT
 
   IF (mpi_grp%size == 1) THEN
-    CALL serialdrv(trunk_sumbal, NRRRR, dels, koffset, kend, GSWP_MID, PLUME, CRU, site)
+    CALL serialdrv(NRRRR, dels, koffset, kend, GSWP_MID, PLUME, CRU, site)
   ELSE
     IF (mpi_grp%rank == 0) THEN
-      CALL mpidrv_master(mpi_grp%comm, trunk_sumbal, dels, koffset, kend, PLUME, CRU)
+      CALL mpidrv_master(mpi_grp%comm, dels, koffset, kend, PLUME, CRU)
     ELSE
       CALL mpidrv_worker(mpi_grp%comm)
     END IF

--- a/src/offline/cable_serial.F90
+++ b/src/offline/cable_serial.F90
@@ -76,7 +76,8 @@ MODULE cable_serial
     LALLOC,                           &
     prepareFiles,                     &
     renameFiles,                      &
-    LUCdriver
+    LUCdriver,                        &
+    compare_consistency_check_values
   USE cable_def_types_mod
   USE cable_IO_vars_module, ONLY: logn,gswpfile,ncciy,leaps,                  &
        fixedCO2,output,check,&
@@ -156,10 +157,8 @@ USE casa_offline_inout_module, ONLY : WRITE_CASA_RESTART_NC, WRITE_CASA_OUTPUT_N
 
 CONTAINS
 
-SUBROUTINE serialdrv(trunk_sumbal, NRRRR, dels, koffset, kend, GSWP_MID, PLUME, CRU, site)
+SUBROUTINE serialdrv(NRRRR, dels, koffset, kend, GSWP_MID, PLUME, CRU, site)
   !! Offline serial driver.
-  DOUBLE PRECISION, INTENT(IN) :: trunk_sumbal
-    !! Reference value for quasi-bitwise reproducibility checks.
   INTEGER, INTENT(IN) :: NRRRR !! Number of repeated spin-up cycles
   REAL, INTENT(INOUT) :: dels !! Time step size in seconds
   INTEGER, INTENT(INOUT) :: koffset !! Timestep to start at
@@ -765,30 +764,8 @@ SUBROUTINE serialdrv(trunk_sumbal, NRRRR, dels, koffset, kend, GSWP_MID, PLUME, 
 
             IF( ktau == kend ) THEN
               nkend = nkend+1
-
-              IF( ABS(new_sumbal-trunk_sumbal) < 1.e-7) THEN
-
-                PRINT *, ""
-                PRINT *, &
-                     "NB. Offline-serial runs spinup cycles:", nkend
-                PRINT *, &
-                     "Internal check shows this version reproduces the trunk sumbal"
-
-              ELSE
-
-                PRINT *, ""
-                PRINT *, &
-                     "NB. Offline-serial runs spinup cycles:", nkend
-                PRINT *, &
-                     "Internal check shows in this version new_sumbal != trunk sumbal"
-                PRINT *, &
-                     "Writing new_sumbal to the file:", TRIM(filename%new_sumbal)
-
-                OPEN( 12, FILE = filename%new_sumbal )
-                WRITE( 12, '(F20.7)' ) new_sumbal  ! written by previous trunk version
-                CLOSE(12)
-
-              ENDIF
+              PRINT *, "NB. Offline-serial runs spinup cycles:", nkend
+              CALL compare_consistency_check_values(new_sumbal)
             ENDIF
 
           ENDIF


### PR DESCRIPTION
The trunk_sumbal value is still used in the offline driver when a consistency check file cannot be find. To avoid using a garbage value and potentially causing an exception, this change moves the tolerance calculation and the trunk_sumbal initialisation into a single subroutine so that trunk_sumbal is used only when it is successfully read from the the consistency check file.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## Checklist

- [x] The new content is accessible and located in the appropriate section
- [x] I have checked that links are valid and point to the intended content
- [x] I have checked my code/text and corrected any misspellings

## Testing

- [x] Are the changes bitwise-compatible with the main branch? If working on an optional feature, are the results bitwise-compatible when this feature is off? If yes, copy benchcab output showing successful completion of the bitwise compatibility tests or equivalent results below this line.

```
2025-03-25 11:11:26,592 - INFO - benchcab.benchcab.py:380 - Running comparison tasks...
2025-03-25 11:11:26,627 - INFO - benchcab.benchcab.py:381 - tasks: 168 (models: 2, sites: 42, science configurations: 4)
2025-03-25 11:14:17,701 - INFO - benchcab.benchcab.py:391 - 0 failed, 168 passed
```

<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--568.org.readthedocs.build/en/568/

<!-- readthedocs-preview cable end -->