### PR TITLE
581 fix library build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,13 +122,18 @@ if(CABLE_LIBRARY)
         src/params/cable_maths_constants_mod.F90
         src/util/cable_runtime_opts_mod.F90
         src/util/cable_common.F90
-        src/coupled/esm16/casa_offline_inout.F90
-        src/coupled/esm16/casa_ncdf.F90
-        src/coupled/esm16/cable_iovars.F90
-        src/coupled/esm16/cable_surface_types.F90
-        src/coupled/esm16/cable_define_types.F90
-        src/coupled/esm16/cable_phenology.F90
-        src/coupled/esm16/cable_LUC_EXPT.F90
+        src/coupled/esm/cable_iovars.F90
+        src/coupled/esm/cable_surface_types.F90
+        src/coupled/esm/cable_define_types.F90
+        src/shared/casa_offline_inout.F90
+        src/shared/casa_ncdf.F90
+        src/shared/cable_phenology.F90
+        src/shared/cable_LUC_EXPT.F90
+        src/coupled/shared/cable_canopy_type_mod.F90
+        src/coupled/shared/cable_soilsnow_type_mod.F90
+        src/coupled/shared/cable_soil_type_mod.F90
+        src/coupled/shared/cable_veg_type_mod.F90
+        src/util/cable_climate_type_mod.F90
     )
 
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,6 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
     )
 endif()
 
-set (CMAKE_Fortran_MODULE_DIRECTRORY ${CMAKE_BINARY_DIR}/include)
 if(CABLE_LIBRARY)
 
     add_library(
@@ -137,7 +136,7 @@ if(CABLE_LIBRARY)
         src/util/cable_climate_type_mod.F90
     )
     target_compile_definitions(cable PRIVATE UM_CBL)
-    target_include_directories(cable PUBLIC ${CMAKE_Fortran_MODULE_DIRECTORY})
+    target_include_directories(cable PUBLIC "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 
     install(TARGETS cable
       EXPORT CABLEFortranTargets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,10 +37,11 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
     )
 endif()
 
+set (CMAKE_Fortran_MODULE_DIRECTRORY ${CMAKE_BINARY_DIR}/mod)
 if(CABLE_LIBRARY)
 
     add_library(
-        cable_science
+        cable
         STATIC
         src/science/albedo/cbl_albedo.F90
         src/science/albedo/cbl_snow_albedo.F90
@@ -135,9 +136,13 @@ if(CABLE_LIBRARY)
         src/coupled/shared/cable_veg_type_mod.F90
         src/util/cable_climate_type_mod.F90
     )
-    target_compile_definitions(cable_science PRIVATE UM_CBL)
+    target_compile_definitions(cable PRIVATE UM_CBL)
+    target_include_directories(cable PUBLIC ${CMAKE_Fortran_MODULE_DIRECTORY})
 
-    install(TARGETS cable_science)
+    install(TARGETS cable
+      EXPORT CABLEFortranTargets
+      LIBRARY DESTINATION lib
+      INCLUDES DESTINATION include)
 else()
 
     add_library(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,7 @@ if(CABLE_LIBRARY)
     )
     target_compile_definitions(cable_science PRIVATE UM_CBL)
 
+    install(TARGETS cable_science)
 else()
 
     add_library(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
     )
 endif()
 
-set (CMAKE_Fortran_MODULE_DIRECTRORY ${CMAKE_BINARY_DIR}/mod)
+set (CMAKE_Fortran_MODULE_DIRECTRORY ${CMAKE_BINARY_DIR}/include)
 if(CABLE_LIBRARY)
 
     add_library(
@@ -143,6 +143,7 @@ if(CABLE_LIBRARY)
       EXPORT CABLEFortranTargets
       LIBRARY DESTINATION lib
       INCLUDES DESTINATION include)
+
 else()
 
     add_library(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,8 +70,8 @@ if(CABLE_LIBRARY)
         src/science/casa-cnp/casa_rplant.F90
         src/science/casa-cnp/casa_sumcflux.F90
         src/science/casa-cnp/casa_variable.F90
-        src/science/gw_hydro/cable_gw_hydro.F90
-        src/science/gw_hydro/cable_psm.F90
+        #src/science/gw_hydro/cable_gw_hydro.F90
+        #src/science/gw_hydro/cable_psm.F90
         src/science/landuse/landuse3.F90
         src/science/landuse/landuse_constant.F90
         src/science/misc/cable_air.F90
@@ -135,6 +135,7 @@ if(CABLE_LIBRARY)
         src/coupled/shared/cable_veg_type_mod.F90
         src/util/cable_climate_type_mod.F90
     )
+    target_compile_definitions(cable_science PRIVATE UM_CBL)
 
 else()
 

--- a/src/coupled/esm/cable_define_types.F90
+++ b/src/coupled/esm/cable_define_types.F90
@@ -36,7 +36,7 @@ USE cable_soil_snow_type_mod, ONLY: soil_snow_type
 USE cable_climate_type_mod,   ONLY: climate_type
 USE cable_soil_type_mod,      ONLY: soil_parameter_type
 USE cable_veg_type_mod,       ONLY: veg_parameter_type
-USE cable_other_constants_mod, ONLY: r_2
+USE cable_other_constants_mod, ONLY: r_2, i_d
 
 !cbl3!USE cable_types_mod!!,          ONLY: mp, l_tile_pts
 !cbl3!USE cable_air_type_mod,       ONLY: air_type

--- a/src/params/cable_other_constants_mod.F90
+++ b/src/params/cable_other_constants_mod.F90
@@ -33,6 +33,7 @@ REAL, PARAMETER :: rad_thresh = 0.001 ! min. zenithal angle for downward SW
 REAL, PARAMETER :: lai_thresh = 0.001 ! min. LAI to be considered as vegetated
 
 INTEGER, PARAMETER :: r_2  = KIND(1.d0) ! SELECTED_REAL_KIND(12, 50)
+INTEGER, PARAMETER :: i_d = KIND(9)
 
 REAL, PARAMETER ::                                                             &
   max_snow_depth = 50000.0,  & ! maximum depth of lying snow on tiles (kg/m2)

--- a/src/science/canopy/cbl_dryLeaf.F90
+++ b/src/science/canopy/cbl_dryLeaf.F90
@@ -497,8 +497,8 @@ IMPLICIT NONE
                      ssnow%rex(i,:), &
                      canopy%fwsoil(i), &
                      REAL(veg%froot(i,:),r_2),&
-                     soil%ssat_vec(i,:), &
-                     soil%swilt_vec(i,:), &
+                     REAL(soil%ssat_vec(i,:), r_2), &
+                     REAL(soil%swilt_vec(i,:), r_2), &
                      MAX(REAL(canopy%fevc(i)/air%rlam(i)/density_liq,r_2),0.0_r_2), &
                      REAL(veg%gamma(i),r_2), &
                      REAL(soil%zse,r_2), REAL(dels,r_2), REAL(veg%zr(i),r_2))


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

The library build of CABLE was broken after the reshuffle to bring the coupled model's versions of CABLE into parity with the standalone model. Further, the library doesn't seem to export the CMake targets correctly, so it doesn't play nicely with Spack.

The library now builds with changes to the included file paths. However, the Spack build is still unable to locate the ```.mod``` files which should be in the ```include``` directory (which is not being created). Various attempts to fix the ```CMakeLists.txt``` file have not been successful.

<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--587.org.readthedocs.build/en/587/

<!-- readthedocs-preview cable end -->