### PR TITLE
Corrected imprecision of timestep in output

### DIFF
--- a/offline/cable_output.F90
+++ b/offline/cable_output.F90
@@ -1999,14 +1999,6 @@ CONTAINS
     ! If this time step is an output time step:
     IF (writenow) THEN
        ! Write to temporary time variable:
-
-       ! Bug: REAL(ktau-backtrack) * dels becomes imprecise at 2**27,
-       ! which is ktau = 74565 for dels = 1800., i.e. less than 3.5
-       ! years, due to the representation of integer as single
-       ! precision float. The fraction of a 32-bit real is normally
-       ! represented with 23 bits; Do not know why the imprecision is
-       ! at 2**27 here -> do multiplication in double precision
-       ! timetemp(1) = REAL(REAL(ktau-backtrack)*dels,r_2)
        timetemp(1) = real(ktau - backtrack, r_2) * real(dels, r_2)
        ! inquire(unit=ncid_out, opened=opened)
        ! if (.not. opened) ok = NF90_OPEN(filename%out, NF90_WRITE, ncid_out)

--- a/offline/cable_output.F90
+++ b/offline/cable_output.F90
@@ -1999,7 +1999,15 @@ CONTAINS
     ! If this time step is an output time step:
     IF (writenow) THEN
        ! Write to temporary time variable:
-       timetemp(1) = REAL(REAL(ktau-backtrack)*dels,r_2)
+
+       ! Bug: REAL(ktau-backtrack) * dels becomes imprecise at 2**27,
+       ! which is ktau = 74565 for dels = 1800., i.e. less than 3.5
+       ! years, due to the representation of integer as single
+       ! precision float. The fraction of a 32-bit real is normally
+       ! represented with 23 bits; Do not know why the imprecision is
+       ! at 2**27 here -> do multiplication in double precision
+       ! timetemp(1) = REAL(REAL(ktau-backtrack)*dels,r_2)
+       timetemp(1) = real(ktau - backtrack, r_2) * real(dels, r_2)
        ! inquire(unit=ncid_out, opened=opened)
        ! if (.not. opened) ok = NF90_OPEN(filename%out, NF90_WRITE, ncid_out)
        ! ok = NF90_INQ_VARID(ncid_out, 'time', varid)


### PR DESCRIPTION
# CABLE

Timestep for output was written as:
```
timetemp(1) = REAL(REAL(ktau-backtrack)*dels,r_2)
```
in  cable_output.F90. This led to imprecisions after 134 217 000 seconds, which is timestep ktau = 74 565 for half hour data, dels = 1800., and corresponds to less than 3.5 years. These are 2^27 seconds. The fraction of a 32-bit real is normally represented with 23 bits; I do not know why the imprecision starts only at 2^27.
The imprecision are about 8 seconds on my computer (Intel Mac), i.e. the dates are, for example, 1994-04-03T18:00:00, 1994-04-03T18:29:52, 1994-04-03T19:00:00, 1994-04-03T19:30:08, 1994-04-03T20:00:00, ...

Solution: do the multiplication in double precision:
```
timetemp(1) = real(ktau - backtrack, r_2) * real(dels, r_2)
```

## Type of change

- [X] Bug fix

## Checklist

- [X] The new content is accessible and located in the appropriate section
- [X] I have checked my code/text and corrected any misspellings