### PR TITLE
Make the code compute the diffuse fraction by default

### DIFF
--- a/core/biogeophys/cable_common.F90
+++ b/core/biogeophys/cable_common.F90
@@ -138,7 +138,7 @@ MODULE cable_common_module
           amphistomatous           = .FALSE., &
           perturb_dva_by_T         = .FALSE., &  ! switch to perturb esat by dva_T_perturbation
           perturb_Ta               = .FALSE., &  ! switch to perturb air temp by Ta_perturbation (site met only)
-          calc_fdiff             = .FALSE.       ! switch to calculate diffuse radiation or prescribe from met
+          calc_fdiff             = .TRUE.       ! switch to calculate diffuse radiation or prescribe from met
      INTEGER ::  &
           CASA_SPIN_STARTYEAR = 1950, &
           CASA_SPIN_ENDYEAR   = 1960, &
@@ -666,7 +666,7 @@ CONTAINS
 #ifdef __MPI__
        call MPI_Abort(0, 131, ierr) ! Do not know comm nor rank here
 #else
-       stop 131
+       error stop 131
 #endif
     end if
 

--- a/offline/cable_cru_TRENDY.F90
+++ b/offline/cable_cru_TRENDY.F90
@@ -163,6 +163,18 @@ SUBROUTINE CRU_INIT(CRU)
     CALL handle_err(ok, "Finding NDep variable")
   END IF
 
+  ! Check for the diffuse fraction
+  IF (CRU%ReadDiffFrac) THEN
+    cable_user%calc_fdiff = .FALSE.
+    ! Make sure we have a dataset for fdiff
+    IF (TRIM(InputFiles(fdiff)) == "None") THEN
+      WRITE(ERROR_UNIT,*) "Specified to read diffuse fraction from"//&
+        " file, but no diffuse fraction file given."
+      ERROR STOP 1
+    END IF
+  ELSE
+    cable_user%calc_fdiff = .TRUE.
+  END IF
   ! Initialise the weather generator
   CALL WGEN_INIT(WG, CRU%mLand, Latitude, REAL(CRU%DtSecs))
 
@@ -197,15 +209,6 @@ SUBROUTINE CRU_GET_SUBDIURNAL_MET(CRU, MET, CurYear, ktau)
 
   ! Purely for readability...
   dt = CRU%DTsecs
-  ! On first step read and check CRU settings and read land-mask
-  if (CALL1) then
-     if (CRU%ReadDiffFrac) then
-        cable_user%calc_fdiff = .false.
-     else
-        cable_user%calc_fdiff = .true.
-     endif
-
-  endif
 
   ! Pass time-step information to CRU
   CRU%CYEAR = CurYear


### PR DESCRIPTION
# CABLE

## Description

The ```CABLE-POP_TRENDY``` branch of the code currently sets ```cable_user%calc_fdiff=.FALSE.``` by default. The only place this was modified was in the CRU meteorology setup, so would effectively break anyone else's simulation not using this workflow who was unaware of this change.

This change changes the default to ```cable_user%calc_fdiff=.TRUE.```, so that the code computes the direct and diffuse fractions via the spitter function. The check used in the CRU/TRENDY has been moved to initialisation. If the user turns off diffuse fraction calculation (via the ```ReadDiffFrac=.TRUE.``` option in the CRU namelist), but doesn't also provide a dataset to read from, the code will now throw an error.

This is not an ideal fix, as we should be checking against the ```cable_user%calc_fdiff``` option, rather than the ```CRU%ReadDiffFrac``` option. I think a better option is to remove the ```CRU%ReadDiffFrac``` option altogether and only have the ```cable_user%calc_fdiff```, given they effectively contain identical information. That would also require minor adjustments to the TRENDY scripts.

Fixes at least part of the problems discussed in #526.

## Type of change

- [x] Bug fix