### PR TITLE
Fix automatic tests

### DIFF
--- a/.github/workflows/model-build-test-ci.yml
+++ b/.github/workflows/model-build-test-ci.yml
@@ -10,6 +10,6 @@ on:
 jobs:
   build:
     name: Build ${{ github.repository }} via spack
-    uses: access-nri/build-ci/.github/workflows/model-1-build.yml@e90ea37002e4f3aed6515482eb2cca9ac5cd2a94
+    uses: access-nri/build-ci/.github/workflows/model-1-build.yml@8c22a98df04c79ced53203461cf05cc8117544a0
     permissions:
       packages: read

--- a/documentation/docs/developer_guide/documentation_guidelines/index.md
+++ b/documentation/docs/developer_guide/documentation_guidelines/index.md
@@ -29,5 +29,5 @@ To help you find the file corresponding to a page, on the rendered [documentatio
 [cheat-sheets]: ../other_resources/cheat_sheets.md
 [api-guidelines]: science_doc.md
 [doc-pages]: https://cable.readthedocs.io/en/latest
-[Hive-contribute]: https://access-hive.org.au/about/contribute/
+[Hive-contribute]: https://docs.access-hive.org.au/about/contribute/
 [cable-lsm-join]: https://github.com/CABLE-LSM/CABLE/issues/110


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

The build CI and the link checker in the documentation were failing. This PR solves both issues.

Updating the CI action version to fix a problem with the build (see [CI issue](https://github.com/ACCESS-NRI/build-ci/issues/215))
Update link to ACCESS-Hive docs with new URL.

## Testing

Please add a reviewer when ready for review.


<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--594.org.readthedocs.build/en/594/

<!-- readthedocs-preview cable end -->