### PR TITLE
Change name of static library for spack reasons

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,13 +139,13 @@ if(CABLE_LIBRARY_TARGET STREQUAL "ESM1.6")
     # Can conditionally include files for other shared apps here
     # e.g. IF (CABLE_LIBRARY_TARGET STREQUAL "AM3")
 
-    add_library(cable_science STATIC ${SOURCES})
-    target_compile_definitions(cable_science PRIVATE UM_CBL)
+    add_library(cable STATIC ${SOURCES})
+    target_compile_definitions(cable PRIVATE UM_CBL)
 
-    target_include_directories(cable_science PUBLIC "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
+    target_include_directories(cable PUBLIC "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 
     message(STATUS "Build the library")
-    install(TARGETS cable_science
+    install(TARGETS cable
       EXPORT CABLEFortranTargets
       LIBRARY DESTINATION lib
       INCLUDES DESTINATION include)


### PR DESCRIPTION
Seems the UM7 spack package requires the library to be named the same as the SPR to be findable, in particular the UM7 spack package which prepares the FCM build. In my testing I changed the static library name to be ```cable```, but I changed it back to ```cable_science``` in the previous PR, forgetting the issues this caused in the UM7 SPR.

## Type of change

- [x] Bug fix


<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--609.org.readthedocs.build/en/609/

<!-- readthedocs-preview cable end -->