### PR TITLE
Move blaze input routine to blaze if clause

### DIFF
--- a/offline/cable_driver.F90
+++ b/offline/cable_driver.F90
@@ -750,11 +750,11 @@ PROGRAM cable_offline_driver
                  end if
               end if
 
-              ! additional params needed for BLAZE
-              if (trim(cable_user%MetType) == 'bios') &
-                   call cable_bios_load_climate_params(climate)
-
               if (cable_user%CALL_BLAZE) then
+                 if (trim(cable_user%mettype) == 'bios') then
+                   call cable_bios_load_climate_params(climate)
+                 endif
+
                  print*, "CLN BLAZE INIT"
                  call INI_BLAZE(mland, rad%latitude(landpt(:)%cstart), &
                       rad%longitude(landpt(:)%cstart), BLAZE)


### PR DESCRIPTION
# CABLE

## Description

The climate parameters required for BLAZE are read in even when BLAZE is not active. The routine should be moved to the ```if (CALL_BLAZE)``` clause. This finishes the work of removing all binary inputs from the standard ```CABLE-POP_TRENDY``` mode of operation.

Fixes #(606)