### PR TITLE
Fix the meteorology bugs identified in issue

### DIFF
--- a/offline/cable_cru_TRENDY.F90
+++ b/offline/cable_cru_TRENDY.F90
@@ -615,7 +615,9 @@ SUBROUTINE get_met_date(SimYear, SimDay, IsRecycled, RecycleStart,&
 
   ! We need to know how many days we expect in the year so check for end of year
   ! behaviour
-  INTEGER :: DaysInYear = 365
+  INTEGER :: DaysInYear
+
+  DaysInYear = 365
 
   ! Set up the first pass at recycling
   MetYear = SimYear
@@ -639,7 +641,7 @@ SUBROUTINE get_met_date(SimYear, SimDay, IsRecycled, RecycleStart,&
   ELSEIF (SimDay < 1) THEN
     ! Go back to last year- set the day later, once we know whether the MetYear
     ! is a leapyear or not
-    MetYear = SimYear - 1
+    MetYear = MetYear - 1
 
     ! This handles any future scenarios where we may change the day by >1
     MetDay = 365 + SimDay
@@ -647,7 +649,7 @@ SUBROUTINE get_met_date(SimYear, SimDay, IsRecycled, RecycleStart,&
       MetDay = 366 + SimDay
     END IF
   ELSEIF (SimDay > DaysInYear) THEN
-    MetYear = SimYear + 1
+    MetYear = MetYear + 1
     MetDay = SimDay - DaysInYear
   ELSE
     MetDay = SimDay


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

Identified some meteorology bugs that caused issues during the later spinup stages. Specific bugs are:

* Incorrect year was retrieved for previous/next day met variables during spin-up
* Calculation of length of year became incorrect over time due to implicit ```SAVE```

Fixes #[570](https://github.com/CABLE-LSM/CABLE/issues/570)

## Type of change

- [x] Bug fix

## Testing

This is not being pushed into the ```main``` branch.
