### PR TITLE
Fix GCC build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
     )
 endif()
 
-set(CABLE_GNU_Fortran_FLAGS -cpp -ffree-form -ffixed-line-length-132)
+set(CABLE_GNU_Fortran_FLAGS -cpp -ffree-form -ffree-line-length-none)
 set(CABLE_GNU_Fortran_FLAGS_DEBUG -O -g -pedantic-errors -Wall -W -Wno-maybe-uninitialized -fbacktrace -ffpe-trap=zero,overflow,underflow -finit-real=nan)
 set(CABLE_GNU_Fortran_FLAGS_RELEASE -O3 -Wno-aggressive-loop-optimizations)
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")

--- a/src/offline/cable_input.F90
+++ b/src/offline/cable_input.F90
@@ -1872,8 +1872,8 @@ CONTAINS
          ENDDO
 
        CASE DEFAULT
-         WRITE(logn, "(A,I,A)") "Error SWdown rank not supported. SWdown in &
-             &met file has ", ndims, " rank"
+         WRITE(logn, "(A,I0,A)") "Error SWdown rank not supported. SWdown in " // &
+             "met file has ", ndims, " rank"
          STOP
        END SELECT 
 
@@ -1910,8 +1910,8 @@ CONTAINS
          ENDDO
 
        CASE DEFAULT
-         WRITE(logn, "(A,I,A)") "Error Tair rank not supported. Tair in &
-             &met file has ", ndims, " rank"
+         WRITE(logn, "(A,I0,A)") "Error Tair rank not supported. Tair in " // &
+             "met file has ", ndims, " rank"
          STOP
        END SELECT
 
@@ -1943,8 +1943,8 @@ CONTAINS
                    REAL(tmpDat4(land_x(i),land_y(i),1,1)) * convert%PSurf
            ENDDO
          CASE DEFAULT
-           WRITE(logn, "(A,I,A)") "Error PSurf rank not supported. PSurf in &
-               &met file has ", ndims, " rank"
+           WRITE(logn, "(A,I0,A)") "Error PSurf rank not supported. PSurf in " // &
+               "met file has ", ndims, " rank"
            STOP
          END SELECT
 
@@ -2004,8 +2004,8 @@ CONTAINS
            ENDDO
          END IF
        CASE DEFAULT
-         WRITE(logn, "(A,I,A)") "Error PSurf rank not supported. PSurf in &
-               &met file has ", ndims, " rank"
+         WRITE(logn, "(A,I0,A)") "Error PSurf rank not supported. PSurf in " // &
+               "met file has ", ndims, " rank"
          STOP
        END SELECT
 
@@ -2038,8 +2038,8 @@ CONTAINS
                    REAL(tmpDat4(land_x(i),land_y(i),1,1))
            ENDDO
          CASE DEFAULT
-           WRITE(logn, "(A,I,A)") "Error Wind rank not supported. Wind in &
-                  &met file has ", ndims, " rank"
+           WRITE(logn, "(A,I0,A)") "Error Wind rank not supported. Wind in " // &
+                  "met file has ", ndims, " rank"
            STOP
          END SELECT ! 3 or 4D for 'Wind' variable
        ELSE ! Vector wind
@@ -2092,8 +2092,8 @@ CONTAINS
                    REAL(tmpDat4(land_x(i),land_y(i),1,1))**2)
            ENDDO
          CASE DEFAULT
-           WRITE(logn, "(A,I,A)") "Error Wind_N rank not supported. Wind_N &
-                  &in met file has ", ndims, " rank"
+           WRITE(logn, "(A,I0,A)") "Error Wind_N rank not supported. Wind_N " // &
+                  "in met file has ", ndims, " rank"
            STOP           
          END SELECT ! 3 or 4D for 'Wind_N' and 'Wind_E' variables
        END IF ! scalar or vector wind - 'Wind' or 'Wind_N'/'Wind_E'
@@ -2127,8 +2127,8 @@ CONTAINS
          ENDDO
 
        CASE DEFAULT
-         WRITE(logn, "(A,I,A)") "Error Rainf rank not supported. Rainf &
-               &in met file has ", ndims, " rank"
+         WRITE(logn, "(A,I0,A)") "Error Rainf rank not supported. Rainf " // &
+               "in met file has ", ndims, " rank"
          STOP           
          
        END SELECT
@@ -2164,8 +2164,8 @@ CONTAINS
             ENDDO
          
           CASE DEFAULT
-            WRITE(logn, "(A,I,A)") "Error Snowf rank not supported. Snowf &
-               &in met file has ", ndims, " rank"
+            WRITE(logn, "(A,I0,A)") "Error Snowf rank not supported. Snowf " // &
+               "in met file has ", ndims, " rank"
             STOP           
          
           END SELECT
@@ -2221,8 +2221,8 @@ CONTAINS
             ENDDO
 
           CASE DEFAULT
-            WRITE(logn, "(A,I,A)") "Error LWdown rank not supported. LWdown &
-               &in met file has ", ndims, " rank"
+            WRITE(logn, "(A,I0,A)") "Error LWdown rank not supported. LWdown " // &
+               "in met file has ", ndims, " rank"
             STOP           
          
           END SELECT
@@ -2259,8 +2259,8 @@ CONTAINS
             END DO
          
          CASE DEFAULT
-            WRITE(logn, "(A,I,A)") "Error CO2air rank not supported. CO2air &
-               &in met file has ", ndims, " rank"
+            WRITE(logn, "(A,I0,A)") "Error CO2air rank not supported. CO2air " // &
+               "in met file has ", ndims, " rank"
             STOP           
          
          END SELECT


### PR DESCRIPTION
Bug fixes for GCC build (compiler version GNU Fortran (GCC) 13.2.0).

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## Checklist

- [x] The new content is accessible and located in the appropriate section
- [x] I have checked that links are valid and point to the intended content
- [x] I have checked my code/text and corrected any misspellings

## Testing

- [x] Are the changes bitwise-compatible with the main branch? If working on an optional feature, are the results bitwise-compatible when this feature is off? If yes, copy benchcab output showing successful completion of the bitwise compatibility tests or equivalent results below this line.

```
2025-08-08 14:03:53,983 - INFO - benchcab.benchcab.py:352 - Running fluxsite tasks...
2025-08-08 14:03:54,010 - INFO - benchcab.benchcab.py:353 - tasks: 336 (models: 2, sites: 42, science configurations: 4)
2025-08-08 14:36:58,173 - INFO - benchcab.benchcab.py:363 - 0 failed, 336 passed
2025-08-08 14:37:07,027 - INFO - benchcab.benchcab.py:380 - Running comparison tasks...
2025-08-08 14:37:07,050 - INFO - benchcab.benchcab.py:381 - tasks: 168 (models: 2, sites: 42, science configurations: 4)
2025-08-08 14:39:57,419 - INFO - benchcab.benchcab.py:391 - 0 failed, 168 passed
```

Please add a reviewer when ready for review.


<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--608.org.readthedocs.build/en/608/

<!-- readthedocs-preview cable end -->