### PR TITLE
Rename and use r2, r1, and i4 as kinds

### DIFF
--- a/core/biogeochem/CASAONLY_LUC.F90
+++ b/core/biogeochem/CASAONLY_LUC.F90
@@ -19,7 +19,6 @@ contains
     USE POP_Types,            Only: POP_TYPE
     USE POPMODULE,            ONLY: POP_init_single
     ! use cable_pop_io,         only: pop_io
-    USE TypeDef,              ONLY: dp
     USE CABLE_LUC_EXPT,       ONLY: LUC_EXPT_TYPE, read_LUH2, &
          ptos, ptog, stog, gtos, pharv, smharv, syharv, &
          ptoc, ptoq, stoc, stoq, ctos, qtos, & 
@@ -70,10 +69,10 @@ contains
     CHARACTER(LEN=99)        :: ncfile
     CHARACTER(LEN=4)         :: cyear
     INTEGER                  :: ktau,ktauday,nday,idoy
-    real(r_2), dimension(mp)      :: cleaf2met, cleaf2str, croot2met, croot2str, cwood2cwd
-    real(r_2), dimension(mp)      :: nleaf2met, nleaf2str, nroot2met, nroot2str, nwood2cwd
-    real(r_2), dimension(mp)      :: pleaf2met, pleaf2str, proot2met, proot2str, pwood2cwd
-    real(r_2), dimension(mp)      :: xnplimit,  xkNlimiting, xklitter, xksoil,xkleaf, xkleafcold, xkleafdry
+    real(r2), dimension(mp)      :: cleaf2met, cleaf2str, croot2met, croot2str, cwood2cwd
+    real(r2), dimension(mp)      :: nleaf2met, nleaf2str, nroot2met, nroot2str, nwood2cwd
+    real(r2), dimension(mp)      :: pleaf2met, pleaf2str, proot2met, proot2str, pwood2cwd
+    real(r2), dimension(mp)      :: xnplimit,  xkNlimiting, xklitter, xksoil,xkleaf, xkleafcold, xkleafdry
 
     ! more variables to store the spinup pool size over the last 10 loops. Added by Yp Wang 30 Nov 2012
     integer :: k, j, l
@@ -83,8 +82,8 @@ contains
     !and fluxes are aggregated (for output)
 
     ! 13C
-    real(dp), dimension(c13o2pools%ntile,c13o2pools%npools) :: casasave
-    real(dp), dimension(c13o2luc%nland,c13o2luc%npools)     :: lucsave
+    real(r2), dimension(c13o2pools%ntile,c13o2pools%npools) :: casasave
+    real(r2), dimension(c13o2luc%nland,c13o2luc%npools)     :: lucsave
     ! integer :: c13o2_file_id
     ! character(len=40), dimension(c13o2_nvars_output) :: c13o2_vars
     ! integer,           dimension(c13o2_nvars_output) :: c13o2_var_ids
@@ -190,18 +189,18 @@ contains
           ! accumulate annual variables for use in POP
           IF (idoy==1) THEN
              ! (assumes 70% of wood NPP is allocated above ground)
-             casaflux%stemnpp  = casaflux%cnpp * casaflux%fracCalloc(:,2) * 0.7_dp
+             casaflux%stemnpp  = casaflux%cnpp * casaflux%fracCalloc(:,2) * 0.7_r2
              casaflux%potstemnpp = casaflux%stemnpp + (casaflux%fracClabile * casaflux%cgpp)
              casabal%LAImax    = casamet%glai
-             casabal%Cleafmean = casapool%cplant(:,1) / real(mdyear,dp) / 1000._dp
-             casabal%Crootmean = casapool%cplant(:,3) / real(mdyear,dp) / 1000._dp
+             casabal%Cleafmean = casapool%cplant(:,1) / real(mdyear,r2) / 1000._r2
+             casabal%Crootmean = casapool%cplant(:,3) / real(mdyear,r2) / 1000._r2
           ELSE
-             casaflux%stemnpp  = casaflux%stemnpp + casaflux%cnpp * casaflux%fracCalloc(:,2) * 0.7_dp
-             casaflux%potstemnpp = casaflux%potstemnpp + (casaflux%cnpp * casaflux%fracCalloc(:,2) * 0.7_dp + &
+             casaflux%stemnpp  = casaflux%stemnpp + casaflux%cnpp * casaflux%fracCalloc(:,2) * 0.7_r2
+             casaflux%potstemnpp = casaflux%potstemnpp + (casaflux%cnpp * casaflux%fracCalloc(:,2) * 0.7_r2 + &
                                                           casaflux%fracClabile * casaflux%cgpp)
              casabal%LAImax    = max(casamet%glai, casabal%LAImax)
-             casabal%Cleafmean = casabal%Cleafmean + casapool%cplant(:,1) / real(mdyear,dp) / 1000._dp
-             casabal%Crootmean = casabal%Crootmean + casapool%cplant(:,3) / real(mdyear,dp) / 1000._dp
+             casabal%Cleafmean = casabal%Cleafmean + casapool%cplant(:,1) / real(mdyear,r2) / 1000._r2
+             casabal%Crootmean = casabal%Crootmean + casapool%cplant(:,3) / real(mdyear,r2) / 1000._r2
           ENDIF
           IF (CABLE_USER%POPLUC) THEN
              IF (idoy==mdyear) THEN ! end of year
@@ -210,28 +209,28 @@ contains
                 CALL READ_LUH2(LUC_EXPT)
 
                 DO k=1,mland
-                   POPLUC%ptos(k)   = real(LUC_EXPT%INPUT(ptos)%VAL(k), dp)
-                   POPLUC%ptog(k)   = real(LUC_EXPT%INPUT(ptog)%VAL(k), dp)
-                   POPLUC%stog(k)   = real(LUC_EXPT%INPUT(stog)%VAL(k), dp)
-                   POPLUC%gtop(k)   = 0.0_dp
-                   POPLUC%gtos(k)   = real(LUC_EXPT%INPUT(gtos)%VAL(k), dp)
-                   POPLUC%pharv(k)  = real(LUC_EXPT%INPUT(pharv)%VAL(k), dp)
-                   POPLUC%smharv(k) = real(LUC_EXPT%INPUT(smharv)%VAL(k), dp)
-                   POPLUC%syharv(k) = real(LUC_EXPT%INPUT(syharv)%VAL(k), dp)
+                   POPLUC%ptos(k)   = real(LUC_EXPT%INPUT(ptos)%VAL(k), r2)
+                   POPLUC%ptog(k)   = real(LUC_EXPT%INPUT(ptog)%VAL(k), r2)
+                   POPLUC%stog(k)   = real(LUC_EXPT%INPUT(stog)%VAL(k), r2)
+                   POPLUC%gtop(k)   = 0.0_r2
+                   POPLUC%gtos(k)   = real(LUC_EXPT%INPUT(gtos)%VAL(k), r2)
+                   POPLUC%pharv(k)  = real(LUC_EXPT%INPUT(pharv)%VAL(k), r2)
+                   POPLUC%smharv(k) = real(LUC_EXPT%INPUT(smharv)%VAL(k), r2)
+                   POPLUC%syharv(k) = real(LUC_EXPT%INPUT(syharv)%VAL(k), r2)
 
-                   POPLUC%ptoc(k) = real(LUC_EXPT%INPUT(ptoc)%VAL(k), dp)
-                   POPLUC%ptoq(k) = real(LUC_EXPT%INPUT(ptoq)%VAL(k), dp)
-                   POPLUC%stoc(k) = real(LUC_EXPT%INPUT(stoc)%VAL(k), dp)
-                   POPLUC%stoq(k) = real(LUC_EXPT%INPUT(stoq)%VAL(k), dp)
-                   POPLUC%ctos(k) = real(LUC_EXPT%INPUT(ctos)%VAL(k), dp)
-                   POPLUC%qtos(k) = real(LUC_EXPT%INPUT(qtos)%VAL(k), dp)
+                   POPLUC%ptoc(k) = real(LUC_EXPT%INPUT(ptoc)%VAL(k), r2)
+                   POPLUC%ptoq(k) = real(LUC_EXPT%INPUT(ptoq)%VAL(k), r2)
+                   POPLUC%stoc(k) = real(LUC_EXPT%INPUT(stoc)%VAL(k), r2)
+                   POPLUC%stoq(k) = real(LUC_EXPT%INPUT(stoq)%VAL(k), r2)
+                   POPLUC%ctos(k) = real(LUC_EXPT%INPUT(ctos)%VAL(k), r2)
+                   POPLUC%qtos(k) = real(LUC_EXPT%INPUT(qtos)%VAL(k), r2)
 
-                   POPLUC%ctor(k) = real(LUC_EXPT%INPUT(ctor)%VAL(k), dp)
-                   POPLUC%qtor(k) = real(LUC_EXPT%INPUT(qtor)%VAL(k), dp)
-                   POPLUC%rtoc(k) = real(LUC_EXPT%INPUT(rtoc)%VAL(k), dp)
-                   POPLUC%rtoq(k) = real(LUC_EXPT%INPUT(rtoq)%VAL(k), dp)
-                   POPLUC%qtoc(k) = real(LUC_EXPT%INPUT(qtoc)%VAL(k), dp)
-                   POPLUC%ctoq(k) = real(LUC_EXPT%INPUT(ctoq)%VAL(k), dp)
+                   POPLUC%ctor(k) = real(LUC_EXPT%INPUT(ctor)%VAL(k), r2)
+                   POPLUC%qtor(k) = real(LUC_EXPT%INPUT(qtor)%VAL(k), r2)
+                   POPLUC%rtoc(k) = real(LUC_EXPT%INPUT(rtoc)%VAL(k), r2)
+                   POPLUC%rtoq(k) = real(LUC_EXPT%INPUT(rtoq)%VAL(k), r2)
+                   POPLUC%qtoc(k) = real(LUC_EXPT%INPUT(qtoc)%VAL(k), r2)
+                   POPLUC%ctoq(k) = real(LUC_EXPT%INPUT(ctoq)%VAL(k), r2)
 
                    POPLUC%thisyear = yyyy
                    
@@ -248,7 +247,7 @@ contains
 
                 ! zero secondary forest tiles in POP where secondary forest area is zero
                 DO k=1,mland
-                   if ( eq((POPLUC%primf(k)-POPLUC%frac_forest(k)), 0.0_dp) &
+                   if ( eq((POPLUC%primf(k)-POPLUC%frac_forest(k)), 0.0_r2) &
                         .and. (.not. LUC_EXPT%prim_only(k)) ) then
 
                       j = landpt(k)%cstart+1
@@ -259,24 +258,24 @@ contains
                          endif
                       enddo
 
-                      casapool%cplant(j,leaf)  = 0.01_dp
+                      casapool%cplant(j,leaf)  = 0.01_r2
                       casapool%nplant(j,leaf)  = casabiome%ratioNCplantmin(veg%iveg(j),leaf) * casapool%cplant(j,leaf)
                       casapool%pplant(j,leaf)  = casabiome%ratioPCplantmin(veg%iveg(j),leaf) * casapool%cplant(j,leaf)
 
-                      casapool%cplant(j,froot) = 0.01_dp
+                      casapool%cplant(j,froot) = 0.01_r2
                       casapool%nplant(j,froot) = casabiome%ratioNCplantmin(veg%iveg(j),froot) * casapool%cplant(j,froot)
                       casapool%pplant(j,froot) = casabiome%ratioPCplantmin(veg%iveg(j),froot) * casapool%cplant(j,froot)
 
-                      casapool%cplant(j,wood)  = 0.01_dp
+                      casapool%cplant(j,wood)  = 0.01_r2
                       casapool%nplant(j,wood)  = casabiome%ratioNCplantmin(veg%iveg(j),wood) * casapool%cplant(j,wood)
                       casapool%pplant(j,wood)  = casabiome%ratioPCplantmin(veg%iveg(j),wood) * casapool%cplant(j,wood)
-                      casaflux%frac_sapwood(j) = 1.0_dp
+                      casaflux%frac_sapwood(j) = 1.0_r2
 
                       ! 13C
                       if (cable_user%c13o2) then
-                         c13o2pools%cplant(j,leaf)  = 0.01_dp ! * vpdbc13 / vpdbc13 ! Divide by 13C
-                         c13o2pools%cplant(j,wood)  = 0.01_dp ! * vpdbc13 / vpdbc13 ! so that about same numerical precision as 12C
-                         c13o2pools%cplant(j,froot) = 0.01_dp ! * vpdbc13 / vpdbc13 !
+                         c13o2pools%cplant(j,leaf)  = 0.01_r2 ! * vpdbc13 / vpdbc13 ! Divide by 13C
+                         c13o2pools%cplant(j,wood)  = 0.01_r2 ! * vpdbc13 / vpdbc13 ! so that about same numerical precision as 12C
+                         c13o2pools%cplant(j,froot) = 0.01_r2 ! * vpdbc13 / vpdbc13 !
                       endif
                    endif
                 ENDDO

--- a/core/biogeochem/POP.F90
+++ b/core/biogeochem/POP.F90
@@ -80,9 +80,9 @@ MODULE TypeDef
 
   ! Define integer kind parameters to accommodate the range of numbers usually
   ! associated with 4, 2, and 1 byte integers.
-  INTEGER,PARAMETER :: i4b = SELECTED_INT_KIND(9)
-  INTEGER,PARAMETER :: i2b = SELECTED_INT_KIND(4)
-  INTEGER,PARAMETER :: i1b = SELECTED_INT_KIND(2)
+  INTEGER,PARAMETER :: i4 = SELECTED_INT_KIND(9)
+  INTEGER,PARAMETER :: i2 = SELECTED_INT_KIND(4)
+  INTEGER,PARAMETER :: i1 = SELECTED_INT_KIND(2)
 
   ! Define single and double precision real kind parameters:
   ! * Kind(1.0)   defines sp as the machine's default size for single precision
@@ -101,7 +101,7 @@ END MODULE TypeDef
 
 MODULE POP_Constants
 
-  USE TYPEdef, ONLY: dp, i4b
+  USE TYPEdef, ONLY: dp, i4
 
   IMPLICIT NONE
 
@@ -171,65 +171,65 @@ MODULE POP_Constants
       !! Multiple of crown diameters within which tree competes with other cohorts \((-)\)
   REAL(dp), PARAMETER :: EPS = 1.0e-12_dp
       !! Precision parameter representing
-  INTEGER(i4b), PARAMETER :: NLAYER = 1 
+  INTEGER(i4), PARAMETER :: NLAYER = 1 
       !! Number of vertical veg layers (1 is currently the only option)
-  INTEGER(i4b), PARAMETER :: NCOHORT_MAX = 20
+  INTEGER(i4), PARAMETER :: NCOHORT_MAX = 20
       !! Maximum number of cohorts
-  INTEGER(i4b), PARAMETER :: NDISTURB = 1 
+  INTEGER(i4), PARAMETER :: NDISTURB = 1 
       !! Number of disturbance regimes (1=total only  or 2=partial and total)
-  INTEGER(i4b), PARAMETER :: PATCH_REPS = 10 
+  INTEGER(i4), PARAMETER :: PATCH_REPS = 10 
       !! Higher number reduces 'noise'
-  INTEGER(i4b), PARAMETER :: NAGE_MAX = 1 
+  INTEGER(i4), PARAMETER :: NAGE_MAX = 1 
       !! Number of maximum ages
-  INTEGER(i4b), PARAMETER :: PATCH_REPS1 = 60 
+  INTEGER(i4), PARAMETER :: PATCH_REPS1 = 60 
       !! Number of first disturbance years
-  INTEGER(i4b), PARAMETER :: PATCH_REPS2 = 1 
+  INTEGER(i4), PARAMETER :: PATCH_REPS2 = 1 
       !! Number of second disturbance years
-  INTEGER(i4b), PARAMETER :: NPATCH = PATCH_REPS1*PATCH_REPS2
+  INTEGER(i4), PARAMETER :: NPATCH = PATCH_REPS1*PATCH_REPS2
       !! Number of Patches
-  INTEGER(i4b), PARAMETER :: NPATCH1D = NPATCH
-  INTEGER(i4b), PARAMETER :: NPATCH2D = NPATCH
-  INTEGER(i4b), PARAMETER ::  HEIGHT_BINS = 12 
+  INTEGER(i4), PARAMETER :: NPATCH1D = NPATCH
+  INTEGER(i4), PARAMETER :: NPATCH2D = NPATCH
+  INTEGER(i4), PARAMETER ::  HEIGHT_BINS = 12 
       !! Number of height categories to keep track of for diagnostics
   REAL(dp), PARAMETER :: BIN_POWER = 1.4_dp 
       !! Factor determining size of height bins
-  INTEGER(i4b), PARAMETER :: TIMEBASE_FACTOR=50
+  INTEGER(i4), PARAMETER :: TIMEBASE_FACTOR=50
       !! Time base factor (to be multiplied by mean dist interval to give TIMEBASE)
       !! for sampling disturbance probabilities from Poisson distribution
   REAL(dp), PARAMETER :: PI=3.14159265358979323846264_dp
-  INTEGER(i4b), PARAMETER :: ALLOM_SWITCH = 2
+  INTEGER(i4), PARAMETER :: ALLOM_SWITCH = 2
       !! Allometry switch:
       !!
       !! - 0: default
       !! - 1: top-end allometry (requires precip as input to POPSTEP)
       !! - 2: Allometry following Model 5b from [Williams 2005](https://doi.org/10.1071/BT04149)
-  INTEGER(i4b), PARAMETER :: MAX_HEIGHT_SWITCH = 2
+  INTEGER(i4), PARAMETER :: MAX_HEIGHT_SWITCH = 2
       !! Max height calculation:
       !!
       !! - 0: binned max height variable
       !! - 1: continuous (needs lots of memory)
       !! - 2: binned by integer heights
-  INTEGER(i4b), PARAMETER :: RESOURCE_SWITCH = 1 
+  INTEGER(i4), PARAMETER :: RESOURCE_SWITCH = 1 
       !! - 0: default
       !! - 1: fraction net resource uptake
-  INTEGER(i4b), PARAMETER :: RECRUIT_SWITCH = 1 
+  INTEGER(i4), PARAMETER :: RECRUIT_SWITCH = 1 
       !! Recruitment switch:
       !!
       !! - 0: default
       !! - 1: Pgap-dependence
-  INTEGER(i4b), PARAMETER :: INTERP_SWITCH = 1 
+  INTEGER(i4), PARAMETER :: INTERP_SWITCH = 1 
       !! Biomass interpolation switch:
       !!
       !! - 0: sum over weighted patches
       !! - 1: sum over interpolated patches
-  INTEGER(i4b), PARAMETER :: SMOOTH_SWITCH = 0 
+  INTEGER(i4), PARAMETER :: SMOOTH_SWITCH = 0 
       !! Smooth disturbance flux switch
-  INTEGER(i4b), PARAMETER :: NYEAR_WINDOW  = 5 
+  INTEGER(i4), PARAMETER :: NYEAR_WINDOW  = 5 
       !! Size of one-side of smoothing window \((y)\)
-  INTEGER(i4b), PARAMETER :: NYEAR_SMOOTH  = 2*NYEAR_WINDOW + 1 
+  INTEGER(i4), PARAMETER :: NYEAR_SMOOTH  = 2*NYEAR_WINDOW + 1 
       !! Smoothing window size \((y)\)
-  INTEGER(i4b), PARAMETER :: NYEAR_HISTORY = NYEAR_SMOOTH-NYEAR_WINDOW
-  INTEGER(i4b), PARAMETER :: AGEMAX = 1000
+  INTEGER(i4), PARAMETER :: NYEAR_HISTORY = NYEAR_SMOOTH-NYEAR_WINDOW
+  INTEGER(i4), PARAMETER :: AGEMAX = 1000
       !! Maximum age \((y)\)
 
 END MODULE POP_Constants
@@ -240,15 +240,15 @@ END MODULE POP_Constants
 
 MODULE POP_Types
 
-  USE TYPEdef, ONLY: dp, i4b
+  USE TYPEdef, ONLY: dp, i4
   USE POP_Constants, ONLY: NCOHORT_MAX, NLAYER, HEIGHT_BINS, NDISTURB, NPATCH, NPATCH2D, &
        NYEAR_HISTORY, AGEMAX
 
   IMPLICIT NONE
 
   TYPE Cohort
-     INTEGER(i4b) :: id
-     INTEGER(i4b) :: age ! cohort age
+     INTEGER(i4) :: id
+     INTEGER(i4) :: age ! cohort age
      REAL(dp)     :: biomass ! cohort biomass
      REAL(dp)     :: density ! landscape tree density (weighted mean over patches)
      REAL(dp)     :: frac_resource_uptake
@@ -272,7 +272,7 @@ MODULE POP_Types
 
   TYPE Layer
      TYPE(Cohort), DIMENSION(NCOHORT_MAX) :: Cohort
-     INTEGER(i4b) :: ncohort ! number of cohorts with density >0
+     INTEGER(i4) :: ncohort ! number of cohorts with density >0
      REAL(dp)     :: biomass ! layer biomass
      REAL(dp)     :: density ! layer tree density
      REAL(dp)     :: hmean ! layer mean tree height (weighted mean over patches)
@@ -301,10 +301,10 @@ MODULE POP_Types
      REAL(dp)     :: sapwood_area_loss
      REAL(dp)     :: growth ! biomass growth in each patch due to stem increment
      REAL(dp)     :: area_growth ! basal area growth in each patch due to stem increment
-     INTEGER(i4b) :: disturbance_interval(NDISTURB)  ! prescribed disturbance(s) interval for this patch
-     INTEGER(i4b) :: first_disturbance_year(NDISTURB)
-     INTEGER(i4b) :: age(NDISTURB) ! number of years since last disturbance(s)
-     INTEGER(i4b) :: id
+     INTEGER(i4) :: disturbance_interval(NDISTURB)  ! prescribed disturbance(s) interval for this patch
+     INTEGER(i4) :: first_disturbance_year(NDISTURB)
+     INTEGER(i4) :: age(NDISTURB) ! number of years since last disturbance(s)
+     INTEGER(i4) :: id
      REAL(dp)     :: frac_NPP
      REAL(dp)     :: frac_respiration
      REAL(dp)     :: frac_light_uptake
@@ -320,8 +320,8 @@ MODULE POP_Types
      REAL(dp), DIMENSION(NPATCH2D)    :: cat_freq      !
      REAL(dp), DIMENSION(NPATCH2D)    :: cat_freq_old  !
      REAL(dp), DIMENSION(NPATCH2D,NDISTURB) :: freq_ranked_age_unique ! unique age weighting
-     INTEGER(i4b), DIMENSION(NPATCH2D, NDISTURB) :: ranked_age_unique ! unique age
-     INTEGER(i4b), DIMENSION(NDISTURB) :: n_age ! number of unique ages
+     INTEGER(i4), DIMENSION(NPATCH2D, NDISTURB) :: ranked_age_unique ! unique age
+     INTEGER(i4), DIMENSION(NDISTURB) :: n_age ! number of unique ages
      REAL(dp), DIMENSION(NLAYER) :: biomass ! landscape stem biomass (weighted mean over patches)
      REAL(dp), DIMENSION(NLAYER) :: density ! landscape tree density (weighted mean over patches)
      REAL(dp), DIMENSION(NLAYER) :: hmean ! landscape mean treen height (weighted mean over patches)
@@ -355,8 +355,8 @@ MODULE POP_Types
      REAL(dp) :: sapwood_area
      REAL(dp) :: sapwood_area_old
      REAL(dp) :: Kclump ! clumping factor
-     INTEGER(i4b) :: npatch_active
-     INTEGER(i4b) :: LU
+     INTEGER(i4) :: npatch_active
+     INTEGER(i4) :: LU
      REAL(dp) :: smoothing_buffer
      REAL(dp) :: smoothing_buffer_cat
      REAL(dp) :: fire_mortality_smoothed
@@ -384,7 +384,7 @@ MODULE POPModule
   !-------------------------------------------------------------------------------
   !* This module contains all subroutines for POP calcs at a single time step.
   !-------------------------------------------------------------------------------
-  USE TYPEdef, ONLY: sp, i4b
+  USE TYPEdef, ONLY: sp, i4
   USE POP_Types
   USE POP_Constants
 
@@ -572,12 +572,12 @@ CONTAINS
     IMPLICIT NONE
 
     TYPE(POP_TYPE), INTENT(INOUT) :: POP
-    INTEGER(i4b),   INTENT(IN)    :: mean_disturbance_interval(:,:)
-    INTEGER(i4b),   INTENT(IN), optional :: m
+    INTEGER(i4),   INTENT(IN)    :: mean_disturbance_interval(:,:)
+    INTEGER(i4),   INTENT(IN), optional :: m
 
-    INTEGER(i4b) :: j, k, g, ipatch, idist, p, c, i
-    INTEGER(i4b) :: disturbance_interval
-    INTEGER(i4b):: Poisson_age(1000)
+    INTEGER(i4) :: j, k, g, ipatch, idist, p, c, i
+    INTEGER(i4) :: disturbance_interval
+    INTEGER(i4):: Poisson_age(1000)
     REAL(dp):: Poisson_weight(1000), CumPoisson_weight(1000)
     INTEGER:: i_max
     INTEGER:: np
@@ -714,7 +714,7 @@ CONTAINS
     TYPE(POP_TYPE), INTENT(INOUT) :: POP
     REAL(dp), INTENT(IN) :: StemNPP(:,:)
     REAL(dp), INTENT(IN) :: disturbance_intensity(:,:)
-    INTEGER(i4b), INTENT(IN) ::  disturbance_interval(:,:)
+    INTEGER(i4), INTENT(IN) ::  disturbance_interval(:,:)
     REAL(dp), INTENT(IN) ::  LAI(:)
     REAL(dp), INTENT(IN) ::  Cleaf(:)
     REAL(dp), INTENT(IN) ::  Croot(:)
@@ -722,8 +722,8 @@ CONTAINS
     REAL(dp), INTENT(IN), OPTIONAL :: frac_intensity1(:), precip(:)
     REAL(dp), INTENT(IN), OPTIONAL :: StemNPP_pot(:)
 
-    INTEGER(i4b) :: idisturb,np,g
-    INTEGER(i4b), allocatable :: it(:)
+    INTEGER(i4) :: idisturb,np,g
+    INTEGER(i4), allocatable :: it(:)
 
     !INTEGER, INTENT(IN) :: wlogn
     pop%it_pop = pop%it_pop + 1
@@ -830,12 +830,12 @@ CONTAINS
     REAL(dp), INTENT(IN), OPTIONAL  :: precip(:)
        !! Precipitation
     REAL(dp), OPTIONAL, INTENT(IN)  :: StemNPP_pot(:)
-    INTEGER(i4b), INTENT(IN)        :: it(:)
+    INTEGER(i4), INTENT(IN)        :: it(:)
 
     REAL(dp) :: densindiv
     REAL(dp) :: tmp,tmp_light,tmp_respiration,tmp_fracnpp, cmass_stem_inc
-    INTEGER(i4b) :: j, k,c, idist
-    INTEGER(i4b) :: ivec(NCOHORT_MAX), nc, np
+    INTEGER(i4) :: j, k,c, idist
+    INTEGER(i4) :: ivec(NCOHORT_MAX), nc, np
     REAL(dp) :: growth_efficiency,cmass_stem
     REAL(dp) :: mort
     REAL(dp) :: cpc, crown_area
@@ -1281,21 +1281,21 @@ CONTAINS
     IMPLICIT NONE
 
     TYPE(POP_TYPE), INTENT(INOUT) :: POP
-    INTEGER(i4b), INTENT(IN) ::  disturbance_interval(:,:), idisturb
+    INTEGER(i4), INTENT(IN) ::  disturbance_interval(:,:), idisturb
 
-    INTEGER(i4b) :: g, i,j,k,agecopy,idcopy
+    INTEGER(i4) :: g, i,j,k,agecopy,idcopy
     REAL(dp), ALLOCATABLE :: midpoint(:)
-    INTEGER(i4b), ALLOCATABLE :: ranked_age(:), ranked_age_init(:)
-    INTEGER(i4b) :: age_tmp
-    INTEGER(i4b), ALLOCATABLE :: ranked_age_unique_id(:), ranked_age_id(:), counter(:)
+    INTEGER(i4), ALLOCATABLE :: ranked_age(:), ranked_age_init(:)
+    INTEGER(i4) :: age_tmp
+    INTEGER(i4), ALLOCATABLE :: ranked_age_unique_id(:), ranked_age_id(:), counter(:)
     REAL(dp), ALLOCATABLE :: tmp(:), freq_tmp(:), freq_tmp1(:)
     REAL(dp) :: freq
-    INTEGER(i4b) :: n_age ! number of unique ages
-    INTEGER(i4b) :: npatch_active ! number of active patches
+    INTEGER(i4) :: n_age ! number of unique ages
+    INTEGER(i4) :: npatch_active ! number of active patches
     REAL(dp):: disturbance_freq
-    INTEGER(i4b) :: i_max, Poisson_age(1000), np
+    INTEGER(i4) :: i_max, Poisson_age(1000), np
     REAL(dp):: CumPoisson_weight(1000)
-    INTEGER(i4b), ALLOCATABLE :: bound(:,:), unique_age(:)
+    INTEGER(i4), ALLOCATABLE :: bound(:,:), unique_age(:)
 
     np = SIZE(POP%POP_grid)
     DO g=1,np
@@ -1424,7 +1424,7 @@ CONTAINS
 
     TYPE(POP_TYPE), INTENT(INOUT) :: POP
 
-    INTEGER(i4b) :: n1, n2, g, REPCOUNT, np, idist
+    INTEGER(i4) :: n1, n2, g, REPCOUNT, np, idist
     REAL(dp) ::  sum_freq
 
     np = SIZE(Pop%pop_grid)
@@ -1488,21 +1488,21 @@ CONTAINS
     REAL(dp), INTENT(IN) ::  LAI(:)
     REAL(dp), INTENT(IN) ::  Cleaf(:)
     REAL(dp), INTENT(IN) ::  Croot(:)
-    INTEGER(i4b), INTENT(IN)        ::  disturbance_interval(:,:)
+    INTEGER(i4), INTENT(IN)        ::  disturbance_interval(:,:)
     REAL(dp), INTENT(IN), OPTIONAL :: precip(:)
-    INTEGER(i4b), INTENT(IN) :: it(:)
-    INTEGER(i4b) :: P, g,i,j,ct, ct_highres
+    INTEGER(i4), INTENT(IN) :: it(:)
+    INTEGER(i4) :: P, g,i,j,ct, ct_highres
     REAL(dp) :: limits(HEIGHT_BINS+1)
     REAL(dp) :: ht, cmass_stem,densindiv, freq, freq_old
     CHARACTER(len=12) :: string1, string2
     CHARACTER(len=9) :: fmt
-    INTEGER(i4b) :: npatch_active  ! number of active patches
-    INTEGER(i4b) :: np, nc, i_height
+    INTEGER(i4) :: npatch_active  ! number of active patches
+    INTEGER(i4) :: np, nc, i_height
     REAL(dp) :: diam,basal, cump
     REAL(dp) :: patch_crown_area(NPATCH2D), patch_crown_cover(NPATCH2D)
     REAL(dp), ALLOCATABLE :: height_list(:), height_list_weight(:)
     REAL(dp) :: height_copy, weight_copy, Pwc, FAVD
-    INTEGER(i4b), PARAMETER :: HEIGHT_BINS_highres=100 ! bins for assessing height_max
+    INTEGER(i4), PARAMETER :: HEIGHT_BINS_highres=100 ! bins for assessing height_max
     REAL(dp), ALLOCATABLE :: limits_highres(:), DENSINDIV_HIGHRES(:)
     REAL(dp) :: tmp2
     integer :: arg1
@@ -1718,7 +1718,7 @@ CONTAINS
           IF (it(g).LE.NYEAR_HISTORY) THEN
              CALL SMOOTH_FLUX(POP,g,it(g))
           ELSE
-             CALL SMOOTH_FLUX(POP,g,int(arg1,i4b))
+             CALL SMOOTH_FLUX(POP,g,int(arg1,i4))
           ENDIF
        ENDIF
 
@@ -1904,12 +1904,12 @@ CONTAINS
     IMPLICIT NONE
 
     TYPE(POP_TYPE), INTENT(INOUT) :: POP
-    INTEGER(i4b), INTENT(IN) ::  idisturb
+    INTEGER(i4), INTENT(IN) ::  idisturb
     REAL(dp), INTENT(IN) :: intensity(:,:)
     REAL(dp), INTENT(IN), OPTIONAL :: frac_intensity1(:)
 
-    INTEGER(i4b) :: j, k, c, nc, np
-    INTEGER(i4b) ::  ivec(NCOHORT_MAX)
+    INTEGER(i4) :: j, k, c, nc, np
+    INTEGER(i4) ::  ivec(NCOHORT_MAX)
     REAL(dp) :: ht, diam
     REAL(dp) :: Psurvival_s, Psurvival, char_height
 
@@ -2039,10 +2039,10 @@ CONTAINS
     IMPLICIT NONE
 
     TYPE(POP_TYPE), INTENT(INOUT) :: POP
-    INTEGER(i4b), INTENT(IN) ::  idisturb
+    INTEGER(i4), INTENT(IN) ::  idisturb
 
-    INTEGER(i4b) :: j, k, c, nc, np
-    INTEGER(i4b) ::  ivec(NCOHORT_MAX)
+    INTEGER(i4) :: j, k, c, nc, np
+    INTEGER(i4) ::  ivec(NCOHORT_MAX)
     REAL(dp) :: Psurvival, frac_mort, Pmort
 
     np = SIZE(Pop%pop_grid)
@@ -2151,10 +2151,10 @@ CONTAINS
     TYPE(POP_TYPE), INTENT(INOUT)  :: POP
       !! POP structure
     REAL(dp), INTENT(IN), OPTIONAL :: precip(:)
-    !INTEGER(i4b), INTENT(IN) :: it(:),idisturb
-    INTEGER(i4b), INTENT(IN) :: idisturb
+    !INTEGER(i4), INTENT(IN) :: it(:),idisturb
+    INTEGER(i4), INTENT(IN) :: idisturb
       !! Disturbance regime (1=total only, 2=total and partial)
-    INTEGER(i4b) :: j, k, np, nc
+    INTEGER(i4) :: j, k, np, nc
 
     np = SIZE(Pop%pop_grid)
 
@@ -2274,7 +2274,7 @@ CONTAINS
     REAL(dp), INTENT(IN), OPTIONAL :: precip(:)
 
     REAL(dp) :: f, mu, densindiv, cmass, ht
-    INTEGER(i4b) :: j, k, ncohort, np
+    INTEGER(i4) :: j, k, ncohort, np
     REAL(dp) :: diam, basal
 
     np = SIZE(Pop%pop_grid)
@@ -2337,10 +2337,10 @@ CONTAINS
 
     TYPE(POP_TYPE), INTENT(INOUT)  :: POP
     REAL(dp), INTENT(IN), OPTIONAL :: precip(:)
-    INTEGER(i4b), INTENT(IN) :: index, grid_index
+    INTEGER(i4), INTENT(IN) :: index, grid_index
 
     REAL(dp) :: f, mu, densindiv, cmass, ht
-    INTEGER(i4b) :: j, k, ncohort, np
+    INTEGER(i4) :: j, k, ncohort, np
     REAL(dp) :: diam,basal
 
     np = SIZE(Pop%pop_grid)
@@ -2396,7 +2396,7 @@ CONTAINS
 
     IMPLICIT NONE
 
-    INTEGER(i4b), INTENT(IN) :: x
+    INTEGER(i4), INTENT(IN) :: x
     REAL(dp), INTENT(IN) ::  lambda
 
     IF (x .LT. 0.0_dp) THEN ! Shouldn't happen but ...
@@ -2486,7 +2486,7 @@ CONTAINS
 
     IMPLICIT NONE
 
-    INTEGER(i4b), INTENT(IN) :: ALLOM_SWITCH
+    INTEGER(i4), INTENT(IN) :: ALLOM_SWITCH
       !! Switch for allometric relationship
     REAL(dp),     INTENT(IN) :: biomass
       !! Biomass (\(kgC.m^{-2}\))
@@ -2558,10 +2558,10 @@ CONTAINS
     REAL(dp),PARAMETER:: HMIN=0.001_dp ! min bound for tree height
     REAL(dp),PARAMETER:: HMAX=100.0_dp ! max bound for tree height
     REAL(dp),PARAMETER:: EPS=0.01_dp ! precision of the root
-    INTEGER(i4b), PARAMETER :: MAXTRIES=25
+    INTEGER(i4), PARAMETER :: MAXTRIES=25
 
     REAL(dp) :: alpha,beta,delta,rh,st,x1,x2,rtbis,dx,fmid,xmid,lhs,rhs
-    INTEGER(i4b) :: b
+    INTEGER(i4) :: b
 
     alpha=4.05_dp*EXP(-0.00032_dp*precip)
     beta=5.4_dp*EXP(0.0014_dp*precip)
@@ -2611,20 +2611,20 @@ CONTAINS
 
     TYPE(POP_TYPE), INTENT(INOUT) :: POP
       !! POP structure
-    INTEGER(i4b), INTENT(IN) ::  disturbance_interval(:,:)
+    INTEGER(i4), INTENT(IN) ::  disturbance_interval(:,:)
       !! Disturbance interval, dimensions (partial dist, total dist) (\(y\)) 
-    INTEGER(i4b), INTENT(IN) ::  it,g
+    INTEGER(i4), INTENT(IN) ::  it,g
 
-    INTEGER(i4b) :: nage,iage, i_min, i_max
-    INTEGER(i4b) :: i_min_growth, i_max_growth
+    INTEGER(i4) :: nage,iage, i_min, i_max
+    INTEGER(i4) :: i_min_growth, i_max_growth
     REAL(dp) :: disturbance_freq, tmp_min, tmp_max, tmp1_min, tmp1_max, tmp_array(NPATCH2D)
     REAL(dp) :: tmp2_min, tmp2_max
     REAL(dp) :: tmp3_min, tmp3_max
     REAL(dp) :: tmp4_min, tmp4_max
     LOGICAL :: MASK(NPATCH2D)
-    INTEGER(i4b) :: age_min, age_max
-    INTEGER(i4b) :: age_min_growth, age_max_growth
-    INTEGER(i4b), ALLOCATABLE :: age(:)
+    INTEGER(i4) :: age_min, age_max
+    INTEGER(i4) :: age_min_growth, age_max_growth
+    INTEGER(i4), ALLOCATABLE :: age(:)
     REAL(dp), ALLOCATABLE ::cmass_age(:), stress_mort_age(:), crowd_mort_age(:)
     REAL(dp), ALLOCATABLE ::csapwood_age(:), sapwood_area_age(:), growth_age(:)
     REAL(dp), ALLOCATABLE ::freq_age(:)
@@ -2909,17 +2909,17 @@ CONTAINS
     IMPLICIT NONE
 
     TYPE(POP_TYPE), INTENT(INOUT) :: POP
-    INTEGER(i4b), INTENT(IN) ::  disturbance_interval(:,:)
-    INTEGER(i4b), INTENT(IN) ::  it,g
+    INTEGER(i4), INTENT(IN) ::  disturbance_interval(:,:)
+    INTEGER(i4), INTENT(IN) ::  it,g
 
-    INTEGER(i4b) :: nage,iage, i_min, i_max
-    INTEGER(i4b) :: i_min_growth, i_max_growth
+    INTEGER(i4) :: nage,iage, i_min, i_max
+    INTEGER(i4) :: i_min_growth, i_max_growth
     REAL(dp) :: disturbance_freq,tmp_min, tmp_max, tmp_array(NPATCH2D)
     REAL(dp) :: tmp5_min, tmp5_max
     LOGICAL :: MASK(NPATCH2D)
-    INTEGER(i4b) :: age_min, age_max
-    INTEGER(i4b) :: age_min_growth, age_max_growth
-    INTEGER(i4b), ALLOCATABLE :: age(:)
+    INTEGER(i4) :: age_min, age_max
+    INTEGER(i4) :: age_min_growth, age_max_growth
+    INTEGER(i4), ALLOCATABLE :: age(:)
     REAL(dp), ALLOCATABLE :: fire_mort_age(:)
     REAL(dp), ALLOCATABLE :: freq_age(:)
 
@@ -3064,9 +3064,9 @@ CONTAINS
     IMPLICIT NONE
 
     TYPE( POP_TYPE ), INTENT(INOUT)  :: pop
-    INTEGER(i4b), INTENT(IN)        ::  disturbance_interval(:,:)
+    INTEGER(i4), INTENT(IN)        ::  disturbance_interval(:,:)
     REAL(dp),  INTENT(IN)            :: burned_area(:), FLI(:)
-    INTEGER(i4b) :: g, np, c, k, it, nc
+    INTEGER(i4) :: g, np, c, k, it, nc
     REAL(dp) :: mort, cmass_stem, dbh
 
 
@@ -3154,28 +3154,28 @@ SUBROUTINE INTERPOLATE_BIOMASS_2D(pop, disturbance_interval,it,g)
 IMPLICIT NONE
 
 TYPE(POP_TYPE), INTENT(INOUT) :: POP
-INTEGER(i4b), INTENT(IN) ::  disturbance_interval(:,:)
-INTEGER(i4b), INTENT(IN) ::  it,g
-INTEGER(i4b), allocatable :: A1(:), A2(:) ! interpolated ages
-INTEGER(i4b), allocatable :: xobs(:), yobs(:)     ! observed ages
+INTEGER(i4), INTENT(IN) ::  disturbance_interval(:,:)
+INTEGER(i4), INTENT(IN) ::  it,g
+INTEGER(i4), allocatable :: A1(:), A2(:) ! interpolated ages
+INTEGER(i4), allocatable :: xobs(:), yobs(:)     ! observed ages
 REAL(dp), allocatable :: z1obs(:), z2obs(:), z3obs(:) ! observed biomass, stress_mort, crowd_mort
 REAL(dp), allocatable :: z1interp(:), z2interp(:), z3interp(:) ! interpolated biomass, stress mortality, crowding mortality
 REAL(dp), allocatable :: freq_interp(:) ! weightings for interpolated age pairs
 REAL(dp), allocatable :: zp(:)  ! euclidean distance from interpolated age pair to observed age pairs
-INTEGER(i4b) :: age_max(2), nrep(NPATCH2D+1)
-INTEGER(i4b) :: tmp1, tmp2, I1, I2,I3,I4
-INTEGER(i4b) :: x1, x2, x3, x4, y1, y2, y3, y4
-INTEGER(i4b) :: p, j, k, n, np, nobs, count_extrap, ct
+INTEGER(i4) :: age_max(2), nrep(NPATCH2D+1)
+INTEGER(i4) :: tmp1, tmp2, I11, I22,I33,I44
+INTEGER(i4) :: x1, x2, x3, x4, y1, y2, y3, y4
+INTEGER(i4) :: p, j, k, n, np, nobs, count_extrap, ct
 LOGICAL :: flag
 REAL(dp) :: biomass(NPATCH2D+1), stress_mort(NPATCH2D+1), crowd_mort(NPATCH2D+1)
-INTEGER(i4b) :: age1(NPATCH2D+1),  age2(NPATCH2D+1)
+INTEGER(i4) :: age1(NPATCH2D+1),  age2(NPATCH2D+1)
 REAL(dp) :: zmin
-INTEGER(i4b), allocatable :: interp_case(:), tmp_array(:), tmp(:)
+INTEGER(i4), allocatable :: interp_case(:), tmp_array(:), tmp(:)
 REAL(dp) :: area(4,4), x(4), y(4),  disturbance_freq1,  disturbance_freq2
-INTEGER(i4b) :: triangle_points(4,3), I_inside_triangle, Ineighbour(8)
+INTEGER(i4) :: triangle_points(4,3), I_inside_triangle, Ineighbour(8)
 LOGICAL ::  MASK_INSIDE_TRIANGLE(4), IS_NEIGHBOUR(8), tmp_logical
 LOGICAL, allocatable :: MASK2(:), MASK3(:), MASK4(:)
-INTEGER(i4b), allocatable :: address(:,:)
+INTEGER(i4), allocatable :: address(:,:)
 #ifdef __MPI__
  integer :: ierr
 #endif
@@ -3304,9 +3304,9 @@ DO p=1,np   ! loop over interpolated age pairs
 
    ! get closest point
    zmin = MINVAL(zp)
-   I1 = MINLOC(zp,1)
-   x1 = xobs(I1)
-   y1 = yobs(I1)
+   I11 = MINLOC(zp,1)
+   x1 = xobs(I11)
+   y1 = yobs(I11)
 
 
    ! check for obs locations forming a quadrangle around interpolating point
@@ -3317,17 +3317,17 @@ DO p=1,np   ! loop over interpolated age pairs
 
    IF ((ANY(MASK2)).and.(ANY(MASK3)).and.(ANY(MASK4)))    THEN
       ! get nearest point with opposing sign of x displacement
-      I2 =  MINLOC(zp,1, MASK2)
-      x2 = xobs(I2)
-      y2 = yobs(I2)
+      I22 =  MINLOC(zp,1, MASK2)
+      x2 = xobs(I22)
+      y2 = yobs(I22)
       ! get nearest point with opposing sign of y displacement
-      I3 =  MINLOC(zp,1, MASK3)
-      x3 = xobs(I3)
-      y3 = yobs(I3)
+      I33 =  MINLOC(zp,1, MASK3)
+      x3 = xobs(I33)
+      y3 = yobs(I33)
       ! get nearest point with opposing sign of x & y displacements
-      I4 =  MINLOC(zp,1, MASK4)
-      x4 = xobs(I4)
-      y4 = yobs(I4)
+      I44 =  MINLOC(zp,1, MASK4)
+      x4 = xobs(I44)
+      y4 = yobs(I44)
 
     tmp_logical = .NOT.( (x2.eq.0.and.y2.eq.0).OR.(x3.eq.0.and.y3.eq.0).OR.(x4.eq.0.and.y4.eq.0))
    ENDIF
@@ -3346,26 +3346,26 @@ DO p=1,np   ! loop over interpolated age pairs
    select case (interp_case(p))
 
    case(1) ! interpolated point is the same as observation
-      z1interp(p) = z1obs(I1)
-      z2interp(p) = z2obs(I1)
-      z3interp(p) = z3obs(I1)
+      z1interp(p) = z1obs(I11)
+      z2interp(p) = z2obs(I11)
+      z3interp(p) = z3obs(I11)
    case(3) ! extrapolation required: set to value of nearest observation
-      z1interp(p) = z1obs(I1)
-      z2interp(p) = z2obs(I1)
-      z3interp(p) = z3obs(I1)
+      z1interp(p) = z1obs(I11)
+      z2interp(p) = z2obs(I11)
+      z3interp(p) = z3obs(I11)
    case(2)  ! quadrangle
       ! get nearest point with opposing sign of x displacement
-      I2 =  MINLOC(zp,1, MASK2)
-      x2 = xobs(I2)
-      y2 = yobs(I2)
+      I22 =  MINLOC(zp,1, MASK2)
+      x2 = xobs(I22)
+      y2 = yobs(I22)
       ! get nearest point with opposing sign of y displacement
-      I3 =  MINLOC(zp,1, MASK3)
-      x3 = xobs(I3)
-      y3 = yobs(I3)
+      I33 =  MINLOC(zp,1, MASK3)
+      x3 = xobs(I33)
+      y3 = yobs(I33)
       ! get nearest point with opposing sign of x & y displacements
-      I4 =  MINLOC(zp,1, MASK4)
-      x4 = xobs(I4)
-      y4 = yobs(I4)
+      I44 =  MINLOC(zp,1, MASK4)
+      x4 = xobs(I44)
+      y4 = yobs(I44)
 
 
       x=real((/x1, x2, x3, x4/),dp)
@@ -3375,25 +3375,25 @@ DO p=1,np   ! loop over interpolated age pairs
       ! triangles, with observation as one vertex
       area = 0.0_dp
       triangle_points = 0
-      triangle_points(1,:) = (/I1, I2, I3/)
+      triangle_points(1,:) = (/I11, I22, I33/)
       area(1,1) = area_triangle(x(1), y(1),x(2), y(2),x(3), y(3))
       area(1,2) = area_triangle(real(A1(p),dp), real(A2(p),dp), x(2), y(2), x(3), y(3))
       area(1,3) = area_triangle(real(A1(p),dp), real(A2(p),dp), x(1), y(1), x(3), y(3))
       area(1,4) = area_triangle(real(A1(p),dp), real(A2(p),dp), x(1), y(1), x(2), y(2))
 
-      triangle_points(2,:) =  (/I1, I2, I4/)
+      triangle_points(2,:) =  (/I11, I22, I44/)
       area(2,1) = area_triangle(x(1), y(1), x(2), y(2), x(4), y(4))
       area(2,2) = area_triangle(real(A1(p),dp), real(A2(p),dp), x(2), y(2), x(4), y(4))
       area(2,3) = area_triangle(real(A1(p),dp), real(A2(p),dp), x(1), y(1), x(4), y(4))
       area(2,4) = area_triangle(real(A1(p),dp), real(A2(p),dp), x(1), y(1), x(2), y(2))
 
-      triangle_points(3,:) =  (/I1, I4, I3/)
+      triangle_points(3,:) =  (/I11, I44, I33/)
       area(3,1) = area_triangle(x(1) , y(1), x(3), y(3),x(4), y(4))
       area(3,2) = area_triangle(real(A1(p),dp), real(A2(p),dp), x(4), y(4), x(3), y(3))
       area(3,3) = area_triangle(real(A1(p),dp), real(A2(p),dp), x(1), y(1), x(3), y(3))
       area(3,4) = area_triangle(real(A1(p),dp), real(A2(p),dp), x(1), y(1), x(4), y(4))
 
-      triangle_points(4,:) =  (/I2, I4, I3/)
+      triangle_points(4,:) =  (/I22, I44, I33/)
       area(4,1) = area_triangle(x(2), y(2), x(3), y(3), x(4), y(4));
       area(4,2) = area_triangle(real(A1(p),dp), real(A2(p),dp), x(4), y(4), x(3), y(3))
       area(4,3) = area_triangle(real(A1(p),dp), real(A2(p),dp), x(2), y(2), x(3), y(3))
@@ -3579,13 +3579,13 @@ SUBROUTINE SMOOTH_FLUX(POP,g,t)
   IMPLICIT NONE
 
   TYPE(POP_TYPE), INTENT(INOUT) :: POP
-  INTEGER(i4b),   INTENT(IN)    :: g, t
+  INTEGER(i4),   INTENT(IN)    :: g, t
 
-  INTEGER(i4b), PARAMETER :: SPAN = NYEAR_WINDOW
+  INTEGER(i4), PARAMETER :: SPAN = NYEAR_WINDOW
   REAL(dp) :: x(NYEAR_SMOOTH), y(NYEAR_SMOOTH), a, b, r
   REAL(dp) :: sumflux, sumsmooth, flux(NYEAR_HISTORY), smoothed_flux
   REAL(dp) :: dbuf
-  INTEGER(i4b) :: t0, tt, n, k
+  INTEGER(i4) :: t0, tt, n, k
 
   ! update fire_mortality_history
 
@@ -3632,12 +3632,12 @@ SUBROUTINE SMOOTH_FLUX_cat(POP,g,t)
   IMPLICIT NONE
 
   TYPE(POP_TYPE), INTENT(INOUT) :: POP
-  INTEGER(i4b), INTENT(IN) :: g, t
-  INTEGER(i4b), PARAMETER :: SPAN = NYEAR_WINDOW
+  INTEGER(i4), INTENT(IN) :: g, t
+  INTEGER(i4), PARAMETER :: SPAN = NYEAR_WINDOW
   REAL(dp) :: x(NYEAR_SMOOTH), y(NYEAR_SMOOTH), a, b, r
   REAL(dp) :: sumflux, sumsmooth, flux(NYEAR_HISTORY), smoothed_flux
   REAL(dp) :: dbuf
-  INTEGER(i4b) :: t0, tt, n, k
+  INTEGER(i4) :: t0, tt, n, k
 
   ! update cat_mortality_history
 
@@ -3690,9 +3690,9 @@ SUBROUTINE REGRESS(x, y, n, a, b, r)
 
   REAL(dp), INTENT(IN) :: x(:), y(:)
   REAL(dp), INTENT(OUT) :: a, b, r
-  INTEGER(i4b), INTENT(IN) :: n
+  INTEGER(i4), INTENT(IN) :: n
   REAL(dp)::  sx,sy,sxx,sxy,delta,meanx,meany,sdx,sdy
-  INTEGER(i4b) :: i
+  INTEGER(i4) :: i
 
   ! Performs a linear regression of array y on array x (n values)
   ! returning parameters a and b in the fitted model: y=a+bx
@@ -3851,17 +3851,17 @@ END SUBROUTINE Allometry
     !   first cohort.
 
     USE POP_types, ONLY: POP_TYPE
-    USE TypeDef,   ONLY: i4b
+    USE TypeDef,   ONLY: i4
 
     IMPLICIT NONE
 
     TYPE(POP_TYPE), INTENT(INOUT) :: POP
-    INTEGER(i4b),   INTENT(IN)    :: disturbance_interval(:,:)
-    INTEGER(i4b),   INTENT(IN)    :: np
-    INTEGER(i4b),   INTENT(IN)    :: Iwood(:)
+    INTEGER(i4),   INTENT(IN)    :: disturbance_interval(:,:)
+    INTEGER(i4),   INTENT(IN)    :: np
+    INTEGER(i4),   INTENT(IN)    :: Iwood(:)
     REAL(dp),       INTENT(IN), OPTIONAL :: precip(:)
 
-    INTEGER(i4b) :: j, k
+    INTEGER(i4) :: j, k
 
     CALL alloc_POP(pop, int(np))
     POP%np     = np
@@ -3872,7 +3872,7 @@ END SUBROUTINE Allometry
 
     CALL ZeroPOP(pop)
 
-    CALL InitPOP2D_Poisson(pop, int(disturbance_interval, i4b))
+    CALL InitPOP2D_Poisson(pop, int(disturbance_interval, i4))
 
     DO j=1, np
        DO k=1, NPATCH2D
@@ -3897,21 +3897,21 @@ END SUBROUTINE Allometry
     !! **Warning:** Code review needed to evaluate redundancy.
  
     USE POP_types, ONLY: POP_TYPE
-    USE TypeDef,   ONLY: i4b
+    USE TypeDef,   ONLY: i4
 
     IMPLICIT NONE
 
     TYPE(POP_TYPE), INTENT(INOUT) :: POP
-    INTEGER(i4b),   INTENT(IN)    :: disturbance_interval(:,:)
-    INTEGER(i4b),   INTENT(IN)    :: n
+    INTEGER(i4),   INTENT(IN)    :: disturbance_interval(:,:)
+    INTEGER(i4),   INTENT(IN)    :: n
     REAL(dp),       INTENT(IN), OPTIONAL :: precip(:)
 
-    INTEGER(i4b) :: j, k
+    INTEGER(i4) :: j, k
 
     POP%it_pop(n) = 0
     CALL ZeroPOP(pop, n)
 
-    CALL InitPOP2D_Poisson(pop, INT(disturbance_interval,i4b), n)
+    CALL InitPOP2D_Poisson(pop, INT(disturbance_interval,i4), n)
 
     DO j=n,n
        DO k=1,NPATCH2D

--- a/core/biogeochem/POPLUC.F90
+++ b/core/biogeochem/POPLUC.F90
@@ -37,18 +37,18 @@
 !*********************************************************************************
 MODULE POPLUC_CONSTANTS
 
-  USE TYPEdef, ONLY: dp, i4b
+  USE TYPEdef, ONLY: dp, i4
 
   implicit none
 
-  INTEGER(i4b), PARAMETER :: LENGTH_SECDF_HISTORY = 4000
-  INTEGER(i4b), PARAMETER :: AGE_MAX = 1000
+  INTEGER(i4), PARAMETER :: LENGTH_SECDF_HISTORY = 4000
+  INTEGER(i4), PARAMETER :: AGE_MAX = 1000
   ! N.B. needs to be the same as veg%disturbance_interval
-  INTEGER(i4b), PARAMETER :: disturbance_interval = 100
+  INTEGER(i4), PARAMETER :: disturbance_interval = 100
   LOGICAL,      PARAMETER :: IFHARVEST=.FALSE.
-  INTEGER(i4b), PARAMETER :: ROTATION=70
-  INTEGER(i4b), PARAMETER :: nLU=3    ! number of land-use tiles (pf, sf, grass)
-  INTEGER(i4b), PARAMETER :: nTrans=4 ! number of possible gross transition types (ptog, ptos, stog, gtos)
+  INTEGER(i4), PARAMETER :: ROTATION=70
+  INTEGER(i4), PARAMETER :: nLU=3    ! number of land-use tiles (pf, sf, grass)
+  INTEGER(i4), PARAMETER :: nTrans=4 ! number of possible gross transition types (ptog, ptos, stog, gtos)
 
 END MODULE POPLUC_CONSTANTS
 
@@ -56,17 +56,17 @@ END MODULE POPLUC_CONSTANTS
 
 MODULE POPLUC_Types
 
-  USE TYPEdef,          ONLY: dp, i4b
+  USE TYPEdef,          ONLY: dp, i4
   USE POPLUC_Constants, ONLY: LENGTH_SECDF_HISTORY, AGE_MAX
 
   implicit none
 
   TYPE POPLUC_TYPE
-     INTEGER(i4b), POINTER :: it
-     INTEGER(i4b), POINTER :: np
-     INTEGER(i4b), POINTER :: firstyear
-     INTEGER(i4b), POINTER :: thisyear
-     INTEGER(i4b), DIMENSION(:),POINTER :: n_event => null() ! number of secondary forest transitions
+     INTEGER(i4), POINTER :: it
+     INTEGER(i4), POINTER :: np
+     INTEGER(i4), POINTER :: firstyear
+     INTEGER(i4), POINTER :: thisyear
+     INTEGER(i4), DIMENSION(:),POINTER :: n_event => null() ! number of secondary forest transitions
      REAL(dp), DIMENSION(:),POINTER :: latitude => null(), longitude => null()
      REAL(dp), DIMENSION(:),POINTER :: primf => null(), secdf => null(), grass => null(), &  ! land cover types
           ptos => null(), ptog => null(), stog => null(), gtop => null(), gtos => null(),    & ! transitions
@@ -117,7 +117,7 @@ MODULE POPLUC_Module
   !-------------------------------------------------------------------------------
   ! * This module contains all subroutines for POPLUC calcs at a single time step.
   !-------------------------------------------------------------------------------
-  USE TYPEdef,              ONLY: dp, sp, i4b
+  USE TYPEdef,              ONLY: dp, sp, i4
   USE POPLUC_Types
   USE POPLUC_Constants
   USE casavariable,         ONLY: casa_pool, casa_balance, casa_flux, casa_biome
@@ -140,9 +140,9 @@ CONTAINS
 
     type(popluc_type), intent(inout) :: popluc
 
-    popluc%firstyear               = 0_i4b
-    popluc%thisyear                = 0_i4b
-    popluc%n_event                 = 0_i4b
+    popluc%firstyear               = 0_i4
+    popluc%thisyear                = 0_i4
+    popluc%n_event                 = 0_i4
     popluc%latitude                = 0.0_dp
     popluc%longitude               = 0.0_dp
     popluc%primf                   = 0.0_dp
@@ -313,12 +313,12 @@ CONTAINS
 
     CHARACTER(5),      INTENT(IN)    :: from_state, to_state
     REAL(dp),          INTENT(INOUT) :: frac_change_grid
-    INTEGER(i4b),      INTENT(IN)    :: g  ! grid cell index
+    INTEGER(i4),      INTENT(IN)    :: g  ! grid cell index
     TYPE(POPLUC_TYPE), INTENT(INOUT) :: POPLUC
 
     REAL(dp) :: frac_open_grid, remaining
-    INTEGER(i4b) :: n  ! position of new element in POPLUC%SecFor array
-    INTEGER(i4b) :: i
+    INTEGER(i4) :: n  ! position of new element in POPLUC%SecFor array
+    INTEGER(i4) :: i
     REAL(dp) :: tmp, tmp1, tmp2
 #ifdef __MPI__
     integer :: ierr
@@ -506,9 +506,9 @@ CONTAINS
     implicit none
 
     type(popluc_type), intent(inout) :: POPLUC
-    integer(i4b),      intent(in)    :: g
+    integer(i4),      intent(in)    :: g
 
-    integer(i4b) :: age, i, iage
+    integer(i4) :: age, i, iage
     real(dp)     :: fac, disturbance_freq
 
     ! First get relative weights for primary forest
@@ -538,9 +538,9 @@ CONTAINS
     IMPLICIT NONE
 
     TYPE(POPLUC_TYPE), INTENT(INOUT) :: POPLUC
-    INTEGER(i4b),      INTENT(IN)    :: g
+    INTEGER(i4),      INTENT(IN)    :: g
 
-    INTEGER(i4b) :: n_event, i
+    INTEGER(i4) :: n_event, i
     REAL(dp):: remaining
     REAL(dp):: tmp, tmp1, tmp2
 
@@ -654,9 +654,9 @@ CONTAINS
     IMPLICIT NONE
 
     TYPE(POPLUC_TYPE), INTENT(INOUT) :: POPLUC
-    INTEGER(i4b),      INTENT(IN)    :: year
+    INTEGER(i4),      INTENT(IN)    :: year
 
-    INTEGER(i4b) :: g
+    INTEGER(i4) :: g
 
     POPLUC%it = POPLUC%it + 1
 
@@ -1575,8 +1575,8 @@ CONTAINS
     TYPE(veg_parameter_type), INTENT(IN)    :: veg  ! vegetation parameters
     TYPE(POP_TYPE),           INTENT(INOUT) :: POP
 
-    INTEGER(i4b), INTENT(IN) :: np
-    INTEGER(i4b) :: j, k, l
+    INTEGER(i4), INTENT(IN) :: np
+    INTEGER(i4) :: j, k, l
 
     CALL alloc_POPLUC(POPLUC,np)
 
@@ -1662,7 +1662,7 @@ CONTAINS
 
     TYPE(POPLUC_TYPE), INTENT(IN) :: POPLUC
     TYPE (LUC_EXPT_TYPE), INTENT(IN) :: LUC_EXPT
-    INTEGER(i4b) :: j, k, l
+    INTEGER(i4) :: j, k, l
 
     DO k=1, POPLUC%np
        j = landpt(k)%cstart
@@ -1685,7 +1685,7 @@ CONTAINS
     TYPE(POPLUC_TYPE),    INTENT(INOUT) :: POPLUC
     TYPE (LUC_EXPT_TYPE), INTENT(IN)    :: LUC_EXPT
 
-    INTEGER(i4b) :: g, np
+    INTEGER(i4) :: g, np
 
     np = POPLUC%np
     DO g=1, np

--- a/core/biogeochem/cable_adjustJVgm.F90
+++ b/core/biogeochem/cable_adjustJVgm.F90
@@ -11,7 +11,6 @@
 !
 MODULE cable_adjust_JV_gm_module
 
-  use cable_def_types_mod, only: dp => r_2
   use cable_def_types_mod, only: mp, veg_parameter_type
   use cable_data_module,   only: icanopy_type, point2constants
   use cable_abort_module,  only: nc_abort
@@ -23,16 +22,16 @@ MODULE cable_adjust_JV_gm_module
 
   integer, parameter :: nrci=3000
   integer, parameter :: nrcic4=1200
-  real(dp) :: gmmax25, Vcmax25Ci, Jmax25Ci, Vcmax25Cc, Jmax25Cc, k25Ci, k25Cc
-  real(dp) :: Rd
-  real(dp) :: Kc_ci, Ko_ci, gammastar_ci, Km_ci
-  real(dp) :: Kc_cc, Ko_cc, gammastar_cc, Km_cc
+  real(r2) :: gmmax25, Vcmax25Ci, Jmax25Ci, Vcmax25Cc, Jmax25Cc, k25Ci, k25Cc
+  real(r2) :: Rd
+  real(r2) :: Kc_ci, Ko_ci, gammastar_ci, Km_ci
+  real(r2) :: Kc_cc, Ko_cc, gammastar_cc, Km_cc
 
   ! gm LUT
-  real(dp), dimension(:,:,:,:), allocatable :: LUT_VcmaxJmax ! Lookup table with Cc-based Vcmax and Jmax
-  real(dp), dimension(:),       allocatable :: LUT_gm        ! gm values in gm LUT
-  real(dp), dimension(:),       allocatable :: LUT_Vcmax     ! Vcmax_ci values in gm LUT
-  real(dp), dimension(:),       allocatable :: LUT_Rd        ! Rd values in gm LUT
+  real(r2), dimension(:,:,:,:), allocatable :: LUT_VcmaxJmax ! Lookup table with Cc-based Vcmax and Jmax
+  real(r2), dimension(:),       allocatable :: LUT_gm        ! gm values in gm LUT
+  real(r2), dimension(:),       allocatable :: LUT_Vcmax     ! Vcmax_ci values in gm LUT
+  real(r2), dimension(:),       allocatable :: LUT_Rd        ! Rd values in gm LUT
 
 CONTAINS
 
@@ -49,37 +48,37 @@ CONTAINS
     integer  :: kmax = 20  ! maximum nr of iterations (inner loop)
     integer  :: zmax = 8   ! maximum nr of iterations (outer loop)
     integer  :: lAn
-    real(dp) :: vstart, v
-    real(dp) :: Vcmax25Cct1  ! Vcmax25Cc of previous iteration
-    real(dp) :: Vcmax_diff
-    real(dp) :: maxdiff = 0.002e-6_dp
-    real(dp), dimension(nrci)  :: An1, Ci1
-    real(dp), dimension(:), allocatable :: An, Ci, Cc, An_Cc
+    real(r2) :: vstart, v
+    real(r2) :: Vcmax25Cct1  ! Vcmax25Cc of previous iteration
+    real(r2) :: Vcmax_diff
+    real(r2) :: maxdiff = 0.002e-6_r2
+    real(r2), dimension(nrci)  :: An1, Ci1
+    real(r2), dimension(:), allocatable :: An, Ci, Cc, An_Cc
 
     ! MINPACK params
     integer, parameter      :: N = 2 ! Number of variables
-    real(dp), dimension(N)  :: X
-    real(dp), allocatable   :: fvec(:)
+    real(r2), dimension(N)  :: X
+    real(r2), allocatable   :: fvec(:)
     integer                 :: info
-    real(dp)                :: tol = 0.00001_dp
+    real(r2)                :: tol = 0.00001_r2
 
     ! assign local ptrs to constants defined in cable_data_module
     call point2constants(C)
 
-    Ci1          = (/(real(i,dp), i=1, nrci, 1)/) / 2.0_dp * 1.0e-6_dp ! 1-1500 umol mol-1
-    Rd           = real(veg%cfrd(p) * veg%vcmax(p) * light_inhibition(1200.0), dp)
-    gmmax25      = real(veg%gm(p), dp)
-    Vcmax25Ci    = real(veg%vcmax(p), dp)
-    Jmax25Ci     = real(veg%ejmax(p), dp)
-    Kc_ci        = real(C%conkc0, dp)
-    Ko_ci        = real(C%conko0, dp)
-    gammastar_ci = real(C%gam0, dp)
-    Kc_cc        = real(C%conkc0cc, dp)
-    Ko_cc        = real(C%conko0cc, dp)
-    gammastar_cc = real(C%gam0cc, dp)
+    Ci1          = (/(real(i,r2), i=1, nrci, 1)/) / 2.0_r2 * 1.0e-6_r2 ! 1-1500 umol mol-1
+    Rd           = real(veg%cfrd(p) * veg%vcmax(p) * light_inhibition(1200.0), r2)
+    gmmax25      = real(veg%gm(p), r2)
+    Vcmax25Ci    = real(veg%vcmax(p), r2)
+    Jmax25Ci     = real(veg%ejmax(p), r2)
+    Kc_ci        = real(C%conkc0, r2)
+    Ko_ci        = real(C%conko0, r2)
+    gammastar_ci = real(C%gam0, r2)
+    Kc_cc        = real(C%conkc0cc, r2)
+    Ko_cc        = real(C%conko0cc, r2)
+    gammastar_cc = real(C%gam0cc, r2)
 
-    Km_ci = Kc_ci * (1.0_dp + 0.21_dp / Ko_ci)
-    Km_cc = Kc_cc * (1.0_dp + 0.21_dp / Ko_cc)
+    Km_ci = Kc_ci * (1.0_r2 + 0.21_r2 / Ko_ci)
+    Km_cc = Kc_cc * (1.0_r2 + 0.21_r2 / Ko_cc)
 
     if (veg%frac4(p) .lt. 0.001) then ! not C4
 
@@ -87,7 +86,7 @@ CONTAINS
       call photosyn25(Ci1, nrci, Vcmax25Ci, Jmax25Ci, Rd, Km_ci, gammastar_ci, An1)
 
       !! 2) Exclude negative parts of the An-Ci curve
-      lAn = count(An1 > 0.0_dp)
+      lAn = count(An1 > 0.0_r2)
 
       allocate(An(lAn))
       allocate(An_Cc(lAn))
@@ -95,8 +94,8 @@ CONTAINS
       allocate(Cc(lAn))
       allocate(fvec(lAn))
 
-      An = pack(An1, An1 > 0.0_dp)
-      Ci = pack(Ci1, An1 > 0.0_dp)
+      An = pack(An1, An1 > 0.0_r2)
+      Ci = pack(Ci1, An1 > 0.0_r2)
 
       Cc_based_OK = .false.
       z = 0
@@ -107,9 +106,9 @@ CONTAINS
          k = 0
          X(:) = [Vcmax25Ci,Jmax25Ci]
          sw = .false.
-         vstart = 1.0_dp
+         vstart = 1.0_r2
          Vcmax25Cct1 = Vcmax25Ci
-         Vcmax_diff = 1.0e-6_dp
+         Vcmax_diff = 1.0e-6_r2
          An_Cc = An
 
          do while (Vcmax_diff > maxdiff .AND. k < kmax)
@@ -126,21 +125,21 @@ CONTAINS
             call photosyn25(Cc, lAn, Vcmax25Cc, Jmax25Cc, Rd, Km_cc, gammastar_cc, An_Cc)
 
             ! safety switch ensuring stability
-            if (minval(An_Cc) < 0.0_dp .and. (.not. sw)) then
+            if (minval(An_Cc) < 0.0_r2 .and. (.not. sw)) then
                sw = .true.
                v  = vstart
             endif
 
             if (sw) then
-               v = max(v - (vstart/(0.8_dp*kmax)),0.0_dp)
-               An_Cc = v * An + (1.0_dp-v) * An_Cc
+               v = max(v - (vstart/(0.8_r2*kmax)),0.0_r2)
+               An_Cc = v * An + (1.0_r2-v) * An_Cc
             endif
          end do
 
          !! Avoid unrealistic Vcmax and Jmax values
-         if ((Vcmax25Cc < 0.9_dp*Vcmax25Ci) .or. (Vcmax25Cc > 2.5_dp*Vcmax25Ci) &
-             .or. (Jmax25Cc < 0.9_dp*Jmax25Ci) .or. (jmax25cc > 1.5_dp*jmax25ci)) then
-            gmmax25 = 1.2_dp * gmmax25 ! If no solution, try again with higher gmmax25
+         if ((Vcmax25Cc < 0.9_r2*Vcmax25Ci) .or. (Vcmax25Cc > 2.5_r2*Vcmax25Ci) &
+             .or. (Jmax25Cc < 0.9_r2*Jmax25Ci) .or. (jmax25cc > 1.5_r2*jmax25ci)) then
+            gmmax25 = 1.2_r2 * gmmax25 ! If no solution, try again with higher gmmax25
          else
             Cc_based_OK = .true.
             veg%vcmaxcc(p) = real(Vcmax25Cc)
@@ -169,19 +168,19 @@ CONTAINS
   subroutine photosyn25_f(M, N, X, fvec, iflag, Anx, Cix, Rd, Km, gammastar)
 
     integer,                intent(in)    :: M, N, iflag
-    real(dp), dimension(N), intent(inout) :: X
-    real(dp), dimension(M), intent(out)   :: fvec
-    real(dp), dimension(M), intent(in)    :: Anx, Cix
-    real(dp),               intent(in)    :: Rd, Km, gammastar
+    real(r2), dimension(N), intent(inout) :: X
+    real(r2), dimension(M), intent(out)   :: fvec
+    real(r2), dimension(M), intent(in)    :: Anx, Cix
+    real(r2),               intent(in)    :: Rd, Km, gammastar
     ! local
-    real(dp), dimension(M) :: Ac, Aj
+    real(r2), dimension(M) :: Ac, Aj
 
     Ac = (X(1) * (Cix - gammastar) / (Cix + Km))
     Aj = (X(2) * (Cix - gammastar) / 4.0 / (Cix + 2.0 * gammastar))
 
     ! avoid discontinuity (e.g. Duursma 2015, PLOS ONE)
-    fvec = Anx  - ( (Ac + Aj - SQRT((Ac + Aj)**2 - 4.0*0.99999999_dp*Ac*Aj)) / &
-                    (2.0*0.99999999_dp) - Rd )
+    fvec = Anx  - ( (Ac + Aj - SQRT((Ac + Aj)**2 - 4.0*0.99999999_r2*Ac*Aj)) / &
+                    (2.0*0.99999999_r2) - Rd )
 
   END SUBROUTINE photosyn25_f
 
@@ -190,11 +189,11 @@ CONTAINS
   subroutine photosyn25(Ciz, nrci, Vcmax25, Jmax25, Rd, Km, gammastar, Anz)
 
     integer,                   intent(in)  :: nrci
-    real(dp), dimension(nrci), intent(in)  :: Ciz
-    real(dp),                  intent(in)  :: Vcmax25, Jmax25, Rd, Km, gammastar
-    real(dp), dimension(nrci), intent(out) :: Anz
+    real(r2), dimension(nrci), intent(in)  :: Ciz
+    real(r2),                  intent(in)  :: Vcmax25, Jmax25, Rd, Km, gammastar
+    real(r2), dimension(nrci), intent(out) :: Anz
     ! local
-    real(dp), dimension(nrci)  :: Wc, We
+    real(r2), dimension(nrci)  :: Wc, We
 
     ! Rubisco-limited
     Wc =  Vcmax25 * (Ciz - gammastar) / (Ciz + Km)
@@ -219,10 +218,10 @@ CONTAINS
     implicit none
 
     character(len=*),                          intent(in)  :: gm_LUT_file
-    real(dp), dimension(:,:,:,:), allocatable, intent(out) :: LUT_VcmaxJmax
-    real(dp), dimension(:),       allocatable, intent(out) :: LUT_gm
-    real(dp), dimension(:),       allocatable, intent(out) :: LUT_vcmax
-    real(dp), dimension(:),       allocatable, intent(out) :: LUT_Rd
+    real(r2), dimension(:,:,:,:), allocatable, intent(out) :: LUT_VcmaxJmax
+    real(r2), dimension(:),       allocatable, intent(out) :: LUT_gm
+    real(r2), dimension(:),       allocatable, intent(out) :: LUT_vcmax
+    real(r2), dimension(:),       allocatable, intent(out) :: LUT_Rd
 
     ! local
     integer  :: ncid_gmlut                      ! netcdf ID
@@ -230,7 +229,7 @@ CONTAINS
     integer  :: gm_dimid, vcmax_dimid, Rd_dimid ! dimension IDs
     integer  :: gm_len, vcmax_len, Rd_len       ! dimensions of LUT
     integer  :: vcmax_id, jmax_id
-    real(dp), dimension(:,:,:), allocatable :: tmp ! for reading
+    real(r2), dimension(:,:,:), allocatable :: tmp ! for reading
 
     ok = nf90_open(trim(gm_LUT_file), nf90_nowrite, ncid_gmlut)
     if (ok /= NF90_NOERR) call nc_abort(ok, 'Error opening gm lookup table.')
@@ -297,10 +296,10 @@ CONTAINS
 
     type(veg_parameter_type),     intent(inout) :: veg           ! vegetation parameters
     integer,                      intent(in)    :: p             ! veg type (tile)
-    real(dp), dimension(:,:,:,:), intent(in)    :: LUT_VcmaxJmax ! Lookup table with Cc-based Vcmax and Jmax
-    real(dp), dimension(:),       intent(in)    :: LUT_gm        ! gm values in gm LUT
-    real(dp), dimension(:),       intent(in)    :: LUT_vcmax     ! Vcmax_ci values in gm LUT
-    real(dp), dimension(:),       intent(in)    :: LUT_Rd        ! Rd values in gm LUT
+    real(r2), dimension(:,:,:,:), intent(in)    :: LUT_VcmaxJmax ! Lookup table with Cc-based Vcmax and Jmax
+    real(r2), dimension(:),       intent(in)    :: LUT_gm        ! gm values in gm LUT
+    real(r2), dimension(:),       intent(in)    :: LUT_vcmax     ! Vcmax_ci values in gm LUT
+    real(r2), dimension(:),       intent(in)    :: LUT_Rd        ! Rd values in gm LUT
 
     ! local
     logical :: val_ok        ! check for NAs
@@ -359,17 +358,17 @@ CONTAINS
     integer  :: i,k
     integer  :: kmax = 1000
     integer  :: lAn
-    real(dp) :: diff, diffx
-    real(dp), dimension(nrcic4) :: An_Ci1, Ci1, Aj_Ci, Ae_Ci
-    real(dp), dimension(:), allocatable :: An_Ci, An_Cc, Ci, Cc
-    real(dp) :: kinc = 0.001_dp  ! increment of k
+    real(r2) :: diff, diffx
+    real(r2), dimension(nrcic4) :: An_Ci1, Ci1, Aj_Ci, Ae_Ci
+    real(r2), dimension(:), allocatable :: An_Ci, An_Cc, Ci, Cc
+    real(r2) :: kinc = 0.001_r2  ! increment of k
 
     if (veg%frac4(p) > 0.001) then ! C4
-       Ci1       = (/(real(i,dp), i=1, nrcic4, 1)/) / 4.0_dp * 1.0e-6_dp
-       Rd        = real(veg%cfrd(p) * veg%vcmax(p) * light_inhibition(1200.0), dp)
-       gmmax25   = real(veg%gm(p), dp)
-       Vcmax25Ci = real(veg%vcmax(p), dp)
-       k25Ci     = real(veg%c4kci(p), dp)
+       Ci1       = (/(real(i,r2), i=1, nrcic4, 1)/) / 4.0_r2 * 1.0e-6_r2
+       Rd        = real(veg%cfrd(p) * veg%vcmax(p) * light_inhibition(1200.0), r2)
+       gmmax25   = real(veg%gm(p), r2)
+       Vcmax25Ci = real(veg%vcmax(p), r2)
+       k25Ci     = real(veg%c4kci(p), r2)
 
        ! 1) calculate An-ci curves (no light limitation)
        Aj_Ci = Vcmax25Ci - Rd
@@ -378,23 +377,23 @@ CONTAINS
        An_Ci1 = min(Aj_Ci, Ae_Ci)
 
        ! 2) exclude negative An values and those not limited by Ci
-       lAn = count((An_Ci1 > 0.0_dp) .and. eq(An_Ci1, Ae_Ci))
+       lAn = count((An_Ci1 > 0.0_r2) .and. eq(An_Ci1, Ae_Ci))
 
        allocate(An_Ci(lAn))
        allocate(An_Cc(lAn))
        allocate(Ci(lAn))
        allocate(Cc(lAn))
 
-       An_Ci = pack(An_Ci1, (An_Ci1 > 0.0_dp) .and. eq(An_Ci1, Ae_Ci))
-       Ci    = pack(Ci1, (An_Ci1 > 0.0_dp) .and. eq(An_Ci1, Ae_Ci))
+       An_Ci = pack(An_Ci1, (An_Ci1 > 0.0_r2) .and. eq(An_Ci1, Ae_Ci))
+       Ci    = pack(Ci1, (An_Ci1 > 0.0_r2) .and. eq(An_Ci1, Ae_Ci))
 
        ! 3) calculate Cc
        Cc = Ci - An_Ci / gmmax25
 
        ! 4) fit k to Cc-based model (a poor man's optimisation...)
        k     = 0
-       diffx = 1.0e6_dp
-       diff  = 0.0_dp
+       diffx = 1.0e6_r2
+       diff  = 0.0_r2
        k25Cc = k25Ci
        do while ((diff < diffx) .and. (k < kmax))
           if (k > 0) then
@@ -406,7 +405,7 @@ CONTAINS
           k = k + 1
        end do
 
-       veg%c4kcc(p) = real(k25Cc - 2.0_dp*kinc) ! single precision
+       veg%c4kcc(p) = real(k25Cc - 2.0_r2*kinc) ! single precision
        ! subtract 2x the increment to get the right value
     else   ! C3 (not used)
       veg%c4kcc(p) = 0.0

--- a/core/biogeochem/cable_optimiseJVratio.F90
+++ b/core/biogeochem/cable_optimiseJVratio.F90
@@ -21,10 +21,8 @@
 MODULE cable_optimise_JV_module
 
   Use cable_def_types_mod, ONLY: met_type, climate_type, canopy_type, veg_parameter_type, &
-       mp, r_2
-
+       mp, r2
   USE cable_data_module,   ONLY: icanopy_type, point2constants
-  USE TypeDef,             ONLY: i4b, dp
   USE cable_common_module, ONLY: cable_user
 
   TYPE( icanopy_type ) :: C
@@ -242,17 +240,17 @@ CONTAINS
 
   subroutine fAn_c3(a, b, c, A2)
 
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
-    real(r_2), intent(in)  :: a, b, c
-    real(r_2), intent(OUT) :: A2
+    real(r2), intent(in)  :: a, b, c
+    real(r2), intent(OUT) :: A2
 
-    real(r_2) :: s2
+    real(r2) :: s2
 
-    s2 = b**2 - 4.0_r_2 * a * c
-    A2 = (-b - sqrt(s2))/(2.0_r_2 * a)
+    s2 = b**2 - 4.0_r2 * a * c
+    A2 = (-b - sqrt(s2))/(2.0_r2 * a)
 
   end subroutine fAn_c3
 
@@ -260,16 +258,16 @@ CONTAINS
 
   subroutine fabc(Cs, g0, x, gamm, beta, Gammastar, Rd, a, b, c)
 
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
     real,      intent(in)  :: Cs, g0, x, gamm, beta, Gammastar, Rd
-    real(r_2), intent(out) :: a, b, c
+    real(r2), intent(out) :: a, b, c
 
-    a = real((1.0-x)*Cs - x*beta, r_2)
-    b = real(-g0*Cs**2 + ((1.0-x)*(Rd-gamm)-g0*beta)*Cs - x*(gamm*Gammastar+Rd*beta), r_2)
-    c = real(-g0*(Rd-gamm)*Cs**2 - g0*(gamm*Gammastar+Rd*beta)*Cs, r_2)
+    a = real((1.0-x)*Cs - x*beta, r2)
+    b = real(-g0*Cs**2 + ((1.0-x)*(Rd-gamm)-g0*beta)*Cs - x*(gamm*Gammastar+Rd*beta), r2)
+    c = real(-g0*(Rd-gamm)*Cs**2 - g0*(gamm*Gammastar+Rd*beta)*Cs, r2)
 
   end subroutine fabc
 
@@ -277,18 +275,18 @@ CONTAINS
 
   subroutine fabcd(Cs, g0, x, gamm, beta, Gammastar, Rd, gm, a, b, c1, d)
 
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
     real,      intent(in)  :: Cs, g0, x, gamm, beta, Gammastar, Rd, gm
-    real(r_2), intent(out) :: a, b, c1, d
+    real(r2), intent(out) :: a, b, c1, d
 
-    a  = real(x, r_2)
-    b  = real((gm+g0-gm*x)*Cs + x*(Rd-gamm) - gm*x*beta, r_2)
+    a  = real(x, r2)
+    b  = real((gm+g0-gm*x)*Cs + x*(Rd-gamm) - gm*x*beta, r2)
     c1 = real(-gm*g0*Cs**2 + ((gm+g0-gm*x)*(Rd-gamm)-gm*g0*beta)*Cs - &
-         gm*x*(gamm*Gammastar+Rd*beta), r_2)
-    d  = real(-gm*g0*(Rd-gamm)*Cs**2 - gm*g0*(gamm*Gammastar+Rd*beta)*Cs, r_2)
+         gm*x*(gamm*Gammastar+Rd*beta), r2)
+    d  = real(-gm*g0*(Rd-gamm)*Cs**2 - gm*g0*(gamm*Gammastar+Rd*beta)*Cs, r2)
 
   end subroutine fabcd
 
@@ -296,15 +294,15 @@ CONTAINS
 
   subroutine fpq(a, b, c, d, p, q)
 
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
-    real(r_2), intent(in)  :: a, b, c, d
-    real(r_2), intent(out) :: p, q
+    real(r2), intent(in)  :: a, b, c, d
+    real(r2), intent(out) :: p, q
 
-    p = (3.0_r_2*a*c - b**2)/(3.0_r_2*a**2)
-    q = (2.0_r_2*b**3 - 9.0_r_2*a*b*c + 27.0_r_2*a**2*d)/(27.0_r_2*a**3)
+    p = (3.0_r2*a*c - b**2)/(3.0_r2*a**2)
+    q = (2.0_r2*b**3 - 9.0_r2*a*b*c + 27.0_r2*a**2*d)/(27.0_r2*a**3)
 
   end subroutine fpq
 
@@ -312,21 +310,21 @@ CONTAINS
 
   subroutine fAm_c3(a, b, c1, d, p, q, Am)
 
-    use cable_def_types_mod, only: r_2
-    use mo_constants, only: pi => pi_dp
+    use cable_def_types_mod, only: r2
+    use mo_constants, only: pi => pi_r2
 
     implicit none
 
-    real(r_2), intent(in)  :: a, b, c1, d, p, q
-    real(r_2), intent(out) :: Am
+    real(r2), intent(in)  :: a, b, c1, d, p, q
+    real(r2), intent(out) :: Am
 
-    real(r_2) :: p3, pq, k
+    real(r2) :: p3, pq, k
 
-    p3 = -p/3.0_r_2
-    pq = max(min(3.0_r_2*q/(2.0_r_2*p)*sqrt(1.0_r_2/p3), &
-         0.999999999999_r_2), -0.999999999999_r_2)
-    k  = 1.0_r_2
-    Am = 2.0_r_2*sqrt(p3)*cos(acos(pq)/3.0_r_2 - 2.0_r_2*pi*k/3.0_r_2) - b/(3.0_r_2*a)
+    p3 = -p/3.0_r2
+    pq = max(min(3.0_r2*q/(2.0_r2*p)*sqrt(1.0_r2/p3), &
+         0.999999999999_r2), -0.999999999999_r2)
+    k  = 1.0_r2
+    Am = 2.0_r2*sqrt(p3)*cos(acos(pq)/3.0_r2 - 2.0_r2*pi*k/3.0_r2) - b/(3.0_r2*a)
 
   end subroutine fAm_c3
 
@@ -336,7 +334,7 @@ CONTAINS
 
     use cable_canopy_module, only: xvcmxt3, xejmxt3, ej3x, xrdt, &
          xgmesT, xvcmxt3_acclim, xejmxt3_acclim
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
@@ -345,9 +343,9 @@ CONTAINS
     INTEGER   :: k, j
     REAL      :: kct, kot ! , tdiff
     REAL      :: x, gamm, beta, gammastar, Rd, gm, jmaxt, trf, vcmax0
-    REAL(r_2) :: a, b, c1, d
-    REAL(r_2) :: p, q  ! if cable_user%explicit_gm
-    REAL(r_2) :: Anc, Ane
+    REAL(r2) :: a, b, c1, d
+    REAL(r2) :: p, q  ! if cable_user%explicit_gm
+    REAL(r2) :: Anc, Ane
     REAL      :: An(nt), Ac(nt), Aj(nt)
 
     CALL point2constants(C)
@@ -476,7 +474,7 @@ CONTAINS
 
     use cable_canopy_module, only: xvcmxt3, xejmxt3, ej3x, xrdt, &
          xgmesT, xvcmxt3_acclim, xejmxt3_acclim
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
@@ -486,8 +484,8 @@ CONTAINS
     INTEGER   :: k, j
     REAL      :: kct, kot, tdiff
     REAL      :: x, gamm,  beta, gammastar, Rd, jmaxt, gm, trf, vcmax0
-    REAL(r_2) :: a, b, c1, d, p, q
-    REAL(r_2) :: Anc, Ane
+    REAL(r2) :: a, b, c1, d, p, q
+    REAL(r2) :: Anc, Ane
     REAL      :: An(nt)
 
     CALL point2constants(C)
@@ -606,7 +604,7 @@ CONTAINS
 
     use cable_canopy_module, only: xvcmxt3, xejmxt3, ej3x, xrdt, &
          xgmesT, xvcmxt3_acclim, xejmxt3_acclim
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
@@ -616,8 +614,8 @@ CONTAINS
     INTEGER   :: k, j  ! k is timestep!
     REAL      :: kct, kot, tdiff
     REAL      :: x, gamm,  beta, gammastar, Rd, jmaxt, gm, trf, vcmax0 ! c1 because C already taken
-    REAL(r_2) :: a, b, c1, d, p, q  ! if cable_user%explicit_gm
-    REAL(r_2) :: Anc, Ane
+    REAL(r2) :: a, b, c1, d, p, q  ! if cable_user%explicit_gm
+    REAL(r2) :: Anc, Ane
     REAL      :: An(nt), Ac(nt), Aj(nt)
     REAL      :: total_An, total_Ac, total_Aj
 
@@ -821,7 +819,7 @@ CONTAINS
 
     use cable_canopy_module, only: xvcmxt3,xejmxt3, ej3x, xrdt, &
          xgmesT, xvcmxt3_acclim, xejmxt3_acclim
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
@@ -832,8 +830,8 @@ CONTAINS
     INTEGER :: k, j
     REAL :: kct, kot, tdiff
     REAL :: x, gamm,  beta, gammastar, Rd, jmaxt, gm, trf, vcmax0
-    REAL(r_2) :: a, b, c1, d, p, q  ! if cable_user%explicit_gm
-    REAL(r_2) :: Anc, Ane
+    REAL(r2) :: a, b, c1, d, p, q  ! if cable_user%explicit_gm
+    REAL(r2) :: Anc, Ane
     REAL :: An(nt), Ac(nt), Aj(nt)
 
     CALL point2constants(C)

--- a/core/biogeochem/cable_phenology.F90
+++ b/core/biogeochem/cable_phenology.F90
@@ -19,8 +19,7 @@
 MODULE cable_phenology_module
 
   Use cable_def_types_mod,  ONLY: met_type, climate_type, canopy_type, &
-       veg_parameter_type, mp, r_2
-  USE TypeDef,              ONLY: i4b, dp
+       veg_parameter_type, mp, r2
   USE cable_IO_vars_module, ONLY: patch
   USE CABLE_COMMON_MODULE,  ONLY: CurYear, filename, cable_user, HANDLE_ERR
 
@@ -51,7 +50,7 @@ CONTAINS
     TYPE (climate_type), INTENT(IN)       :: climate  ! climate variables
     INTEGER :: np, days
     REAL:: gdd0
-    REAL(r_2) :: phen_tmp
+    REAL(r2) :: phen_tmp
     REAL, PARAMETER :: k_chilla = 0, k_chillb = 100, k_chillk = 0.05
     REAL, PARAMETER :: APHEN_MAX = 200.0, ndays_raingreenup = 60
     INTEGER, PARAMETER:: COLDEST_DAY_NHEMISPHERE = 355
@@ -59,7 +58,7 @@ CONTAINS
     REAL :: phengdd5ramp
 
     DO np= 1,mp
-       phen_tmp = 1.0_r_2
+       phen_tmp = 1.0_r2
        ! evergreen pfts
        if (veg%iveg(np) == 1 .or. veg%iveg(np) == 2 .or. veg%iveg(np) == 5) then
           phen%doyphase(np,1) = -50
@@ -79,11 +78,11 @@ CONTAINS
 
           if (climate%gdd5(np).gt.gdd0 .and. phen%aphen(np).lt. APHEN_MAX) then
 
-             phen_tmp = min(1.0_r_2, real((climate%gdd5(np)-gdd0)/phengdd5ramp,dp))
+             phen_tmp = min(1.0_r2, real((climate%gdd5(np)-gdd0)/phengdd5ramp,r2))
 
           else
 
-             phen_tmp = 0.0_r_2
+             phen_tmp = 0.0_r2
 
           endif
 
@@ -94,9 +93,9 @@ CONTAINS
 
           if (climate%gdd5(np).gt.0.1) THEN
              phengdd5ramp = 200
-             phen_tmp = min(1.0_r_2, real(climate%gdd5(np)/phengdd5ramp,r_2))
+             phen_tmp = min(1.0_r2, real(climate%gdd5(np)/phengdd5ramp,r2))
           ELSE
-             phen_tmp = 0.0_r_2
+             phen_tmp = 0.0_r2
           ENDIF
           !if (np==3) write(61,*) 'chk1',np, climate%doy,climate%gdd5(np), phen_tmp
        endif
@@ -106,11 +105,11 @@ CONTAINS
           if (veg%iveg(np).ge.6.and.veg%iveg(np).le.10) then ! (grass or crops) need to include raingreen savanna trees here too
              ! if (climate%dmoist(np).lt. mmoisture_min) phen_tmp = 0.0
              if (climate%GMD(np) .GE. 1 .and. climate%GMD(np) .LT. ndays_raingreenup) THEN
-                phen_tmp = min(phen_tmp, 0.99_r_2)
+                phen_tmp = min(phen_tmp, 0.99_r2)
              elseif (climate%GMD(np) .EQ. 0) THEN
-                phen_tmp = 0.0_r_2
+                phen_tmp = 0.0_r2
              elseif (climate%GMD(np) .GE. ndays_raingreenup) THEN
-                phen_tmp = min(phen_tmp, 1.0_r_2)
+                phen_tmp = min(phen_tmp, 1.0_r2)
              endif
              !if (np==3) write(61,*) 'chk2',np, climate%doy,climate%GMD(np), phen_tmp
           endif
@@ -123,21 +122,21 @@ CONTAINS
           !    if (phen_tmp.gt.0.0 .and.( phen%phase(np).eq.3 .or. phen%phase(np).eq.0 )) then
           !       phen%phase(np) = 1 ! greenup
           !       phen%doyphase(np,1) = climate%doy
-          !    elseif (phen_tmp.ge.1.0_r_2 .and. phen%phase(np).eq.1) then
+          !    elseif (phen_tmp.ge.1.0_r2 .and. phen%phase(np).eq.1) then
           !       phen%phase(np) = 2 ! steady LAI
           !       phen%doyphase(np,2) = climate%doy
-          !    elseif (phen_tmp.lt.1.0_r_2 .and. phen%phase(np).eq.2) then
+          !    elseif (phen_tmp.lt.1.0_r2 .and. phen%phase(np).eq.2) then
           !       phen%phase(np) = 3 ! senescence
           !       phen%doyphase(np,3) = climate%doy
           !    endif
 
-          if ((phen_tmp.gt.0.0_r_2) .and. (phen_tmp.lt.1.0_r_2)) then
+          if ((phen_tmp.gt.0.0_r2) .and. (phen_tmp.lt.1.0_r2)) then
              phen%phase(np) = 1 ! greenup
              phen%doyphase(np,1) = climate%doy
-          elseif (ge(phen_tmp, 1.0_r_2)) then
+          elseif (ge(phen_tmp, 1.0_r2)) then
              phen%phase(np) = 2 ! steady LAI
              phen%doyphase(np,2) = climate%doy
-          elseif (eq(phen_tmp, 0.0_r_2)) then
+          elseif (eq(phen_tmp, 0.0_r2)) then
              phen%phase(np) = 3 ! senescence
              phen%doyphase(np,3) = climate%doy
           endif

--- a/core/biogeochem/casa_cable.F90
+++ b/core/biogeochem/casa_cable.F90
@@ -39,7 +39,6 @@ contains
     USE casavariable
     USE phenvariable
     USE cable_common_module,    ONLY: CABLE_USER
-    USE TypeDef,                ONLY: dp
     USE POP_TYPES,              ONLY: POP_TYPE
     USE cable_phenology_module, ONLY: cable_phenology_clim
     use casa_inout,             only: biogeochem
@@ -75,13 +74,13 @@ contains
     type(c13o2_pool),           intent(inout) :: c13o2pools
 
     ! local variables added ypwang 5/nov/2012
-    real(r_2), dimension(mp)  :: cleaf2met, cleaf2str, croot2met, croot2str, cwood2cwd
-    real(r_2), dimension(mp)  :: nleaf2met, nleaf2str, nroot2met, nroot2str, nwood2cwd
-    real(r_2), dimension(mp)  :: pleaf2met, pleaf2str, proot2met, proot2str, pwood2cwd
-    real(r_2), dimension(mp)  :: xnplimit,  xkNlimiting, xklitter, xksoil ,xkleaf,xkleafcold,xkleafdry
+    real(r2), dimension(mp)  :: cleaf2met, cleaf2str, croot2met, croot2str, cwood2cwd
+    real(r2), dimension(mp)  :: nleaf2met, nleaf2str, nroot2met, nroot2str, nwood2cwd
+    real(r2), dimension(mp)  :: pleaf2met, pleaf2str, proot2met, proot2str, pwood2cwd
+    real(r2), dimension(mp)  :: xnplimit,  xkNlimiting, xklitter, xksoil ,xkleaf,xkleafcold,xkleafdry
 
     ! 13C
-    real(dp), dimension(:,:), allocatable :: casasave
+    real(r2), dimension(:,:), allocatable :: casasave
 
     ! 13C
     if (cable_user%c13o2) allocate(casasave(c13o2pools%ntile,c13o2pools%npools))
@@ -91,46 +90,46 @@ contains
        IF ( (TRIM(cable_user%MetType) == 'cru') .OR. &
             (TRIM(cable_user%MetType) == 'plume') .OR. &
             (TRIM(cable_user%MetType) == 'site') ) THEN
-          casaflux%Pdep    = real(met%Pdep, r_2)
-          casaflux%Nmindep = real(met%Ndep, r_2)
+          casaflux%Pdep    = real(met%Pdep, r2)
+          casaflux%Nmindep = real(met%Ndep, r2)
        ENDIF
 
        IF (ktau == kstart) THEN
-          casamet%tairk = 0.0_r_2
-          casamet%tsoil = 0.0_r_2
-          casamet%moist = 0.0_r_2
+          casamet%tairk = 0.0_r2
+          casamet%tsoil = 0.0_r2
+          casamet%moist = 0.0_r2
        ENDIF
 
        IF (MOD(ktau, ktauday) == 1) THEN
-          casamet%tairk = real(met%tk, r_2)
-          casamet%tsoil = real(ssnow%tgg, r_2)
+          casamet%tairk = real(met%tk, r2)
+          casamet%tsoil = real(ssnow%tgg, r2)
           ! casamet%moist = max(ssnow%wb - ssnow%wbice, 0.0)
-          casamet%moist = max(ssnow%wb, 0.0_r_2)
-          casaflux%cgpp = real((-canopy%fpn+canopy%frday)*dels, r_2)
-          casaflux%crmplant(:, leaf) = real(canopy%frday*dels, r_2)
+          casamet%moist = max(ssnow%wb, 0.0_r2)
+          casaflux%cgpp = real((-canopy%fpn+canopy%frday)*dels, r2)
+          casaflux%crmplant(:, leaf) = real(canopy%frday*dels, r2)
           ! 13C
           if (cable_user%c13o2) then
-             c13o2flux%cAn12 = sum(canopy%An,2)    * real(dels, r_2)
-             c13o2flux%cAn   = sum(c13o2flux%An,2) * real(dels, r_2)
+             c13o2flux%cAn12 = sum(canopy%An,2)    * real(dels, r2)
+             c13o2flux%cAn   = sum(c13o2flux%An,2) * real(dels, r2)
           endif
        ELSE
-          casamet%tairk = casamet%tairk + real(met%tk, r_2)
-          casamet%tsoil = casamet%tsoil + real(ssnow%tgg, r_2)
-          !casamet%moist = casamet%moist + max(ssnow%wb -  ssnow%wbice, 0.0_r_2)
-          casamet%moist = casamet%moist + max(ssnow%wb, 0.0_r_2)
-          casaflux%cgpp = casaflux%cgpp + real((-canopy%fpn+canopy%frday)*dels, r_2)
-          casaflux%crmplant(:, leaf) = casaflux%crmplant(:, leaf) + real(canopy%frday*dels, r_2)
+          casamet%tairk = casamet%tairk + real(met%tk, r2)
+          casamet%tsoil = casamet%tsoil + real(ssnow%tgg, r2)
+          !casamet%moist = casamet%moist + max(ssnow%wb -  ssnow%wbice, 0.0_r2)
+          casamet%moist = casamet%moist + max(ssnow%wb, 0.0_r2)
+          casaflux%cgpp = casaflux%cgpp + real((-canopy%fpn+canopy%frday)*dels, r2)
+          casaflux%crmplant(:, leaf) = casaflux%crmplant(:, leaf) + real(canopy%frday*dels, r2)
           ! 13C
           if (cable_user%c13o2) then
-             c13o2flux%cAn12 = c13o2flux%cAn12 + sum(canopy%An,2)    * real(dels, r_2)
-             c13o2flux%cAn   = c13o2flux%cAn   + sum(c13o2flux%An,2) * real(dels, r_2)
+             c13o2flux%cAn12 = c13o2flux%cAn12 + sum(canopy%An,2)    * real(dels, r2)
+             c13o2flux%cAn   = c13o2flux%cAn   + sum(c13o2flux%An,2) * real(dels, r2)
           endif
        ENDIF
 
        IF (MOD((ktau-kstart+1), ktauday) == 0) THEN  ! end of day
-          casamet%tairk = casamet%tairk / real(ktauday, r_2)
-          casamet%tsoil = casamet%tsoil / real(ktauday, r_2)
-          casamet%moist = casamet%moist / real(ktauday, r_2)
+          casamet%tairk = casamet%tairk / real(ktauday, r2)
+          casamet%tsoil = casamet%tsoil / real(ktauday, r2)
+          casamet%moist = casamet%moist / real(ktauday, r2)
 
           IF (icycle > 0) THEN
              IF (trim(cable_user%PHENOLOGY_SWITCH) == 'climate') THEN
@@ -156,23 +155,23 @@ contains
              IF (cable_user%CALL_POP) THEN
                 ! accumulate annual variables for use in POP
                 IF (MOD(ktau/ktauday, LOY) == 1) THEN
-                   casaflux%stemnpp  =  casaflux%cnpp * casaflux%fracCalloc(:,2) * 0.7_r_2
+                   casaflux%stemnpp  =  casaflux%cnpp * casaflux%fracCalloc(:,2) * 0.7_r2
                    ! (assumes 70% of wood NPP is allocated above ground)
                    casaflux%potstemnpp = casaflux%stemnpp + (casaflux%fracClabile * casaflux%cgpp)
                    casabal%LAImax    = casamet%glai
-                   casabal%Cleafmean = casapool%cplant(:,1) / real(LOY,r_2) / 1000.0_r_2
-                   casabal%Crootmean = casapool%cplant(:,3) / real(LOY,r_2) / 1000.0_r_2
+                   casabal%Cleafmean = casapool%cplant(:,1) / real(LOY,r2) / 1000.0_r2
+                   casabal%Crootmean = casapool%cplant(:,3) / real(LOY,r2) / 1000.0_r2
                 ELSE
-                   casaflux%stemnpp  = casaflux%stemnpp + casaflux%cnpp * casaflux%fracCalloc(:,2) * 0.7_r_2
-                   casaflux%potstemnpp = casaflux%potstemnpp + (casaflux%cnpp * casaflux%fracCalloc(:,2) * 0.7_dp + &
+                   casaflux%stemnpp  = casaflux%stemnpp + casaflux%cnpp * casaflux%fracCalloc(:,2) * 0.7_r2
+                   casaflux%potstemnpp = casaflux%potstemnpp + (casaflux%cnpp * casaflux%fracCalloc(:,2) * 0.7_r2 + &
                                                                 casaflux%fracClabile * casaflux%cgpp)
                    casabal%LAImax    = max(casamet%glai, casabal%LAImax)
-                   casabal%Cleafmean = casabal%Cleafmean + casapool%cplant(:,1) / real(LOY,r_2) / 1000.0_r_2
-                   casabal%Crootmean = casabal%Crootmean + casapool%cplant(:,3) / real(LOY,r_2) / 1000.0_r_2
+                   casabal%Cleafmean = casabal%Cleafmean + casapool%cplant(:,1) / real(LOY,r2) / 1000.0_r2
+                   casabal%Crootmean = casabal%Crootmean + casapool%cplant(:,3) / real(LOY,r2) / 1000.0_r2
                 ENDIF
              ELSE
-                casaflux%stemnpp = 0.0_r_2
-                casaflux%potstemnpp = 0.0_r_2
+                casaflux%stemnpp = 0.0_r2
+                casaflux%potstemnpp = 0.0_r2
              ENDIF ! CALL_POP
 
           ENDIF ! icycle > 0
@@ -201,23 +200,23 @@ contains
           IF (cable_user%CALL_POP) THEN
              ! accumulate annual variables for use in POP
              IF (MOD(ktau/ktauday,LOY)==1) THEN
-                casaflux%stemnpp  = casaflux%cnpp * casaflux%fracCalloc(:,2) * 0.7_r_2
+                casaflux%stemnpp  = casaflux%cnpp * casaflux%fracCalloc(:,2) * 0.7_r2
                 ! (assumes 70% of wood NPP is allocated above ground)
                 casaflux%potstemnpp = casaflux%stemnpp + (casaflux%fracClabile * casaflux%cgpp)
                 casabal%LAImax    = casamet%glai
-                casabal%Cleafmean = casapool%cplant(:,1) / real(LOY,r_2) / 1000.0_r_2
-                casabal%Crootmean = casapool%cplant(:,3) / real(LOY,r_2) / 1000.0_r_2
+                casabal%Cleafmean = casapool%cplant(:,1) / real(LOY,r2) / 1000.0_r2
+                casabal%Crootmean = casapool%cplant(:,3) / real(LOY,r2) / 1000.0_r2
              ELSE
-                casaflux%stemnpp  = casaflux%stemnpp + casaflux%cnpp * casaflux%fracCalloc(:,2) * 0.7_r_2
-                casaflux%potstemnpp = casaflux%potstemnpp + (casaflux%cnpp * casaflux%fracCalloc(:,2) * 0.7_dp + &
+                casaflux%stemnpp  = casaflux%stemnpp + casaflux%cnpp * casaflux%fracCalloc(:,2) * 0.7_r2
+                casaflux%potstemnpp = casaflux%potstemnpp + (casaflux%cnpp * casaflux%fracCalloc(:,2) * 0.7_r2 + &
                                                              casaflux%fracClabile * casaflux%cgpp)
                 casabal%LAImax    = max(casamet%glai, casabal%LAImax)
-                casabal%Cleafmean = casabal%Cleafmean + casapool%cplant(:,1) / real(LOY,r_2) / 1000.0_r_2
-                casabal%Crootmean = casabal%Crootmean + casapool%cplant(:,3) / real(LOY,r_2) / 1000.0_r_2
+                casabal%Cleafmean = casabal%Cleafmean + casapool%cplant(:,1) / real(LOY,r2) / 1000.0_r2
+                casabal%Crootmean = casabal%Crootmean + casapool%cplant(:,3) / real(LOY,r2) / 1000.0_r2
              ENDIF
           ELSE
-             casaflux%stemnpp = 0.0_r_2
-             casaflux%potstemnpp = 0.0_r_2
+             casaflux%stemnpp = 0.0_r2
+             casaflux%potstemnpp = 0.0_r2
           ENDIF ! CALL_POP
 
        ENDIF ! end of day
@@ -230,13 +229,13 @@ contains
 
   SUBROUTINE POPdriver(casaflux, casabal, veg, POP)
 
-    use cable_def_types_mod
+    use cable_def_types_mod, only: r2, mp, veg_parameter_type
     use casadimension
     use casaparm
     use casavariable
     use phenvariable
     use cable_common_module,  only: CABLE_USER
-    use TypeDef,              only: i4b, dp
+    use TypeDef,              only: i4
     use POPModule,            only: POPStep
     use POP_TYPES,            only: POP_TYPE
 
@@ -247,10 +246,10 @@ contains
     type(veg_parameter_type), INTENT(IN)    :: veg  ! vegetation parameters
     type(POP_TYPE),           INTENT(INOUT) :: POP
 
-    real(dp)              :: StemNPP(mp,2)
-    real(dp)              :: PotStemNPP(mp)
-    real(dp), allocatable :: NPPtoGPP(:)
-    real(dp), allocatable :: LAImax(:), Cleafmean(:), Crootmean(:)
+    real(r2)              :: StemNPP(mp,2)
+    real(r2)              :: PotStemNPP(mp)
+    real(r2), allocatable :: NPPtoGPP(:)
+    real(r2), allocatable :: LAImax(:), Cleafmean(:), Crootmean(:)
     !! vh_js !!
     integer,  allocatable :: Iw(:) ! array of indices corresponding to woody (shrub or forest) tiles
 
@@ -264,24 +263,24 @@ contains
        Iw = POP%Iwood
 
        StemNPP(:,1) = casaflux%stemnpp
-       StemNPP(:,2) = 0.0_dp
+       StemNPP(:,2) = 0.0_r2
        ! JK: define an unstressed (potential) stem NPP that could be achieved
        !     in the absence of nutrient limitation. PotStemNPP is used only 
        !     for the calculation of stress (=resource) mortality in POP.
        PotStemNPP(:) = casaflux%potstemnpp
 
-       where (casabal%FCgppyear > 1.e-5_dp .and. casabal%FCnppyear > 1.e-5_dp)
+       where (casabal%FCgppyear > 1.e-5_r2 .and. casabal%FCnppyear > 1.e-5_r2)
           NPPtoGPP = casabal%FCnppyear / casabal%FCgppyear
        elsewhere
-          NPPtoGPP = 0.5_dp
+          NPPtoGPP = 0.5_r2
        endwhere
        LAImax    = casabal%LAImax
        Cleafmean = casabal%cleafmean
        Crootmean = casabal%Crootmean
 
-       CALL POPStep(pop, max(StemNPP(Iw,:)/1000.0_dp, 0.0001_dp), int(veg%disturbance_interval(Iw,:), i4b), &
-                    real(veg%disturbance_intensity(Iw,:), dp), &
-                    max(LAImax(Iw), 0.001_dp), Cleafmean(Iw), Crootmean(Iw), NPPtoGPP(Iw), max(PotStemNPP(Iw)/1000.0_dp, 0.0001_dp))
+       CALL POPStep(pop, max(StemNPP(Iw,:)/1000.0_r2, 0.0001_r2), int(veg%disturbance_interval(Iw,:), i4), &
+                    real(veg%disturbance_intensity(Iw,:), r2), &
+                    max(LAImax(Iw), 0.001_r2), Cleafmean(Iw), Crootmean(Iw), NPPtoGPP(Iw), max(PotStemNPP(Iw)/1000.0_r2, 0.0001_r2))
     endif ! CALL_POP
 
   END SUBROUTINE POPdriver
@@ -291,7 +290,7 @@ contains
   subroutine read_casa_dump(ncfile, casamet, casaflux,phen, climate, c13o2flux, ncall, kend, allatonce)
 
     use netcdf
-    use cable_def_types_mod, only: r_2, ms, mp, climate_type
+    use cable_def_types_mod, only: r2, ms, mp, climate_type
     use casadimension,       only: mplant, mdyear, icycle
     use casavariable,        only: casa_met, casa_flux
     use phenvariable
@@ -351,12 +350,12 @@ contains
          "last_precip  " &
          /)
 
-    real(r_2), dimension(mp)        :: tairk,  cgpp, mtemp, frec, Ndep, Pdep, cAn12, cAn13
-    real(r_2), dimension(mp,ms)     :: tsoil, moist
-    real(r_2), dimension(mp,mplant) :: crmplant
-    real(r_2), dimension(mp)        :: phenphase, phendoyphase1, &
+    real(r2), dimension(mp)        :: tairk,  cgpp, mtemp, frec, Ndep, Pdep, cAn12, cAn13
+    real(r2), dimension(mp,ms)     :: tsoil, moist
+    real(r2), dimension(mp,mplant) :: crmplant
+    real(r2), dimension(mp)        :: phenphase, phendoyphase1, &
          phendoyphase2,  phendoyphase3,  phendoyphase4
-    real(r_2), dimension(mp)        :: dprecip, aprecip_av20, du10_max, drhum,  dtemp_max, &
+    real(r2), dimension(mp)        :: dprecip, aprecip_av20, du10_max, drhum,  dtemp_max, &
          dtemp_min, KBDI,  D_MacArthur, FFDI, DSLR, last_precip
 
 
@@ -538,7 +537,7 @@ contains
   SUBROUTINE write_casa_dump( ncfile, casamet, casaflux, phen, climate, c13o2flux, n_call, kend )
 
     USE netcdf
-    USE cable_def_types_mod,   ONLY : r_2, ms, mp, climate_type
+    USE cable_def_types_mod,   ONLY : r2, ms, mp, climate_type
     USE cable_common_module,   ONLY : cable_user
 #ifndef UM_BUILD
     USE cable_diag_module,     ONLY : def_dims, def_vars, &
@@ -627,13 +626,13 @@ contains
 
     !local only
     INTEGER :: ncok      !ncdf return status
-    real(r_2), dimension(mp) :: zeros
+    real(r2), dimension(mp) :: zeros
 
     ! END header
 #ifndef UM_BUILD
     dim_len(1)        = mp
     dim_len(num_dims) = NF90_unlimited
-    zeros = 0.0_r_2
+    zeros = 0.0_r2
 
     IF (n_call == 1) THEN
 
@@ -667,13 +666,13 @@ contains
     CALL put_var_nc(ncid, var_name(5), casamet%moist, n_call, ms)
     CALL put_var_nc(ncid, var_name(6), casaflux%cgpp, n_call)
     CALL put_var_nc(ncid, var_name(7), casaflux%crmplant, n_call, mplant)
-    CALL put_var_nc(ncid, var_name(8), real(phen%phase, r_2), n_call)
-    CALL put_var_nc(ncid, var_name(9), real(phen%doyphase(:,1), r_2), n_call)
-    CALL put_var_nc(ncid, var_name(10), real(phen%doyphase(:,2), r_2), n_call)
-    CALL put_var_nc(ncid, var_name(11), real(phen%doyphase(:,3), r_2), n_call)
-    CALL put_var_nc(ncid, var_name(12), real(phen%doyphase(:,4), r_2), n_call)
-    CALL put_var_nc(ncid, var_name(13), real(climate%qtemp_max_last_year, r_2), n_call)
-    CALL put_var_nc(ncid, var_name(14), real(climate%frec, r_2), n_call)
+    CALL put_var_nc(ncid, var_name(8), real(phen%phase, r2), n_call)
+    CALL put_var_nc(ncid, var_name(9), real(phen%doyphase(:,1), r2), n_call)
+    CALL put_var_nc(ncid, var_name(10), real(phen%doyphase(:,2), r2), n_call)
+    CALL put_var_nc(ncid, var_name(11), real(phen%doyphase(:,3), r2), n_call)
+    CALL put_var_nc(ncid, var_name(12), real(phen%doyphase(:,4), r2), n_call)
+    CALL put_var_nc(ncid, var_name(13), real(climate%qtemp_max_last_year, r2), n_call)
+    CALL put_var_nc(ncid, var_name(14), real(climate%frec, r2), n_call)
     if (icycle>1) then
        CALL put_var_nc(ncid, var_name(15), casaflux%Nmindep, n_call)
     else
@@ -694,17 +693,17 @@ contains
     endif
     ! BLAZE
     if (cable_user%call_blaze) then
-       CALL put_var_nc(ncid, var_name(19), real(climate%dprecip, r_2), n_call)
-       CALL put_var_nc(ncid, var_name(20), real(climate%aprecip_av20, r_2), n_call)
-       CALL put_var_nc(ncid, var_name(21), real(climate%du10_max, r_2), n_call)
-       CALL put_var_nc(ncid, var_name(22), real(climate%drhum, r_2), n_call)
-       CALL put_var_nc(ncid, var_name(23), real(climate%dtemp_max, r_2), n_call)
-       CALL put_var_nc(ncid, var_name(24), real(climate%dtemp_min, r_2), n_call)
-       CALL put_var_nc(ncid, var_name(25), real(climate%KBDI, r_2), n_call)
-       CALL put_var_nc(ncid, var_name(26), real(climate%D_MacArthur, r_2), n_call)
-       CALL put_var_nc(ncid, var_name(27), real(climate%FFDI, r_2), n_call)
-       CALL put_var_nc(ncid, var_name(28), real(climate%DSLR, r_2), n_call)
-       CALL put_var_nc(ncid, var_name(29), real(climate%last_precip, r_2), n_call)
+       CALL put_var_nc(ncid, var_name(19), real(climate%dprecip, r2), n_call)
+       CALL put_var_nc(ncid, var_name(20), real(climate%aprecip_av20, r2), n_call)
+       CALL put_var_nc(ncid, var_name(21), real(climate%du10_max, r2), n_call)
+       CALL put_var_nc(ncid, var_name(22), real(climate%drhum, r2), n_call)
+       CALL put_var_nc(ncid, var_name(23), real(climate%dtemp_max, r2), n_call)
+       CALL put_var_nc(ncid, var_name(24), real(climate%dtemp_min, r2), n_call)
+       CALL put_var_nc(ncid, var_name(25), real(climate%KBDI, r2), n_call)
+       CALL put_var_nc(ncid, var_name(26), real(climate%D_MacArthur, r2), n_call)
+       CALL put_var_nc(ncid, var_name(27), real(climate%FFDI, r2), n_call)
+       CALL put_var_nc(ncid, var_name(28), real(climate%DSLR, r2), n_call)
+       CALL put_var_nc(ncid, var_name(29), real(climate%last_precip, r2), n_call)
     else
        CALL put_var_nc(ncid, var_name(19), zeros, n_call)
        CALL put_var_nc(ncid, var_name(20), zeros, n_call)
@@ -756,7 +755,7 @@ contains
 
     ! local variables
     integer np,ivt
-    real(r_2), dimension(mp) :: ncleafx, npleafx, pleafx, nleafx ! local variables
+    real(r2), dimension(mp) :: ncleafx, npleafx, pleafx, nleafx ! local variables
     ! real, dimension(17) ::  xnslope
     ! !ASKJK - what are these hard-coded parameters? Why hard-coded?
     ! data xnslope/0.80,1.00,2.00,1.00,1.00,1.00,0.50,1.00,0.34,1.00,1.00,1.00,1.00,1.00,1.00,1.00,1.00/
@@ -786,9 +785,9 @@ contains
        ivt=veg%iveg(np)
        IF (casamet%iveg2(np)/=icewater &
             .AND. casamet%glai(np)>casabiome%glaimin(ivt)  &
-            .AND. casapool%cplant(np,leaf)>0.0_r_2) THEN
+            .AND. casapool%cplant(np,leaf)>0.0_r2) THEN
 
-          IF (icycle>1 .AND. casapool%cplant(np,leaf)>0.0_r_2) THEN
+          IF (icycle>1 .AND. casapool%cplant(np,leaf)>0.0_r2) THEN
              ncleafx(np) = MIN(casabiome%ratioNCplantmax(ivt,leaf), &
                   MAX(casabiome%ratioNCplantmin(ivt,leaf), &
                   casapool%nplant(np,leaf)/casapool%cplant(np,leaf)))
@@ -805,9 +804,9 @@ contains
                 veg%vcmax(np) = real(casabiome%nintercept(ivt) &
                      + casabiome%nslope(ivt)*ncleafx(np)/casabiome%sla(ivt)) * 1.0e-6
              ELSE
-                IF (casapool%nplant(np,leaf)>0.0_r_2.AND.casapool%pplant(np,leaf)>0.0_r_2) THEN
+                IF (casapool%nplant(np,leaf)>0.0_r2.AND.casapool%pplant(np,leaf)>0.0_r2) THEN
                    veg%vcmax(np) = real(casabiome%nintercept(ivt)  &
-                        + casabiome%nslope(ivt)*(0.4_r_2+9.0_r_2/npleafx(np)) &
+                        + casabiome%nslope(ivt)*(0.4_r2+9.0_r2/npleafx(np)) &
                         * ncleafx(np)/casabiome%sla(ivt)) * 1.0e-6
                 ELSE
                    veg%vcmax(np) = real(casabiome%nintercept(ivt) &
@@ -832,7 +831,7 @@ contains
           elseif (ivt.eq.1) then
              ! account here for spring recovery
              veg%vcmax(np) = real( vcmax_np(nleafx(np), pleafx(np)) * &
-                  casabiome%vcmax_scalar(ivt) * real(climate%frec(np),r_2) )
+                  casabiome%vcmax_scalar(ivt) * real(climate%frec(np),r2) )
              veg%ejmax(np) = veg%bjv(np) * veg%vcmax(np)
           else
              veg%vcmax(np) = real( vcmax_np(nleafx(np), pleafx(np)) * &
@@ -848,37 +847,37 @@ contains
                 vcmax_ref(np) = veg%vcmax(np)
              else ! Vcmax_ref as Vcmax with mean nutrient concentrations
                 ! nleafx = ncleafx/sla
-                ! ncleafx = (casabiome%ratioNCplantmin(ivt,leaf) + casabiome%ratioNCplantmax(ivt,leaf)) / 2.0_r_2
+                ! ncleafx = (casabiome%ratioNCplantmin(ivt,leaf) + casabiome%ratioNCplantmax(ivt,leaf)) / 2.0_r2
                 if (icycle>1) then
                    vcmax_ref(np) = real( &
                         vcmax_np( &
                         ( (casabiome%ratioNCplantmin(ivt,leaf) + &
-                        casabiome%ratioNCplantmax(ivt,leaf)) / 2.0_r_2 ) / &
+                        casabiome%ratioNCplantmax(ivt,leaf)) / 2.0_r2 ) / &
                         casabiome%sla(ivt), pleafx(np) ) * &
                         casabiome%vcmax_scalar(ivt) )
                 endif
                 if (icycle>2) then
                    ! pleaf = nleafx / npleafx
-                   ! npleafx = casabiome%ratioNPplantmin(ivt,leaf) + casabiome%ratioNPplantmax(ivt,leaf)) / 2.0_r_2
+                   ! npleafx = casabiome%ratioNPplantmin(ivt,leaf) + casabiome%ratioNPplantmax(ivt,leaf)) / 2.0_r2
                    vcmax_ref(np) = real( &
                         vcmax_np( &
                         ( (casabiome%ratioNCplantmin(ivt,leaf) + &
-                        casabiome%ratioNCplantmax(ivt,leaf)) / 2.0_r_2 ) / &
+                        casabiome%ratioNCplantmax(ivt,leaf)) / 2.0_r2 ) / &
                         casabiome%sla(ivt), &
                         ( (casabiome%ratioNCplantmin(ivt,leaf) + &
-                        casabiome%ratioNCplantmax(ivt,leaf)) / 2.0_r_2 ) / &
+                        casabiome%ratioNCplantmax(ivt,leaf)) / 2.0_r2 ) / &
                         casabiome%sla(ivt) / &
                         (casabiome%ratioNPplantmin(ivt,leaf) + &
-                        casabiome%ratioNPplantmax(ivt,leaf)) / 2.0_r_2 ) * &
+                        casabiome%ratioNPplantmax(ivt,leaf)) / 2.0_r2 ) * &
                         casabiome%vcmax_scalar(ivt) )
                 endif
              endif
 
              ! slopes from database as presented in Knauer et al. 2019, GCB
              if (ivt .EQ. 1 .OR. ivt .EQ. 3) then
-                gm_vcmax_slope = 0.0035e6_r_2
+                gm_vcmax_slope = 0.0035e6_r2
              else
-                gm_vcmax_slope = 0.0020e6_r_2
+                gm_vcmax_slope = 0.0020e6_r2
              endif
 
              veg%gm(np) = veg%gmmax(np) + &
@@ -988,10 +987,10 @@ contains
     !   else
     if (icycle>0) then
        canopy%frp(:)  = real((casaflux%crmplant(:,wood) + casaflux%crmplant(:,froot) + &
-            casaflux%crgplant(:)) / 86400.0_r_2)
-       canopy%frs(:)  = real(casaflux%Crsoil(:) / 86400.0_r_2)
-       canopy%frpw(:) = real(casaflux%crmplant(:,wood) / 86400.0_r_2)
-       canopy%frpr(:) = real(casaflux%crmplant(:,froot) / 86400.0_r_2)
+            casaflux%crgplant(:)) / 86400.0_r2)
+       canopy%frs(:)  = real(casaflux%Crsoil(:) / 86400.0_r2)
+       canopy%frpw(:) = real(casaflux%crmplant(:,wood) / 86400.0_r2)
+       canopy%frpr(:) = real(casaflux%crmplant(:,froot) / 86400.0_r2)
     endif
 
     if (ktau == kstart) then
@@ -1024,10 +1023,10 @@ contains
     ELSE
        IF (l_vcmaxFeedbk) THEN
           canopy%fnee = canopy%fpn + canopy%frs + canopy%frp &
-               + real(casaflux%clabloss(:) / 86400.0_r_2)
+               + real(casaflux%clabloss(:) / 86400.0_r2)
        ELSE
           canopy%fnee = real((casaflux%Crsoil - casaflux%cnpp + &
-               casaflux%clabloss) / 86400.0_r_2)
+               casaflux%clabloss) / 86400.0_r2)
        ENDIF
     ENDIF
 
@@ -1143,22 +1142,22 @@ contains
     type(casa_flux),           intent(inout) :: casaflux
     type(casa_met),            intent(in)    :: casamet
     type(casa_balance),        intent(inout) :: casabal
-    real(r_2), dimension(mp),  intent(in)    :: avgcleaf2met,avgcleaf2str,avgcroot2met,avgcroot2str,avgcwood2cwd
-    real(r_2), dimension(mp),  intent(in)    :: avgnleaf2met,avgnleaf2str,avgnroot2met,avgnroot2str,avgnwood2cwd
-    real(r_2), dimension(mp),  intent(in)    :: avgpleaf2met,avgpleaf2str,avgproot2met,avgproot2str,avgpwood2cwd
-    real(r_2), dimension(mp),  intent(in)    :: avgcnpp
-    real(r_2), dimension(mp),  intent(in)    :: avgxkNlimiting, avgxklitter, avgxksoil
-    real(r_2), dimension(mp),  intent(in)    :: avgratioNCsoilmic, avgratioNCsoilslow, avgratioNCsoilpass
-    real(r_2), dimension(mp),  intent(in)    :: avgnsoilmin, avgpsoillab, avgpsoilsorb, avgpsoilocc
-    real(r_2), dimension(mp),  intent(in)    :: avg_c13leaf2met, avg_c13leaf2str
-    real(r_2), dimension(mp),  intent(in)    :: avg_c13root2met, avg_c13root2str, avg_c13wood2cwd
+    real(r2), dimension(mp),  intent(in)    :: avgcleaf2met,avgcleaf2str,avgcroot2met,avgcroot2str,avgcwood2cwd
+    real(r2), dimension(mp),  intent(in)    :: avgnleaf2met,avgnleaf2str,avgnroot2met,avgnroot2str,avgnwood2cwd
+    real(r2), dimension(mp),  intent(in)    :: avgpleaf2met,avgpleaf2str,avgproot2met,avgproot2str,avgpwood2cwd
+    real(r2), dimension(mp),  intent(in)    :: avgcnpp
+    real(r2), dimension(mp),  intent(in)    :: avgxkNlimiting, avgxklitter, avgxksoil
+    real(r2), dimension(mp),  intent(in)    :: avgratioNCsoilmic, avgratioNCsoilslow, avgratioNCsoilpass
+    real(r2), dimension(mp),  intent(in)    :: avgnsoilmin, avgpsoillab, avgpsoilsorb, avgpsoilocc
+    real(r2), dimension(mp),  intent(in)    :: avg_c13leaf2met, avg_c13leaf2str
+    real(r2), dimension(mp),  intent(in)    :: avg_c13root2met, avg_c13root2str, avg_c13wood2cwd
     ! 13C
     type(c13o2_pool),          intent(inout) :: c13o2pools
 
     ! local variables
-    real(r_2), dimension(mso) :: Psorder, xPsoil50 ! , Pweasoil
-    real(r_2), dimension(mso) :: fracPlab, fracPocc ! , fracPsorb, fracPorg
-    real(r_2), dimension(mp)  :: totPsoil
+    real(r2), dimension(mso) :: Psorder, xPsoil50 ! , Pweasoil
+    real(r2), dimension(mso) :: fracPlab, fracPocc ! , fracPsorb, fracPorg
+    real(r2), dimension(mp)  :: totPsoil
     integer :: npt
 
     ! Soiltype     soilnumber soil P(g P/m2)
@@ -1174,72 +1173,72 @@ contains
     ! Spodosol    10      41.0
     ! Ultisol     11      51.5
     ! Vertisol    12      190.6
-    data Psorder/61.3_r_2, 103.9_r_2, 92.8_r_2, 136.9_r_2, 98.2_r_2, 107.6_r_2, 84.1_r_2, &
-         110.1_r_2, 35.4_r_2, 41.0_r_2, 51.5_r_2, 190.6_r_2/
-    ! data Pweasoil/0.05_r_2, 0.04_r_2, 0.03_r_2, 0.02_r_2, 0.01_r_2, 0.009_r_2, 0.008_r_2, &
-    !      0.007_r_2, 0.006_r_2, 0.005_r_2, 0.004_r_2, 0.003_r_2/
-    data fracPlab/0.08_r_2, 0.08_r_2, 0.10_r_2, 0.02_r_2, 0.08_r_2, 0.08_r_2, 0.08_r_2, &
-         0.06_r_2, 0.02_r_2, 0.05_r_2, 0.09_r_2, 0.05_r_2/
-    ! data fracPsorb/0.32_r_2, 0.37_r_2, 0.57_r_2, 0.67_r_2, 0.37_r_2, 0.37_r_2, 0.37_r_2, &
-    !      0.32_r_2, 0.24_r_2, 0.22_r_2, 0.21_r_2, 0.38_r_2/
-    data fracPocc/0.36_r_2, 0.38_r_2, 0.25_r_2, 0.26_r_2, 0.38_r_2, 0.38_r_2, 0.38_r_2, &
-         0.44_r_2, 0.38_r_2, 0.38_r_2, 0.37_r_2, 0.45_r_2/
-    ! data fracPorg/0.25_r_2, 0.17_r_2, 0.08_r_2, 0.05_r_2, 0.17_r_2, 0.17_r_2, 0.17_r_2, &
-    !      0.18_r_2, 0.36_r_2, 0.35_r_2, 0.34_r_2, 0.12_r_2/
-    data xPsoil50/7.6_r_2, 4.1_r_2, 4.2_r_2, 3.4_r_2, 4.1_r_2, 4.1_r_2, 4.8_r_2, 4.1_r_2, &
-         6.9_r_2, 6.9_r_2, 6.9_r_2, 1.7_r_2/
+    data Psorder/61.3_r2, 103.9_r2, 92.8_r2, 136.9_r2, 98.2_r2, 107.6_r2, 84.1_r2, &
+         110.1_r2, 35.4_r2, 41.0_r2, 51.5_r2, 190.6_r2/
+    ! data Pweasoil/0.05_r2, 0.04_r2, 0.03_r2, 0.02_r2, 0.01_r2, 0.009_r2, 0.008_r2, &
+    !      0.007_r2, 0.006_r2, 0.005_r2, 0.004_r2, 0.003_r2/
+    data fracPlab/0.08_r2, 0.08_r2, 0.10_r2, 0.02_r2, 0.08_r2, 0.08_r2, 0.08_r2, &
+         0.06_r2, 0.02_r2, 0.05_r2, 0.09_r2, 0.05_r2/
+    ! data fracPsorb/0.32_r2, 0.37_r2, 0.57_r2, 0.67_r2, 0.37_r2, 0.37_r2, 0.37_r2, &
+    !      0.32_r2, 0.24_r2, 0.22_r2, 0.21_r2, 0.38_r2/
+    data fracPocc/0.36_r2, 0.38_r2, 0.25_r2, 0.26_r2, 0.38_r2, 0.38_r2, 0.38_r2, &
+         0.44_r2, 0.38_r2, 0.38_r2, 0.37_r2, 0.45_r2/
+    ! data fracPorg/0.25_r2, 0.17_r2, 0.08_r2, 0.05_r2, 0.17_r2, 0.17_r2, 0.17_r2, &
+    !      0.18_r2, 0.36_r2, 0.35_r2, 0.34_r2, 0.12_r2/
+    data xPsoil50/7.6_r2, 4.1_r2, 4.2_r2, 3.4_r2, 4.1_r2, 4.1_r2, 4.8_r2, 4.1_r2, &
+         6.9_r2, 6.9_r2, 6.9_r2, 1.7_r2/
 
     ! compute the mean litter input in g(C, N and P)/day from plant pools
-    casaflux%fromLtoS = 0.0_r_2
-    casaflux%fromStoS = 0.0_r_2
+    casaflux%fromLtoS = 0.0_r2
+    casaflux%fromStoS = 0.0_r2
 
-    casabal%sumcbal(:) = 0.0_r_2
-    casabal%sumnbal(:) = 0.0_r_2
-    casabal%sumpbal(:) = 0.0_r_2
+    casabal%sumcbal(:) = 0.0_r2
+    casabal%sumnbal(:) = 0.0_r2
+    casabal%sumpbal(:) = 0.0_r2
 
     do npt=1, mp
-       if ((casamet%iveg2(npt)/=icewater) .and. (avgcnpp(npt) > 0.0_r_2)) then
-          casaflux%fromLtoS(npt,mic,metb) = 0.45_r_2
+       if ((casamet%iveg2(npt)/=icewater) .and. (avgcnpp(npt) > 0.0_r2)) then
+          casaflux%fromLtoS(npt,mic,metb) = 0.45_r2
           ! metb -> mic
-          casaflux%fromLtoS(npt,mic,str)  = 0.45_r_2 * (1.0_r_2 - casabiome%fracLigninplant(veg%iveg(npt),leaf))
+          casaflux%fromLtoS(npt,mic,str)  = 0.45_r2 * (1.0_r2 - casabiome%fracLigninplant(veg%iveg(npt),leaf))
           ! str -> mic
-          casaflux%fromLtoS(npt,slow,str) = 0.7_r_2 * casabiome%fracLigninplant(veg%iveg(npt),leaf)
+          casaflux%fromLtoS(npt,slow,str) = 0.7_r2 * casabiome%fracLigninplant(veg%iveg(npt),leaf)
           ! str -> slow
-          casaflux%fromLtoS(npt,mic,cwd)  = 0.40_r_2 * (1.0_r_2 - casabiome%fracLigninplant(veg%iveg(npt),wood))
+          casaflux%fromLtoS(npt,mic,cwd)  = 0.40_r2 * (1.0_r2 - casabiome%fracLigninplant(veg%iveg(npt),wood))
           ! CWD -> fmic
-          casaflux%fromLtoS(npt,slow,cwd) = 0.7_r_2 * casabiome%fracLigninplant(veg%iveg(npt),wood)
+          casaflux%fromLtoS(npt,slow,cwd) = 0.7_r2 * casabiome%fracLigninplant(veg%iveg(npt),wood)
           ! CWD -> slow
           !! set the following two backflow to set (see Bolker 199x)
-          !    casaflux%fromStoS(npt,mic,slow)  = 0.45_r_2 * (0.997_r_2 - 0.009_r_2 *soil%clay(npt))
-          !    casaflux%fromStoS(npt,mic,pass)  = 0.45_r_2
+          !    casaflux%fromStoS(npt,mic,slow)  = 0.45_r2 * (0.997_r2 - 0.009_r2 *soil%clay(npt))
+          !    casaflux%fromStoS(npt,mic,pass)  = 0.45_r2
 
-          casaflux%fromStoS(npt,slow,mic)  = (0.85_r_2 - 0.68_r_2 * (soil%clay(npt)+soil%silt(npt))) &
-               * (0.997_r_2 - 0.032_r_2*soil%clay(npt))
-          casaflux%fromStoS(npt,pass,mic)  = (0.85_r_2 - 0.68_r_2 * (soil%clay(npt)+soil%silt(npt))) &
-               * (0.003_r_2 + 0.032_r_2*soil%clay(npt))
-          casaflux%fromStoS(npt,pass,slow) = 0.45_r_2 * (0.003_r_2 + 0.009_r_2 * soil%clay(npt) )
+          casaflux%fromStoS(npt,slow,mic)  = (0.85_r2 - 0.68_r2 * (soil%clay(npt)+soil%silt(npt))) &
+               * (0.997_r2 - 0.032_r2*soil%clay(npt))
+          casaflux%fromStoS(npt,pass,mic)  = (0.85_r2 - 0.68_r2 * (soil%clay(npt)+soil%silt(npt))) &
+               * (0.003_r2 + 0.032_r2*soil%clay(npt))
+          casaflux%fromStoS(npt,pass,slow) = 0.45_r2 * (0.003_r2 + 0.009_r2 * soil%clay(npt) )
 
           casaflux%klitter(npt,metb) = avgxkNlimiting(npt) * avgxklitter(npt) * casabiome%litterrate(veg%iveg(npt),metb)
           casaflux%klitter(npt,str)  = avgxkNlimiting(npt) * avgxklitter(npt) * casabiome%litterrate(veg%iveg(npt),str) * &
-               exp(-3.0_r_2*casabiome%fracLigninplant(veg%iveg(npt),leaf))
+               exp(-3.0_r2*casabiome%fracLigninplant(veg%iveg(npt),leaf))
           casaflux%klitter(npt,cwd)  = avgxkNlimiting(npt) * avgxklitter(npt) * casabiome%litterrate(veg%iveg(npt),cwd)
 
           casaflux%ksoil(npt,mic)    = avgxksoil(npt) * casabiome%soilrate(veg%iveg(npt),mic) * &
-               (1.0_r_2 - 0.75_r_2 * (soil%silt(npt)+soil%clay(npt)))
+               (1.0_r2 - 0.75_r2 * (soil%silt(npt)+soil%clay(npt)))
           casaflux%ksoil(npt,slow)   = avgxksoil(npt) * casabiome%soilrate(veg%iveg(npt),slow)
           casaflux%ksoil(npt,pass)   = avgxksoil(npt) * casabiome%soilrate(veg%iveg(npt),pass)
 
           if (veg%iveg(npt)==cropland) then     ! for cultivated land type
-             casaflux%ksoil(npt,mic)  = casaflux%ksoil(npt,mic)  * 1.25_r_2
-             casaflux%ksoil(npt,slow) = casaflux%ksoil(npt,slow) * 1.5_r_2
-             casaflux%ksoil(npt,pass) = casaflux%ksoil(npt,pass) * 1.5_r_2
+             casaflux%ksoil(npt,mic)  = casaflux%ksoil(npt,mic)  * 1.25_r2
+             casaflux%ksoil(npt,slow) = casaflux%ksoil(npt,slow) * 1.5_r2
+             casaflux%ksoil(npt,pass) = casaflux%ksoil(npt,pass) * 1.5_r2
           endif
        endif
     enddo
 
     do npt=1, mp
 
-       if ((casamet%iveg2(npt) /= icewater) .and. (avgcnpp(npt) > 0.0_r_2)) then
+       if ((casamet%iveg2(npt) /= icewater) .and. (avgcnpp(npt) > 0.0_r2)) then
 
           ! MC - Do first P then N and then C so that each equilibrium solution uses the incoming pools not updated yet
           if (icycle<=2) then
@@ -1300,8 +1299,8 @@ contains
           if (icycle<=1) then
              casapool%nlitter(npt,:) = casapool%ratioNClitter(npt,:) * casapool%Clitter(npt,:)
              casapool%nsoil(npt,:)   = casapool%ratioNCsoil(npt,:)   * casapool%Csoil(npt,:)
-             casapool%nsoilmin(npt)  = 2.0_r_2
-             casabal%sumnbal(npt)    = 0.0_r_2
+             casapool%nsoilmin(npt)  = 2.0_r2
+             casabal%sumnbal(npt)    = 0.0_r2
           else
              ! compute steady-state litter and soil N pool sizes
              casapool%nlitter(npt,metb) = (avgnleaf2met(npt)+avgnroot2met(npt)) / casaflux%klitter(npt,metb)

--- a/core/biogeochem/casa_cnp.F90
+++ b/core/biogeochem/casa_cnp.F90
@@ -65,8 +65,8 @@ MODULE casa_cnp_module
 
   implicit none
 
-  real(r_2), parameter :: zero = 0.0_r_2
-  real(r_2), parameter :: one  = 1.0_r_2
+  real(r2), parameter :: zero = 0.0_r2
+  real(r2), parameter :: one  = 1.0_r2
 
 CONTAINS
 
@@ -75,10 +75,10 @@ CONTAINS
 
     IMPLICIT NONE
 
-    REAL(r_2), DIMENSION(mp), INTENT(OUT) :: xnplimit
-    REAL(r_2), DIMENSION(mp), INTENT(OUT) :: xNuptake
-    REAL(r_2), DIMENSION(mp), INTENT(OUT) :: xPuptake
-    REAL(r_2), DIMENSION(mp), INTENT(OUT) :: xNPuptake
+    REAL(r2), DIMENSION(mp), INTENT(OUT) :: xnplimit
+    REAL(r2), DIMENSION(mp), INTENT(OUT) :: xNuptake
+    REAL(r2), DIMENSION(mp), INTENT(OUT) :: xPuptake
+    REAL(r2), DIMENSION(mp), INTENT(OUT) :: xNPuptake
     TYPE (veg_parameter_type),    INTENT(INOUT) :: veg  ! vegetation parameters
     TYPE (casa_biome),            INTENT(INOUT) :: casabiome
     TYPE (casa_pool),             INTENT(INOUT) :: casapool
@@ -87,94 +87,94 @@ CONTAINS
 
     ! local variables
     INTEGER :: np
-    REAL(r_2), DIMENSION(mp)        :: xnlimit,xplimit
-    REAL(r_2), DIMENSION(mp)        :: xncleaf,xpcleaf
-    REAL(r_2), DIMENSION(mp)        :: xnCnpp,xpCnpp
-    REAL(r_2), DIMENSION(mp,mplant) :: Nreqmax, Nreqmin, NtransPtoP
-    REAL(r_2), DIMENSION(mp)        :: totNreqmax,totNreqmin
-    !REAL(r_2), DIMENSION(mp)        :: xNuptake,xPuptake
-    REAL(r_2), DIMENSION(mp,mplant) :: Preqmax, Preqmin, PtransPtoP
-    REAL(r_2), DIMENSION(mp)        :: totPreqmax,totPreqmin
+    REAL(r2), DIMENSION(mp)        :: xnlimit,xplimit
+    REAL(r2), DIMENSION(mp)        :: xncleaf,xpcleaf
+    REAL(r2), DIMENSION(mp)        :: xnCnpp,xpCnpp
+    REAL(r2), DIMENSION(mp,mplant) :: Nreqmax, Nreqmin, NtransPtoP
+    REAL(r2), DIMENSION(mp)        :: totNreqmax,totNreqmin
+    !REAL(r2), DIMENSION(mp)        :: xNuptake,xPuptake
+    REAL(r2), DIMENSION(mp,mplant) :: Preqmax, Preqmin, PtransPtoP
+    REAL(r2), DIMENSION(mp)        :: totPreqmax,totPreqmin
 
-    xnlimit  = 1.0_r_2
-    xplimit  = 1.0_r_2
-    xnplimit = 1.0_r_2
-    casaflux%fracClabile(:) = 0.0_r_2
+    xnlimit  = 1.0_r2
+    xplimit  = 1.0_r2
+    xnplimit = 1.0_r2
+    casaflux%fracClabile(:) = 0.0_r2
 
     SELECT CASE(icycle)
     CASE(2)
        WHERE(casamet%iveg2/=icewater)
-          xncleaf(:) = casapool%nplant(:,leaf)/(casapool%cplant(:,leaf)+1.0e-10_r_2)
+          xncleaf(:) = casapool%nplant(:,leaf)/(casapool%cplant(:,leaf)+1.0e-10_r2)
           !xnlimit(:) = xncleaf(:)/(xncleaf(:)+casabiome%KminN(veg%iveg(:)))
-          xnlimit(:) = xncleaf(:)/(xncleaf(:)+0.01_r_2)
-          xplimit(:) = 1.0_r_2
+          xnlimit(:) = xncleaf(:)/(xncleaf(:)+0.01_r2)
+          xplimit(:) = 1.0_r2
           xnplimit(:) =min(xnlimit(:),xplimit(:)) * casabiome%xnpmax(veg%iveg(:))
        ENDWHERE
     CASE(3)
        WHERE(casamet%iveg2/=icewater)
-          xncleaf(:) = casapool%nplant(:,leaf)/(casapool%cplant(:,leaf)+1.0e-10_r_2)
-          xnlimit(:) = xncleaf(:)/(xncleaf(:)+0.01_r_2)
-          xpcleaf(:) = casapool%pplant(:,leaf)/(casapool%cplant(:,leaf)+1.0e-10_r_2)
+          xncleaf(:) = casapool%nplant(:,leaf)/(casapool%cplant(:,leaf)+1.0e-10_r2)
+          xnlimit(:) = xncleaf(:)/(xncleaf(:)+0.01_r2)
+          xpcleaf(:) = casapool%pplant(:,leaf)/(casapool%cplant(:,leaf)+1.0e-10_r2)
           !xplimit(:) = xpcleaf(:)/(xpcleaf(:)+casabiome%Kuplabp(veg%iveg(:)))
-          xplimit(:) = xpcleaf(:)/(xpcleaf(:)+0.0006_r_2)
-          !xnplimit(:) = min(1.0_r_2,casabiome%Kuptake(veg%iveg(:))*min(xnlimit(:),xplimit(:)))
+          xplimit(:) = xpcleaf(:)/(xpcleaf(:)+0.0006_r2)
+          !xnplimit(:) = min(1.0_r2,casabiome%Kuptake(veg%iveg(:))*min(xnlimit(:),xplimit(:)))
           xnplimit(:) =min(xnlimit(:),xplimit(:)) * casabiome%xnpmax(veg%iveg(:))
        ENDWHERE
     END SELECT
 
     ! now check if soil nutrient supply can meet the plant uptake,
     ! otherwise reduce NPP
-    xNuptake = 1.0_r_2
-    xPuptake = 1.0_r_2
+    xNuptake = 1.0_r2
+    xPuptake = 1.0_r2
 
     IF (icycle >1) THEN
-       Nreqmin(:,:)    = 0.0_r_2
-       Nreqmax(:,:)    = 0.0_r_2
-       NtransPtoP(:,:) = 0.0_r_2
-       totNreqmax = 0.0_r_2
-       totNreqmin = 0.0_r_2
-       xNuptake   = 1.0_r_2
+       Nreqmin(:,:)    = 0.0_r2
+       Nreqmax(:,:)    = 0.0_r2
+       NtransPtoP(:,:) = 0.0_r2
+       totNreqmax = 0.0_r2
+       totNreqmin = 0.0_r2
+       xNuptake   = 1.0_r2
 
-       xnCnpp = max(0.0_r_2,casaflux%Cnpp)
+       xnCnpp = max(0.0_r2,casaflux%Cnpp)
        call casa_Nrequire(xnCnpp,Nreqmin,Nreqmax,NtransPtoP,veg, &
             casabiome,casapool,casaflux,casamet)
        DO np=1, mp
           IF(casamet%iveg2(np)/=icewater) THEN
              totNreqmax(np) = Nreqmax(np,leaf)+Nreqmax(np,wood)+Nreqmax(np,froot)
              totNreqmin(np) = Nreqmin(np,leaf)+Nreqmin(np,wood)+Nreqmin(np,froot)
-             xNuptake(np)   = MAX(0.0_r_2, MIN(1.0_r_2, casapool%Nsoilmin(np) &
-                  /(totNreqmin(np)*deltpool + 1.e-10_r_2)))
+             xNuptake(np)   = MAX(0.0_r2, MIN(1.0_r2, casapool%Nsoilmin(np) &
+                  /(totNreqmin(np)*deltpool + 1.e-10_r2)))
           ENDIF
        ENDDO
     ENDIF
     IF (icycle >2) THEN
-       Preqmin(:,:)       = 0.0_r_2
-       Preqmax(:,:)       = 0.0_r_2
-       PtransPtoP(:,:)    = 0.0_r_2
-       totPreqmax = 0.0_r_2
-       totPreqmin = 0.0_r_2
-       xPuptake   = 1.0_r_2
-       xpCnpp = max(0.0_r_2, casaflux%Cnpp)
+       Preqmin(:,:)       = 0.0_r2
+       Preqmax(:,:)       = 0.0_r2
+       PtransPtoP(:,:)    = 0.0_r2
+       totPreqmax = 0.0_r2
+       totPreqmin = 0.0_r2
+       xPuptake   = 1.0_r2
+       xpCnpp = max(0.0_r2, casaflux%Cnpp)
        call casa_Prequire(xpCnpp,Preqmin,Preqmax,PtransPtoP,veg, &
             casabiome,casapool,casaflux,casamet)
        DO np=1, mp
           IF (casamet%iveg2(np)/=icewater) THEN
              totPreqmax(np) = Preqmax(np,leaf)+Preqmax(np,wood)+Preqmax(np,froot)
              totPreqmin(np) = Preqmin(np,leaf)+Preqmin(np,wood)+Preqmin(np,froot)
-             xPuptake(np)   = MAX(0.0_r_2, MIN(1.0_r_2, casapool%psoillab(np) &
-                  /(totPreqmin(np)*deltpool + 1.e-10_r_2)))
+             xPuptake(np)   = MAX(0.0_r2, MIN(1.0_r2, casapool%psoillab(np) &
+                  /(totPreqmin(np)*deltpool + 1.e-10_r2)))
           ENDIF
        ENDDO
     ENDIF
 
-    xnplimit(:)  = 1.0_r_2
+    xnplimit(:)  = 1.0_r2
     xNPuptake(:) = min(xnuptake(:), xpuptake(:))
     do np =1, mp
-       if (casamet%iveg2(np)/=icewater.and.casaflux%cnpp(np) > 0.0_r_2.and.xNPuptake(np) < 1.0_r_2) then
+       if (casamet%iveg2(np)/=icewater.and.casaflux%cnpp(np) > 0.0_r2.and.xNPuptake(np) < 1.0_r2) then
 
-          if (casaflux%fHarvest(np) .lt. 0.1_r_2) then   ! N limitation on growth not applied to crop/pasture
-             casaflux%fracClabile(np) =min(1.0_r_2, max(0.0_r_2, (1.0_r_2 - xNPuptake(np)))) * &
-                  max(0.0_r_2, casaflux%cnpp(np))/(casaflux%cgpp(np) + 1.e-10_r_2)
+          if (casaflux%fHarvest(np) .lt. 0.1_r2) then   ! N limitation on growth not applied to crop/pasture
+             casaflux%fracClabile(np) =min(1.0_r2, max(0.0_r2, (1.0_r2 - xNPuptake(np)))) * &
+                  max(0.0_r2, casaflux%cnpp(np))/(casaflux%cgpp(np) + 1.e-10_r2)
              casaflux%cnpp(np)    = casaflux%cnpp(np) - casaflux%fracClabile(np) * casaflux%cgpp(np)
           endif
        endif
@@ -210,17 +210,17 @@ CONTAINS
     INTEGER , INTENT(IN) :: LALLOC
 
     ! local variables
-    REAL(r_2), DIMENSION(mp,mplant) :: fracCallocx
-    REAL(r_2), DIMENSION(mp)        :: xLalloc,xwsalloc,xTalloc
-    REAL(r_2), DIMENSION(mp)        :: xWorNalloc,xNalloc,xWalloc
-    REAL(r_2), DIMENSION(mp)        :: totfracCalloc
-    REAL(r_2), DIMENSION(mp)        :: newLAI
+    REAL(r2), DIMENSION(mp,mplant) :: fracCallocx
+    REAL(r2), DIMENSION(mp)        :: xLalloc,xwsalloc,xTalloc
+    REAL(r2), DIMENSION(mp)        :: xWorNalloc,xNalloc,xWalloc
+    REAL(r2), DIMENSION(mp)        :: totfracCalloc
+    REAL(r2), DIMENSION(mp)        :: newLAI
 
     ! initlization
-    casaflux%fracCalloc  = 0.0_r_2
-    !casaflux%fracClabile = 0.0_r_2
-    fracCallocx = 0.0_r_2
-    newLAI = 0.0_r_2
+    casaflux%fracCalloc  = 0.0_r2
+    !casaflux%fracClabile = 0.0_r2
+    fracCallocx = 0.0_r2
+    newLAI = 0.0_r2
     SELECT CASE (LALLOC)
     CASE(2)   !
        ! calculate the allocation coefficients
@@ -228,31 +228,31 @@ CONTAINS
 
     CASE(1)   ! dynamic allocation
        WHERE(casamet%iveg2/=icewater)
-          xLalloc(:) = min(1.0_r_2,max(0.0_r_2,exp(-0.5_r_2*casamet%glai(:))))   ! L limiting
+          xLalloc(:) = min(1.0_r2,max(0.0_r2,exp(-0.5_r2*casamet%glai(:))))   ! L limiting
           ! Pseudo-nutrient limitation calculation
-          WHERE(casamet%tsoilavg > 0.0_r_2)
-             xwsalloc(:) = min( max(casamet%moistavg(:)-soil%swilt(:),0.0_r_2) &
-                  /(soil%sfc(:)-soil%swilt(:)), 1.0_r_2)
+          WHERE(casamet%tsoilavg > 0.0_r2)
+             xwsalloc(:) = min( max(casamet%moistavg(:)-soil%swilt(:),0.0_r2) &
+                  /(soil%sfc(:)-soil%swilt(:)), 1.0_r2)
           ELSE WHERE
-             xwsalloc(:) = 0.01_r_2
+             xwsalloc(:) = 0.01_r2
           END WHERE
-          xTalloc(:)    = min(1.0_r_2,max(0.0_r_2,Q10alloc** &
-               ((casamet%tsoilavg(:)-TkzeroC-30.0_r_2)/10.0_r_2) )) !T limiting
-          xNalloc(:)    = min(1.0_r_2,max(0.0_r_2,xwsalloc(:)*xTalloc(:)))     !N limiting
-          xWalloc(:)    = min(1.0_r_2,max(0.0_r_2,casamet%btran(:)))           !W limiting
+          xTalloc(:)    = min(1.0_r2,max(0.0_r2,Q10alloc** &
+               ((casamet%tsoilavg(:)-TkzeroC-30.0_r2)/10.0_r2) )) !T limiting
+          xNalloc(:)    = min(1.0_r2,max(0.0_r2,xwsalloc(:)*xTalloc(:)))     !N limiting
+          xWalloc(:)    = min(1.0_r2,max(0.0_r2,casamet%btran(:)))           !W limiting
           xWorNalloc(:) = min(xWalloc(:),xNalloc(:))
           WHERE(casamet%lnonwood==0)
-             casaflux%fracCalloc(:,FROOT) = R0 * 3.0_r_2 * xLalloc(:) &
-                  / (xLalloc(:)+ 2.0_r_2*xWorNalloc(:))
-             casaflux%fracCalloc(:,WOOD)  = S0 * 3.0_r_2 * xWorNalloc(:) &
-                  / (2.0_r_2*xLalloc(:)+ xWorNalloc(:))
-             casaflux%fracCalloc(:,LEAF)  = 1.0_r_2 - casaflux%fracCalloc(:,FROOT) &
+             casaflux%fracCalloc(:,FROOT) = R0 * 3.0_r2 * xLalloc(:) &
+                  / (xLalloc(:)+ 2.0_r2*xWorNalloc(:))
+             casaflux%fracCalloc(:,WOOD)  = S0 * 3.0_r2 * xWorNalloc(:) &
+                  / (2.0_r2*xLalloc(:)+ xWorNalloc(:))
+             casaflux%fracCalloc(:,LEAF)  = 1.0_r2 - casaflux%fracCalloc(:,FROOT) &
                   - casaflux%fracCalloc(:,WOOD)
           ELSE WHERE
-             casaflux%fracCalloc(:,FROOT) = R0 * 3.0_r_2 * xLalloc(:) &
-                  / (xLalloc(:)+2.0_r_2*xWorNalloc(:))
-             casaflux%fracCalloc(:,WOOD)  = 0.0_r_2
-             casaflux%fracCalloc(:,LEAF)  = 1.0_r_2 - casaflux%fracCalloc(:,FROOT)
+             casaflux%fracCalloc(:,FROOT) = R0 * 3.0_r2 * xLalloc(:) &
+                  / (xLalloc(:)+2.0_r2*xWorNalloc(:))
+             casaflux%fracCalloc(:,WOOD)  = 0.0_r2
+             casaflux%fracCalloc(:,LEAF)  = 1.0_r2 - casaflux%fracCalloc(:,FROOT)
           END WHERE
        END WHERE
     CASE (0)   ! fixed allocation
@@ -264,27 +264,27 @@ CONTAINS
        ! POP tree demography module. (Ticket #61)
        WHERE(casamet%lnonwood==0)
           casaflux%fracCalloc(:,FROOT) = casabiome%fracnpptop(veg%iveg(:),FROOT)
-          casaflux%fracCalloc(:,WOOD)  = 0.01_r_2
-          casaflux%fracCalloc(:,LEAF)  = 1.0_r_2 - casaflux%fracCalloc(:,FROOT) - &
+          casaflux%fracCalloc(:,WOOD)  = 0.01_r2
+          casaflux%fracCalloc(:,LEAF)  = 1.0_r2 - casaflux%fracCalloc(:,FROOT) - &
                casaflux%fracCalloc(:,WOOD)
           newLAI = casamet%glai + (casaflux%fracCalloc(:,LEAF) * casaflux%cnpp - &
                casaflux%kplant_tot(:,leaf) * casapool%cplant(:,LEAF)) * casabiome%sla(veg%iveg(:))
-          where ( (casaflux%sapwood_area.gt.1.0e-6_r_2) .and. &
+          where ( (casaflux%sapwood_area.gt.1.0e-6_r2) .and. &
                (newLAI.gt.(casabiome%la_to_sa(veg%iveg(:)) * casaflux%sapwood_area)) .and. &
-               (casaflux%cnpp.gt.0.0_r_2) )
+               (casaflux%cnpp.gt.0.0_r2) )
              casaflux%fracCalloc(:,LEAF) = ( (casabiome%la_to_sa(veg%iveg(:))*casaflux%sapwood_area &
                   - casamet%glai) / casabiome%sla(veg%iveg(:)) &
                   + casaflux%kplant_tot(:,leaf) * casapool%cplant(:,LEAF) ) / casaflux%cnpp
 
-             casaflux%fracCalloc(:,LEAF) = max(0.0_r_2, casaflux%fracCalloc(:,LEAF))
-             casaflux%fracCalloc(:,LEAF) = min(1.0_r_2 - casaflux%fracCalloc(:,FROOT) - &
+             casaflux%fracCalloc(:,LEAF) = max(0.0_r2, casaflux%fracCalloc(:,LEAF))
+             casaflux%fracCalloc(:,LEAF) = min(1.0_r2 - casaflux%fracCalloc(:,FROOT) - &
                   casaflux%fracCalloc(:,WOOD), casaflux%fracCalloc(:,LEAF))
-             casaflux%fracCalloc(:,WOOD) = 1.0_r_2 - casaflux%fracCalloc(:,FROOT) - &
+             casaflux%fracCalloc(:,WOOD) = 1.0_r2 - casaflux%fracCalloc(:,FROOT) - &
                   casaflux%fracCalloc(:,LEAF)
           end where
        ELSEWHERE
           casaflux%fracCalloc(:,FROOT) = casabiome%fracnpptop(veg%iveg(:),FROOT)
-          casaflux%fracCalloc(:,WOOD)  = 0.0_r_2
+          casaflux%fracCalloc(:,WOOD)  = 0.0_r2
           casaflux%fracCalloc(:,LEAF)  = casabiome%fracnpptop(veg%iveg(:),LEAF)
        ENDWHERE
 
@@ -307,42 +307,42 @@ CONTAINS
 
        WHERE(casamet%iveg2/=icewater)
           WHERE(phen%phase==0)
-             casaflux%fracCalloc(:,leaf)  = 0.0_r_2
+             casaflux%fracCalloc(:,leaf)  = 0.0_r2
              casaflux%fracCalloc(:,froot) =  casaflux%fracCalloc(:,froot) &
                   /(casaflux%fracCalloc(:,froot) &
                   +casaflux%fracCalloc(:,wood))
-             casaflux%fracCalloc(:,wood)  = 1.0_r_2 -casaflux%fracCalloc(:,froot)
+             casaflux%fracCalloc(:,wood)  = 1.0_r2 -casaflux%fracCalloc(:,froot)
           END WHERE
 
           WHERE(phen%phase==1)
-             casaflux%fracCalloc(:,leaf)  = 0.95_r_2
+             casaflux%fracCalloc(:,leaf)  = 0.95_r2
              WHERE(casamet%lnonwood==0)  !woodland or forest
-                casaflux%fracCalloc(:,froot) = 0.5_r_2*(1.0_r_2-casaflux%fracCalloc(:,leaf))
-                casaflux%fracCalloc(:,wood)  = 0.5_r_2*(1.0_r_2-casaflux%fracCalloc(:,leaf))
+                casaflux%fracCalloc(:,froot) = 0.5_r2*(1.0_r2-casaflux%fracCalloc(:,leaf))
+                casaflux%fracCalloc(:,wood)  = 0.5_r2*(1.0_r2-casaflux%fracCalloc(:,leaf))
              ELSEWHERE !grassland
-                casaflux%fracCalloc(:,froot) = 1.0_r_2-casaflux%fracCalloc(:,leaf)
+                casaflux%fracCalloc(:,froot) = 1.0_r2-casaflux%fracCalloc(:,leaf)
              ENDWHERE
           END WHERE
 
           WHERE(phen%phase==3)
              !      casaflux%fracClabile(:)  = casaflux%fracCalloc(:,leaf)
-             casaflux%fracCalloc(:,froot) = 1.0_r_2-casaflux%fracCalloc(:,wood)
-             casaflux%fracCalloc(:,leaf)  = 0.0_r_2
+             casaflux%fracCalloc(:,froot) = 1.0_r2-casaflux%fracCalloc(:,wood)
+             casaflux%fracCalloc(:,leaf)  = 0.0_r2
           ENDWHERE
 
 
           ! IF Prognostic LAI reached glaimax, no C is allocated to leaf
           ! Q.Zhang 17/03/2011
           WHERE(casamet%glai(:)>=casabiome%glaimax(veg%iveg(:)))
-             casaflux%fracCalloc(:,leaf)  = 0.0_r_2
+             casaflux%fracCalloc(:,leaf)  = 0.0_r2
              casaflux%fracCalloc(:,froot) =  casaflux%fracCalloc(:,froot) &
                   /(casaflux%fracCalloc(:,froot) &
                   +casaflux%fracCalloc(:,wood))
-             casaflux%fracCalloc(:,wood)  = 1.0_r_2 -casaflux%fracCalloc(:,froot)
+             casaflux%fracCalloc(:,wood)  = 1.0_r2 -casaflux%fracCalloc(:,froot)
           ENDWHERE
 
           ! added in for negative NPP and one of biomass pool being zero ypw 27/jan/2014
-          WHERE(casaflux%Cnpp<0.0_r_2)
+          WHERE(casaflux%Cnpp<0.0_r2)
              casaflux%fracCalloc(:,leaf)  = casaflux%Crmplant(:,leaf)  / sum(casaflux%Crmplant,2)
              casaflux%fracCalloc(:,wood)  = casaflux%Crmplant(:,wood)  / sum(casaflux%Crmplant,2)
              casaflux%fracCalloc(:,froot) = casaflux%Crmplant(:,froot) / sum(casaflux%Crmplant,2)
@@ -351,7 +351,7 @@ CONTAINS
           !! vh_js !!
           !! as long as biomass is positive, adjust allocation to be
           !! proportional to stock when NPP -ve (Ticket#108)
-          WHERE(casaflux%Cnpp<0.0_r_2 .and. sum(casapool%Cplant,2)>0.0_r_2  )
+          WHERE(casaflux%Cnpp<0.0_r2 .and. sum(casapool%Cplant,2)>0.0_r2  )
              casaflux%fracCalloc(:,leaf)  = casapool%Cplant(:,leaf)  / sum(casapool%Cplant,2)
              casaflux%fracCalloc(:,wood)  = casapool%Cplant(:,wood)  / sum(casapool%Cplant,2)
              casaflux%fracCalloc(:,froot) = casapool%Cplant(:,froot) / sum(casapool%Cplant,2)
@@ -361,26 +361,26 @@ CONTAINS
     ELSE
        WHERE(casamet%iveg2/=icewater)
           WHERE(phen%phase==0)
-             casaflux%fracCalloc(:,leaf)  = 0.0_r_2
+             casaflux%fracCalloc(:,leaf)  = 0.0_r2
              casaflux%fracCalloc(:,froot) = casaflux%fracCalloc(:,froot) &
                   / ( casaflux%fracCalloc(:,froot) + casaflux%fracCalloc(:,wood) )
              WHERE (casamet%lnonwood==0)
-                casaflux%fracCalloc(:,wood) = 1.0_r_2 - casaflux%fracCalloc(:,froot)
+                casaflux%fracCalloc(:,wood) = 1.0_r2 - casaflux%fracCalloc(:,froot)
              ELSEWHERE
-                casaflux%fracCalloc(:,wood) = 0.0_r_2
+                casaflux%fracCalloc(:,wood) = 0.0_r2
              ENDWHERE
           END WHERE
 
           WHERE(phen%phase==1.and.casamet%lnonwood==1)
-             casaflux%fracCalloc(:,leaf)  = 0.80_r_2
-             casaflux%fracCalloc(:,froot) = 1.0_r_2 - casaflux%fracCalloc(:,leaf)
-             casaflux%fracCalloc(:,wood)  = 0.0_r_2
+             casaflux%fracCalloc(:,leaf)  = 0.80_r2
+             casaflux%fracCalloc(:,froot) = 1.0_r2 - casaflux%fracCalloc(:,leaf)
+             casaflux%fracCalloc(:,wood)  = 0.0_r2
           ENDWHERE
 
           WHERE(phen%phase==3)
              ! casaflux%fracClabile(:) = casaflux%fracCalloc(:,leaf)
-             casaflux%fracCalloc(:,froot) = 1.0_r_2-casaflux%fracCalloc(:,wood)
-             casaflux%fracCalloc(:,leaf)  = 0.0_r_2
+             casaflux%fracCalloc(:,froot) = 1.0_r2-casaflux%fracCalloc(:,wood)
+             casaflux%fracCalloc(:,leaf)  = 0.0_r2
           ENDWHERE
 
           !! vh !!
@@ -392,49 +392,49 @@ CONTAINS
           ! IF Prognostic LAI reached glaimax, no C is allocated to leaf
           ! Q.Zhang 17/03/2011
           WHERE (casamet%glai(:)>=casabiome%glaimax(veg%iveg(:)))
-             casaflux%fracCalloc(:,leaf)  = 0.0_r_2
+             casaflux%fracCalloc(:,leaf)  = 0.0_r2
              casaflux%fracCalloc(:,froot) = casaflux%fracCalloc(:,froot) &
                   / ( casaflux%fracCalloc(:,froot) + casaflux%fracCalloc(:,wood) )
              WHERE (casamet%lnonwood==0)
-                casaflux%fracCalloc(:,wood) = 1.0_r_2 -casaflux%fracCalloc(:,froot)
+                casaflux%fracCalloc(:,wood) = 1.0_r2 -casaflux%fracCalloc(:,froot)
              ELSEWHERE
-                casaflux%fracCalloc(:,wood) = 0.0_r_2
+                casaflux%fracCalloc(:,wood) = 0.0_r2
              ENDWHERE
           ENDWHERE
 
           WHERE (casamet%glai(:) < casabiome%glaimin(veg%iveg(:)))
-             casaflux%fracCalloc(:,leaf) = 0.8_r_2
+             casaflux%fracCalloc(:,leaf) = 0.8_r2
              WHERE(casamet%lnonwood==0) ! woodland or forest
-                casaflux%fracCalloc(:,froot) = 0.5_r_2 * (1.0_r_2 - casaflux%fracCalloc(:,leaf))
-                casaflux%fracCalloc(:,wood)  = 0.5_r_2 * (1.0_r_2 - casaflux%fracCalloc(:,leaf))
+                casaflux%fracCalloc(:,froot) = 0.5_r2 * (1.0_r2 - casaflux%fracCalloc(:,leaf))
+                casaflux%fracCalloc(:,wood)  = 0.5_r2 * (1.0_r2 - casaflux%fracCalloc(:,leaf))
              ELSEWHERE                  ! grassland
-                casaflux%fracCalloc(:,froot) = 1.0_r_2 - casaflux%fracCalloc(:,leaf)
-                casaflux%fracCalloc(:,wood)  = 0.0_r_2
+                casaflux%fracCalloc(:,froot) = 1.0_r2 - casaflux%fracCalloc(:,leaf)
+                casaflux%fracCalloc(:,wood)  = 0.0_r2
              ENDWHERE
           ENDWHERE
 
           ! added in for negative NPP and one of biomass pool being zero ypw 27/jan/2014
-          WHERE(casaflux%Cnpp < 0.0_r_2)
+          WHERE(casaflux%Cnpp < 0.0_r2)
              WHERE(casamet%lnonwood==0)  !woodland or forest
                 casaflux%fracCalloc(:,leaf)  = casaflux%Crmplant(:,leaf)  / sum(casaflux%Crmplant,2)
                 casaflux%fracCalloc(:,wood)  = casaflux%Crmplant(:,wood)  / sum(casaflux%Crmplant,2)
                 casaflux%fracCalloc(:,froot) = casaflux%Crmplant(:,froot) / sum(casaflux%Crmplant,2)
              ELSEWHERE
                 casaflux%fracCalloc(:,leaf)  = casaflux%Crmplant(:,leaf)  / sum(casaflux%Crmplant,2)
-                casaflux%fracCalloc(:,wood)  = 0.0_r_2
+                casaflux%fracCalloc(:,wood)  = 0.0_r2
                 casaflux%fracCalloc(:,froot) = casaflux%Crmplant(:,froot) / sum(casaflux%Crmplant,2)
              ENDWHERE
           ENDWHERE
 
           !! vh_js !!  Ticket#108
-          WHERE(casaflux%Cnpp<0.0_r_2 .and. sum(casapool%Cplant,2)>0.0_r_2  )
+          WHERE(casaflux%Cnpp<0.0_r2 .and. sum(casapool%Cplant,2)>0.0_r2  )
              WHERE(casamet%lnonwood==0)  !woodland or forest
                 casaflux%fracCalloc(:,leaf)  = casapool%Cplant(:,leaf)  / sum(casapool%Cplant,2)
                 casaflux%fracCalloc(:,wood)  = casapool%Cplant(:,wood)  / sum(casapool%Cplant,2)
                 casaflux%fracCalloc(:,froot) = casapool%Cplant(:,froot) / sum(casapool%Cplant,2)
              ELSEWHERE
                 casaflux%fracCalloc(:,leaf)  = casapool%Cplant(:,leaf)  / sum(casapool%Cplant,2)
-                casaflux%fracCalloc(:,wood)  = 0.0_r_2
+                casaflux%fracCalloc(:,wood)  = 0.0_r2
                 casaflux%fracCalloc(:,froot) = casapool%Cplant(:,froot) / sum(casapool%Cplant,2)
              ENDWHERE
           ENDWHERE
@@ -463,15 +463,15 @@ CONTAINS
     TYPE (casa_pool),           INTENT(INOUT) :: casapool
     TYPE (casa_flux),           INTENT(INOUT) :: casaflux
 
-    real(r_2), parameter :: wolf_alpha1 = 6.22_r_2
-    real(r_2), parameter :: wolf_beta   = -1.33_r_2
-    real(r_2), parameter :: wolf_c1     = -wolf_alpha1 / (1.0_r_2+wolf_beta)
-    real(r_2), parameter :: wolf_c2     = 1.0_r_2 / (1.0_r_2+wolf_beta)
+    real(r2), parameter :: wolf_alpha1 = 6.22_r2
+    real(r2), parameter :: wolf_beta   = -1.33_r2
+    real(r2), parameter :: wolf_c1     = -wolf_alpha1 / (1.0_r2+wolf_beta)
+    real(r2), parameter :: wolf_c2     = 1.0_r2 / (1.0_r2+wolf_beta)
     !
     ! local variables
     integer   npt
-    real(r_2), dimension(mp) :: totbmdm,ntree,nppdm
-    real(r_2), dimension(mp) :: gleaf,gwood,gcroot,gfroot,gtot
+    real(r2), dimension(mp) :: totbmdm,ntree,nppdm
+    real(r2), dimension(mp) :: gleaf,gwood,gcroot,gfroot,gtot
     !
     ! input
     !  totleaf, totwood, totcroot, totfroot :    g C m-2
@@ -481,22 +481,22 @@ CONTAINS
     !
 
     do npt=1,mp
-       IF ((casamet%iveg2(npt)==3) .and. (casaflux%cnpp(npt)>0.0001_r_2)) THEN  !forest types
+       IF ((casamet%iveg2(npt)==3) .and. (casaflux%cnpp(npt)>0.0001_r2)) THEN  !forest types
           ! 10.0 for convert gc/m2 to kg/ha
-          totbmdm(npt) = sum(casapool%cplant(npt,:)) *10.0_r_2 / fracCbiomass
-          totbmdm(npt) = max(30000.0_r_2, totbmdm(npt))
+          totbmdm(npt) = sum(casapool%cplant(npt,:)) *10.0_r2 / fracCbiomass
+          totbmdm(npt) = max(30000.0_r2, totbmdm(npt))
           ! calculate tree stocking density
           ! tree ha-1, based on eqn (4) of Wolf et al. 2011, GBC
-          ntree(npt) = 10.0_r_2**(wolf_c1+wolf_c2*log10(totbmdm(npt)))
-          ntree(npt) = min(200000.0_r_2,ntree(npt))
+          ntree(npt) = 10.0_r2**(wolf_c1+wolf_c2*log10(totbmdm(npt)))
+          ntree(npt) = min(200000.0_r2,ntree(npt))
           ! changed by ypw 23/april/2012 to avoid negative npp
           ! in kg dm tree-1 yr-1
-          nppdm(npt)  = (abs(casaflux%cnpp(npt)) *365.0_r_2*0.001_r_2/fracCbiomass)/(0.0001_r_2*ntree(npt))
+          nppdm(npt)  = (abs(casaflux%cnpp(npt)) *365.0_r2*0.001_r2/fracCbiomass)/(0.0001_r2*ntree(npt))
 
-          gleaf(npt)  = 0.156_r_2*(nppdm(npt)**1.106_r_2)     ! Figure 2a of Wolf, Field and Berry (2011)
-          gwood(npt)  = 0.232_r_2*(nppdm(npt)**1.165_r_2)     ! Figure 2b of Wolf, Field and Berry (2011)
-          gcroot(npt) = 0.0348_r_2*(nppdm(npt)**1.310_r_2)    ! Figure 2d of Wolf, Field and Berry (2011)
-          gfroot(npt) = 0.247_r_2*(nppdm(npt)**0.987_r_2)     ! Figure 2c of Wolf, Field and Berry (2011)
+          gleaf(npt)  = 0.156_r2*(nppdm(npt)**1.106_r2)     ! Figure 2a of Wolf, Field and Berry (2011)
+          gwood(npt)  = 0.232_r2*(nppdm(npt)**1.165_r2)     ! Figure 2b of Wolf, Field and Berry (2011)
+          gcroot(npt) = 0.0348_r2*(nppdm(npt)**1.310_r2)    ! Figure 2d of Wolf, Field and Berry (2011)
+          gfroot(npt) = 0.247_r2*(nppdm(npt)**0.987_r2)     ! Figure 2c of Wolf, Field and Berry (2011)
           gtot(npt)   = gleaf(npt) + gwood(npt) + gcroot(npt) + gfroot(npt)
 
           casaflux%fracCalloc(npt,leaf)  = gleaf(npt)/gtot(npt)
@@ -527,31 +527,31 @@ CONTAINS
     type(climate_type),       intent(in)    :: climate
 
     integer :: npt, ivt
-    real(r_2), dimension(mp)        :: Ygrow        ! growth efficiency Q.Zhang 22/02/2011
-    real(r_2), dimension(mp,mplant) :: ratioPNplant ! Q.Zhang 22/02/2011
+    real(r2), dimension(mp)        :: Ygrow        ! growth efficiency Q.Zhang 22/02/2011
+    real(r2), dimension(mp,mplant) :: ratioPNplant ! Q.Zhang 22/02/2011
     ! reduction in wood and root respiration when NPP <0.0
-    real(r_2), dimension(mp)        :: delcrmwood,delcrmfroot
-    real(r_2), dimension(mp)        :: resp_coeff_root, resp_coeff_sapwood
-    real(r_2), dimension(mp)        :: nleaf, pleaf, vcmaxmax
-    real(r_2) :: c1, c2, c3, c5 ! coefficients for acclimation of maintenance respiration
+    real(r2), dimension(mp)        :: delcrmwood,delcrmfroot
+    real(r2), dimension(mp)        :: resp_coeff_root, resp_coeff_sapwood
+    real(r2), dimension(mp)        :: nleaf, pleaf, vcmaxmax
+    real(r2) :: c1, c2, c3, c5 ! coefficients for acclimation of maintenance respiration
 
-    resp_coeff_root    = 1.0_r_2
-    resp_coeff_sapwood = 1.0_r_2
-    ratioPNplant       = 0.0_r_2
-    Ygrow              = 0.0_r_2
+    resp_coeff_root    = 1.0_r2
+    resp_coeff_sapwood = 1.0_r2
+    ratioPNplant       = 0.0_r2
+    Ygrow              = 0.0_r2
 
-    WHERE(casapool%Nplant > 0.0_r_2)
-       ratioPNplant = casapool%Pplant / (casapool%Nplant+ 1.e-10_r_2)
+    WHERE(casapool%Nplant > 0.0_r2)
+       ratioPNplant = casapool%Pplant / (casapool%Nplant+ 1.e-10_r2)
     ENDWHERE
 
-    Ygrow(:) = 0.65_r_2 + 0.2_r_2*ratioPNplant(:,leaf)/(ratioPNplant(:,leaf)+1.0_r_2/15.0_r_2)
+    Ygrow(:) = 0.65_r2 + 0.2_r2*ratioPNplant(:,leaf)/(ratioPNplant(:,leaf)+1.0_r2/15.0_r2)
 
-    casaflux%crmplant(:,wood)  = 0.0_r_2
-    casaflux%crmplant(:,froot) = 0.0_r_2
-    delcrmwood  = 0.0_r_2
-    delcrmfroot = 0.0_r_2
-    casaflux%crgplant = 0.0_r_2
-    casaflux%clabloss = 0.0_r_2
+    casaflux%crmplant(:,wood)  = 0.0_r2
+    casaflux%crmplant(:,froot) = 0.0_r2
+    delcrmwood  = 0.0_r2
+    delcrmfroot = 0.0_r2
+    casaflux%crgplant = 0.0_r2
+    casaflux%clabloss = 0.0_r2
 
     if (cable_user%CALL_climate) then
        ! coefficients required to implement T-acclimation of autotrophic respiration (Ticket # 110)
@@ -564,31 +564,31 @@ CONTAINS
           pleaf(npt) = casabiome%ratioPcplantmax(ivt,leaf)/casabiome%sla(ivt)
           if (ivt.eq.7) then
              ! special for C4 grass: set here to value from  parameter file
-             vcmaxmax(npt) = real(veg%vcmax(npt), r_2)
+             vcmaxmax(npt) = real(veg%vcmax(npt), r2)
           else
              vcmaxmax(npt) = vcmax_np(nleaf(npt), pleaf(npt)) * casabiome%vcmax_scalar(ivt)
           endif
 
           if (veg%iveg(npt).eq.2 .or. veg%iveg(npt).eq.4) then
              ! broadleaf forestNESP2pt9_BLAZE
-             c1 = 1.2818_r_2 * 1.e-6_r_2
-             ! c1 = 1.3805e-6_r_2 ! null model
+             c1 = 1.2818_r2 * 1.e-6_r2
+             ! c1 = 1.3805e-6_r2 ! null model
           elseif(veg%iveg(npt).eq.1 .or. veg%iveg(npt).eq.3) then
              ! needleleaf forest
-             c1 = 1.2877_r_2 * 1.e-6_r_2
-             ! c1 = 1.3247e-6_r_2 ! null model
+             c1 = 1.2877_r2 * 1.e-6_r2
+             ! c1 = 1.3247e-6_r2 ! null model
           elseif (veg%iveg(npt).eq.6 .or. veg%iveg(npt).eq.8 .or. veg%iveg(npt).eq.9) then
              ! C3 grass, tundra, crop
-             c1 = 1.6737_r_2 * 1.e-6_r_2
-             ! c1 = 1.8904e-6_r_2 ! null model
+             c1 = 1.6737_r2 * 1.e-6_r2
+             ! c1 = 1.8904e-6_r2 ! null model
           else
              ! shrubs and other (C4 grass and crop)
-             c1 = 1.5758_r_2 * 1.0e-6_r_2
-             !c1 = 1.7265e-6_r_2 ! null model
+             c1 = 1.5758_r2 * 1.0e-6_r2
+             !c1 = 1.7265e-6_r2 ! null model
           endif
-          c2 = 0.0116_r_2
-          c3 = -0.0334_r_2 * 1.e-6_r_2
-          c5 = 1.0_r_2 / vcmaxmax(npt) / 0.0116_r_2 * 0.60_r_2
+          c2 = 0.0116_r2
+          c3 = -0.0334_r2 * 1.e-6_r2
+          c5 = 1.0_r2 / vcmaxmax(npt) / 0.0116_r2 * 0.60_r2
           resp_coeff_root(npt) = casapool%nplant(npt,froot) * c5 * &
                (c1 + c2 *vcmaxmax(npt)*climate%frec(npt)  + c3 * climate%qtemp_max_last_year(npt) )
 
@@ -604,37 +604,37 @@ CONTAINS
        !  acclimation of autotrophic respiration Ticket #110
        where(casamet%iveg2/=icewater)
 
-          where(casamet%tairk > 250.0_r_2)
-             where(casapool%cplant(:,wood) > 1.e-6_r_2)
+          where(casamet%tairk > 250.0_r2)
+             where(casapool%cplant(:,wood) > 1.e-6_r2)
                 casaflux%crmplant(:,wood) = resp_coeff_sapwood * &
                      casabiome%rmplant(veg%iveg(:),wood) &
-                     * exp( 308.56_r_2*(1.0_r_2/56.02_r_2 - &
-                     1.0_r_2 / (casamet%tairk(:)+46.02_r_2-tkzeroc)) )
+                     * exp( 308.56_r2*(1.0_r2/56.02_r2 - &
+                     1.0_r2 / (casamet%tairk(:)+46.02_r2-tkzeroc)) )
 
              endwhere
              !vh! prevent floating underflow with this mask
-             where (casapool%Clabile(:) > 1.0e-8_r_2)
+             where (casapool%Clabile(:) > 1.0e-8_r2)
                 casaflux%clabloss(:) = casabiome%kclabrate(veg%iveg(:)) &
-                     * max(0.0_r_2,casapool%Clabile(:)) &
-                     * exp( 308.56_r_2*(1.0_r_2/56.02_r_2 - &
-                     1.0_r_2 / (casamet%tairk(:)+46.02_r_2-tkzeroc)) )
+                     * max(0.0_r2,casapool%Clabile(:)) &
+                     * exp( 308.56_r2*(1.0_r2/56.02_r2 - &
+                     1.0_r2 / (casamet%tairk(:)+46.02_r2-tkzeroc)) )
              endwhere
           endwhere
 
-          where((casamet%tsoilavg > 250.0_r_2) .and. (casapool%cplant(:,froot)>1.0e-6_r_2))
+          where((casamet%tsoilavg > 250.0_r2) .and. (casapool%cplant(:,froot)>1.0e-6_r2))
              casaflux%crmplant(:,froot) = resp_coeff_root * &
                   casabiome%rmplant(veg%iveg(:),froot) &
-                  * exp( 308.56_r_2*(1.0_r_2/56.02_r_2 - &
-                  1.0_r_2 / (casamet%tsoilavg(:)+46.02_r_2-tkzeroc)) )
+                  * exp( 308.56_r2*(1.0_r2/56.02_r2 - &
+                  1.0_r2 / (casamet%tsoilavg(:)+46.02_r2-tkzeroc)) )
           endwhere
 
-          where((casaflux%Cgpp-sum(Casaflux%crmplant,2))>0.0_r_2)
-             !casaflux%crgplant(:)  = 0.25* max(0.0_r_2,casaflux%Cgpp(:)-SUM(casaflux%crmplant(:,:),2))
+          where((casaflux%Cgpp-sum(Casaflux%crmplant,2))>0.0_r2)
+             !casaflux%crgplant(:)  = 0.25* max(0.0_r2,casaflux%Cgpp(:)-SUM(casaflux%crmplant(:,:),2))
              ! Growth efficiency correlated to leaf N:P ratio. Q.Zhang @ 22/02/2011
-             casaflux%crgplant(:)  = (1.0_r_2-Ygrow(:)) * &
-                  max(0.0_r_2,casaflux%Cgpp(:)-SUM(casaflux%crmplant(:,:),2))
+             casaflux%crgplant(:)  = (1.0_r2-Ygrow(:)) * &
+                  max(0.0_r2,casaflux%Cgpp(:)-SUM(casaflux%crmplant(:,:),2))
           elsewhere
-             casaflux%crgplant(:) = 0.0_r_2
+             casaflux%crgplant(:) = 0.0_r2
           endwhere
 
        endwhere ! /= icewater
@@ -645,37 +645,37 @@ CONTAINS
 
        where(casamet%iveg2/=icewater)
 
-          where(casamet%tairk > 250.0_r_2)
-             where(casapool%cplant(:,wood) > 1.e-6_r_2)
+          where(casamet%tairk > 250.0_r2)
+             where(casapool%cplant(:,wood) > 1.e-6_r2)
                 casaflux%crmplant(:,wood) = casaflux%frac_sapwood(:) * &
                      casabiome%rmplant(veg%iveg(:),wood) &
                      * casapool%nplant(:,wood) &
-                     * exp(308.56_r_2*(1.0_r_2/56.02_r_2 - &
-                     1.0_r_2 / (casamet%tairk(:)+46.02_r_2-tkzeroc)))
+                     * exp(308.56_r2*(1.0_r2/56.02_r2 - &
+                     1.0_r2 / (casamet%tairk(:)+46.02_r2-tkzeroc)))
              endwhere
              casaflux%clabloss(:) = casabiome%kclabrate(veg%iveg(:)) &
-                  * max(0.0_r_2,casapool%Clabile(:)) &
-                  * exp(308.56_r_2*(1.0_r_2/56.02_r_2 - &
-                  1.0_r_2 / (casamet%tairk(:)+46.02_r_2-tkzeroc)))
+                  * max(0.0_r2,casapool%Clabile(:)) &
+                  * exp(308.56_r2*(1.0_r2/56.02_r2 - &
+                  1.0_r2 / (casamet%tairk(:)+46.02_r2-tkzeroc)))
           endwhere
 
-          where((casamet%tsoilavg > 250.0_r_2) .and. (casapool%cplant(:,froot) > 1.0e-6_r_2))
+          where((casamet%tsoilavg > 250.0_r2) .and. (casapool%cplant(:,froot) > 1.0e-6_r2))
              casaflux%crmplant(:,froot) =  casabiome%rmplant(veg%iveg(:),froot) &
                   * casapool%nplant(:,froot) &
-                  * exp(308.56_r_2*(1.0_r_2/56.02_r_2 - &
-                  1.0_r_2 / (casamet%tsoilavg(:)+46.02_r_2-tkzeroc)))
+                  * exp(308.56_r2*(1.0_r2/56.02_r2 - &
+                  1.0_r2 / (casamet%tsoilavg(:)+46.02_r2-tkzeroc)))
           endwhere
           !    casaflux%crmplant(:,leaf) = casaflux%crmplant(:,leaf) + casaflux%clabloss(:)
 
-          where((casaflux%Cgpp-sum(casaflux%crmplant,2))>0.0_r_2)
+          where((casaflux%Cgpp-sum(casaflux%crmplant,2))>0.0_r2)
              !casaflux%crgplant(:)  = 0.25* max(0.0,casaflux%Cgpp(:)-SUM(casaflux%crmplant(:,:),2))
              ! Growth efficiency correlated to leaf N:P ratio. Q.Zhang @ 22/02/2011
-             casaflux%crgplant(:)  = (1.0_r_2-Ygrow(:)) * &
-                  max(0.0_r_2,casaflux%Cgpp(:)-SUM(casaflux%crmplant(:,:),2))
+             casaflux%crgplant(:)  = (1.0_r2-Ygrow(:)) * &
+                  max(0.0_r2,casaflux%Cgpp(:)-SUM(casaflux%crmplant(:,:),2))
           elsewhere
-             casaflux%crgplant(:) = 0.0_r_2
+             casaflux%crgplant(:) = 0.0_r2
           endwhere
-          !casaflux%Cnpp(:) = MAX(0.0_r_2,(casaflux%Cgpp(:)-SUM(casaflux%crmplant(:,:),2) &
+          !casaflux%Cnpp(:) = MAX(0.0_r2,(casaflux%Cgpp(:)-SUM(casaflux%crmplant(:,:),2) &
           !                 - casaflux%crgplant(:)))
           ! changes made by yp wang 5 april 2013
           casaflux%Cnpp(:) = casaflux%Cgpp(:) - sum(casaflux%Crmplant(:,:),2) - casaflux%Crgplant(:)
@@ -704,21 +704,21 @@ CONTAINS
 
     IMPLICIT NONE
 
-    REAL(r_2), DIMENSION(mp), INTENT(OUT)   :: xkleafcold
-    REAL(r_2), DIMENSION(mp), INTENT(OUT)   :: xkleafdry
-    REAL(r_2), DIMENSION(mp), INTENT(OUT)   :: xkleaf
+    REAL(r2), DIMENSION(mp), INTENT(OUT)   :: xkleafcold
+    REAL(r2), DIMENSION(mp), INTENT(OUT)   :: xkleafdry
+    REAL(r2), DIMENSION(mp), INTENT(OUT)   :: xkleaf
     TYPE(veg_parameter_type), INTENT(INOUT) :: veg  ! vegetation parameters
     TYPE(casa_biome),         INTENT(INOUT) :: casabiome
     TYPE(casa_met),           INTENT(INOUT) :: casamet
     TYPE(phen_variable),      INTENT(INOUT) :: phen
 
     ! local variables
-    REAL(r_2), DIMENSION(mp) :: xcoldleaf
+    REAL(r2), DIMENSION(mp) :: xcoldleaf
     INTEGER :: npt
 
-    xkleafcold(:) = 0.0_r_2
-    xkleafdry(:)  = 0.0_r_2
-    xkleaf(:)     = 1.0_r_2
+    xkleafcold(:) = 0.0_r2
+    xkleafdry(:)  = 0.0_r2
+    xkleaf(:)     = 1.0_r2
 
     ! BP changed the WHERE construct to DO-IF for Mk3L (jun2010)
     DO npt=1, mp
@@ -727,37 +727,37 @@ CONTAINS
           ! effect of cold or drought stress on leaf litter fall
           ! calculate cold stress (eqn (18), Arora 2005, GCB 11:39-59)
           IF (ge(casamet%tairk(npt), phen%TKshed(veg%iveg(npt)))) THEN
-             xcoldleaf(npt) = 1.0_r_2
+             xcoldleaf(npt) = 1.0_r2
           ELSE
-             IF ( le( casamet%tairk(npt), (phen%TKshed(veg%iveg(npt)) - 5.0_r_2) ) ) THEN
-                xcoldleaf(npt) = 0.0_r_2
+             IF ( le( casamet%tairk(npt), (phen%TKshed(veg%iveg(npt)) - 5.0_r2) ) ) THEN
+                xcoldleaf(npt) = 0.0_r2
              ELSE
-                !MC - Error? ->  ( casamet%tairk(npt) - (phen%TKshed(veg%iveg(npt))-5.0_r_2) ) / 5.0_r_2
-                xcoldleaf(npt) = ( casamet%tairk(npt) -  phen%TKshed(veg%iveg(npt))-5.0_r_2  ) / 5.0_r_2
+                !MC - Error? ->  ( casamet%tairk(npt) - (phen%TKshed(veg%iveg(npt))-5.0_r2) ) / 5.0_r2
+                xcoldleaf(npt) = ( casamet%tairk(npt) -  phen%TKshed(veg%iveg(npt))-5.0_r2  ) / 5.0_r2
              ENDIF
           ENDIF
-          xcoldleaf(npt) = min(1.0_r_2, max(0.0_r_2, xcoldleaf(npt)))
+          xcoldleaf(npt) = min(1.0_r2, max(0.0_r2, xcoldleaf(npt)))
           xkleafcold(npt) = casabiome%xkleafcoldmax(veg%iveg(npt)) &
-               * (1.0_r_2-xcoldleaf(npt))**casabiome%xkleafcoldexp(veg%iveg(npt))
+               * (1.0_r2-xcoldleaf(npt))**casabiome%xkleafcoldexp(veg%iveg(npt))
           xkleafdry(npt)  = casabiome%xkleafdrymax(veg%iveg(npt)) &
-               * (1.0_r_2-casamet%btran(npt))**casabiome%xkleafdryexp(veg%iveg(npt))
-          IF (phen%phase(npt)==1) xkleaf(npt) = 0.0_r_2
+               * (1.0_r2-casamet%btran(npt))**casabiome%xkleafdryexp(veg%iveg(npt))
+          IF (phen%phase(npt)==1) xkleaf(npt) = 0.0_r2
           ! vh ! account for high rate of leaf loss during senescence
           if (trim(cable_user%PHENOLOGY_SWITCH)=='climate') then
              ! increases base turnover rate by a factor of 13
              ! (for base turnover time of 1y, this reduces it to 4 weeks)
              IF ((phen%phase(npt)==3 .or. phen%phase(npt)==0) .and. casamet%lnonwood(npt)==0) &
-                  xkleaf(npt)= 13.0_r_2
+                  xkleaf(npt)= 13.0_r2
              IF ((phen%phase(npt)==3 .or. phen%phase(npt)==0) .and. casamet%lnonwood(npt)==1) &
-                  xkleaf(npt)= 13.0_r_2 * 0.5_r_2
+                  xkleaf(npt)= 13.0_r2 * 0.5_r2
           endif
-          if (xkleafcold(npt) < 0.0_r_2) print*, 'ERR KK01 ', npt, xkleafcold(npt), &
+          if (xkleafcold(npt) < 0.0_r2) print*, 'ERR KK01 ', npt, xkleafcold(npt), &
                casabiome%xkleafcoldmax(veg%iveg(npt)), &
-               (1.0_r_2-xcoldleaf(npt)) , casabiome%xkleafcoldexp(veg%iveg(npt))
-          if (xkleafdry(npt) < 0.0_r_2) print*, 'ERR KK02 ', npt, xkleafdry(npt), &
+               (1.0_r2-xcoldleaf(npt)) , casabiome%xkleafcoldexp(veg%iveg(npt))
+          if (xkleafdry(npt) < 0.0_r2) print*, 'ERR KK02 ', npt, xkleafdry(npt), &
                casabiome%xkleafdrymax(veg%iveg(npt)), &
-               (1.0_r_2-casamet%btran(npt)), casabiome%xkleafdryexp(veg%iveg(npt))
-          if (xkleaf(npt) < 0.0_r_2) print*, 'ERR KK03 ', npt, xkleaf(npt)
+               (1.0_r2-casamet%btran(npt)), casabiome%xkleafdryexp(veg%iveg(npt))
+          if (xkleaf(npt) < 0.0_r2) print*, 'ERR KK03 ', npt, xkleaf(npt)
        END IF
     END DO
 
@@ -766,20 +766,20 @@ CONTAINS
     !  !    effect of cold or drought stress on leaf litter fall
     !  !    calculate cold stress (eqn (18), Arora 2005, GCB 11:39-59)
     !    WHERE(casamet%tairk(:)>=phen%TKshed(veg%iveg(:)))
-    !      xcoldleaf(:) = 1.0_r_2
+    !      xcoldleaf(:) = 1.0_r2
     !    ELSEWHERE
     !      WHERE(casamet%tairk(:)<=(phen%TKshed(veg%iveg(:))-5.0))
-    !        xcoldleaf(:)=0.0_r_2
+    !        xcoldleaf(:)=0.0_r2
     !      ELSEWHERE
     !        xcoldleaf(:) = (casamet%tairk(:)-phen%TKshed(veg%iveg(:))-5.0)/5.0
     !      ENDWHERE
     !    ENDWHERE
-    !    xcoldleaf(:) = min(1.0_r_2,max(0.0_r_2,xcoldleaf(:)))
-    !    xkleafcold(:) = casabiome%xkleafcoldmax(veg%iveg(:)) * (1.0_r_2-xcoldleaf(:)) &
+    !    xcoldleaf(:) = min(1.0_r2,max(0.0_r2,xcoldleaf(:)))
+    !    xkleafcold(:) = casabiome%xkleafcoldmax(veg%iveg(:)) * (1.0_r2-xcoldleaf(:)) &
     !                 ** casabiome%xkleafcoldexp(veg%iveg(:))
-    !    xkleafdry(:) = casabiome%xkleafdrymax(veg%iveg(:))*(1.0_r_2-casamet%btran(:))&
+    !    xkleafdry(:) = casabiome%xkleafdrymax(veg%iveg(:))*(1.0_r2-casamet%btran(:))&
     !                 ** casabiome%xkleafdryexp(veg%iveg(:))
-    !    WHERE(phen%phase(:)==1) xkleaf(:)= 0.0_r_2
+    !    WHERE(phen%phase(:)==1) xkleaf(:)= 0.0_r2
     !  ENDWHERE
 
   END SUBROUTINE casa_xrateplant
@@ -797,70 +797,70 @@ CONTAINS
     !     xk(mp):          modifier of soil litter decomposition rate (dimensionless)
     IMPLICIT NONE
 
-    REAL(r_2), DIMENSION(mp),  INTENT(OUT)   :: xklitter, xksoil
+    REAL(r2), DIMENSION(mp),  INTENT(OUT)   :: xklitter, xksoil
     TYPE(veg_parameter_type),  INTENT(INOUT) :: veg  ! vegetation parameters
     TYPE(soil_parameter_type), INTENT(INOUT) :: soil ! soil parameters
     TYPE(casa_met),            INTENT(INOUT) :: casamet
     TYPE(casa_biome),          INTENT(INOUT) :: casabiome
 
     ! local variables
-    REAL(r_2), parameter :: wfpscoefa = 0.55_r_2   ! Kelly et al. (2000) JGR, Figure 2b), optimal wfps
-    REAL(r_2), parameter :: wfpscoefb = 1.70_r_2   ! Kelly et al. (2000) JGR, Figure 2b)
-    REAL(r_2), parameter :: wfpscoefc = -0.007_r_2 ! Kelly et al. (2000) JGR, Figure 2b)
-    REAL(r_2), parameter :: wfpscoefd = 3.22_r_2   ! Kelly et al. (2000) JGR, Figure 2b)
-    REAL(r_2), parameter :: wfpscoefe = 6.6481_r_2 ! =wfpscoefd*(wfpscoefb-wfpscoefa)/(wfpscoefa-wfpscoefc)
+    REAL(r2), parameter :: wfpscoefa = 0.55_r2   ! Kelly et al. (2000) JGR, Figure 2b), optimal wfps
+    REAL(r2), parameter :: wfpscoefb = 1.70_r2   ! Kelly et al. (2000) JGR, Figure 2b)
+    REAL(r2), parameter :: wfpscoefc = -0.007_r2 ! Kelly et al. (2000) JGR, Figure 2b)
+    REAL(r2), parameter :: wfpscoefd = 3.22_r2   ! Kelly et al. (2000) JGR, Figure 2b)
+    REAL(r2), parameter :: wfpscoefe = 6.6481_r2 ! =wfpscoefd*(wfpscoefb-wfpscoefa)/(wfpscoefa-wfpscoefc)
     ! ! Kirschbaum function parameters
-    ! REAL(r_2), parameter :: xkalpha=-3.764   ! Kirschbaum (1995, SBB)
-    ! REAL(r_2), parameter :: xkbeta=0.204
-    ! REAL(r_2), parameter :: xktoptc=36.9
+    ! REAL(r2), parameter :: xkalpha=-3.764   ! Kirschbaum (1995, SBB)
+    ! REAL(r2), parameter :: xkbeta=0.204
+    ! REAL(r2), parameter :: xktoptc=36.9
     ! Trudinger2016 function parameters (from Trudinger 2016)
-    REAL(r_2), parameter :: wfpswidth1 = 1.2160310E+00_r_2
-    REAL(r_2), parameter :: wfpswidth2 = 6.4620150E-01_r_2
-    REAL(r_2), parameter :: wfpswidth3 = 4.9625073E-01_r_2
-    REAL(r_2), parameter :: wfpsscale1 = 1.6193957E+00_r_2
-    REAL(r_2), parameter :: wfpswidth0 = 1.3703876E-02_r_2
-    REAL(r_2), parameter :: wfpsquad   = 8.0000000E-01_r_2
+    REAL(r2), parameter :: wfpswidth1 = 1.2160310E+00_r2
+    REAL(r2), parameter :: wfpswidth2 = 6.4620150E-01_r2
+    REAL(r2), parameter :: wfpswidth3 = 4.9625073E-01_r2
+    REAL(r2), parameter :: wfpsscale1 = 1.6193957E+00_r2
+    REAL(r2), parameter :: wfpswidth0 = 1.3703876E-02_r2
+    REAL(r2), parameter :: wfpsquad   = 8.0000000E-01_r2
 
     ! Trudinger2016 function parameters (corresponds to Haverd 2013)
-    ! REAL(r_2), parameter :: wfpswidth1=0.78_r_2
-    ! REAL(r_2), parameter :: wfpswidth2=0_r_2
-    ! REAL(r_2), parameter :: wfpswidth3=1.5_r_2
-    ! REAL(r_2), parameter :: wfpsscale1=10.0_r_2
-    ! REAL(r_2), parameter :: wfpswidth0 = 0.0_r_2
-    ! REAL(r_2), parameter :: wfpsquad=0.0_r_2
+    ! REAL(r2), parameter :: wfpswidth1=0.78_r2
+    ! REAL(r2), parameter :: wfpswidth2=0_r2
+    ! REAL(r2), parameter :: wfpswidth3=1.5_r2
+    ! REAL(r2), parameter :: wfpsscale1=10.0_r2
+    ! REAL(r2), parameter :: wfpswidth0 = 0.0_r2
+    ! REAL(r2), parameter :: wfpsquad=0.0_r2
 
     ! DAMM temporary variables
-    REAL(r_2) :: O2, vol_air_content, Enz, Dliq, Dva
+    REAL(r2) :: O2, vol_air_content, Enz, Dliq, Dva
 
-    REAL(r_2), DIMENSION(mp)       :: xkwater,xktemp
-    REAL(r_2), DIMENSION(mp)       :: fwps,tsavg
+    REAL(r2), DIMENSION(mp)       :: xkwater,xktemp
+    REAL(r2), DIMENSION(mp)       :: fwps,tsavg
     ! Custom soil respiration - see Ticket #42
-    REAL(r_2), DIMENSION(mp)       :: smrf,strf,slopt,wlt,tsoil,sopt
-    REAL(r_2) :: f0
+    REAL(r2), DIMENSION(mp)       :: smrf,strf,slopt,wlt,tsoil,sopt
+    REAL(r2) :: f0
     !,tsurfavg  !!, msurfavg
     INTEGER :: npt
 
-    xklitter(:) = 1.0_r_2
-    xksoil(:)   = 1.0_r_2
+    xklitter(:) = 1.0_r2
+    xksoil(:)   = 1.0_r2
     fwps(:)     = casamet%moistavg(:) / soil%ssat(:)
     tsavg(:)    = casamet%tsoilavg(:)
 
     ! Custom soil respiration - see Ticket #42
     tsoil(:)    = tsavg(:) - TKzeroC !tsoil in C
-    strf(:)     = 1.0_r_2
-    smrf(:)     = 1.0_r_2
-    slopt(:)    = 1.0_r_2
-    sopt(:)     = 1.0_r_2
+    strf(:)     = 1.0_r2
+    smrf(:)     = 1.0_r2
+    slopt(:)    = 1.0_r2
+    sopt(:)     = 1.0_r2
 
     ! BP changed the WHERE construct to DO-IF for Mk3L (jun2010)
     DO npt=1,mp
        IF(casamet%iveg2(npt)/=icewater) THEN
-          xktemp(npt)  = casabiome%q10soil(veg%iveg(npt))**(0.1_r_2*(tsavg(npt)-TKzeroC-35.0_r_2))
+          xktemp(npt)  = casabiome%q10soil(veg%iveg(npt))**(0.1_r2*(tsavg(npt)-TKzeroC-35.0_r2))
 
           xkwater(npt) = ((fwps(npt)-wfpscoefb)/(wfpscoefa-wfpscoefb))**wfpscoefe &
                * ((fwps(npt)-wfpscoefc)/(wfpscoefa-wfpscoefc))**wfpscoefd
           IF (veg%iveg(npt) == cropland .OR. veg%iveg(npt) == croplnd2) &
-               xkwater(npt)=1.0_r_2
+               xkwater(npt)=1.0_r2
           xklitter(npt) = casabiome%xkoptlitter(veg%iveg(npt)) * xktemp(npt) * xkwater(npt)
 
           IF( .NOT. cable_user%SRF) THEN
@@ -873,25 +873,25 @@ CONTAINS
              IF(trim(cable_user%SMRF_NAME)=='CASA-CNP') THEN
                 smrf(npt)=xkwater(npt)
              ELSE IF (trim(cable_user%SMRF_NAME)=='SOILN') then
-                sopt(npt)=0.92_r_2
-                slopt(npt)=wlt(npt)+0.1_r_2          !SLOPT is the lower optimum
+                sopt(npt)=0.92_r2
+                slopt(npt)=wlt(npt)+0.1_r2          !SLOPT is the lower optimum
                 IF (fwps(npt)>sopt(npt)) THEN
-                   smrf(npt)=0.2_r_2+0.8_r_2*(1.0_r_2-fwps(npt))/(1.0_r_2-sopt(npt))
+                   smrf(npt)=0.2_r2+0.8_r2*(1.0_r2-fwps(npt))/(1.0_r2-sopt(npt))
                 ELSE IF(slopt(npt)<=fwps(npt) .AND. fwps(npt)<=sopt(npt)) THEN
-                   smrf(npt) = 1.0_r_2
+                   smrf(npt) = 1.0_r2
                 ELSE IF (wlt(npt)<=fwps(npt) .AND. fwps(npt) <slopt(npt)) THEN
-                   smrf(npt)=0.01_r_2+0.99_r_2*(fwps(npt)-wlt(npt))/(slopt(npt)-wlt(npt))
+                   smrf(npt)=0.01_r2+0.99_r2*(fwps(npt)-wlt(npt))/(slopt(npt)-wlt(npt))
                 ELSE IF (fwps(npt)<wlt(npt)) THEN
-                   smrf(npt) = 0.01_r_2
+                   smrf(npt) = 0.01_r2
                 END IF
              ELSE IF (trim(cable_user%SMRF_NAME)=='TRIFFID') THEN
-                sopt(npt) = 0.5_r_2 * (1.0_r_2+wlt(npt))
+                sopt(npt) = 0.5_r2 * (1.0_r2+wlt(npt))
                 IF (fwps(npt) > sopt(npt)) THEN
-                   smrf(npt) =1.0_r_2-0.8_r_2*(fwps(npt)-sopt(npt))
+                   smrf(npt) =1.0_r2-0.8_r2*(fwps(npt)-sopt(npt))
                 ELSE IF (wlt(npt)<fwps(npt) .AND. fwps(npt)<=sopt(npt)) THEN
-                   smrf(npt)=0.01_r_2+0.8_r_2*((fwps(npt)-wlt(npt))/(sopt(npt)-wlt(npt)))
+                   smrf(npt)=0.01_r2+0.8_r2*((fwps(npt)-wlt(npt))/(sopt(npt)-wlt(npt)))
                 ELSE IF (fwps(npt)<wlt(npt)) THEN
-                   smrf(npt) = 0.2_r_2
+                   smrf(npt) = 0.2_r2
                 END IF
              ELSE IF (trim(cable_user%SMRF_NAME)=='Trudinger2016') THEN
 
@@ -899,18 +899,18 @@ CONTAINS
                    smrf(npt) = wfpsquad *fwps(npt)**2
                 else
                    if (fwps(npt) .le. (wfpswidth0+wfpswidth1)) then
-                      f0 = 0.5_r_2 * ( 1.0_r_2 - &
-                           cos(3.1415_r_2 * ((wfpsscale1 - 1) * wfpswidth1) / (wfpswidth1 * wfpsscale1)) )
+                      f0 = 0.5_r2 * ( 1.0_r2 - &
+                           cos(3.1415_r2 * ((wfpsscale1 - 1) * wfpswidth1) / (wfpswidth1 * wfpsscale1)) )
                       smrf(npt) = max( (wfpsquad * fwps(npt)**2),  &
-                           ( (0.5_r_2 * (1.0_r_2 - &
-                           cos(3.1415_r_2 * (fwps(npt) - wfpswidth0 + (wfpsscale1 - 1) * wfpswidth1) / &
-                           (wfpswidth1 * wfpsscale1))) - f0) / (1.0_r_2 - f0) ) )
+                           ( (0.5_r2 * (1.0_r2 - &
+                           cos(3.1415_r2 * (fwps(npt) - wfpswidth0 + (wfpsscale1 - 1) * wfpswidth1) / &
+                           (wfpswidth1 * wfpsscale1))) - f0) / (1.0_r2 - f0) ) )
                    else
                       if (fwps(npt) .le. wfpswidth0 + wfpswidth1+wfpswidth2) then
-                         smrf(npt) = 1.0_r_2
+                         smrf(npt) = 1.0_r2
                       else
-                         smrf(npt) = 0.5_r_2 * ( 1.0_r_2 + &
-                              cos(3.1415_r_2 * (fwps(npt) - wfpswidth0 - wfpswidth1 - wfpswidth2) / &
+                         smrf(npt) = 0.5_r2 * ( 1.0_r2 + &
+                              cos(3.1415_r2 * (fwps(npt) - wfpswidth0 - wfpswidth1 - wfpswidth2) / &
                               wfpswidth3) )
                       endif
                    endif
@@ -923,19 +923,19 @@ CONTAINS
              ELSE if (trim(cable_user%STRF_NAME)=='K1995') THEN
                 !Kirschbaum from Kirschbaum 1995, eq (4) in SBB, .66 is to collapse smrf
                 !to same area
-                strf(npt)=exp(-3.764_r_2+0.204_r_2*tsoil(npt)*(1.0_r_2-0.5_r_2*tsoil(npt)/36.9_r_2))/0.66_r_2
+                strf(npt)=exp(-3.764_r2+0.204_r2*tsoil(npt)*(1.0_r2-0.5_r2*tsoil(npt)/36.9_r2))/0.66_r2
              ELSE IF (trim(cable_user%STRF_NAME)=='PnET-CN') THEN
-                strf(npt)=0.68_r_2*exp(0.1_r_2*(tsoil(npt)-7.1_r_2))/12.64_r_2
+                strf(npt)=0.68_r2*exp(0.1_r2*(tsoil(npt)-7.1_r2))/12.64_r2
              ELSE if (trim(cable_user%STRF_NAME)=='LT1994') THEN
                 ! Lloyd & Taylor, Func. Ec. 8, 315, 1994, Eq 11.
                 ! Normalised to 10 deg C
-                strf(npt)= exp(308.56_r_2*(1.0_r_2/56.02_r_2-1.0_r_2         &
-                     / (max(tsoil(npt),-20.0_r_2)+46.02_r_2)))/ &
-                     (exp(308.56_r_2*(1.0_r_2/56.02_r_2-1.0_r_2         &
-                     / (10.0_r_2 + 46.02_r_2))))
+                strf(npt)= exp(308.56_r2*(1.0_r2/56.02_r2-1.0_r2         &
+                     / (max(tsoil(npt),-20.0_r2)+46.02_r2)))/ &
+                     (exp(308.56_r2*(1.0_r2/56.02_r2-1.0_r2         &
+                     / (10.0_r2 + 46.02_r2))))
              ELSE if (trim(cable_user%STRF_NAME)=='Q10') THEN
                 ! Q10 normalised to 10 deg C
-                strf(npt) = casabiome%q10soil(veg%iveg(npt))**(0.1_r_2*(tsavg(npt)-TKzeroC-10.0_r_2))
+                strf(npt) = casabiome%q10soil(veg%iveg(npt))**(0.1_r2*(tsavg(npt)-TKzeroC-10.0_r2))
              END IF
 
              IF (trim(cable_user%STRF_NAME)=='DAMM' .and. trim(cable_user%SMRF_NAME)=='DAMM') THEN
@@ -947,29 +947,29 @@ CONTAINS
                 ! and diffusivity of Enzyme in the liquid phase (T-dependences of diffusivities taken from
                 ! (Haverd and Cuntz 2010, J. Hyd., 388, (2010), 438-455 ).
 
-                vol_air_content = max(soil%ssat(npt) - casamet%moistavg(npt), 0.0_r_2)
+                vol_air_content = max(soil%ssat(npt) - casamet%moistavg(npt), 0.0_r2)
 
-                Dva = 1.67_r_2 * 0.209_r_2 * ((casamet%tsoilavg(npt)/TKzeroC) ** 1.88_r_2 )/ &
-                     (((10.0_r_2  + TKzeroC) / TKzeroC) ** 1.88_r_2 )
-                O2 = Dva * (vol_air_content**(4._r_2/3._r_2))
+                Dva = 1.67_r2 * 0.209_r2 * ((casamet%tsoilavg(npt)/TKzeroC) ** 1.88_r2 )/ &
+                     (((10.0_r2  + TKzeroC) / TKzeroC) ** 1.88_r2 )
+                O2 = Dva * (vol_air_content**(4._r2/3._r2))
 
-                Dliq = 3.17_r_2 * casamet%moistavg(npt)**3 * &
-                     exp(-577.0_r_2 / (casamet%tsoilavg(npt) - 145._r_2)) / &
-                     exp(-577.0_r_2 / ((10.0_r_2 + 273.15_r_2) - 145._r_2))
+                Dliq = 3.17_r2 * casamet%moistavg(npt)**3 * &
+                     exp(-577.0_r2 / (casamet%tsoilavg(npt) - 145._r2)) / &
+                     exp(-577.0_r2 / ((10.0_r2 + 273.15_r2) - 145._r2))
 
                 Enz=casabiome%DAMM_EnzPool(veg%iveg(npt))* Dliq
 
                 ! Arrhenius temperature response function, normalised to 10 deg C.
-                strf(npt) = exp(-casabiome%DAMM_Ea(veg%iveg(npt))/(8.314e-3_r_2 &
+                strf(npt) = exp(-casabiome%DAMM_Ea(veg%iveg(npt))/(8.314e-3_r2 &
                      * (casamet%tsoilavg(npt)))) /                   &
-                     (exp(-casabiome%DAMM_Ea(veg%iveg(npt))/(8.314e-3_r_2 &
-                     * 283.0_r_2)))
+                     (exp(-casabiome%DAMM_Ea(veg%iveg(npt))/(8.314e-3_r2 &
+                     * 283.0_r2)))
 
                 ! moisture response function
                 smrf(npt) =  (Enz/(Enz+casabiome%DAMM_KMcp(veg%iveg(npt)))) &
                      * (O2/(casabiome%DAMM_KMO2(veg%iveg(npt))+O2))
 
-                xksoil(npt)   = (10.0_r_2**casabiome%DAMM_alpha(veg%iveg(npt)))* smrf(npt) * strf(npt)
+                xksoil(npt)   = (10.0_r2**casabiome%DAMM_alpha(veg%iveg(npt)))* smrf(npt) * strf(npt)
                 xklitter(npt) = xksoil(npt)
 
              ELSE
@@ -1002,7 +1002,7 @@ CONTAINS
 
     implicit none
 
-    real(r_2), dimension(mp), intent(in)    :: xkleafcold, xkleafdry, xkleaf
+    real(r2), dimension(mp), intent(in)    :: xkleafcold, xkleafdry, xkleaf
     type(veg_parameter_type), intent(inout) :: veg       ! vegetation parameters
     type(casa_biome),         intent(inout) :: casabiome
     type(casa_pool),          intent(inout) :: casapool
@@ -1010,36 +1010,36 @@ CONTAINS
     type(casa_met),           intent(inout) :: casamet
 
     ! local variables
-    real(r_2), dimension(mp,mplant) :: ratioligninton
+    real(r2), dimension(mp,mplant) :: ratioligninton
     integer :: npt
 
-    casaflux%fromPtoL(:,:,:) = 0.0_r_2
-    casaflux%kplant(:,:)     = 0.0_r_2
-    casaflux%kplant_tot(:,:) = 0.0_r_2
+    casaflux%fromPtoL(:,:,:) = 0.0_r2
+    casaflux%kplant(:,:)     = 0.0_r2
+    casaflux%kplant_tot(:,:) = 0.0_r2
 
     where (casamet%iveg2 /= icewater)
        ! using max function to avoid dividing by zero, ypw 14/may/2008
        ratioLignintoN(:,leaf)  = ( casapool%Cplant(:,leaf) &
-            / ( max(1.0e-10_r_2, casapool%Nplant(:,leaf)) * casabiome%ftransNPtoL(veg%iveg(:),leaf) ) ) &
+            / ( max(1.0e-10_r2, casapool%Nplant(:,leaf)) * casabiome%ftransNPtoL(veg%iveg(:),leaf) ) ) &
             * casabiome%fracLigninplant(veg%iveg(:),leaf)
        ratioLignintoN(:,froot) = ( casapool%Cplant(:,froot) &
-            / ( max(1.0e-10_r_2, casapool%Nplant(:,froot)) * casabiome%ftransNPtoL(veg%iveg(:),froot) ) ) &
+            / ( max(1.0e-10_r2, casapool%Nplant(:,froot)) * casabiome%ftransNPtoL(veg%iveg(:),froot) ) ) &
             * casabiome%fracLigninplant(veg%iveg(:),froot)
 
-       casaflux%fromPtoL(:,metb,leaf)  = max(0.001_r_2, 0.85_r_2 - 0.018_r_2 * ratioLignintoN(:,leaf))
-       casaflux%fromPtoL(:,metb,froot) = max(0.001_r_2, 0.85_r_2 - 0.018_r_2 * ratioLignintoN(:,froot))
-       casaflux%fromPtoL(:,str,leaf)   = 1.0_r_2 - casaflux%fromPtoL(:,metb,leaf)
-       casaflux%fromPtoL(:,str,froot)  = 1.0_r_2 - casaflux%fromPtoL(:,metb,froot)
-       casaflux%fromPtoL(:,cwd,wood)   = 1.0_r_2
+       casaflux%fromPtoL(:,metb,leaf)  = max(0.001_r2, 0.85_r2 - 0.018_r2 * ratioLignintoN(:,leaf))
+       casaflux%fromPtoL(:,metb,froot) = max(0.001_r2, 0.85_r2 - 0.018_r2 * ratioLignintoN(:,froot))
+       casaflux%fromPtoL(:,str,leaf)   = 1.0_r2 - casaflux%fromPtoL(:,metb,leaf)
+       casaflux%fromPtoL(:,str,froot)  = 1.0_r2 - casaflux%fromPtoL(:,metb,froot)
+       casaflux%fromPtoL(:,cwd,wood)   = 1.0_r2
 
        casaflux%kplant(:,leaf)  = casabiome%plantrate(veg%iveg(:),leaf) * xkleaf(:) + xkleafcold(:) + &
             xkleafdry(:)
        casaflux%kplant(:,wood)  = casabiome%plantrate(veg%iveg(:),wood)
        casaflux%kplant(:,froot) = casabiome%plantrate(veg%iveg(:),froot)
     endwhere
-    if (any(casaflux%kplant(:,leaf) < 0.0_r_2)) then
+    if (any(casaflux%kplant(:,leaf) < 0.0_r2)) then
        do npt=1, mp
-          if (casaflux%kplant(npt,leaf) < 0.0_r_2) then
+          if (casaflux%kplant(npt,leaf) < 0.0_r2) then
              print*, 'ERR KK10 ', npt, casaflux%kplant(npt,leaf)
              print*, 'ERR KK11 ', npt, casabiome%plantrate(veg%iveg(npt),leaf), xkleaf(npt), &
                   xkleafcold(npt), xkleafdry(npt)
@@ -1053,21 +1053,21 @@ CONTAINS
     where (casamet%iveg2 /= icewater)
        ! total turnover rate includes turnover by fire
        casaflux%kplant_tot(:,leaf)  = casaflux%kplant(:,leaf)  + &
-            (1.0_r_2-casaflux%kplant(:,leaf))  * casaflux%kplant_fire(:,leaf)
+            (1.0_r2-casaflux%kplant(:,leaf))  * casaflux%kplant_fire(:,leaf)
        casaflux%kplant_tot(:,froot) = casaflux%kplant(:,froot) + &
-            (1.0_r_2-casaflux%kplant(:,froot)) * casaflux%kplant_fire(:,froot)
+            (1.0_r2-casaflux%kplant(:,froot)) * casaflux%kplant_fire(:,froot)
        casaflux%kplant_tot(:,wood)  = casaflux%kplant(:,wood)  + &
-            (1.0_r_2-casaflux%kplant(:,wood))  * casaflux%kplant_fire(:,wood)
+            (1.0_r2-casaflux%kplant(:,wood))  * casaflux%kplant_fire(:,wood)
        ! adjust leaf flux to litter for crop/pasture removal
-       casaflux%fromPtoL(:,str,leaf)  = casaflux%fromPtoL(:,str,leaf)  * (1.0_r_2-casaflux%fharvest)
-       casaflux%fromPtoL(:,metb,leaf) = casaflux%fromPtoL(:,metb,leaf) * (1.0_r_2-casaflux%fharvest)
+       casaflux%fromPtoL(:,str,leaf)  = casaflux%fromPtoL(:,str,leaf)  * (1.0_r2-casaflux%fharvest)
+       casaflux%fromPtoL(:,metb,leaf) = casaflux%fromPtoL(:,metb,leaf) * (1.0_r2-casaflux%fharvest)
     endwhere
 
     ! When glai<glaimin, leaf biomass will not decrease anymore. (Q.Zhang 10/03/2011)
     do npt=1, mp
        if (casamet%glai(npt) .le. casabiome%glaimin(veg%iveg(npt))) then
-          casaflux%kplant(npt,leaf)     = 0.0_r_2
-          casaflux%kplant_tot(npt,leaf) = 0.0_r_2
+          casaflux%kplant(npt,leaf)     = 0.0_r2
+          casaflux%kplant_tot(npt,leaf) = 0.0_r2
        endif
     enddo
 
@@ -1091,7 +1091,7 @@ CONTAINS
 
     implicit none
 
-    real(r_2), dimension(mp),  intent(in)    :: xklitter, xksoil
+    real(r2), dimension(mp),  intent(in)    :: xklitter, xksoil
     type(veg_parameter_type),  intent(inout) :: veg        ! vegetation parameters
     type(soil_parameter_type), intent(inout) :: soil       ! soil parameters
     type(casa_biome),          intent(inout) :: casabiome
@@ -1101,35 +1101,35 @@ CONTAINS
     ! local variables
     integer :: j, k, kk, nland             ! i: for plant pool, j for litter, k for soil
 
-    casaflux%fromLtoS(:,:,:) = 0.0_r_2
-    casaflux%fromStoS(:,:,:) = 0.0_r_2
+    casaflux%fromLtoS(:,:,:) = 0.0_r2
+    casaflux%fromStoS(:,:,:) = 0.0_r2
 
     do k=1, msoil
-       casaflux%fromStoS(:,k,k) = -1.0_r_2     ! flow from soil to soil
+       casaflux%fromStoS(:,k,k) = -1.0_r2     ! flow from soil to soil
     enddo
-    casaflux%fromLtoCO2(:,:) = 0.0_r_2         ! flow from L or S to CO2
-    casaflux%fromStoCO2(:,:) = 0.0_r_2
+    casaflux%fromLtoCO2(:,:) = 0.0_r2         ! flow from L or S to CO2
+    casaflux%fromStoCO2(:,:) = 0.0_r2
 
-    casaflux%klitter(:,:)     = 0.0_r_2        ! initialize klitter (Q.Zhang 03/03/2011)
-    casaflux%klitter_tot(:,:) = 0.0_r_2
+    casaflux%klitter(:,:)     = 0.0_r2        ! initialize klitter (Q.Zhang 03/03/2011)
+    casaflux%klitter_tot(:,:) = 0.0_r2
 
     where (casamet%iveg2/=icewater)
        casaflux%klitter(:,metb) = xklitter(:) * casabiome%litterrate(veg%iveg(:),metb)
        casaflux%klitter(:,str)  = xklitter(:) * casabiome%litterrate(veg%iveg(:),str) * &
-            exp(-3.0_r_2*casabiome%fracLigninplant(veg%iveg(:),leaf))
+            exp(-3.0_r2*casabiome%fracLigninplant(veg%iveg(:),leaf))
        casaflux%klitter(:,cwd)  = xklitter(:) * casabiome%litterrate(veg%iveg(:),cwd)
 
        ! add fire turnover of litter
        casaflux%klitter_tot(:,metb) = casaflux%klitter(:,metb) + &
-            (1.0_r_2-casaflux%klitter(:,metb)) * casaflux%klitter_fire(:,metb)
+            (1.0_r2-casaflux%klitter(:,metb)) * casaflux%klitter_fire(:,metb)
        casaflux%klitter_tot(:,str)  = casaflux%klitter(:,str)  + &
-            (1.0_r_2-casaflux%klitter(:,str))  * casaflux%klitter_fire(:,str)
+            (1.0_r2-casaflux%klitter(:,str))  * casaflux%klitter_fire(:,str)
        casaflux%klitter_tot(:,cwd)  = casaflux%klitter(:,cwd)  + &
-            (1.0_r_2-casaflux%klitter(:,cwd))  * casaflux%klitter_fire(:,cwd)
+            (1.0_r2-casaflux%klitter(:,cwd))  * casaflux%klitter_fire(:,cwd)
 
        ! soil turnover
        casaflux%ksoil(:,mic)  = xksoil(:) * casabiome%soilrate(veg%iveg(:),mic) * &
-            (1.0_r_2 - 0.75_r_2 *(soil%silt(:)+soil%clay(:)))
+            (1.0_r2 - 0.75_r2 *(soil%silt(:)+soil%clay(:)))
        casaflux%ksoil(:,slow) = xksoil(:) * casabiome%soilrate(veg%iveg(:),slow)
        casaflux%ksoil(:,pass) = xksoil(:) * casabiome%soilrate(veg%iveg(:),pass)
        casaflux%kplab(:)      = xksoil(:) * casabiome%xkplab(casamet%isorder(:))
@@ -1137,40 +1137,40 @@ CONTAINS
        casaflux%kpocc(:)      = xksoil(:) * casabiome%xkpocc(casamet%isorder(:))
 
        where (veg%iveg==cropland) ! for cultivated land type
-          casaflux%ksoil(:,mic)  = casaflux%ksoil(:,mic)  * 1.25_r_2
-          casaflux%ksoil(:,slow) = casaflux%ksoil(:,slow) * 1.5_r_2
-          casaflux%ksoil(:,pass) = casaflux%ksoil(:,pass) * 1.5_r_2
+          casaflux%ksoil(:,mic)  = casaflux%ksoil(:,mic)  * 1.25_r2
+          casaflux%ksoil(:,slow) = casaflux%ksoil(:,slow) * 1.5_r2
+          casaflux%ksoil(:,pass) = casaflux%ksoil(:,pass) * 1.5_r2
        endwhere  !
 
-       where (casaflux%fcrop > 0.1_r_2) ! 50% increase in soil C turnover in cropping areas
+       where (casaflux%fcrop > 0.1_r2) ! 50% increase in soil C turnover in cropping areas
           casaflux%ksoil(:,mic)  = casaflux%ksoil(:,mic) * &
-               ((1.0_r_2-casaflux%fcrop) + 1.5_r_2*casaflux%fcrop)
+               ((1.0_r2-casaflux%fcrop) + 1.5_r2*casaflux%fcrop)
           casaflux%ksoil(:,slow) = casaflux%ksoil(:,slow) * &
-               ((1.0_r_2-casaflux%fcrop) + 1.5_r_2*casaflux%fcrop)
+               ((1.0_r2-casaflux%fcrop) + 1.5_r2*casaflux%fcrop)
           casaflux%ksoil(:,pass) = casaflux%ksoil(:,pass) * &
-               ((1.0_r_2-casaflux%fcrop) + 1.5_r_2*casaflux%fcrop)
+               ((1.0_r2-casaflux%fcrop) + 1.5_r2*casaflux%fcrop)
        endwhere
 
        ! flow from litter to soil
        ! metb -> mic
-       casaflux%fromLtoS(:,mic,metb) = 0.45_r_2
+       casaflux%fromLtoS(:,mic,metb) = 0.45_r2
        ! str  -> mic
-       casaflux%fromLtoS(:,mic,str)  = 0.45_r_2*(1.0_r_2-casabiome%fracLigninplant(veg%iveg(:),leaf))
+       casaflux%fromLtoS(:,mic,str)  = 0.45_r2*(1.0_r2-casabiome%fracLigninplant(veg%iveg(:),leaf))
        ! str  -> slow
-       casaflux%fromLtoS(:,slow,str) = 0.7_r_2 * casabiome%fracLigninplant(veg%iveg(:),leaf)
+       casaflux%fromLtoS(:,slow,str) = 0.7_r2 * casabiome%fracLigninplant(veg%iveg(:),leaf)
        ! cwd  -> fmic
-       casaflux%fromLtoS(:,mic,cwd)  = 0.40_r_2*(1.0_r_2-casabiome%fracLigninplant(veg%iveg(:),wood))
+       casaflux%fromLtoS(:,mic,cwd)  = 0.40_r2*(1.0_r2-casabiome%fracLigninplant(veg%iveg(:),wood))
        ! cwd  -> slow
-       casaflux%fromLtoS(:,slow,cwd) = 0.7_r_2 * casabiome%fracLigninplant(veg%iveg(:),wood)
+       casaflux%fromLtoS(:,slow,cwd) = 0.7_r2 * casabiome%fracLigninplant(veg%iveg(:),wood)
 
        ! set the following two backflow to set (see Bolker 199x)
-       !   casaflux%fromStoS(:,mic,slow)  = 0.45_r_2 * (0.997_r_2 - 0.009_r_2 *soil%clay(:))
-       !   casaflux%fromStoS(:,mic,pass)  = 0.45_r_2
-       casaflux%fromStoS(:,slow,mic)  = (0.85_r_2 - 0.68_r_2 * (soil%clay(:)+soil%silt(:))) * &
-            (0.997_r_2 - 0.032_r_2*soil%clay(:))
-       casaflux%fromStoS(:,pass,mic)  = (0.85_r_2 - 0.68_r_2 * (soil%clay(:)+soil%silt(:))) * &
-            (0.003_r_2 + 0.032_r_2*soil%clay(:))
-       casaflux%fromStoS(:,pass,slow) = 0.45_r_2 * (0.003_r_2 + 0.009_r_2 * soil%clay(:))
+       !   casaflux%fromStoS(:,mic,slow)  = 0.45_r2 * (0.997_r2 - 0.009_r2 *soil%clay(:))
+       !   casaflux%fromStoS(:,mic,pass)  = 0.45_r2
+       casaflux%fromStoS(:,slow,mic)  = (0.85_r2 - 0.68_r2 * (soil%clay(:)+soil%silt(:))) * &
+            (0.997_r2 - 0.032_r2*soil%clay(:))
+       casaflux%fromStoS(:,pass,mic)  = (0.85_r2 - 0.68_r2 * (soil%clay(:)+soil%silt(:))) * &
+            (0.003_r2 + 0.032_r2*soil%clay(:))
+       casaflux%fromStoS(:,pass,slow) = 0.45_r2 * (0.003_r2 + 0.009_r2 * soil%clay(:))
     endwhere ! /= icewater
 
     do nland=1, mp
@@ -1179,7 +1179,7 @@ CONTAINS
              do k=1, msoil
                 casaflux%fromLtoCO2(nland,j) = casaflux%fromLtoCO2(nland,j) + casaflux%fromLtoS(nland,k,j)
              enddo
-             casaflux%fromLtoCO2(nland,j) = 1.0_r_2 - casaflux%fromLtoCO2(nland,j)
+             casaflux%fromLtoCO2(nland,j) = 1.0_r2 - casaflux%fromLtoCO2(nland,j)
           enddo
           do k=1, msoil
              do kk=1, msoil
@@ -1211,47 +1211,47 @@ CONTAINS
     type(casa_flux),          intent(inout) :: casaflux
     type(casa_met),           intent(inout) :: casamet
     ! added by ypwang following Chris Lu 5/nov/2012
-    real(r_2), dimension(mp), intent(out)   :: cleaf2met, cleaf2str, croot2met, croot2str, cwood2cwd, &
+    real(r2), dimension(mp), intent(out)   :: cleaf2met, cleaf2str, croot2met, croot2str, cwood2cwd, &
          nleaf2met, nleaf2str, nroot2met, nroot2str, nwood2cwd, &
          pleaf2met, pleaf2str, proot2met, proot2str, pwood2cwd
 
     integer   :: npt, nL, nP
-    real(r_2) :: Ygrow, ratioPNplant
-    ! real(r_2) :: dF
+    real(r2) :: Ygrow, ratioPNplant
+    ! real(r2) :: dF
 
     ! casa
-    casaflux%FluxCtolitter         = 0.0_r_2
-    casaflux%FluxCLeaftoLitter     = 0.0_r_2
-    casaflux%FluxCWoodtoLitter     = 0.0_r_2
-    casaflux%FluxCFineRoottoLitter = 0.0_r_2
-    casaflux%FluxNtolitter         = 0.0_r_2
-    casaflux%FluxPtolitter         = 0.0_r_2
+    casaflux%FluxCtolitter         = 0.0_r2
+    casaflux%FluxCLeaftoLitter     = 0.0_r2
+    casaflux%FluxCWoodtoLitter     = 0.0_r2
+    casaflux%FluxCFineRoottoLitter = 0.0_r2
+    casaflux%FluxNtolitter         = 0.0_r2
+    casaflux%FluxPtolitter         = 0.0_r2
     ! fire
-    casaflux%fluxCtoCO2_plant_fire = 0.0_r_2
-    casaflux%fluxNtoAtm_fire       = 0.0_r_2
+    casaflux%fluxCtoCO2_plant_fire = 0.0_r2
+    casaflux%fluxNtoAtm_fire       = 0.0_r2
     ! 13C
-    casaflux%FluxFromPtoL          = 0.0_r_2
-    casaflux%FluxFromPtoCO2        = 0.0_r_2
-    casaflux%FluxFromPtoHarvest    = 0.0_r_2
+    casaflux%FluxFromPtoL          = 0.0_r2
+    casaflux%FluxFromPtoCO2        = 0.0_r2
+    casaflux%FluxFromPtoHarvest    = 0.0_r2
 
     ! added by ypwang following Chris Lu 5/nov/2012
-    cleaf2met = 0.0_r_2
-    cleaf2str = 0.0_r_2
-    croot2met = 0.0_r_2
-    croot2str = 0.0_r_2
-    cwood2cwd = 0.0_r_2
+    cleaf2met = 0.0_r2
+    cleaf2str = 0.0_r2
+    croot2met = 0.0_r2
+    croot2str = 0.0_r2
+    cwood2cwd = 0.0_r2
 
-    nleaf2met = 0.0_r_2
-    nleaf2str = 0.0_r_2
-    nroot2met = 0.0_r_2
-    nroot2str = 0.0_r_2
-    nwood2cwd = 0.0_r_2
+    nleaf2met = 0.0_r2
+    nleaf2str = 0.0_r2
+    nroot2met = 0.0_r2
+    nroot2str = 0.0_r2
+    nwood2cwd = 0.0_r2
 
-    pleaf2met = 0.0_r_2
-    pleaf2str = 0.0_r_2
-    proot2met = 0.0_r_2
-    proot2str = 0.0_r_2
-    pwood2cwd = 0.0_r_2
+    pleaf2met = 0.0_r2
+    pleaf2str = 0.0_r2
+    proot2met = 0.0_r2
+    proot2str = 0.0_r2
+    pwood2cwd = 0.0_r2
 
     !MPI
     do npt=1, mp
@@ -1263,37 +1263,37 @@ CONTAINS
           !! vh_js !!
           ! adjust turnover and autotrophic respiration to avoid negative stocks
           ! Ticket#108
-          where ( ( (casapool%dcplantdt(npt,2:3)*deltpool + casapool%cplant(npt,2:3)) .lt. 0.0_r_2 ) &
+          where ( ( (casapool%dcplantdt(npt,2:3)*deltpool + casapool%cplant(npt,2:3)) .lt. 0.0_r2 ) &
                .or. ( (casapool%dcplantdt(npt,2:3)*deltpool + casapool%cplant(npt,2:3)) &
-               .lt. 0.5_r_2 * casapool%cplant(npt,2:3) ) )
-             casaflux%kplant(npt,2:3)     = 0.0_r_2
-             casaflux%kplant_tot(npt,2:3) = 0.0_r_2
-             !MCfire - casaflux%kplant_fire(npt,2:3) = 0.0_r_2 ?
-             casaflux%crmplant(npt,2:3)   = 0.0_r_2
+               .lt. 0.5_r2 * casapool%cplant(npt,2:3) ) )
+             casaflux%kplant(npt,2:3)     = 0.0_r2
+             casaflux%kplant_tot(npt,2:3) = 0.0_r2
+             !MCfire - casaflux%kplant_fire(npt,2:3) = 0.0_r2 ?
+             casaflux%crmplant(npt,2:3)   = 0.0_r2
           endwhere
-          if (any((casapool%cplant(npt,:) + casapool%dcplantdt(npt,:)*deltpool) .lt. 0.0_r_2 )) then
-             casaflux%kplant(npt,1)     = 0.0_r_2
-             casaflux%kplant_tot(npt,1) = 0.0_r_2
-             !MCfire - casaflux%kplant_fire(npt,1) = 0.0_r_2 ?
-             casaflux%crmplant(npt,1) = min(casaflux%crmplant(npt,1), 0.5_r_2*casaflux%cgpp(npt))
+          if (any((casapool%cplant(npt,:) + casapool%dcplantdt(npt,:)*deltpool) .lt. 0.0_r2 )) then
+             casaflux%kplant(npt,1)     = 0.0_r2
+             casaflux%kplant_tot(npt,1) = 0.0_r2
+             !MCfire - casaflux%kplant_fire(npt,1) = 0.0_r2 ?
+             casaflux%crmplant(npt,1) = min(casaflux%crmplant(npt,1), 0.5_r2*casaflux%cgpp(npt))
           endif
 
           ! revise turnover and NPP and dcplantdt to reflect above adjustments
           casaflux%Cplant_turnover(npt,:) = casaflux%kplant_tot(npt,:)  * casapool%cplant(npt,:)
-          if ( any((casapool%cplant(npt,:) + casapool%dcplantdt(npt,:)*deltpool) .lt. 0.0_r_2) &
+          if ( any((casapool%cplant(npt,:) + casapool%dcplantdt(npt,:)*deltpool) .lt. 0.0_r2) &
                .or. any((casapool%cplant(npt,2:3) + casapool%dcplantdt(npt,2:3)*deltpool) &
-               .lt. 0.5_r_2 * casapool%cplant(npt,2:3)) ) then
-             ratioPNplant = 0.0_r_2
-             if (casapool%Nplant(npt,leaf) > 0.0_r_2) &
-                  ratioPNplant = casapool%Pplant(npt,leaf)/(casapool%Nplant(npt,leaf) + 1.e-10_r_2)
+               .lt. 0.5_r2 * casapool%cplant(npt,2:3)) ) then
+             ratioPNplant = 0.0_r2
+             if (casapool%Nplant(npt,leaf) > 0.0_r2) &
+                  ratioPNplant = casapool%Pplant(npt,leaf)/(casapool%Nplant(npt,leaf) + 1.e-10_r2)
 
-             Ygrow = 0.65_r_2 + 0.2_r_2*ratioPNplant / (ratioPNplant+1.0_r_2/15.0_r_2)
-             IF ((casaflux%Cgpp(npt)-SUM(casaflux%crmplant(npt,:))) > 0.0_r_2) THEN
+             Ygrow = 0.65_r2 + 0.2_r2*ratioPNplant / (ratioPNplant+1.0_r2/15.0_r2)
+             IF ((casaflux%Cgpp(npt)-SUM(casaflux%crmplant(npt,:))) > 0.0_r2) THEN
                 ! Growth efficiency correlated to leaf N:P ratio. Q.Zhang @ 22/02/2011
-                casaflux%crgplant(npt) = (1.0_r_2-Ygrow) * max(0.0_r_2,casaflux%Cgpp(npt) - &
+                casaflux%crgplant(npt) = (1.0_r2-Ygrow) * max(0.0_r2,casaflux%Cgpp(npt) - &
                      SUM(casaflux%crmplant(npt,:)))
              ELSE
-                casaflux%crgplant(npt) = 0.0_r_2
+                casaflux%crgplant(npt) = 0.0_r2
              ENDIF
           endif
 
@@ -1306,24 +1306,24 @@ CONTAINS
 
           ! MC - above is not enough to keep Cplant >= 0,
           !      e.g. casaflux%Cgpp(npt)-sum(casaflux%crmplant(npt,:)) < 0. while Cplant<<
-          if ( any((casapool%cplant(npt,:) + casapool%dcplantdt(npt,:) * deltpool) < 0.0_r_2) ) then
+          if ( any((casapool%cplant(npt,:) + casapool%dcplantdt(npt,:) * deltpool) < 0.0_r2) ) then
              ! 1st, no plant internal turnover
-             where ( (casapool%cplant(npt,:) + casapool%dcplantdt(npt,:) * deltpool) < 0.0_r_2 )
-                casaflux%kplant(npt,:)     = 0.0_r_2
-                casaflux%kplant_tot(npt,:) = 0.0_r_2
-                !MCfire - casaflux%kplant_fire(npt,1) = 0.0_r_2 ?
-                casaflux%Cplant_turnover(npt,:) = 0.0_r_2
+             where ( (casapool%cplant(npt,:) + casapool%dcplantdt(npt,:) * deltpool) < 0.0_r2 )
+                casaflux%kplant(npt,:)     = 0.0_r2
+                casaflux%kplant_tot(npt,:) = 0.0_r2
+                !MCfire - casaflux%kplant_fire(npt,1) = 0.0_r2 ?
+                casaflux%Cplant_turnover(npt,:) = 0.0_r2
              endwhere
              ! 2nd, nothing to labile pool
-             casaflux%fracClabile(npt) = 0.0_r_2
+             casaflux%fracClabile(npt) = 0.0_r2
              ! 3rd, only respire less than available carbon
-             if ((casaflux%Cgpp(npt) - sum(casaflux%Crmplant(npt,:))) < 0.0_r_2) then
-                casaflux%Crgplant(npt) = 0.0_r_2
-                where (casaflux%fracCalloc(npt,:) > 0.0_r_2)
+             if ((casaflux%Cgpp(npt) - sum(casaflux%Crmplant(npt,:))) < 0.0_r2) then
+                casaflux%Crgplant(npt) = 0.0_r2
+                where (casaflux%fracCalloc(npt,:) > 0.0_r2)
                    casaflux%Crmplant(npt,:) = min(casaflux%Crmplant(npt,:), &
                         casaflux%Cgpp(npt) + casapool%Cplant(npt,:) / casaflux%fracCalloc(npt,:) / deltpool)
                 elsewhere
-                   casaflux%Crmplant(npt,:) = 0.0_r_2
+                   casaflux%Crmplant(npt,:) = 0.0_r2
                 endwhere
              endif
              ! recalc
@@ -1331,14 +1331,14 @@ CONTAINS
                   casaflux%Crgplant(npt) - casaflux%fracClabile(npt) * casaflux%Cgpp(npt)
              casapool%dCplantdt(npt,:) = casaflux%Cnpp(npt) * casaflux%fracCalloc(npt,:) - &
                   casaflux%kplant_tot(npt,:) * casapool%Cplant(npt,:)
-             if ( any((casapool%Cplant(npt,:) + casapool%dCplantdt(npt,:) * deltpool) < 0.0_r_2) ) &
+             if ( any((casapool%Cplant(npt,:) + casapool%dCplantdt(npt,:) * deltpool) < 0.0_r2) ) &
                   write(*,*) 'ERR Tonnerre de Brest !'
           endif
 
           ! JK: additional output variables required for TRENDY
-          casaflux%CallocLeaf(npt)     = max(0.0_r_2, casaflux%Cnpp(npt) * casaflux%fracCalloc(npt,leaf))
-          casaflux%CallocWood(npt)     = max(0.0_r_2, casaflux%Cnpp(npt) * casaflux%fracCalloc(npt,wood))
-          casaflux%CallocFineRoot(npt) = max(0.0_r_2, casaflux%Cnpp(npt) * casaflux%fracCalloc(npt,froot))
+          casaflux%CallocLeaf(npt)     = max(0.0_r2, casaflux%Cnpp(npt) * casaflux%fracCalloc(npt,leaf))
+          casaflux%CallocWood(npt)     = max(0.0_r2, casaflux%Cnpp(npt) * casaflux%fracCalloc(npt,wood))
+          casaflux%CallocFineRoot(npt) = max(0.0_r2, casaflux%Cnpp(npt) * casaflux%fracCalloc(npt,froot))
 
           ! change here made by ypw on 26 august 2011
           ! calculate fraction C to labile pool as a fraction of gpp, not npp
@@ -1356,62 +1356,62 @@ CONTAINS
                casapool%cplant(npt,froot)
           cwood2cwd(npt) = casaflux%fromPtoL(npt,cwd,wood) * casaflux%kplant(npt,wood) * &
                casapool%cplant(npt,wood)
-          if (cleaf2met(npt) < 0.0_r_2) print*, 'ERR PP01 ', npt, cleaf2met(npt), &
+          if (cleaf2met(npt) < 0.0_r2) print*, 'ERR PP01 ', npt, cleaf2met(npt), &
                casaflux%fromPtoL(npt,metb,leaf), casaflux%kplant(npt,leaf), casapool%cplant(npt,leaf)
-          if (cleaf2str(npt) < 0.0_r_2) print*, 'ERR PP02 ', npt, cleaf2str(npt), &
+          if (cleaf2str(npt) < 0.0_r2) print*, 'ERR PP02 ', npt, cleaf2str(npt), &
                casaflux%fromPtoL(npt,str,leaf), casaflux%kplant(npt,leaf), casapool%cplant(npt,leaf)
-          if (croot2met(npt) < 0.0_r_2) print*, 'ERR PP03 ', npt, croot2met(npt), &
+          if (croot2met(npt) < 0.0_r2) print*, 'ERR PP03 ', npt, croot2met(npt), &
                casaflux%fromPtoL(npt,metb,froot), casaflux%kplant(npt,froot), casapool%cplant(npt,froot)
-          if (croot2str(npt) < 0.0_r_2) print*, 'ERR PP04 ', npt, croot2str(npt), &
+          if (croot2str(npt) < 0.0_r2) print*, 'ERR PP04 ', npt, croot2str(npt), &
                casaflux%fromPtoL(npt,str,froot), casaflux%kplant(npt,froot), casapool%cplant(npt,froot)
-          if (cwood2cwd(npt) < 0.0_r_2) print*, 'ERR PP05 ', npt, cwood2cwd(npt), &
+          if (cwood2cwd(npt) < 0.0_r2) print*, 'ERR PP05 ', npt, cwood2cwd(npt), &
                casaflux%fromPtoL(npt,cwd,wood), casaflux%kplant(npt,wood), casapool%cplant(npt,wood)
 
           ! add fire component to above fluxes
           cleaf2met(npt) = cleaf2met(npt) + casaflux%fromPtoL_fire(npt,metb,leaf) &
-               * (1.0_r_2 - casaflux%kplant(npt,leaf)) * casaflux%kplant_fire(npt,leaf) * &
+               * (1.0_r2 - casaflux%kplant(npt,leaf)) * casaflux%kplant_fire(npt,leaf) * &
                casapool%cplant(npt,leaf)
           cleaf2str(npt) = cleaf2str(npt) + casaflux%fromPtoL_fire(npt,str,leaf) &
-               * (1.0_r_2 - casaflux%kplant(npt,leaf)) * casaflux%kplant_fire(npt,leaf) * &
+               * (1.0_r2 - casaflux%kplant(npt,leaf)) * casaflux%kplant_fire(npt,leaf) * &
                casapool%cplant(npt,leaf)
           croot2met(npt) = croot2met(npt) + casaflux%fromPtoL_fire(npt,metb,froot) &
-               * (1.0_r_2 - casaflux%kplant(npt,froot)) * casaflux%kplant_fire(npt,froot) * &
+               * (1.0_r2 - casaflux%kplant(npt,froot)) * casaflux%kplant_fire(npt,froot) * &
                casapool%cplant(npt,froot)
           croot2str(npt) = croot2str(npt) + casaflux%fromPtoL_fire(npt,str,froot) &
-               * (1.0_r_2 - casaflux%kplant(npt,froot)) * casaflux%kplant_fire(npt,froot) * &
+               * (1.0_r2 - casaflux%kplant(npt,froot)) * casaflux%kplant_fire(npt,froot) * &
                casapool%cplant(npt,froot)
           cwood2cwd(npt) = cwood2cwd(npt) + casaflux%fromPtoL_fire(npt,cwd,wood) &
-               * (1.0_r_2 - casaflux%kplant(npt,wood)) * casaflux%kplant_fire(npt,wood) * &
+               * (1.0_r2 - casaflux%kplant(npt,wood)) * casaflux%kplant_fire(npt,wood) * &
                casapool%cplant(npt,wood)
-          if (cleaf2met(npt) < 0.0_r_2) print*, 'ERR PP06 ', npt, cleaf2met(npt), &
+          if (cleaf2met(npt) < 0.0_r2) print*, 'ERR PP06 ', npt, cleaf2met(npt), &
                casaflux%fromPtoL_fire(npt,metb,leaf), &
-               (1.0_r_2 - casaflux%kplant(npt,leaf)), casaflux%kplant_fire(npt,leaf), &
+               (1.0_r2 - casaflux%kplant(npt,leaf)), casaflux%kplant_fire(npt,leaf), &
                casapool%cplant(npt,leaf)
-          if (cleaf2str(npt) < 0.0_r_2) print*, 'ERR PP07 ', npt, cleaf2str(npt), &
+          if (cleaf2str(npt) < 0.0_r2) print*, 'ERR PP07 ', npt, cleaf2str(npt), &
                casaflux%fromPtoL_fire(npt,str,leaf), &
-               (1.0_r_2 - casaflux%kplant(npt,leaf)), casaflux%kplant_fire(npt,leaf), &
+               (1.0_r2 - casaflux%kplant(npt,leaf)), casaflux%kplant_fire(npt,leaf), &
                casapool%cplant(npt,leaf)
-          if (croot2met(npt) < 0.0_r_2) print*, 'ERR PP08 ', npt, croot2met(npt), &
+          if (croot2met(npt) < 0.0_r2) print*, 'ERR PP08 ', npt, croot2met(npt), &
                casaflux%fromPtoL_fire(npt,metb,froot), &
-               (1.0_r_2 - casaflux%kplant(npt,froot)), casaflux%kplant_fire(npt,froot), &
+               (1.0_r2 - casaflux%kplant(npt,froot)), casaflux%kplant_fire(npt,froot), &
                casapool%cplant(npt,froot)
-          if (croot2str(npt) < 0.0_r_2) print*, 'ERR PP09 ', npt, croot2str(npt), &
+          if (croot2str(npt) < 0.0_r2) print*, 'ERR PP09 ', npt, croot2str(npt), &
                casaflux%fromPtoL_fire(npt,str,froot), &
-               (1.0_r_2 - casaflux%kplant(npt,froot)), casaflux%kplant_fire(npt,froot), &
+               (1.0_r2 - casaflux%kplant(npt,froot)), casaflux%kplant_fire(npt,froot), &
                casapool%cplant(npt,froot)
-          if (cwood2cwd(npt) < 0.0_r_2) print*, 'ERR PP10 ', npt, cwood2cwd(npt), &
+          if (cwood2cwd(npt) < 0.0_r2) print*, 'ERR PP10 ', npt, cwood2cwd(npt), &
                casaflux%fromPtoL_fire(npt,cwd,wood), &
-               (1.0_r_2 - casaflux%kplant(npt,wood)), casaflux%kplant_fire(npt,wood), &
+               (1.0_r2 - casaflux%kplant(npt,wood)), casaflux%kplant_fire(npt,wood), &
                casapool%cplant(npt,wood)
 
           ! fire flux to atmosphere from burnt plant material
-          casaflux%fluxCtoCO2_plant_fire(npt) = 0.0_r_2
-          casaflux%FluxFromPtoCO2(npt,:)      = 0.0_r_2
+          casaflux%fluxCtoCO2_plant_fire(npt) = 0.0_r2
+          casaflux%FluxFromPtoCO2(npt,:)      = 0.0_r2
           do nP=1, mplant
              casaflux%FluxFromPtoCO2(npt,nP) = &
-                  (1.0_r_2-casaflux%kplant(npt,nP)) * casaflux%kplant_fire(npt,nP) * &
+                  (1.0_r2-casaflux%kplant(npt,nP)) * casaflux%kplant_fire(npt,nP) * &
                   casapool%cplant(npt,nP) * &
-                  (1.0_r_2 - sum(casaflux%fromPtoL_fire(npt,:,nP)))
+                  (1.0_r2 - sum(casaflux%fromPtoL_fire(npt,:,nP)))
              casaflux%fluxCtoCO2_plant_fire(npt) = casaflux%fluxCtoCO2_plant_fire(npt) + &
                   casaflux%FluxFromPtoCO2(npt,nP)
           enddo
@@ -1438,14 +1438,14 @@ CONTAINS
           ! between-pool fluxes for 13CO2
           casaflux%FluxFromPtoL(npt,leaf,metb)  = cleaf2met(npt)
           casaflux%FluxFromPtoL(npt,froot,metb) = croot2met(npt)
-          casaflux%FluxFromPtoL(npt,wood,metb)  = 0.0_r_2
+          casaflux%FluxFromPtoL(npt,wood,metb)  = 0.0_r2
 
           casaflux%FluxFromPtoL(npt,leaf,str)  = cleaf2str(npt)
           casaflux%FluxFromPtoL(npt,froot,str) = croot2str(npt)
-          casaflux%FluxFromPtoL(npt,wood,str)  = 0.0_r_2
+          casaflux%FluxFromPtoL(npt,wood,str)  = 0.0_r2
 
-          casaflux%FluxFromPtoL(npt,leaf,cwd)  = 0.0_r_2
-          casaflux%FluxFromPtoL(npt,froot,cwd) = 0.0_r_2
+          casaflux%FluxFromPtoL(npt,leaf,cwd)  = 0.0_r2
+          casaflux%FluxFromPtoL(npt,froot,cwd) = 0.0_r2
           casaflux%FluxFromPtoL(npt,wood,cwd)  = cwood2cwd(npt)
 
           casaflux%FluxFromPtoHarvest(npt) = casaflux%FluxFromPtoHarvest(npt) + &
@@ -1454,12 +1454,12 @@ CONTAINS
           ! Nitrogen
           IF (icycle > 1) THEN
 
-             !IF (casaflux%fracNalloc(npt,leaf) > 0.0_r_2) THEN
+             !IF (casaflux%fracNalloc(npt,leaf) > 0.0_r2) THEN
              casapool%dNplantdt(npt,leaf)  = - casaflux%kplant(npt,leaf) * casapool%Nplant(npt,leaf) &
                                              * casabiome%ftransNPtoL(veg%iveg(npt),leaf)
              ! add turnover due to fire
              casapool%dNplantdt(npt,leaf)  =  casapool%dNplantdt(npt,leaf) - &
-                     (1.0_r_2 - casaflux%kplant(npt,leaf))*casaflux%kplant_fire(npt,leaf) * &
+                     (1.0_r2 - casaflux%kplant(npt,leaf))*casaflux%kplant_fire(npt,leaf) * &
                      casapool%Nplant(npt,leaf)
              !else
              !   casapool%dNplantdt(npt,leaf)  = - casaflux%kplant_tot(npt,leaf) * casapool%Nplant(npt,leaf)
@@ -1470,10 +1470,10 @@ CONTAINS
                      * casabiome%ftransNPtoL(veg%iveg(npt),wood)
                 ! add turnover due to fire
                 casapool%dNplantdt(npt,wood)  =  casapool%dNplantdt(npt,wood) - &
-                     (1.0_r_2 - casaflux%kplant(npt,wood))*casaflux%kplant_fire(npt,wood) * &
+                     (1.0_r2 - casaflux%kplant(npt,wood))*casaflux%kplant_fire(npt,wood) * &
                      casapool%Nplant(npt,wood)
              ELSE
-                casapool%dNplantdt(npt,wood) = 0.0_r_2
+                casapool%dNplantdt(npt,wood) = 0.0_r2
              ENDIF
 
              casapool%dNplantdt(npt,froot)  = - casaflux%kplant(npt,froot) * casapool%Nplant(npt,froot) &
@@ -1481,7 +1481,7 @@ CONTAINS
 
              ! add turnover due to fire
              casapool%dNplantdt(npt,froot)  =  casapool%dNplantdt(npt,froot) - &
-                  (1.0_r_2 - casaflux%kplant(npt,froot))*casaflux%kplant_fire(npt,froot) * &
+                  (1.0_r2 - casaflux%kplant(npt,froot))*casaflux%kplant_fire(npt,froot) * &
                   casapool%Nplant(npt,froot)
 
              nleaf2str(npt) = casaflux%fromPtoL(npt,str,leaf) * casaflux%kplant(npt,leaf)  &
@@ -1491,10 +1491,10 @@ CONTAINS
 
              ! add N flux from leaves and roots to structural litter due to fire
              nleaf2str(npt) = nleaf2str(npt) + casaflux%fromPtoL_fire(npt,str,leaf) * &
-                  (1.0_r_2 - casaflux%kplant(npt,leaf)) *  &
+                  (1.0_r2 - casaflux%kplant(npt,leaf)) *  &
                   casaflux%kplant_fire(npt,leaf) * casapool%cplant(npt,leaf) * ratioNCstrfix
              nroot2str(npt) = nroot2str(npt) + casaflux%fromPtoL_fire(npt,str,froot) * &
-                  (1.0_r_2 - casaflux%kplant(npt,froot)) *  &
+                  (1.0_r2 - casaflux%kplant(npt,froot)) *  &
                   casaflux%kplant_fire(npt,froot) * casapool%cplant(npt,froot) * ratioNCstrfix
 
              ! flux of leaf N to met litter: need to deduct harvest losses
@@ -1508,21 +1508,21 @@ CONTAINS
                   casaflux%kplant(npt,leaf) * casapool%nplant(npt,leaf) * casaflux%fharvest(npt)
 
              ! Nitrogen lost to fire
-             casaflux%fluxNtoAtm_fire(npt) = (1.0_r_2 - casaflux%kplant(npt,leaf))* &
+             casaflux%fluxNtoAtm_fire(npt) = (1.0_r2 - casaflux%kplant(npt,leaf))* &
                   casaflux%kplant_fire(npt,leaf) * casapool%Nplant(npt,leaf) &
-                  * (1.0_r_2 - casaflux%fromPtoL_fire(npt,str,leaf)) + &
-                  (1.0_r_2 - casaflux%kplant(npt,froot))*casaflux%kplant_fire(npt,froot) * &
+                  * (1.0_r2 - casaflux%fromPtoL_fire(npt,str,leaf)) + &
+                  (1.0_r2 - casaflux%kplant(npt,froot))*casaflux%kplant_fire(npt,froot) * &
                   casapool%Nplant(npt,froot) &
-                  * (1.0_r_2 - casaflux%fromPtoL_fire(npt,str,froot)) + &
-                  (1.0_r_2 - casaflux%kplant(npt,wood))*casaflux%kplant_fire(npt,wood) * &
+                  * (1.0_r2 - casaflux%fromPtoL_fire(npt,str,froot)) + &
+                  (1.0_r2 - casaflux%kplant(npt,wood))*casaflux%kplant_fire(npt,wood) * &
                   casapool%Nplant(npt,wood) &
-                  * (1.0_r_2 - casaflux%fromPtoL_fire(npt,str,wood))
+                  * (1.0_r2 - casaflux%fromPtoL_fire(npt,str,wood))
           ENDIF
 
           ! Phosphorus
           IF (icycle >2) THEN
             ! JK: check if following condition makes sense at all.
-             !IF(casaflux%fracPalloc(npt,leaf) > 0.0_r_2) THEN
+             !IF(casaflux%fracPalloc(npt,leaf) > 0.0_r2) THEN
                 casapool%dPplantdt(npt,leaf) = - casaflux%kplant(npt,leaf) * casapool%Pplant(npt,leaf) &
                                                * casabiome%ftransPPtoL(veg%iveg(npt),leaf)
              !else
@@ -1542,15 +1542,15 @@ CONTAINS
 
              ! add P loss by fire
              casapool%dPplantdt(npt,leaf) = casapool%dPplantdt(npt,leaf) - &
-                  (1.0_r_2 - casaflux%kplant(npt,leaf) ) * casaflux%kplant_fire(npt,leaf) * &
+                  (1.0_r2 - casaflux%kplant(npt,leaf) ) * casaflux%kplant_fire(npt,leaf) * &
                   casapool%Pplant(npt,leaf)
 
              casapool%dPplantdt(npt,froot)  = casapool%dPplantdt(npt,froot) - &
-                  (1.0_r_2 - casaflux%kplant(npt,froot) ) * casaflux%kplant_fire(npt,froot) * &
+                  (1.0_r2 - casaflux%kplant(npt,froot) ) * casaflux%kplant_fire(npt,froot) * &
                   casapool%Pplant(npt,froot)
 
              casapool%dPplantdt(npt,wood)  = casapool%dPplantdt(npt,wood) - &
-                  (1.0_r_2 - casaflux%kplant(npt,wood) ) * casaflux%kplant_fire(npt,wood) * &
+                  (1.0_r2 - casaflux%kplant(npt,wood) ) * casaflux%kplant_fire(npt,wood) * &
                   casapool%Pplant(npt,wood)
 
              ! pleaf2str(npt) = pleaf2str(npt) + casaflux%fromPtoL_fire(npt,str,leaf) * &
@@ -1565,11 +1565,11 @@ CONTAINS
 
              ! assume all plant phosphorous release by fire goes to litter
              pleaf2str(npt) = pleaf2str(npt) +  casaflux%kplant_fire(npt,leaf)*  &
-                  (1.0_r_2 - casaflux%kplant(npt,leaf)) * ratioNCstrfix/ratioNPstrfix * &
+                  (1.0_r2 - casaflux%kplant(npt,leaf)) * ratioNCstrfix/ratioNPstrfix * &
                   casapool%cplant(npt,leaf)
 
              proot2str(npt) = proot2str(npt) + casaflux%kplant_fire(npt,froot)*  &
-                  (1.0_r_2 - casaflux%kplant(npt,froot)) * ratioNCstrfix/ratioNPstrfix * &
+                  (1.0_r2 - casaflux%kplant(npt,froot)) * ratioNCstrfix/ratioNPstrfix * &
                   casapool%cplant(npt,froot)
 
              ! end Ploss by fire
@@ -1589,7 +1589,7 @@ CONTAINS
                      + casaflux%fromPtoL(npt,nL,nP) * casaflux%kplant(npt,nP) * &
                      casapool%cplant(npt,nP) &
                                 ! inputs from fire
-                     + casaflux%kplant_fire(npt,nP)*(1.0_r_2 - casaflux%kplant(npt,nP)) * &
+                     + casaflux%kplant_fire(npt,nP)*(1.0_r2 - casaflux%kplant(npt,nP)) * &
                      casapool%cplant(npt,nP)* casaflux%fromPtoL_fire(npt,nL,nP)
              enddo
              ! JK: add fluxes from plant components to separate outputs
@@ -1598,7 +1598,7 @@ CONTAINS
                   + casaflux%fromPtoL(npt,nL,leaf) * casaflux%kplant(npt,leaf) * &
                   casapool%cplant(npt,leaf) &
                                 ! inputs from fire
-                  + casaflux%kplant_fire(npt,leaf)*(1.0_r_2 - casaflux%kplant(npt,leaf)) * &
+                  + casaflux%kplant_fire(npt,leaf)*(1.0_r2 - casaflux%kplant(npt,leaf)) * &
                   casapool%cplant(npt,leaf) * casaflux%fromPtoL_fire(npt,nL,leaf)
 
              ! Wood to Litter
@@ -1606,7 +1606,7 @@ CONTAINS
                   + casaflux%fromPtoL(npt,nL,wood) * casaflux%kplant(npt,wood) * &
                   casapool%cplant(npt,wood) &
                                 ! inputs from fire
-                  + casaflux%kplant_fire(npt,wood)*(1.0_r_2 - casaflux%kplant(npt,wood)) * &
+                  + casaflux%kplant_fire(npt,wood)*(1.0_r2 - casaflux%kplant(npt,wood)) * &
                   casapool%cplant(npt,wood) * casaflux%fromPtoL_fire(npt,nL,wood)
 
              ! Fine Root to Litter
@@ -1614,7 +1614,7 @@ CONTAINS
                   + casaflux%fromPtoL(npt,nL,froot) * casaflux%kplant(npt,froot) * &
                   casapool%cplant(npt,froot) &
                                 ! inputs from fire
-                  + casaflux%kplant_fire(npt,froot)*(1.0_r_2 - casaflux%kplant(npt,froot)) * &
+                  + casaflux%kplant_fire(npt,froot)*(1.0_r2 - casaflux%kplant(npt,froot)) * &
                   casapool%cplant(npt,froot) * casaflux%fromPtoL_fire(npt,nL,froot)
 
           enddo
@@ -1691,88 +1691,88 @@ CONTAINS
     type(casa_biome),         intent(inout) :: casabiome
 
     ! local variables
-    real(r_2), dimension(mp) :: xdplabsorb, fluxptase
-    real(r_2), dimension(mp) :: Nimb,Pimb  ! imbalance mineralisation, immobilisation
+    real(r2), dimension(mp) :: xdplabsorb, fluxptase
+    real(r2), dimension(mp) :: Nimb,Pimb  ! imbalance mineralisation, immobilisation
     integer   :: j, jj, k, kk, kkk, nL, nS, nSS, nland
-    real(r_2) :: iflux
+    real(r2) :: iflux
 
     ! casa
-    casaflux%fluxCtoCO2   = 0.0_r_2
-    casaflux%fluxCtosoil  = 0.0_r_2
-    casaflux%fluxNtosoil  = 0.0_r_2
-    casaflux%fluxPtosoil  = 0.0_r_2
-    casaflux%Crsoil       = 0.0_r_2 ! initialization added by BP jul2010
-    casapool%dClitterdt   = 0.0_r_2
-    casapool%dCsoildt     = 0.0_r_2
+    casaflux%fluxCtoCO2   = 0.0_r2
+    casaflux%fluxCtosoil  = 0.0_r2
+    casaflux%fluxNtosoil  = 0.0_r2
+    casaflux%fluxPtosoil  = 0.0_r2
+    casaflux%Crsoil       = 0.0_r2 ! initialization added by BP jul2010
+    casapool%dClitterdt   = 0.0_r2
+    casapool%dCsoildt     = 0.0_r2
 
-    casapool%dNlitterdt   = 0.0_r_2
-    casapool%dNsoildt     = 0.0_r_2
-    casapool%dNsoilmindt  = 0.0_r_2
-    casaflux%Nsmin        = 0.0_r_2
-    casaflux%Nsimm        = 0.0_r_2
-    casaflux%Nsnet        = 0.0_r_2
-    casaflux%Nminloss     = 0.0_r_2
-    casaflux%Nminleach    = 0.0_r_2
-    casaflux%Nlittermin   = 0.0_r_2
+    casapool%dNlitterdt   = 0.0_r2
+    casapool%dNsoildt     = 0.0_r2
+    casapool%dNsoilmindt  = 0.0_r2
+    casaflux%Nsmin        = 0.0_r2
+    casaflux%Nsimm        = 0.0_r2
+    casaflux%Nsnet        = 0.0_r2
+    casaflux%Nminloss     = 0.0_r2
+    casaflux%Nminleach    = 0.0_r2
+    casaflux%Nlittermin   = 0.0_r2
 
-    casapool%dPlitterdt   = 0.0_r_2
-    casapool%dPsoildt     = 0.0_r_2
-    casapool%dPsoillabdt  = 0.0_r_2
-    casapool%dPsoilsorbdt = 0.0_r_2
-    casapool%dPsoiloccdt  = 0.0_r_2
-    casaflux%Psmin        = 0.0_r_2
-    casaflux%Psimm        = 0.0_r_2
-    casaflux%Psnet        = 0.0_r_2
-    casaflux%Pleach       = 0.0_r_2
-    casaflux%Ploss        = 0.0_r_2
-    casaflux%Plittermin   = 0.0_r_2
-    fluxptase             = 0.0_r_2
-    Nimb                  = 0.0_r_2
-    Pimb                  = 0.0_r_2
+    casapool%dPlitterdt   = 0.0_r2
+    casapool%dPsoildt     = 0.0_r2
+    casapool%dPsoillabdt  = 0.0_r2
+    casapool%dPsoilsorbdt = 0.0_r2
+    casapool%dPsoiloccdt  = 0.0_r2
+    casaflux%Psmin        = 0.0_r2
+    casaflux%Psimm        = 0.0_r2
+    casaflux%Psnet        = 0.0_r2
+    casaflux%Pleach       = 0.0_r2
+    casaflux%Ploss        = 0.0_r2
+    casaflux%Plittermin   = 0.0_r2
+    fluxptase             = 0.0_r2
+    Nimb                  = 0.0_r2
+    Pimb                  = 0.0_r2
 
     !13C
-    casaflux%fluxCtoCO2_litter_fire = 0.0_r_2
-    casaflux%FluxFromLtoS           = 0.0_r_2
-    casaflux%FluxFromStoS           = 0.0_r_2
-    casaflux%FluxFromStoCO2         = 0.0_r_2
-    casaflux%FluxFromLtoCO2         = 0.0_r_2
+    casaflux%fluxCtoCO2_litter_fire = 0.0_r2
+    casaflux%FluxFromLtoS           = 0.0_r2
+    casaflux%FluxFromStoS           = 0.0_r2
+    casaflux%FluxFromStoCO2         = 0.0_r2
+    casaflux%FluxFromLtoCO2         = 0.0_r2
 
     do nland=1, mp
        if (casamet%iveg2(nland) /= icewater) then
 
           ! MC - avoid -ve litter pools
           where ((casapool%clitter(nland,:) + (casaflux%fluxCtolitter(nland,:) - &
-               casaflux%klitter_tot(nland,:) * casapool%clitter(nland,:))*deltpool) < 0.0_r_2)
-             casaflux%klitter(nland,:)     = 0.0_r_2
-             casaflux%klitter_tot(nland,:) = 0.0_r_2
-             !MCfire - casaflux%klitter_fire(nland,:) = 0.0_r_2 ?
+               casaflux%klitter_tot(nland,:) * casapool%clitter(nland,:))*deltpool) < 0.0_r2)
+             casaflux%klitter(nland,:)     = 0.0_r2
+             casaflux%klitter_tot(nland,:) = 0.0_r2
+             !MCfire - casaflux%klitter_fire(nland,:) = 0.0_r2 ?
           end where
 
           if (icycle > 1) then
              !vh! set klitter to zero where Nlitter will go -ve
              ! (occurs occasionally for metabolic litter pool) Ticket#108
-             where (casaflux%klitter(nland,:) * max(0.0_r_2, casapool%Nlitter(nland,:)) > &
+             where (casaflux%klitter(nland,:) * max(0.0_r2, casapool%Nlitter(nland,:)) > &
                   casapool%Nlitter(nland,:) + casaflux%fluxNtolitter(nland,:))
-                casaflux%klitter(nland,:)     = 0.0_r_2
-                casaflux%klitter_tot(nland,:) = 0.0_r_2
-                !MCfire - casaflux%klitter_fire(nland,:) = 0.0_r_2 ?
+                casaflux%klitter(nland,:)     = 0.0_r2
+                casaflux%klitter_tot(nland,:) = 0.0_r2
+                !MCfire - casaflux%klitter_fire(nland,:) = 0.0_r2 ?
              end where
           endif
 
           if (icycle > 2) then
              !vh! set klitter to zero where Plitter will go -ve
              ! (occurs occasionally for metabolic litter pool) Ticket#108
-             where (casaflux%klitter(nland,:) * max(0.0_r_2,casapool%Plitter(nland,:)).gt. &
+             where (casaflux%klitter(nland,:) * max(0.0_r2,casapool%Plitter(nland,:)).gt. &
                   casapool%Plitter(nland,:)+casaflux%fluxPtolitter(nland,:))
-                casaflux%klitter(nland,:)     = 0.0_r_2
-                casaflux%klitter_tot(nland,:) = 0.0_r_2
-                !MCfire - casaflux%klitter_fire(nland,:) = 0.0_r_2 ?
+                casaflux%klitter(nland,:)     = 0.0_r2
+                casaflux%klitter_tot(nland,:) = 0.0_r2
+                !MCfire - casaflux%klitter_fire(nland,:) = 0.0_r2 ?
              end where
           endif
 
           ! fire flux to atmosphere from burnt litter material
           do nL=1, mlitter
-             iflux = (1.0_r_2-casaflux%klitter(nland,nL)) * casaflux%klitter_fire(nland,nL) * &
+             iflux = (1.0_r2-casaflux%klitter(nland,nL)) * casaflux%klitter_fire(nland,nL) * &
                   casapool%clitter(nland,nL)
              casaflux%fluxCtoCO2_litter_fire(nland) = casaflux%fluxCtoCO2_litter_fire(nland) + iflux
              casaflux%FluxFromLtoCO2(nland,nL)      = casaflux%FluxFromLtoCO2(nland,nL)      + iflux
@@ -1794,8 +1794,8 @@ CONTAINS
 
           ! MC - avoid -ve soil pools
           where ((casapool%csoil(nland,:) + (casaflux%fluxCtosoil(nland,:) - &
-               casaflux%ksoil(nland,:) * casapool%csoil(nland,:))*deltpool) < 0.0_r_2)
-             casaflux%ksoil(nland,:) = 0.0_r_2
+               casaflux%ksoil(nland,:) * casapool%csoil(nland,:))*deltpool) < 0.0_r2)
+             casaflux%ksoil(nland,:) = 0.0_r2
           end where
 
           do nS=1, msoil
@@ -1845,7 +1845,7 @@ CONTAINS
 
              ! JK: ensure immobilization does not exceed gross mineralisation (Psmin)
              Nimb(nland) = (casaflux%Nsmin(nland) + casaflux%Nlittermin(nland)) / &
-                  MAX(ABS(casaflux%Nsimm(nland)), 1.0e-12_r_2)
+                  MAX(ABS(casaflux%Nsimm(nland)), 1.0e-12_r2)
              casaflux%Nsimm(nland) = -MIN((casaflux%Nsmin(nland) + casaflux%Nlittermin(nland)), &
                   ABS(casaflux%Nsimm(nland)))
              ! net mineralization
@@ -1854,18 +1854,18 @@ CONTAINS
                   + casaflux%Nsimm(nland)
              
              ! N volatilisation and leaching
-             IF(casapool%Nsoilmin(nland) > 2.0_r_2 .AND. casamet%tsoilavg(nland) > 273.12_r_2) THEN
+             IF(casapool%Nsoilmin(nland) > 2.0_r2 .AND. casamet%tsoilavg(nland) > 273.12_r2) THEN
                 casaflux%Nminloss(nland)   = casaflux%fNminloss(nland)  &
-                                             * MAX(0.0_r_2,casaflux%Nsnet(nland))
+                                             * MAX(0.0_r2,casaflux%Nsnet(nland))
                 casaflux%Nminleach(nland)  = casaflux%fNminleach(nland) &
-                                             * MAX(0.0_r_2,casapool%Nsoilmin(nland))
+                                             * MAX(0.0_r2,casapool%Nsoilmin(nland))
              ELSE
                 casaflux%Nminloss(nland)   = casaflux%fNminloss(nland)  &
-                     * MAX(0.0_r_2,casaflux%Nsnet(nland)) &
-                     * MAX(0.0_r_2,casapool%Nsoilmin(nland)/2.0_r_2)
+                     * MAX(0.0_r2,casaflux%Nsnet(nland)) &
+                     * MAX(0.0_r2,casapool%Nsoilmin(nland)/2.0_r2)
                 casaflux%Nminleach(nland)  = casaflux%fNminleach(nland) &
-                     * MAX(0.0_r_2,casapool%Nsoilmin(nland)) &
-                     * MAX(0.0_r_2,casapool%Nsoilmin(nland)/2.0_r_2)
+                     * MAX(0.0_r2,casapool%Nsoilmin(nland)) &
+                     * MAX(0.0_r2,casapool%Nsoilmin(nland)/2.0_r2)
              ENDIF
              DO k=1,msoil
                 DO j=1,mlitter
@@ -1887,7 +1887,7 @@ CONTAINS
              ENDDO    ! end of "k"
 
              ! JK: ensure immobilization does not exceed Nsmin (FluxNtosoil should equal Nsimm)
-             casaflux%FluxNtosoil(nland,:) = casaflux%FluxNtosoil(nland,:) * MIN(1.0_r_2, Nimb(nland))     
+             casaflux%FluxNtosoil(nland,:) = casaflux%FluxNtosoil(nland,:) * MIN(1.0_r2, Nimb(nland))     
 
           ENDIF ! end of icycle > 1
 
@@ -1926,7 +1926,7 @@ CONTAINS
              ! JK: ensure immobilization does not exceed gross mineralisation (Psmin+Plittermin)
              !     (if Psoillab would fall below 0?)
              Pimb(nland) = (casaflux%Psmin(nland) + casaflux%Plittermin(nland)) / &
-                  MAX(ABS(casaflux%Psimm(nland)), 1.0e-12_r_2)
+                  MAX(ABS(casaflux%Psimm(nland)), 1.0e-12_r2)
              casaflux%Psimm(nland) = -MIN((casaflux%Psmin(nland) + casaflux%Plittermin(nland)), &
                   ABS(casaflux%Psimm(nland)))
 
@@ -1935,9 +1935,9 @@ CONTAINS
                   +casaflux%Psimm(nland)
              ! net mineralization
              !      casaflux%Pleach(nland)  =  (1.0e-4) &
-             !                                 * max(0.0_r_2,casapool%Psoillab(nland))
+             !                                 * max(0.0_r2,casapool%Psoillab(nland))
              casaflux%Pleach(nland)  =  casaflux%fPleach(nland) &
-                  * max(0.0_r_2,casapool%Psoillab(nland))
+                  * max(0.0_r2,casapool%Psoillab(nland))
 
              DO k=1,msoil
                 DO j=1,mlitter
@@ -1966,7 +1966,7 @@ CONTAINS
              ENDDO    ! end of "k"
 
              ! JK: ensure immobilization does not exceed Psmin (FluxPtosoil should equal Psimm)
-             casaflux%FluxPtosoil(nland,:) = casaflux%FluxPtosoil(nland,:) * MIN(1.0_r_2, Pimb(nland))
+             casaflux%FluxPtosoil(nland,:) = casaflux%FluxPtosoil(nland,:) * MIN(1.0_r2, Pimb(nland))
              ! need to account for flow from sorbed to occluded pool
           ENDIF ! end of icycle > 2
 
@@ -1987,7 +1987,7 @@ CONTAINS
           IF (icycle > 1) THEN
              casapool%dNlitterdt(nland,:) =  casaflux%fluxNtolitter(nland,:) &
                   - casaflux%klitter(nland,:) &
-                  * max(0.0_r_2, casapool%Nlitter(nland,:))
+                  * max(0.0_r2, casapool%Nlitter(nland,:))
 
              casapool%dNsoildt(nland,:) = casaflux%FluxNtosoil(nland,:) &
                   - casaflux%ksoil(nland,:) * casapool%Nsoil(nland,:)
@@ -2001,19 +2001,19 @@ CONTAINS
           ! Phosphorus
           IF (icycle >2) THEN
              fluxptase(nland) =  casabiome%prodptase( veg%iveg(nland) )    &
-                  * max( 0.0_r_2, ( casapool%Psoil(nland,2)                   &
+                  * max( 0.0_r2, ( casapool%Psoil(nland,2)                   &
                   * casaflux%ksoil(nland,2)                &
                   + casapool%Psoil(nland,3)                &
                   * casaflux%ksoil(nland,3) )              &
                   )                                                 &
-                  * max( 0.0_r_2, ( casabiome%costNPup( veg%iveg(nland) )    &
-                  - 15.0_r_2 )                                 &
+                  * max( 0.0_r2, ( casabiome%costNPup( veg%iveg(nland) )    &
+                  - 15.0_r2 )                                 &
                   )                                                 &
-                  / ( max( 0.0_r_2, ( casabiome%costNPup( veg%iveg(nland) )  &
-                  - 15.0_r_2 )                               &
-                  ) + 150.0_r_2                                       &
+                  / ( max( 0.0_r2, ( casabiome%costNPup( veg%iveg(nland) )  &
+                  - 15.0_r2 )                               &
+                  ) + 150.0_r2                                       &
                   )
-             xdplabsorb(nland) = 1.0_r_2+ casaflux%Psorbmax(nland)*casaflux%kmlabp(nland) &
+             xdplabsorb(nland) = 1.0_r2+ casaflux%Psorbmax(nland)*casaflux%kmlabp(nland) &
                   /((casaflux%kmlabp(nland)+casapool%Psoillab(nland))**2)
 
              casapool%dPlitterdt(nland,:) = casaflux%fluxPtolitter(nland,:)  &
@@ -2047,7 +2047,7 @@ CONTAINS
              !     write(*,*) 'dPsoillabdt: ' ,  casapool%dPsoillabdt,  xdplabsorb(nland)
              casapool%dPsoillabdt(nland)  = casapool%dPsoillabdt(nland)/xdplabsorb(nland)
              !    write(*,*) 'dPsoillabdt: ' ,  casapool%dPsoillabdt
-             casapool%dPsoilsorbdt(nland) = 0.0_r_2
+             casapool%dPsoilsorbdt(nland) = 0.0_r2
 
              casapool%dPsoiloccdt(nland)  = casaflux%kpsorb(nland)* casapool%Psoilsorb(nland) &
                   - casaflux%kpocc(nland) * casapool%Psoilocc(nland)
@@ -2056,7 +2056,7 @@ CONTAINS
 
              !      casaflux%Ploss(nland)       = casaflux%fPleach(nland) &
              !                                 * max(zero,casapool%Psoillab(nland))
-             casaflux%Ploss(nland)       = 0.0_r_2
+             casaflux%Ploss(nland)       = 0.0_r2
           ENDIF ! end icycle>2
 
        endif ! end of casamet%iveg2(nland) /= icewater
@@ -2079,17 +2079,17 @@ CONTAINS
     type(casa_met),            intent(inout) :: casamet
 
     integer :: ns, nland
-    real(r_2) :: froot, sfc, swilt
+    real(r2) :: froot, sfc, swilt
 
-    casamet%tsoilavg = 0.0_r_2
-    casamet%moistavg = 0.0_r_2
-    casamet%btran    = 0.0_r_2
+    casamet%tsoilavg = 0.0_r2
+    casamet%moistavg = 0.0_r2
+    casamet%btran    = 0.0_r2
 
     do ns=1, ms
        do nland=1, mp
-          froot = real(veg%froot(nland,ns), r_2)
-          sfc   = real(soil%sfc(nland),     r_2)
-          swilt = real(soil%swilt(nland),   r_2)
+          froot = real(veg%froot(nland,ns), r2)
+          sfc   = real(soil%sfc(nland),     r2)
+          swilt = real(soil%swilt(nland),   r2)
           casamet%tsoilavg(nland)  = casamet%tsoilavg(nland) + froot * casamet%tsoil(nland,ns)
 
           if (trim(cable_user%SMRF_NAME)=='Trudinger2016' .or. &
@@ -2105,12 +2105,12 @@ CONTAINS
           !         * (min(soil%sfc(nland),casamet%moist(nland,ns))-soil%swilt(nland)) &
           !         /(soil%sfc(nland)-soil%swilt(nland))
           casamet%btran(nland) = casamet%btran(nland) + &
-               froot * max(min(sfc,casamet%moist(nland,ns)) - swilt, 0.0_r_2) / (sfc - swilt)
+               froot * max(min(sfc,casamet%moist(nland,ns)) - swilt, 0.0_r2) / (sfc - swilt)
        enddo ! nland=1, mp
     enddo ! ns=1, ms
 
     ! MC - secure kplant > 0.
-    casamet%btran = min(max(casamet%btran, 0.0_r_2 ), 1.0_r_2)
+    casamet%btran = min(max(casamet%btran, 0.0_r2 ), 1.0_r2)
 
   END SUBROUTINE avgsoil
 
@@ -2119,7 +2119,7 @@ CONTAINS
     ! computing the reduction in litter and SOM decomposition
     ! when decomposition rate is N-limiting
     IMPLICIT NONE
-    REAL(r_2), DIMENSION(mp), INTENT(INOUT) :: xkNlimiting
+    REAL(r2), DIMENSION(mp), INTENT(INOUT) :: xkNlimiting
     TYPE (casa_pool),         INTENT(INOUT) :: casapool
     TYPE (casa_flux),         INTENT(INOUT) :: casaflux
     TYPE (casa_met),          INTENT(INOUT) :: casamet
@@ -2129,22 +2129,22 @@ CONTAINS
 
     ! local variables
     INTEGER :: j,k,kk,nland
-    REAL(r_2), DIMENSION(mp)         :: xFluxNlittermin
-    REAL(r_2), DIMENSION(mp)         :: xFluxNsoilmin
-    REAL(r_2), DIMENSION(mp)         :: xFluxNsoilimm
-    REAL(r_2), DIMENSION(mp)         :: xFluxNsoilminnet
+    REAL(r2), DIMENSION(mp)         :: xFluxNlittermin
+    REAL(r2), DIMENSION(mp)         :: xFluxNsoilmin
+    REAL(r2), DIMENSION(mp)         :: xFluxNsoilimm
+    REAL(r2), DIMENSION(mp)         :: xFluxNsoilminnet
     ! A maximum Clitter set to avoid positive feedback for litter accumulation
     ! when N mode is activated. (Q.Zhang 23/05/2011)
-    !  real(r_2), dimension(17)         :: xClitter
+    !  real(r2), dimension(17)         :: xClitter
     !  data xClitter/100.0,100.0,100.0,100.0,50.0,150.0,150.0,100.0,&
     !                150.0,150.0,100.0, 20.0,20.0, 20.0, 20.0, 20.0,20.0/
 
-    xkNlimiting  = 1.0_r_2
+    xkNlimiting  = 1.0_r2
     !  set N mineral N fluxes to zero
-    xFluxNlittermin(:)  = 0.0_r_2
-    xFluxNsoilmin(:)    = 0.0_r_2
-    xFluxNsoilimm(:)    = 0.0_r_2  !negative for microbial upatek and postive for release of mineral N
-    xFluxNsoilminnet(:) = 0.0_r_2
+    xFluxNlittermin(:)  = 0.0_r2
+    xFluxNsoilmin(:)    = 0.0_r2
+    xFluxNsoilimm(:)    = 0.0_r2  !negative for microbial upatek and postive for release of mineral N
+    xFluxNsoilminnet(:) = 0.0_r2
 
     !  calculate gross mineralisation
     DO nland=1,mp
@@ -2152,11 +2152,11 @@ CONTAINS
 
           ! calculate C:N ratio of newly formed SOM as function of soil mineral N pool
           ! TODO: revisit this if statement
-          IF (casapool%Nsoilmin(nland) < 2.0_r_2) THEN
+          IF (casapool%Nsoilmin(nland) < 2.0_r2) THEN
              casapool%ratioNCsoilnew(nland,:) = casapool%ratioNCsoilmin(nland,:)  &
                   + (casapool%ratioNCsoilmax(nland,:) &
                   -casapool%ratioNCsoilmin(nland,:)) &
-                  * max(0.0_r_2, casapool%Nsoilmin(nland)) / 2.0_r_2
+                  * max(0.0_r2, casapool%Nsoilmin(nland)) / 2.0_r2
           ELSE
              casapool%ratioNCsoilnew(nland,:) = casapool%ratioNCsoilmax(nland,:)
           ENDIF
@@ -2193,22 +2193,22 @@ CONTAINS
 
     ! Q.Zhang 23/05/2011 test code according to YPW
     WHERE(casamet%iveg2(:)/=icewater)
-       WHERE((xFluxNsoilminnet(:)*deltpool + (casapool%Nsoilmin(:)-2.0_r_2)) > 0.0_r_2 &
-            .OR. xFluxNsoilminnet(:) .ge. 0.0_r_2)
-          xkNlimiting(:) = 1.0_r_2
+       WHERE((xFluxNsoilminnet(:)*deltpool + (casapool%Nsoilmin(:)-2.0_r2)) > 0.0_r2 &
+            .OR. xFluxNsoilminnet(:) .ge. 0.0_r2)
+          xkNlimiting(:) = 1.0_r2
        ELSEWHERE
-          xkNlimiting(:) = MAX(0.0_r_2, - (casapool%Nsoilmin(:)-0.5_r_2) &
+          xkNlimiting(:) = MAX(0.0_r2, - (casapool%Nsoilmin(:)-0.5_r2) &
                                      /(deltpool*xFluxNsoilminnet(:)))
-          xkNlimiting(:) = MIN(1.0_r_2, xkNlimiting(:))
+          xkNlimiting(:) = MIN(1.0_r2, xkNlimiting(:))
        ENDWHERE
        ! Q.Zhang 23/05/2011 test
        ! If pool size larger than xClitter, turnover rate will not constrained by Nsoilmin.
        !    where(casapool%clitter(:,1) > xClitter(veg%iveg(:)))
-       !     xkNlimiting(:) = 1.0_r_2
+       !     xkNlimiting(:) = 1.0_r2
        !    end where
        ! end (Q.Zhang 23/05/2011)
        where(sum(casapool%clitter,2) > casabiome%maxfinelitter(veg%iveg(:)) + casabiome%maxcwd(veg%iveg(:)))
-          xkNlimiting(:) = 1.0_r_2
+          xkNlimiting(:) = 1.0_r2
        end where
     ENDWHERE
 
@@ -2227,23 +2227,23 @@ CONTAINS
     TYPE(casa_pool),          INTENT(INOUT) :: casapool
     TYPE(casa_flux),          INTENT(INOUT) :: casaflux
     TYPE(casa_met),           INTENT(INOUT) :: casamet
-    !REAL(r_2), DIMENSION(mp), INTENT(IN)    :: xkNlimiting
-    REAL(r_2), DIMENSION(mp), INTENT(IN)    :: xNuptake
+    !REAL(r2), DIMENSION(mp), INTENT(IN)    :: xkNlimiting
+    REAL(r2), DIMENSION(mp), INTENT(IN)    :: xNuptake
 
     ! local variables
-    REAL(r_2), DIMENSION(mp,mplant) :: Nreqmax, Nreqmin, NtransPtoP, plantNuptake
-    REAL(r_2), DIMENSION(mp)        :: totNreqmax, totNreqmin
-    REAL(r_2), DIMENSION(mp)        :: xnCnpp
+    REAL(r2), DIMENSION(mp,mplant) :: Nreqmax, Nreqmin, NtransPtoP, plantNuptake
+    REAL(r2), DIMENSION(mp)        :: totNreqmax, totNreqmin
+    REAL(r2), DIMENSION(mp)        :: xnCnpp
 
-    Nreqmin(:,:)       = 0.0_r_2
-    Nreqmax(:,:)       = 0.0_r_2
-    NtransPtoP(:,:)    = 0.0_r_2
-    totNreqmax         = 0.0_r_2
-    totNreqmin         = 0.0_r_2
+    Nreqmin(:,:)       = 0.0_r2
+    Nreqmax(:,:)       = 0.0_r2
+    NtransPtoP(:,:)    = 0.0_r2
+    totNreqmax         = 0.0_r2
+    totNreqmin         = 0.0_r2
 
-    casaflux%Nminuptake(:)     = 0.0_r_2
-    casaflux%fracNalloc(:,:)   = 0.0_r_2
-    xnCnpp = max(0.0_r_2,casaflux%Cnpp)
+    casaflux%Nminuptake(:)     = 0.0_r2
+    casaflux%fracNalloc(:,:)   = 0.0_r2
+    xnCnpp = max(0.0_r2,casaflux%Cnpp)
     call casa_Nrequire(xnCnpp,Nreqmin,Nreqmax,NtransPtoP,veg, &
          casabiome,casapool,casaflux,casamet)
          WHERE(casamet%iveg2/=icewater)
@@ -2251,7 +2251,7 @@ CONTAINS
          !totNreqmin(:) = Nreqmin(:,leaf)+Nreqmin(:,wood)+Nreqmin(:,froot)
      
           ! JK: reduce plantPuptake if NPP already reduced because of limited N supply (casa_xnp)
-          WHERE(xNuptake(:) .lt. 1.0_r_2)
+          WHERE(xNuptake(:) .lt. 1.0_r2)
             plantNuptake(:,leaf) = Nreqmin(:,leaf)
             plantNuptake(:,wood) = Nreqmin(:,wood)
             plantNuptake(:,froot) = Nreqmin(:,froot)
@@ -2267,16 +2267,16 @@ CONTAINS
          ! JK: make sure PlantNuptake does not exceed Nminsoil
          casaflux%Nminuptake(:) = PlantNuptake(:,leaf) + PlantNuptake(:,wood) + PlantNuptake(:,froot)
          plantNuptake(:,leaf)  = MIN(plantNuptake(:,leaf), &
-              plantNuptake(:,leaf)/MAX(casaflux%Nminuptake(:),1.0e-10_r_2) * casapool%Nsoilmin(:))
+              plantNuptake(:,leaf)/MAX(casaflux%Nminuptake(:),1.0e-10_r2) * casapool%Nsoilmin(:))
          plantNuptake(:,wood)  = MIN(plantNuptake(:,wood), &
-              plantNuptake(:,wood)/MAX(casaflux%Nminuptake(:),1.0e-10_r_2) * casapool%Nsoilmin(:))
+              plantNuptake(:,wood)/MAX(casaflux%Nminuptake(:),1.0e-10_r2) * casapool%Nsoilmin(:))
          plantNuptake(:,froot) = MIN(plantNuptake(:,froot), &
-              plantNuptake(:,froot)/MAX(casaflux%Nminuptake(:),1.0e-10_r_2) * casapool%Nsoilmin(:))
+              plantNuptake(:,froot)/MAX(casaflux%Nminuptake(:),1.0e-10_r2) * casapool%Nsoilmin(:))
 
          casaflux%Nminuptake(:) = PlantNuptake(:,leaf) + PlantNuptake(:,wood) + PlantNuptake(:,froot)
-         casaflux%fracNalloc(:,leaf)  = PlantNuptake(:,leaf)/MAX(casaflux%Nminuptake(:),1.0e-10_r_2)
-         casaflux%fracNalloc(:,wood)  = PlantNuptake(:,wood)/MAX(casaflux%Nminuptake(:),1.0e-10_r_2)
-         casaflux%fracNalloc(:,froot) = PlantNuptake(:,froot)/MAX(casaflux%Nminuptake(:),1.0e-10_r_2)
+         casaflux%fracNalloc(:,leaf)  = PlantNuptake(:,leaf)/MAX(casaflux%Nminuptake(:),1.0e-10_r2)
+         casaflux%fracNalloc(:,wood)  = PlantNuptake(:,wood)/MAX(casaflux%Nminuptake(:),1.0e-10_r2)
+         casaflux%fracNalloc(:,froot) = PlantNuptake(:,froot)/MAX(casaflux%Nminuptake(:),1.0e-10_r2)
          
        ENDWHERE
 
@@ -2289,9 +2289,9 @@ CONTAINS
        casabiome,casapool,casaflux,casamet)
     !
     IMPLICIT NONE
-    REAL(r_2), DIMENSION(mp),        INTENT(IN)    :: xnCnpp
-    REAL(r_2), DIMENSION(mp,mplant), INTENT(INOUT) :: Nreqmax, Nreqmin
-    REAL(r_2), DIMENSION(mp,mplant), INTENT(INOUT) :: NtransPtoP
+    REAL(r2), DIMENSION(mp),        INTENT(IN)    :: xnCnpp
+    REAL(r2), DIMENSION(mp,mplant), INTENT(INOUT) :: Nreqmax, Nreqmin
+    REAL(r2), DIMENSION(mp,mplant), INTENT(INOUT) :: NtransPtoP
     TYPE (veg_parameter_type),             INTENT(INOUT) :: veg
     TYPE (casa_biome),                     INTENT(INOUT) :: casabiome
     TYPE (casa_pool),                      INTENT(INOUT) :: casapool
@@ -2300,11 +2300,11 @@ CONTAINS
 
     ! local variable
     INTEGER :: np
-    REAL(r_2), DIMENSION(mp,mplant)     :: ncplantmax
+    REAL(r2), DIMENSION(mp,mplant)     :: ncplantmax
 
-    Nreqmin(:,:)    = 0.0_r_2
-    Nreqmax(:,:)    = 0.0_r_2
-    NtransPtoP(:,:) = 0.0_r_2
+    Nreqmin(:,:)    = 0.0_r2
+    Nreqmax(:,:)    = 0.0_r2
+    NtransPtoP(:,:) = 0.0_r2
 
     DO np=1,mp
        IF (casamet%iveg2(np)/=icewater) THEN
@@ -2314,15 +2314,15 @@ CONTAINS
           !    ncplantmax(np,leaf) =casabiome%ratioNCplantmin(veg%iveg(np),leaf)  &
           !         +(casabiome%ratioNCplantmax(veg%iveg(np),leaf) - &
           !         casabiome%ratioNCplantmin(veg%iveg(np),leaf)) &
-          !         * min(1.0_r_2, max(0.0_r_2, 2.0_r_2**(0.5_r_2*casapool%Nsoilmin(np))-1.0_r_2))
+          !         * min(1.0_r2, max(0.0_r2, 2.0_r2**(0.5_r2*casapool%Nsoilmin(np))-1.0_r2))
           !    ncplantmax(np,wood) =casabiome%ratioNCplantmin(veg%iveg(np),wood) &
           !         +(casabiome%ratioNCplantmax(veg%iveg(np),wood) - &
           !         casabiome%ratioNCplantmin(veg%iveg(np),wood)) &
-          !         * min(1.0_r_2,max(0.0_r_2,2.0_r_2**(0.5_r_2*casapool%Nsoilmin(np))-1.0_r_2))
+          !         * min(1.0_r2,max(0.0_r2,2.0_r2**(0.5_r2*casapool%Nsoilmin(np))-1.0_r2))
           !    ncplantmax(np,froot) =casabiome%ratioNCplantmin(veg%iveg(np),froot)  &
           !         +(casabiome%ratioNCplantmax(veg%iveg(np),froot) - &
           !         casabiome%ratioNCplantmin(veg%iveg(np),froot)) &
-          !         * min(1.0_r_2,max(0.0_r_2,2.0_r_2**(0.5_r_2*casapool%Nsoilmin(np))-1.0_r_2))
+          !         * min(1.0_r2,max(0.0_r2,2.0_r2**(0.5_r2*casapool%Nsoilmin(np))-1.0_r2))
           ! else
           ncplantmax(np,leaf)  = casabiome%ratioNCplantmax(veg%iveg(np),leaf)
           ncplantmax(np,wood)  = casabiome%ratioNCplantmax(veg%iveg(np),wood)
@@ -2341,33 +2341,33 @@ CONTAINS
                * casabiome%ratioNCplantmin(veg%iveg(np),froot)
 
           NtransPtoP(np,leaf) = casaflux%kplant(np,leaf)*casapool%Nplant(np,leaf) &
-               * (1.0_r_2-casabiome%ftransNPtoL(veg%iveg(np),leaf))
+               * (1.0_r2-casabiome%ftransNPtoL(veg%iveg(np),leaf))
           NtransPtoP(np,wood) = casaflux%kplant(np,wood)*casapool%Nplant(np,wood) &
-               * (1.0_r_2-casabiome%ftransNPtoL(veg%iveg(np),wood))
+               * (1.0_r2-casabiome%ftransNPtoL(veg%iveg(np),wood))
           NtransPtoP(np,froot) = casaflux%kplant(np,froot)*casapool%Nplant(np,froot) &
-               * (1.0_r_2-casabiome%ftransNPtoL(veg%iveg(np),froot))
+               * (1.0_r2-casabiome%ftransNPtoL(veg%iveg(np),froot))
 
-          Nreqmax(np,leaf)  = max(0.0_r_2,Nreqmax(np,leaf) - NtransPtoP(np,leaf))
-          Nreqmax(np,wood)  = max(0.0_r_2,Nreqmax(np,wood) - NtransPtoP(np,wood))
-          Nreqmax(np,froot) = max(0.0_r_2,Nreqmax(np,froot) - NtransPtoP(np,froot))
-          Nreqmin(np,leaf)  = max(0.0_r_2,Nreqmin(np,leaf) - NtransPtoP(np,leaf))
-          Nreqmin(np,wood)  = max(0.0_r_2,Nreqmin(np,wood) - NtransPtoP(np,wood))
-          Nreqmin(np,froot) = max(0.0_r_2,Nreqmin(np,froot) - NtransPtoP(np,froot))
+          Nreqmax(np,leaf)  = max(0.0_r2,Nreqmax(np,leaf) - NtransPtoP(np,leaf))
+          Nreqmax(np,wood)  = max(0.0_r2,Nreqmax(np,wood) - NtransPtoP(np,wood))
+          Nreqmax(np,froot) = max(0.0_r2,Nreqmax(np,froot) - NtransPtoP(np,froot))
+          Nreqmin(np,leaf)  = max(0.0_r2,Nreqmin(np,leaf) - NtransPtoP(np,leaf))
+          Nreqmin(np,wood)  = max(0.0_r2,Nreqmin(np,wood) - NtransPtoP(np,wood))
+          Nreqmin(np,froot) = max(0.0_r2,Nreqmin(np,froot) - NtransPtoP(np,froot))
 
-          if (casapool%nplant(np,leaf) / (casapool%cplant(np,leaf) + 1.0e-10_r_2) > &
+          if (casapool%nplant(np,leaf) / (casapool%cplant(np,leaf) + 1.0e-10_r2) > &
                casabiome%ratioNCplantmax(veg%iveg(np),leaf)) then
-             Nreqmax(np,leaf) = 0.0_r_2
-             Nreqmin(np,leaf) = 0.0_r_2
+             Nreqmax(np,leaf) = 0.0_r2
+             Nreqmin(np,leaf) = 0.0_r2
           endif
-          if (casapool%nplant(np,wood) / (casapool%cplant(np,wood) + 1.0e-10_r_2) > &
+          if (casapool%nplant(np,wood) / (casapool%cplant(np,wood) + 1.0e-10_r2) > &
                casabiome%ratioNCplantmax(veg%iveg(np),wood)) then
-             Nreqmax(np,wood) = 0.0_r_2
-             Nreqmin(np,wood) = 0.0_r_2
+             Nreqmax(np,wood) = 0.0_r2
+             Nreqmin(np,wood) = 0.0_r2
           endif
-          if (casapool%nplant(np,froot) / (casapool%cplant(np,froot) + 1.0e-10_r_2) > &
+          if (casapool%nplant(np,froot) / (casapool%cplant(np,froot) + 1.0e-10_r2) > &
                casabiome%ratioNCplantmax(veg%iveg(np),froot)) then
-             Nreqmax(np,froot) = 0.0_r_2
-             Nreqmin(np,froot) = 0.0_r_2
+             Nreqmax(np,froot) = 0.0_r2
+             Nreqmin(np,froot) = 0.0_r2
           endif
 
        ENDIF
@@ -2387,23 +2387,23 @@ CONTAINS
     TYPE(casa_pool),          INTENT(INOUT) :: casapool
     TYPE(casa_flux),          INTENT(INOUT) :: casaflux
     TYPE(casa_met),           INTENT(INOUT) :: casamet
-    !REAL(r_2), DIMENSION(mp), INTENT(IN)    :: xkNlimiting
-    REAL(r_2), DIMENSION(mp), INTENT(IN)    :: xPuptake
+    !REAL(r2), DIMENSION(mp), INTENT(IN)    :: xkNlimiting
+    REAL(r2), DIMENSION(mp), INTENT(IN)    :: xPuptake
 
     ! local variables
-    REAL(r_2), DIMENSION(mp,mplant) :: Preqmax, Preqmin, PtransPtoP, plantPuptake
-    REAL(r_2), DIMENSION(mp)        :: totPreqmax, totPreqmin
-    REAL(r_2), DIMENSION(mp)        :: xpCnpp
+    REAL(r2), DIMENSION(mp,mplant) :: Preqmax, Preqmin, PtransPtoP, plantPuptake
+    REAL(r2), DIMENSION(mp)        :: totPreqmax, totPreqmin
+    REAL(r2), DIMENSION(mp)        :: xpCnpp
 
-    Preqmin(:,:)             = 0.0_r_2
-    Preqmax(:,:)             = 0.0_r_2
-    PtransPtoP(:,:)          = 0.0_r_2
-    casaflux%Plabuptake(:)   = 0.0_r_2
-    casaflux%fracPalloc(:,:) = 0.0_r_2
-    totPreqmax               = 0.0_r_2
-    totPreqmin               = 0.0_r_2
+    Preqmin(:,:)             = 0.0_r2
+    Preqmax(:,:)             = 0.0_r2
+    PtransPtoP(:,:)          = 0.0_r2
+    casaflux%Plabuptake(:)   = 0.0_r2
+    casaflux%fracPalloc(:,:) = 0.0_r2
+    totPreqmax               = 0.0_r2
+    totPreqmin               = 0.0_r2
 
-    xpCnpp = max(0.0_r_2,casaflux%cnpp)
+    xpCnpp = max(0.0_r2,casaflux%cnpp)
     call casa_Prequire(xpCnpp,Preqmin,Preqmax,PtransPtoP,veg, &
          casabiome,casapool,casaflux,casamet)
 
@@ -2412,7 +2412,7 @@ CONTAINS
        totPreqmin(:) = Preqmin(:,leaf)+Preqmin(:,wood)+Preqmin(:,froot)
 
        ! JK: reduce plantPuptake if NPP already reduced because of limited P supply (casa_xnp)
-       WHERE(xPuptake(:) .lt. 1.0_r_2)
+       WHERE(xPuptake(:) .lt. 1.0_r2)
           plantPuptake(:,leaf) = Preqmin(:,leaf)
           plantPuptake(:,wood) = Preqmin(:,wood)
           plantPuptake(:,froot) = Preqmin(:,froot)
@@ -2428,16 +2428,16 @@ CONTAINS
        ! JK: make sure plantPuptake does not exceed Psoillab
        casaflux%Plabuptake(:) = plantPuptake(:,leaf) + plantPuptake(:,wood) + plantPuptake(:,froot)
        plantPuptake(:,leaf)  = MIN(plantPuptake(:,leaf), &
-            plantPuptake(:,leaf)/MAX(casaflux%Plabuptake(:),1.0e-10_r_2) * casapool%Psoillab(:))
+            plantPuptake(:,leaf)/MAX(casaflux%Plabuptake(:),1.0e-10_r2) * casapool%Psoillab(:))
        plantPuptake(:,wood)  = MIN(plantPuptake(:,wood), &
-            plantPuptake(:,wood)/MAX(casaflux%Plabuptake(:),1.0e-10_r_2) * casapool%Psoillab(:))
+            plantPuptake(:,wood)/MAX(casaflux%Plabuptake(:),1.0e-10_r2) * casapool%Psoillab(:))
        plantPuptake(:,froot) = MIN(plantPuptake(:,froot), &
-            plantPuptake(:,froot)/MAX(casaflux%Plabuptake(:),1.0e-10_r_2) * casapool%Psoillab(:))
+            plantPuptake(:,froot)/MAX(casaflux%Plabuptake(:),1.0e-10_r2) * casapool%Psoillab(:))
 
        casaflux%Plabuptake(:) = plantPuptake(:,leaf) + plantPuptake(:,wood) + plantPuptake(:,froot)
-       casaflux%fracPalloc(:,leaf)  = plantPuptake(:,leaf)/MAX(casaflux%Plabuptake(:),1.0e-10_r_2)
-       casaflux%fracPalloc(:,wood)  = plantPuptake(:,wood)/MAX(casaflux%Plabuptake(:),1.0e-10_r_2)
-       casaflux%fracPalloc(:,froot) = plantPuptake(:,froot)/MAX(casaflux%Plabuptake(:),1.0e-10_r_2)
+       casaflux%fracPalloc(:,leaf)  = plantPuptake(:,leaf)/MAX(casaflux%Plabuptake(:),1.0e-10_r2)
+       casaflux%fracPalloc(:,wood)  = plantPuptake(:,wood)/MAX(casaflux%Plabuptake(:),1.0e-10_r2)
+       casaflux%fracPalloc(:,froot) = plantPuptake(:,froot)/MAX(casaflux%Plabuptake(:),1.0e-10_r2)
 
     ENDWHERE
 
@@ -2458,9 +2458,9 @@ CONTAINS
 
     IMPLICIT NONE
 
-    REAL(r_2), DIMENSION(mp),        INTENT(IN)    :: xpCnpp
-    REAL(r_2), DIMENSION(mp,mplant), INTENT(INOUT) :: Preqmax, Preqmin
-    REAL(r_2), DIMENSION(mp,mplant), INTENT(INOUT) :: PtransPtoP
+    REAL(r2), DIMENSION(mp),        INTENT(IN)    :: xpCnpp
+    REAL(r2), DIMENSION(mp,mplant), INTENT(INOUT) :: Preqmax, Preqmin
+    REAL(r2), DIMENSION(mp,mplant), INTENT(INOUT) :: PtransPtoP
     TYPE(veg_parameter_type),        INTENT(INOUT) :: veg
     TYPE(casa_biome),                INTENT(INOUT) :: casabiome
     TYPE(casa_pool),                 INTENT(INOUT) :: casapool
@@ -2470,61 +2470,61 @@ CONTAINS
     ! local variables
     INTEGER :: np
 
-    Preqmin(:,:)    = 0.0_r_2
-    Preqmax(:,:)    = 0.0_r_2
-    PtransPtoP(:,:) = 0.0_r_2
+    Preqmin(:,:)    = 0.0_r2
+    Preqmax(:,:)    = 0.0_r2
+    PtransPtoP(:,:) = 0.0_r2
 
     do np=1,mp
        if (casamet%iveg2(np)/=icewater) then
           Preqmax(np,leaf) = xpCnpp(np)* casaflux%fracCalloc(np,leaf) &
-               * (casapool%Nplant(np,leaf)/(casapool%Cplant(np,leaf)+1.0e-10_r_2)) &
+               * (casapool%Nplant(np,leaf)/(casapool%Cplant(np,leaf)+1.0e-10_r2)) &
                / casabiome%ratioNPplantmin(veg%iveg(np),leaf)
           Preqmax(np,wood) = xpCnpp(np)* casaflux%fracCalloc(np,wood) &
-               * (casapool%Nplant(np,wood)/(casapool%Cplant(np,wood)+1.0e-10_r_2)) &
+               * (casapool%Nplant(np,wood)/(casapool%Cplant(np,wood)+1.0e-10_r2)) &
                / casabiome%ratioNPplantmin(veg%iveg(np),wood)
           Preqmax(np,froot) = xpCnpp(np)* casaflux%fracCalloc(np,froot) &
-               * (casapool%Nplant(np,froot)/(casapool%Cplant(np,froot)+1.0e-10_r_2)) &
+               * (casapool%Nplant(np,froot)/(casapool%Cplant(np,froot)+1.0e-10_r2)) &
                / casabiome%ratioNPplantmin(veg%iveg(np),froot)
 
           Preqmin(np,leaf) = xpCnpp(np) * casaflux%fracCalloc(np,leaf) &
-               * (casapool%Nplant(np,leaf)/(casapool%Cplant(np,leaf)+1.0e-10_r_2)) &
+               * (casapool%Nplant(np,leaf)/(casapool%Cplant(np,leaf)+1.0e-10_r2)) &
                / casabiome%ratioNPplantmax(veg%iveg(np),leaf)
           Preqmin(np,wood) = xpCnpp(np) * casaflux%fracCalloc(np,wood) &
-               * (casapool%Nplant(np,wood)/(casapool%Cplant(np,wood)+1.0e-10_r_2)) &
+               * (casapool%Nplant(np,wood)/(casapool%Cplant(np,wood)+1.0e-10_r2)) &
                / casabiome%ratioNPplantmax(veg%iveg(np),wood)
           Preqmin(np,froot) = xpCnpp(np) * casaflux%fracCalloc(np,froot) &
-               * (casapool%Nplant(np,froot)/(casapool%Cplant(np,froot)+1.0e-10_r_2)) &
+               * (casapool%Nplant(np,froot)/(casapool%Cplant(np,froot)+1.0e-10_r2)) &
                / casabiome%ratioNPplantmax(veg%iveg(np),froot)
 
           PtransPtoP(np,leaf) = casaflux%kplant(np,leaf)*casapool%Pplant(np,leaf) &
-               * (1.0_r_2-casabiome%ftransPPtoL(veg%iveg(np),leaf))
+               * (1.0_r2-casabiome%ftransPPtoL(veg%iveg(np),leaf))
           PtransPtoP(np,wood) = casaflux%kplant(np,wood)*casapool%Pplant(np,wood) &
-               * (1.0_r_2-casabiome%ftransPPtoL(veg%iveg(np),wood))
+               * (1.0_r2-casabiome%ftransPPtoL(veg%iveg(np),wood))
           PtransPtoP(np,froot) = casaflux%kplant(np,froot)*casapool%Pplant(np,froot) &
-               * (1.0_r_2-casabiome%ftransPPtoL(veg%iveg(np),froot))
+               * (1.0_r2-casabiome%ftransPPtoL(veg%iveg(np),froot))
 
-          Preqmax(np,leaf)  = max(0.0_r_2,Preqmax(np,leaf) - PtransPtoP(np,leaf))
-          Preqmax(np,wood)  = max(0.0_r_2,Preqmax(np,wood) - PtransPtoP(np,wood))
-          Preqmax(np,froot) = max(0.0_r_2,Preqmax(np,froot) - PtransPtoP(np,froot))
+          Preqmax(np,leaf)  = max(0.0_r2,Preqmax(np,leaf) - PtransPtoP(np,leaf))
+          Preqmax(np,wood)  = max(0.0_r2,Preqmax(np,wood) - PtransPtoP(np,wood))
+          Preqmax(np,froot) = max(0.0_r2,Preqmax(np,froot) - PtransPtoP(np,froot))
 
-          Preqmin(np,leaf)  = max(0.0_r_2,Preqmin(np,leaf) - PtransPtoP(np,leaf))
-          Preqmin(np,wood)  = max(0.0_r_2,Preqmin(np,wood) - PtransPtoP(np,wood))
-          Preqmin(np,froot) = max(0.0_r_2,Preqmin(np,froot) - PtransPtoP(np,froot))
+          Preqmin(np,leaf)  = max(0.0_r2,Preqmin(np,leaf) - PtransPtoP(np,leaf))
+          Preqmin(np,wood)  = max(0.0_r2,Preqmin(np,wood) - PtransPtoP(np,wood))
+          Preqmin(np,froot) = max(0.0_r2,Preqmin(np,froot) - PtransPtoP(np,froot))
 
-          if (casapool%pplant(np,leaf)/(casapool%nplant(np,leaf)+1.0e-10_r_2) > &
-               1.0_r_2/casabiome%ratioNPplantmin(veg%iveg(np),leaf)) then
-             Preqmax(np,leaf) = 0.0_r_2
-             Preqmin(np,leaf) = 0.0_r_2
+          if (casapool%pplant(np,leaf)/(casapool%nplant(np,leaf)+1.0e-10_r2) > &
+               1.0_r2/casabiome%ratioNPplantmin(veg%iveg(np),leaf)) then
+             Preqmax(np,leaf) = 0.0_r2
+             Preqmin(np,leaf) = 0.0_r2
           endif
-          if (casapool%pplant(np,wood)/(casapool%nplant(np,wood)+1.0e-10_r_2) > &
-               1.0_r_2/casabiome%ratioNPplantmin(veg%iveg(np),wood)) then
-             Preqmax(np,wood) = 0.0_r_2
-             Preqmin(np,wood) = 0.0_r_2
+          if (casapool%pplant(np,wood)/(casapool%nplant(np,wood)+1.0e-10_r2) > &
+               1.0_r2/casabiome%ratioNPplantmin(veg%iveg(np),wood)) then
+             Preqmax(np,wood) = 0.0_r2
+             Preqmin(np,wood) = 0.0_r2
           endif
-          if(casapool%pplant(np,froot)/(casapool%nplant(np,froot)+1.0e-10_r_2) > &
-               1.0_r_2/casabiome%ratioNPplantmin(veg%iveg(np),froot)) then
-             Preqmax(np,froot) = 0.0_r_2
-             Preqmin(np,froot) = 0.0_r_2
+          if(casapool%pplant(np,froot)/(casapool%nplant(np,froot)+1.0e-10_r2) > &
+               1.0_r2/casabiome%ratioNPplantmin(veg%iveg(np),froot)) then
+             Preqmax(np,froot) = 0.0_r2
+             Preqmin(np,froot) = 0.0_r2
           endif
 
        endif
@@ -2553,12 +2553,12 @@ CONTAINS
     do np=1, mp
 
        if (casamet%iveg2(np) == icewater) then
-          casamet%glai(np) = 0.0_r_2
+          casamet%glai(np) = 0.0_r2
        else
           casapool%cplant(np,:) = casapool%cplant(np,:) + casapool%dcplantdt(np,:) * deltpool
           casapool%clabile(np)  = casapool%clabile(np)  + casapool%dclabiledt(np)  * deltpool
 
-          if (casapool%cplant(np,leaf) > 0.0_r_2) then
+          if (casapool%cplant(np,leaf) > 0.0_r2) then
              if (icycle >1) casapool%Nplant(np,:) = casapool%Nplant(np,:) + casapool%dNplantdt(np,:)*deltpool
              if (icycle >2) casapool%Pplant(np,:) = casapool%Pplant(np,:) + casapool%dPplantdt(np,:)*deltpool
           endif
@@ -2581,7 +2581,7 @@ CONTAINS
              ! vh ! put lower bound of 1.0e-3 to prevent Nsoilmin from going negative
              ! Ticket #108
              casapool%Nsoilmin(np)  = max(casapool%Nsoilmin(np) + casapool%dNsoilmindt(np) * &
-                  deltpool,1.0e-3_r_2)
+                  deltpool,1.0e-3_r2)
           ENDIF
 
           IF (icycle >2) THEN
@@ -2591,7 +2591,7 @@ CONTAINS
              ! but that doesn't close P mass balance.
              ! Psoillab should never fall that low. Lower limit decreased to 1.0e-5
              casapool%Psoillab(np)  = max(casapool%Psoillab(np) + casapool%dPsoillabdt(np) * deltpool, &
-                  1.0e-5_r_2)
+                  1.0e-5_r2)
              casapool%Psoilsorb(np) = casaflux%Psorbmax(np) * casapool%Psoillab(np) / &
                   (casaflux%kmlabp(np) + casapool%Psoillab(np))
              !      casapool%Psoilsorb(np) = casapool%Psoilsorb(np)  &
@@ -2600,58 +2600,58 @@ CONTAINS
           ENDIF
 
           do i=1, mplant
-             if (casapool%cplant(np,i) < 0.0_r_2)  then
+             if (casapool%cplant(np,i) < 0.0_r2)  then
                 write(57,*) 'Cpool: np,ivt', np, casamet%lat(np), casamet%lon(np), &
                      casamet%iveg2(np), casapool%cplant(np,:)
                 write(*,*)  'Cpool: np,ivt', np, casamet%lat(np), casamet%lon(np), &
                      casamet%iveg2(np), casapool%cplant(np,:)
                 call casa_poolzero(np, 1, casapool)
-                casapool%cplant(np,i) = max(0.0_r_2, casapool%cplant(np,i))
+                casapool%cplant(np,i) = max(0.0_r2, casapool%cplant(np,i))
              endif
           enddo
 
           IF (icycle >1) THEN
              DO i=1, mplant
-                IF(casapool%nplant(np,i) < 0.0_r_2) THEN
+                IF(casapool%nplant(np,i) < 0.0_r2) THEN
                    WRITE(57,*) 'Npool:', 'np,ivt,ipool',np,casamet%iveg2(np),casapool%nplant(np,:)
                    call casa_poolzero(np,2,casapool)
-                   casapool%nplant(np,i) = max(0.0_r_2, casapool%nplant(np,i))
+                   casapool%nplant(np,i) = max(0.0_r2, casapool%nplant(np,i))
                 ENDIF
              ENDDO
           ENDIF ! end of "icycle >1"
 
           do j=1, mlitter
-             if (casapool%clitter(np,j) < 0.0_r_2) then
+             if (casapool%clitter(np,j) < 0.0_r2) then
                 write(57,*) 'Clitter: np,ivt2', np, casamet%iveg2(np), casapool%clitter(np,:)
                 write(*,*)  'Clitter: np,ivt2', np, casamet%iveg2(np), casapool%clitter(np,:)
                 call casa_poolzero(np, 3, casapool)
-                casapool%clitter(np,j) = max(0.0_r_2, casapool%clitter(np,j))
+                casapool%clitter(np,j) = max(0.0_r2, casapool%clitter(np,j))
              endif
           enddo
 
           do k=1, msoil
-             if (casapool%csoil(np,k) < 0.0_r_2) then
+             if (casapool%csoil(np,k) < 0.0_r2) then
                 write(57,*) 'Csoil: np,ivt2', np, casamet%iveg2(np), casapool%csoil(np,:)
                 write(*,*)  'Csoil: np,ivt2', np, casamet%iveg2(np), casapool%csoil(np,:)
                 call casa_poolzero(np, 5, casapool)
-                casapool%csoil(np,k) = max(0.0_r_2, casapool%csoil(np,k))
+                casapool%csoil(np,k) = max(0.0_r2, casapool%csoil(np,k))
              endif
           enddo
 
           !  check if any pool size, and terminate model run if any pool size is negative!!
           IF (icycle >1) THEN
              DO j=1, mlitter
-                IF (casapool%nlitter(np, j) < 0.0_r_2)  THEN
+                IF (casapool%nlitter(np, j) < 0.0_r2)  THEN
                    WRITE(57,*) 'Nlitter: np, ivt2 ', np, casamet%iveg2(np), casapool%Nlitter(np, :)
                    call casa_poolzero(np, 4, casapool)
-                   casapool%nlitter(np, j) = max(0.0_r_2, casapool%nlitter(np, j))
+                   casapool%nlitter(np, j) = max(0.0_r2, casapool%nlitter(np, j))
                 ENDIF
              ENDDO
              DO k=1, msoil
-                IF(casapool%nsoil(np, k) < 0.0_r_2) THEN
+                IF(casapool%nsoil(np, k) < 0.0_r2) THEN
                    WRITE(57,*) 'Nsoil: np, ivt2', np, casamet%iveg2(np), casapool%nsoil(np, :)
                    call casa_poolzero(np, 6, casapool)
-                   casapool%nsoil(np, k) = max(0.0_r_2, casapool%nsoil(np, k))
+                   casapool%nsoil(np, k) = max(0.0_r2, casapool%nsoil(np, k))
                 ENDIF
              ENDDO
           ENDIF  !end of "icycle >1"
@@ -2708,24 +2708,24 @@ CONTAINS
     integer,            intent(in)    :: idoy
 
     ! local variables
-    REAL(r_2), DIMENSION(mp) :: cbalplant, nbalplant, pbalplant
-    REAL(r_2), DIMENSION(mp) :: cbalsoil,  nbalsoil,  pbalsoil
+    REAL(r2), DIMENSION(mp) :: cbalplant, nbalplant, pbalplant
+    REAL(r2), DIMENSION(mp) :: cbalsoil,  nbalsoil,  pbalsoil
 
-    real(r_2), dimension(mp) :: tmp1, tmp2, tmp3, tmp4, tmp5, tmp6
-    real(r_2)                :: tmp7, tmp8, tmp9, tmp10, tmp11, tmp12, tmp13, tmp14
-    real(r_2), parameter     :: prec = 1.0e-10_r_2
+    real(r2), dimension(mp) :: tmp1, tmp2, tmp3, tmp4, tmp5, tmp6
+    real(r2)                :: tmp7, tmp8, tmp9, tmp10, tmp11, tmp12, tmp13, tmp14
+    real(r2), parameter     :: prec = 1.0e-10_r2
     integer                  :: i
 
-    cbalplant(:) = 0.0_r_2
-    cbalsoil(:)  = 0.0_r_2
-    nbalplant(:) = 0.0_r_2
-    nbalsoil(:)  = 0.0_r_2
-    pbalplant(:) = 0.0_r_2
-    pbalsoil(:)  = 0.0_r_2
+    cbalplant(:) = 0.0_r2
+    cbalsoil(:)  = 0.0_r2
+    nbalplant(:) = 0.0_r2
+    nbalsoil(:)  = 0.0_r2
+    pbalplant(:) = 0.0_r2
+    pbalsoil(:)  = 0.0_r2
 
-    casabal%cbalance(:)  = 0.0_r_2
-    casabal%nbalance(:)  = 0.0_r_2
-    casabal%pbalance(:)  = 0.0_r_2
+    casabal%cbalance(:)  = 0.0_r2
+    casabal%nbalance(:)  = 0.0_r2
+    casabal%pbalance(:)  = 0.0_r2
 
     ! C balance
 
@@ -2769,7 +2769,7 @@ CONTAINS
     tmp3 = (sum(casaflux%kplant * casabal%cplantlast,2) - &
          casaflux%kplant(:,leaf) * casabal%cplantlast(:,leaf) * casaflux%fharvest) * deltpool
     tmp4 = casaflux%Crsoil(:) * deltpool
-    tmp5 = sum((1.0_r_2-casaflux%kplant) * casaflux%kplant_fire * casabal%cplantlast,2) * deltpool
+    tmp5 = sum((1.0_r2-casaflux%kplant) * casaflux%kplant_fire * casabal%cplantlast,2) * deltpool
     tmp6 = (casaflux%fluxCtoCO2_plant_fire + casaflux%fluxCtoCO2_litter_fire) * deltpool
     Cbalsoil(:) = tmp1 + tmp2 - tmp3 + tmp4 - tmp5 + tmp6
     if (any(abs(Cbalsoil) > prec) .and. (idoy > 0)) then
@@ -2789,15 +2789,15 @@ CONTAINS
              write(*,*) '  Fluxes               ', tmp3(i) - tmp4(i) + tmp5(i) - tmp6(i)
              ! fire debug - mass bal on litter
              tmp7 = sum(casaflux%kplant(i,:) * casabal%cplantlast(i,:)) ! plant input
-             tmp8 = sum(casaflux%kplant_fire(i,:) * (1.0_r_2 - casaflux%kplant(i,:)) * &
+             tmp8 = sum(casaflux%kplant_fire(i,:) * (1.0_r2 - casaflux%kplant(i,:)) * &
                   casabal%cplantlast(i,:)) - casaflux%fluxctoco2_plant_fire(i)
              tmp9 = sum(casaflux%klitter(i,:) * casabal%clitterlast(i,:))
-             tmp10 = sum(casaflux%klitter_fire(i,:) * (1.0_r_2 - casaflux%klitter(i,:)) * &
+             tmp10 = sum(casaflux%klitter_fire(i,:) * (1.0_r2 - casaflux%klitter(i,:)) * &
                   casabal%clitterlast(i,:))
              tmp11 = sum(casaflux%kplant_tot(i,:) * casabal%cplantlast(i,:))
              tmp12 = casaflux%fluxCtoCO2_plant_fire(i)
              tmp13 = sum(casaflux%klitter_tot(i,:) * casabal%clitterlast(i,:))
-             tmp14 = sum(casaflux%kplant_fire(i,:) * (1.0_r_2 - casaflux%kplant(i,:)) * &
+             tmp14 = sum(casaflux%kplant_fire(i,:) * (1.0_r2 - casaflux%kplant(i,:)) * &
                   casabal%cplantlast(i,:))
              write(*,*) '  plant input to litter (base turnover):        ', tmp7
              write(*,*) '  plant input to litter (fire):                 ', tmp8
@@ -2946,19 +2946,19 @@ CONTAINS
 
   FUNCTION vcmax_np(nleaf, pleaf)
 
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
-    real(r_2), intent(in) :: nleaf ! leaf N in g N m-2 leaf
-    real(r_2), intent(in) :: pleaf ! leaf P in g P m-2 leaf
-    real(r_2)             :: vcmax_np
+    real(r2), intent(in) :: nleaf ! leaf N in g N m-2 leaf
+    real(r2), intent(in) :: pleaf ! leaf P in g P m-2 leaf
+    real(r2)             :: vcmax_np
 
     ! Walker, A. P. et al.: The relationship of leaf photosynthetic traits - Vcmax and Jmax -
     !   to leaf nitrogen, leaf phosphorus, and specific leaf area: a meta-analysis and modeling study,
     !   Ecology and Evolution, 4, 3218-3235, 2014.
-    vcmax_np = exp(3.946_r_2 + 0.921_r_2*log(nleaf) + 0.121_r_2*log(pleaf) + &
-         0.282_r_2*log(pleaf)*log(nleaf)) * 1.0e-6_r_2 ! units of mol m-2 (leaf)
+    vcmax_np = exp(3.946_r2 + 0.921_r2*log(nleaf) + 0.121_r2*log(pleaf) + &
+         0.282_r2*log(pleaf)*log(nleaf)) * 1.0e-6_r2 ! units of mol m-2 (leaf)
 
   END FUNCTION vcmax_np
 

--- a/core/biogeochem/casa_inout.F90
+++ b/core/biogeochem/casa_inout.F90
@@ -41,7 +41,7 @@
 !   biogeochem
 module casa_inout
 
-  use cable_def_types_mod,  only: mland, r_1
+  use cable_def_types_mod,  only: mland, r1
   use cable_IO_vars_module, only: landpt, mask, patch, max_vegpatches, xdimsize, ydimsize, &
                                   land_x, land_y, lat_all, lon_all, latitude, longitude
   use netcdf
@@ -49,17 +49,17 @@ module casa_inout
   implicit none
 
   ! Define temporary output arrays for use in write_casa_output_grid_nc and write_casa_output_patch_nc
-  REAL(KIND=r_1), DIMENSION(:,:,:), ALLOCATABLE :: otmp3patch
-  REAL(KIND=r_1), DIMENSION(:,:,:), ALLOCATABLE :: otmp3plant
-  REAL(KIND=r_1), DIMENSION(:,:,:), ALLOCATABLE :: otmp3litter
-  REAL(KIND=r_1), DIMENSION(:,:,:), ALLOCATABLE :: otmp3soil
+  REAL(KIND=r1), DIMENSION(:,:,:), ALLOCATABLE :: otmp3patch
+  REAL(KIND=r1), DIMENSION(:,:,:), ALLOCATABLE :: otmp3plant
+  REAL(KIND=r1), DIMENSION(:,:,:), ALLOCATABLE :: otmp3litter
+  REAL(KIND=r1), DIMENSION(:,:,:), ALLOCATABLE :: otmp3soil
 
-  REAL(KIND=r_1), DIMENSION(:,:,:,:), ALLOCATABLE :: otmp4patch
-  REAL(KIND=r_1), DIMENSION(:,:,:,:), ALLOCATABLE :: otmp4plant
-  REAL(KIND=r_1), DIMENSION(:,:,:,:), ALLOCATABLE :: otmp4litter
-  REAL(KIND=r_1), DIMENSION(:,:,:,:), ALLOCATABLE :: otmp4soil
+  REAL(KIND=r1), DIMENSION(:,:,:,:), ALLOCATABLE :: otmp4patch
+  REAL(KIND=r1), DIMENSION(:,:,:,:), ALLOCATABLE :: otmp4plant
+  REAL(KIND=r1), DIMENSION(:,:,:,:), ALLOCATABLE :: otmp4litter
+  REAL(KIND=r1), DIMENSION(:,:,:,:), ALLOCATABLE :: otmp4soil
 
-  REAL(KIND=r_1) :: ncmissingr = -1.0e+33
+  REAL(KIND=r1) :: ncmissingr = -1.0e+33
 
 contains
 
@@ -68,7 +68,7 @@ contains
     ! This is done to have zero in MPI and non MPI code
     ! if .not. cable_user%casa_dump_read.
 
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
     use casavariable,        only: casa_met
     use phenvariable,        only: phen_variable
     use cable_common_module, only: cable_user
@@ -78,46 +78,46 @@ contains
     type(casa_met),      intent(inout) :: casamet
     type(phen_variable), intent(inout) :: phen
 
-    casamet%Tairkspin      = 0.0_r_2
-    casamet%Tsoilspin_1    = 0.0_r_2
-    casamet%Tsoilspin_2    = 0.0_r_2
-    casamet%Tsoilspin_3    = 0.0_r_2
-    casamet%Tsoilspin_4    = 0.0_r_2
-    casamet%Tsoilspin_5    = 0.0_r_2
-    casamet%Tsoilspin_6    = 0.0_r_2
-    casamet%moistspin_1    = 0.0_r_2
-    casamet%moistspin_2    = 0.0_r_2
-    casamet%moistspin_3    = 0.0_r_2
-    casamet%moistspin_4    = 0.0_r_2
-    casamet%moistspin_5    = 0.0_r_2
-    casamet%moistspin_6    = 0.0_r_2
-    casamet%cgppspin       = 0.0_r_2
-    casamet%crmplantspin_1 = 0.0_r_2
-    casamet%crmplantspin_2 = 0.0_r_2
-    casamet%crmplantspin_3 = 0.0_r_2
+    casamet%Tairkspin      = 0.0_r2
+    casamet%Tsoilspin_1    = 0.0_r2
+    casamet%Tsoilspin_2    = 0.0_r2
+    casamet%Tsoilspin_3    = 0.0_r2
+    casamet%Tsoilspin_4    = 0.0_r2
+    casamet%Tsoilspin_5    = 0.0_r2
+    casamet%Tsoilspin_6    = 0.0_r2
+    casamet%moistspin_1    = 0.0_r2
+    casamet%moistspin_2    = 0.0_r2
+    casamet%moistspin_3    = 0.0_r2
+    casamet%moistspin_4    = 0.0_r2
+    casamet%moistspin_5    = 0.0_r2
+    casamet%moistspin_6    = 0.0_r2
+    casamet%cgppspin       = 0.0_r2
+    casamet%crmplantspin_1 = 0.0_r2
+    casamet%crmplantspin_2 = 0.0_r2
+    casamet%crmplantspin_3 = 0.0_r2
     phen%phasespin      = 0
     phen%doyphasespin_1 = 0
     phen%doyphasespin_2 = 0
     phen%doyphasespin_3 = 0
     phen%doyphasespin_4 = 0
-    casamet%mtempspin = 0.0_r_2
-    casamet%frecspin  = 0.0_r_2
+    casamet%mtempspin = 0.0_r2
+    casamet%frecspin  = 0.0_r2
     if (cable_user%c13o2) then
-       casamet%cAn12spin = 0.0_r_2
-       casamet%cAn13spin = 0.0_r_2
+       casamet%cAn12spin = 0.0_r2
+       casamet%cAn13spin = 0.0_r2
     end if
     if (cable_user%call_blaze) then
-       casamet%dprecip_spin      = 0.0_r_2
-       casamet%aprecip_av20_spin = 0.0_r_2
-       casamet%du10_max_spin     = 0.0_r_2
-       casamet%drhum_spin        = 0.0_r_2
-       casamet%dtemp_max_spin    = 0.0_r_2
-       casamet%dtemp_max_spin    = 0.0_r_2
-       casamet%KBDI_spin         = 0.0_r_2
-       casamet%D_MacArthur_spin  = 0.0_r_2
-       casamet%FFDI_spin         = 0.0_r_2
+       casamet%dprecip_spin      = 0.0_r2
+       casamet%aprecip_av20_spin = 0.0_r2
+       casamet%du10_max_spin     = 0.0_r2
+       casamet%drhum_spin        = 0.0_r2
+       casamet%dtemp_max_spin    = 0.0_r2
+       casamet%dtemp_max_spin    = 0.0_r2
+       casamet%KBDI_spin         = 0.0_r2
+       casamet%D_MacArthur_spin  = 0.0_r2
+       casamet%FFDI_spin         = 0.0_r2
        casamet%DSLR_spin         = 0
-       casamet%last_precip_spin  = 0.0_r_2
+       casamet%last_precip_spin  = 0.0_r2
     end if
 
   end subroutine zero_casa_dump
@@ -146,38 +146,38 @@ contains
     TYPE (phen_variable),       INTENT(INOUT) :: phen
 
     ! local variables
-    REAL(r_2), DIMENSION(mvtype)       :: leafage,frootage,woodage
-    REAL(r_2), DIMENSION(mvtype)       :: cwdage,metage,strage
-    REAL(r_2), DIMENSION(mvtype)       :: micage,slowage,passage,clabileage,slax
-    REAL(r_2), DIMENSION(mvtype,mplant):: ratioCNplant
-    REAL(r_2), DIMENSION(mvtype,msoil) :: ratioCNsoil,ratioCNsoilmin,ratioCNsoilmax
-    REAL(r_2), DIMENSION(ms)           :: depthsoila,depthsoilb
-    REAL(r_2), DIMENSION(mvtype)       :: xfNminloss, xfNminleach, xnfixrate
-    REAL(r_2), DIMENSION(mvtype)       :: cleaf,cwood,cfroot,      &
+    REAL(r2), DIMENSION(mvtype)       :: leafage,frootage,woodage
+    REAL(r2), DIMENSION(mvtype)       :: cwdage,metage,strage
+    REAL(r2), DIMENSION(mvtype)       :: micage,slowage,passage,clabileage,slax
+    REAL(r2), DIMENSION(mvtype,mplant):: ratioCNplant
+    REAL(r2), DIMENSION(mvtype,msoil) :: ratioCNsoil,ratioCNsoilmin,ratioCNsoilmax
+    REAL(r2), DIMENSION(ms)           :: depthsoila,depthsoilb
+    REAL(r2), DIMENSION(mvtype)       :: xfNminloss, xfNminleach, xnfixrate
+    REAL(r2), DIMENSION(mvtype)       :: cleaf,cwood,cfroot,      &
          cmet,cstr,ccwd,          &
          cmic,cslow,cpass
-    REAL(r_2), DIMENSION(mvtype)       :: nleaf,nwood,nfroot,      &
+    REAL(r2), DIMENSION(mvtype)       :: nleaf,nwood,nfroot,      &
          nmet,nstr,ncwd,          &
          nmic,nslow,npass,xnsoilmin
-    REAL(r_2), DIMENSION(mvtype)       :: xpleaf, xpwood, xpfroot, &
+    REAL(r2), DIMENSION(mvtype)       :: xpleaf, xpwood, xpfroot, &
          xpmet, xpstr, xpcwd,     &
          xpmic,xpslow,xppass,xplab,xpsorb,xpocc
-    REAL(r_2), DIMENSION(mso)       :: xkmlabp,xpsorbmax,xfPleach
-    REAL(r_2), DIMENSION(mso,msoil) :: ratioNPsoil
-    REAL(r_2), DIMENSION(mvtype)       :: xfherbivore,xxkleafcoldmax, xxkleafdrymax
-    REAL(r_2), DIMENSION(mvtype,ms)    :: fracroot
-    REAL(r_2) ::  xratioNPleafmin,xratioNPleafmax,         &
+    REAL(r2), DIMENSION(mso)       :: xkmlabp,xpsorbmax,xfPleach
+    REAL(r2), DIMENSION(mso,msoil) :: ratioNPsoil
+    REAL(r2), DIMENSION(mvtype)       :: xfherbivore,xxkleafcoldmax, xxkleafdrymax
+    REAL(r2), DIMENSION(mvtype,ms)    :: fracroot
+    REAL(r2) ::  xratioNPleafmin,xratioNPleafmax,         &
          xratioNPwoodmin,xratioNPwoodmax,         &
          xratioNPfrootmin,xratioNPfrootmax
     INTEGER :: i,iv1,nv,ns,npt,iso
     INTEGER :: nv0,nv1,nv2,nv3,nv4,nv6,nv7,nv8,nv9,nv10,nv11,nv12,nv13
-    REAL(r_2), DIMENSION(mvtype)       :: xxnpmax,xq10soil,xxkoptlitter,xxkoptsoil,xprodptase, &
+    REAL(r2), DIMENSION(mvtype)       :: xxnpmax,xq10soil,xxkoptlitter,xxkoptsoil,xprodptase, &
          xcostnpup,xmaxfinelitter,xmaxcwd,xnintercept,xnslope
 
 
-    REAL(r_2), DIMENSION(mvtype)       :: la_to_sa, vcmax_scalar, disturbance_interval
-    REAL(r_2), DIMENSION(mvtype)       :: DAMM_EnzPool, DAMM_KMO2,DAMM_KMcp, DAMM_Ea, DAMM_alpha
-    REAL(r_2), DIMENSION(mso)          :: xxkplab,xxkpsorb,xxkpocc
+    REAL(r2), DIMENSION(mvtype)       :: la_to_sa, vcmax_scalar, disturbance_interval
+    REAL(r2), DIMENSION(mvtype)       :: DAMM_EnzPool, DAMM_KMO2,DAMM_KMcp, DAMM_Ea, DAMM_alpha
+    REAL(r2), DIMENSION(mso)          :: xxkplab,xxkpsorb,xxkpocc
     
     INTEGER :: biomeunit
 
@@ -335,13 +335,13 @@ contains
 
     CLOSE(biomeunit)
 
-    fracroot   = 0.0_r_2
-    depthsoila = 0.0_r_2
-    depthsoilb = 0.0_r_2
+    fracroot   = 0.0_r2
+    depthsoila = 0.0_r2
+    depthsoilb = 0.0_r2
     DO ns=1, ms
        depthsoilb(ns) = depthsoilb(ns) + soil%zse(ns)
        IF (ns==1) THEN
-          depthsoila(ns) = 0.0_r_2
+          depthsoila(ns) = 0.0_r2
        ELSE
           depthsoila(ns) = depthsoilb(ns-1)
        ENDIF
@@ -349,10 +349,10 @@ contains
 
     DO nv=1,mvtype
        casabiome%sla(nv)             = slax(nv)
-       casabiome%fraclabile(nv,leaf) = deltcasa*0.6_r_2    !1/day
-       casabiome%fraclabile(nv,froot)= deltcasa*0.4_r_2    !1/day
-       casabiome%fraclabile(nv,wood) = deltcasa*0.0_r_2
-       casabiome%plantrate(nv,leaf)  = deltcasa/(leafage(nv)*(1.0_r_2-xfherbivore(nv)))
+       casabiome%fraclabile(nv,leaf) = deltcasa*0.6_r2    !1/day
+       casabiome%fraclabile(nv,froot)= deltcasa*0.4_r2    !1/day
+       casabiome%fraclabile(nv,wood) = deltcasa*0.0_r2
+       casabiome%plantrate(nv,leaf)  = deltcasa/(leafage(nv)*(1.0_r2-xfherbivore(nv)))
        casabiome%plantrate(nv,froot) = deltcasa/frootage(nv)
        casabiome%plantrate(nv,wood)  = deltcasa/woodage(nv)
        casabiome%litterrate(nv,metb) = deltcasa/metage(nv)
@@ -371,7 +371,7 @@ contains
        casabiome%q10soil(nv)         = xq10soil(nv)
        casabiome%xkoptlitter(nv)     = xxkoptlitter(nv)
        casabiome%xkoptsoil(nv)       = xxkoptsoil(nv)
-       casabiome%prodptase(nv)       = xprodptase(nv)/365.0_r_2   ! convert from yearly to daily
+       casabiome%prodptase(nv)       = xprodptase(nv)/365.0_r2   ! convert from yearly to daily
        casabiome%costnpup(nv)        = xcostnpup(nv)
        casabiome%maxfinelitter(nv)   = xmaxfinelitter(nv)
        casabiome%maxcwd(nv)          = xmaxcwd(nv)
@@ -401,12 +401,12 @@ contains
        !    veg%froot(npt,:) = fracroot(iv1,:)
        casamet%iveg2(npt) =casabiome%ivt2(iv1)
        casamet%lnonwood(npt) = 1
-       casapool%cplant(npt,wood)  = 0.0_r_2
-       casapool%clitter(npt,cwd)  = 0.0_r_2
-       casapool%nplant(npt,wood)  = 0.0_r_2
-       casapool%nlitter(npt,cwd)  = 0.0_r_2
-       casapool%pplant(npt,wood)  = 0.0_r_2
-       casapool%plitter(npt,cwd)  = 0.0_r_2
+       casapool%cplant(npt,wood)  = 0.0_r2
+       casapool%clitter(npt,cwd)  = 0.0_r2
+       casapool%nplant(npt,wood)  = 0.0_r2
+       casapool%nlitter(npt,cwd)  = 0.0_r2
+       casapool%pplant(npt,wood)  = 0.0_r2
+       casapool%plitter(npt,cwd)  = 0.0_r2
        IF (casamet%iveg2(npt)==forest.or.casamet%iveg2(npt)==shrub) THEN
           casamet%lnonwood(npt) = 0
           casapool%cplant(npt,wood)  = Cwood(iv1)
@@ -417,7 +417,7 @@ contains
           casapool%plitter(npt,cwd)  = xpcwd(iv1)
           !! vh_js !!
           IF (cable_user%CALL_POP) THEN  ! initialise very small wood pool, so POP can start from zero.
-             casapool%cplant(npt,wood) = 0.01_r_2
+             casapool%cplant(npt,wood) = 0.01_r2
              casapool%nplant(npt,wood)= casabiome%ratioNCplantmin(iv1,wood)* casapool%cplant(npt,wood)
              casapool%pplant(npt,wood)= casabiome%ratioPCplantmin(iv1,wood)* casapool%cplant(npt,wood)
           ENDIF
@@ -425,14 +425,14 @@ contains
        ENDIF
        casapool%cplant(npt,leaf)     = cleaf(iv1)
        casapool%cplant(npt,froot)    = cfroot(iv1)
-       casapool%clabile(npt)         = 0.0_r_2
+       casapool%clabile(npt)         = 0.0_r2
        casapool%clitter(npt,metb)    = cmet(iv1)
        casapool%clitter(npt,str)     = cstr(iv1)
        casapool%csoil(npt,mic)       = cmic(iv1)
        casapool%csoil(npt,slow)      = cslow(iv1)
        casapool%csoil(npt,pass)      = cpass(iv1)
        IF (icycle==1) THEN
-          casapool%ratioNCplant(npt,:)  = 1.0_r_2/ratioCNplant(iv1,:)
+          casapool%ratioNCplant(npt,:)  = 1.0_r2/ratioCNplant(iv1,:)
        ENDIF
 
        ! initializing glai in case not reading pool file (eg. during spin)
@@ -441,7 +441,7 @@ contains
 
        casaflux%fNminloss(npt)   = xfNminloss(iv1)
        ! comment out by ypw 12/07/2009
-       casaflux%fNminleach(npt)  = 10.0_r_2*xfNminleach(iv1) * deltcasa
+       casaflux%fNminleach(npt)  = 10.0_r2*xfNminleach(iv1) * deltcasa
        ! casaflux%fNminleach(npt)  = xfNminleach(iv1)
        casapool%nplant(npt,leaf) = nleaf(iv1)
        casapool%nplant(npt,froot)= nfroot(iv1)
@@ -463,20 +463,20 @@ contains
        casapool%psoillab(npt)    = xplab(iv1)
        casapool%psoilsorb(npt)   = xpsorb(iv1)
        casapool%psoilocc(npt)    = xpocc(iv1)
-       casapool%Psoillab(npt)    = 0.0_r_2
+       casapool%Psoillab(npt)    = 0.0_r2
        casaflux%kmlabp(npt)      = xkmlabp(iso)
        casaflux%psorbmax(npt)    = xpsorbmax(iso)
-       casaflux%fpleach(npt)     = xfPleach(iso) /(365.0_r_2)    ! convert from 1/year to 1/day
+       casaflux%fpleach(npt)     = xfPleach(iso) /(365.0_r2)    ! convert from 1/year to 1/day
        ! we used the spatially explicit estimate N fixation by Wang and Houlton (GRL)
-       ! casaflux%Nminfix(npt)     = xnfixrate(iv1)/365.0_r_2
-       casapool%ratioNCplant(npt,:)  = 1.0_r_2/ratioCNplant(iv1,:)
+       ! casaflux%Nminfix(npt)     = xnfixrate(iv1)/365.0_r2
+       casapool%ratioNCplant(npt,:)  = 1.0_r2/ratioCNplant(iv1,:)
        casapool%ratioNPplant(npt,:)  = casabiome%ratioNPplantmin(iv1,:)
-       casapool%ratioNClitter(npt,:) = casapool%nlitter(npt,:)/(casapool%clitter(npt,:)+1.0e-10_r_2)
-       casapool%ratioNPlitter(npt,:) = casapool%nlitter(npt,:)/(casapool%plitter(npt,:)+1.0e-10_r_2)
-       casapool%ratioNCsoil(npt,:)   = 1.0_r_2/ratioCNsoil(iv1,:)
+       casapool%ratioNClitter(npt,:) = casapool%nlitter(npt,:)/(casapool%clitter(npt,:)+1.0e-10_r2)
+       casapool%ratioNPlitter(npt,:) = casapool%nlitter(npt,:)/(casapool%plitter(npt,:)+1.0e-10_r2)
+       casapool%ratioNCsoil(npt,:)   = 1.0_r2/ratioCNsoil(iv1,:)
        casapool%ratioNPsoil(npt,:)   = ratioNPsoil(iso,:)
-       casapool%ratioNCsoilmin(npt,:)   = 1.0_r_2/ratioCNsoilmax(iv1,:)
-       casapool%ratioNCsoilmax(npt,:)   = 1.0_r_2/ratioCNsoilmin(iv1,:)
+       casapool%ratioNCsoilmin(npt,:)   = 1.0_r2/ratioCNsoilmax(iv1,:)
+       casapool%ratioNCsoilmax(npt,:)   = 1.0_r2/ratioCNsoilmin(iv1,:)
        casapool%ratioNCsoilnew(npt,:)   = casapool%ratioNCsoilmax(npt,:)
     ENDDO
 
@@ -514,7 +514,7 @@ contains
     INTEGER, DIMENSION(271,mvtype) :: greenup, fall,  phendoy1
     INTEGER, DIMENSION(npheno)     :: greenupx,fallx,xphendoy1
     INTEGER, DIMENSION(npheno)     :: ivtx
-    REAL(r_2), DIMENSION(271)      :: xlat
+    REAL(r2), DIMENSION(271)      :: xlat
 
     INTEGER :: phenunit
 
@@ -593,94 +593,94 @@ contains
 
     !MC - remove zeroing because done in load_parameters before
     ! !CLN initialise all !!!!! THIS NEEDS FIXING because of e.g. ICE-WATER
-    ! casaflux%Cgpp         = 0.0_r_2
-    ! casaflux%Cnpp         = 0.0_r_2
-    ! casaflux%Crp          = 0.0_r_2
-    ! casaflux%Crgplant     = 0.0_r_2
-    ! ! casaflux%Nminfix      = 0.0_r_2
-    ! casaflux%Nminuptake   = 0.0_r_2
-    ! casaflux%Plabuptake   = 0.0_r_2
-    ! casaflux%Clabloss     = 0.0_r_2
-    ! casaflux%fracClabile  = 0.0_r_2
-    ! casaflux%stemnpp      = 0.0_r_2
-    ! casaflux%frac_sapwood = 0.0_r_2
-    ! casaflux%sapwood_area = 0.0_r_2
-    ! casaflux%FluxCtohwp   = 0.0_r_2
-    ! casaflux%FluxCtoClear = 0.0_r_2
-    ! casaflux%fracCalloc   = 0.0_r_2
-    ! casaflux%fracNalloc   = 0.0_r_2
-    ! casaflux%fracPalloc   = 0.0_r_2
-    ! casaflux%Crmplant     = 0.0_r_2
-    ! casaflux%kplant       = 0.0_r_2
-    ! casaflux%kplant_fire  = 0.0_r_2
-    ! casaflux%kplant_tot   = 0.0_r_2
+    ! casaflux%Cgpp         = 0.0_r2
+    ! casaflux%Cnpp         = 0.0_r2
+    ! casaflux%Crp          = 0.0_r2
+    ! casaflux%Crgplant     = 0.0_r2
+    ! ! casaflux%Nminfix      = 0.0_r2
+    ! casaflux%Nminuptake   = 0.0_r2
+    ! casaflux%Plabuptake   = 0.0_r2
+    ! casaflux%Clabloss     = 0.0_r2
+    ! casaflux%fracClabile  = 0.0_r2
+    ! casaflux%stemnpp      = 0.0_r2
+    ! casaflux%frac_sapwood = 0.0_r2
+    ! casaflux%sapwood_area = 0.0_r2
+    ! casaflux%FluxCtohwp   = 0.0_r2
+    ! casaflux%FluxCtoClear = 0.0_r2
+    ! casaflux%fracCalloc   = 0.0_r2
+    ! casaflux%fracNalloc   = 0.0_r2
+    ! casaflux%fracPalloc   = 0.0_r2
+    ! casaflux%Crmplant     = 0.0_r2
+    ! casaflux%kplant       = 0.0_r2
+    ! casaflux%kplant_fire  = 0.0_r2
+    ! casaflux%kplant_tot   = 0.0_r2
 
-    ! casaflux%fromPtoL      = 0.0_r_2
-    ! casaflux%fromPtoL_fire = 0.0_r_2
+    ! casaflux%fromPtoL      = 0.0_r2
+    ! casaflux%fromPtoL_fire = 0.0_r2
 
-    ! casaflux%Cnep         = 0.0_r_2
-    ! casaflux%Crsoil       = 0.0_r_2
-    ! casapool%dClabiledt   = 0.0_r_2
-    ! ! casaflux%Nmindep      =  casaflux%Nmindep /2.0_r_2
-    ! ! casaflux%Nmindep      = 0.0_r_2
-    ! casaflux%Nminloss     = 0.0_r_2
-    ! casaflux%Nminleach    = 0.0_r_2
-    ! casaflux%Nupland      = 0.0_r_2
-    ! casaflux%Nlittermin   = 0.0_r_2
-    ! casaflux%Nsmin        = 0.0_r_2
-    ! casaflux%Nsimm        = 0.0_r_2
-    ! casaflux%Nsnet        = 0.0_r_2
-    ! ! casaflux%fNminloss    = 0.0_r_2
-    ! ! casaflux%fNminleach   = 0.0_r_2
-    ! ! casaflux%Pdep         = 0.0_r_2
-    ! ! casaflux%Pwea         = 0.0_r_2
-    ! casaflux%Pleach       = 0.0_r_2
-    ! casaflux%Ploss        = 0.0_r_2
-    ! casaflux%Pupland      = 0.0_r_2
-    ! casaflux%Plittermin   = 0.0_r_2
-    ! casaflux%Psmin        = 0.0_r_2
-    ! casaflux%Psimm        = 0.0_r_2
-    ! casaflux%Psnet        = 0.0_r_2
-    ! ! casaflux%fPleach      = 0.0_r_2 !vh ! this should be a parameter, not a flux variable
-    ! casaflux%kplab        = 0.0_r_2
-    ! casaflux%kpsorb       = 0.0_r_2
-    ! casaflux%kpocc        = 0.0_r_2
-    ! ! casaflux%kmlabp       = 0.0_r_2  !vh ! this should be a paramter, not a flux variable
-    ! ! casaflux%Psorbmax     = 0.0_r_2 !vh ! this should be a paramter, not a flux variable
+    ! casaflux%Cnep         = 0.0_r2
+    ! casaflux%Crsoil       = 0.0_r2
+    ! casapool%dClabiledt   = 0.0_r2
+    ! ! casaflux%Nmindep      =  casaflux%Nmindep /2.0_r2
+    ! ! casaflux%Nmindep      = 0.0_r2
+    ! casaflux%Nminloss     = 0.0_r2
+    ! casaflux%Nminleach    = 0.0_r2
+    ! casaflux%Nupland      = 0.0_r2
+    ! casaflux%Nlittermin   = 0.0_r2
+    ! casaflux%Nsmin        = 0.0_r2
+    ! casaflux%Nsimm        = 0.0_r2
+    ! casaflux%Nsnet        = 0.0_r2
+    ! ! casaflux%fNminloss    = 0.0_r2
+    ! ! casaflux%fNminleach   = 0.0_r2
+    ! ! casaflux%Pdep         = 0.0_r2
+    ! ! casaflux%Pwea         = 0.0_r2
+    ! casaflux%Pleach       = 0.0_r2
+    ! casaflux%Ploss        = 0.0_r2
+    ! casaflux%Pupland      = 0.0_r2
+    ! casaflux%Plittermin   = 0.0_r2
+    ! casaflux%Psmin        = 0.0_r2
+    ! casaflux%Psimm        = 0.0_r2
+    ! casaflux%Psnet        = 0.0_r2
+    ! ! casaflux%fPleach      = 0.0_r2 !vh ! this should be a parameter, not a flux variable
+    ! casaflux%kplab        = 0.0_r2
+    ! casaflux%kpsorb       = 0.0_r2
+    ! casaflux%kpocc        = 0.0_r2
+    ! ! casaflux%kmlabp       = 0.0_r2  !vh ! this should be a paramter, not a flux variable
+    ! ! casaflux%Psorbmax     = 0.0_r2 !vh ! this should be a paramter, not a flux variable
 
-    ! casaflux%klitter       = 0.0_r_2
-    ! casaflux%klitter_fire  = 0.0_r_2
-    ! casaflux%ksoil         = 0.0_r_2
-    ! casaflux%fromLtoS      = 0.0_r_2
-    ! casaflux%fromStoS      = 0.0_r_2
-    ! casaflux%fromLtoCO2    = 0.0_r_2
-    ! casaflux%fromStoCO2    = 0.0_r_2
-    ! casaflux%FluxCtolitter = 0.0_r_2
-    ! casaflux%FluxNtolitter = 0.0_r_2
-    ! casaflux%FluxPtolitter = 0.0_r_2
-    ! casaflux%FluxCtosoil   = 0.0_r_2
-    ! casaflux%FluxNtosoil   = 0.0_r_2
-    ! casaflux%FluxPtosoil   = 0.0_r_2
-    ! casaflux%FluxCtoCO2    = 0.0_r_2
-    ! casaflux%FluxCtoCO2_plant_fire  = 0.0_r_2
-    ! casaflux%FluxCtoCO2_litter_fire = 0.0_r_2
+    ! casaflux%klitter       = 0.0_r2
+    ! casaflux%klitter_fire  = 0.0_r2
+    ! casaflux%ksoil         = 0.0_r2
+    ! casaflux%fromLtoS      = 0.0_r2
+    ! casaflux%fromStoS      = 0.0_r2
+    ! casaflux%fromLtoCO2    = 0.0_r2
+    ! casaflux%fromStoCO2    = 0.0_r2
+    ! casaflux%FluxCtolitter = 0.0_r2
+    ! casaflux%FluxNtolitter = 0.0_r2
+    ! casaflux%FluxPtolitter = 0.0_r2
+    ! casaflux%FluxCtosoil   = 0.0_r2
+    ! casaflux%FluxNtosoil   = 0.0_r2
+    ! casaflux%FluxPtosoil   = 0.0_r2
+    ! casaflux%FluxCtoCO2    = 0.0_r2
+    ! casaflux%FluxCtoCO2_plant_fire  = 0.0_r2
+    ! casaflux%FluxCtoCO2_litter_fire = 0.0_r2
 
-    ! casaflux%FluxFromPtoL       = 0.0_r_2
-    ! casaflux%FluxFromLtoS       = 0.0_r_2
-    ! casaflux%FluxFromStoS       = 0.0_r_2
-    ! casaflux%FluxFromPtoCO2     = 0.0_r_2
-    ! casaflux%FluxFromLtoCO2     = 0.0_r_2
-    ! casaflux%FluxFromStoCO2     = 0.0_r_2
-    ! casaflux%FluxFromPtoHarvest = 0.0_r_2
+    ! casaflux%FluxFromPtoL       = 0.0_r2
+    ! casaflux%FluxFromLtoS       = 0.0_r2
+    ! casaflux%FluxFromStoS       = 0.0_r2
+    ! casaflux%FluxFromPtoCO2     = 0.0_r2
+    ! casaflux%FluxFromLtoCO2     = 0.0_r2
+    ! casaflux%FluxFromStoCO2     = 0.0_r2
+    ! casaflux%FluxFromPtoHarvest = 0.0_r2
 
-    ! casaflux%Cplant_turnover                     = 0.0_r_2
-    ! casaflux%Cplant_turnover_disturbance         = 0.0_r_2
-    ! casaflux%Cplant_turnover_crowding            = 0.0_r_2
-    ! casaflux%Cplant_turnover_resource_limitation = 0.0_r_2
-    ! casaflux%fHarvest = 0.0_r_2
-    ! casaflux%Charvest = 0.0_r_2
-    ! casaflux%Nharvest = 0.0_r_2
-    ! casaflux%fcrop    = 0.0_r_2
+    ! casaflux%Cplant_turnover                     = 0.0_r2
+    ! casaflux%Cplant_turnover_disturbance         = 0.0_r2
+    ! casaflux%Cplant_turnover_crowding            = 0.0_r2
+    ! casaflux%Cplant_turnover_resource_limitation = 0.0_r2
+    ! casaflux%fHarvest = 0.0_r2
+    ! casaflux%Charvest = 0.0_r2
+    ! casaflux%Nharvest = 0.0_r2
+    ! casaflux%fcrop    = 0.0_r2
 
     phen%doyphase(:,1) = -50
     phen%doyphase(:,2) = phen%doyphase(:,1) + 14
@@ -690,44 +690,44 @@ contains
     phen%phen(:)  = 1
     phen%aphen(:) = 0
 
-    ! casapool%dCplantdt     = 0.0_r_2
-    ! casapool%dNplantdt     = 0.0_r_2
-    ! casapool%dPplantdt     = 0.0_r_2
-    ! casapool%dNsoilmindt   = 0.0_r_2
-    ! casapool%dPsoillabdt   = 0.0_r_2
-    ! casapool%dPsoilsorbdt  = 0.0_r_2
-    ! casapool%dPsoiloccdt   = 0.0_r_2
-    ! casapool%dClitterdt    = 0.0_r_2
-    ! casapool%dNlitterdt    = 0.0_r_2
-    ! casapool%dPlitterdt    = 0.0_r_2
-    ! casapool%dCsoildt      = 0.0_r_2
-    ! casapool%dNsoildt      = 0.0_r_2
-    ! casapool%dPsoildt      = 0.0_r_2
-    ! casapool%ratioNClitter = 0.0_r_2
-    ! casapool%ratioNCsoil   = 0.0_r_2
-    ! casapool%ratioPClitter = 0.0_r_2
-    ! casapool%ratioPCsoil   = 0.0_r_2
+    ! casapool%dCplantdt     = 0.0_r2
+    ! casapool%dNplantdt     = 0.0_r2
+    ! casapool%dPplantdt     = 0.0_r2
+    ! casapool%dNsoilmindt   = 0.0_r2
+    ! casapool%dPsoillabdt   = 0.0_r2
+    ! casapool%dPsoilsorbdt  = 0.0_r2
+    ! casapool%dPsoiloccdt   = 0.0_r2
+    ! casapool%dClitterdt    = 0.0_r2
+    ! casapool%dNlitterdt    = 0.0_r2
+    ! casapool%dPlitterdt    = 0.0_r2
+    ! casapool%dCsoildt      = 0.0_r2
+    ! casapool%dNsoildt      = 0.0_r2
+    ! casapool%dPsoildt      = 0.0_r2
+    ! casapool%ratioNClitter = 0.0_r2
+    ! casapool%ratioNCsoil   = 0.0_r2
+    ! casapool%ratioPClitter = 0.0_r2
+    ! casapool%ratioPCsoil   = 0.0_r2
     ! !CLN add more if necessary
 
-    casapool%Nsoilmin(:) = 2.5_r_2
+    casapool%Nsoilmin(:) = 2.5_r2
     !MC - Check if next commented 2 if-blocks are necessary
     ! if (icycle > 1) then
-    !    casapool%nplant     = MAX(1.e-6_r_2, casapool%nplant)
-    !    casapool%nlitter    = MAX(1.e-6_r_2, casapool%nlitter)
-    !    casapool%nsoil      = MAX(1.e-6_r_2, casapool%nsoil)
-    !    casapool%nsoilmin   = MAX(1.e-6_r_2, casapool%nsoilmin)
+    !    casapool%nplant     = MAX(1.e-6_r2, casapool%nplant)
+    !    casapool%nlitter    = MAX(1.e-6_r2, casapool%nlitter)
+    !    casapool%nsoil      = MAX(1.e-6_r2, casapool%nsoil)
+    !    casapool%nsoilmin   = MAX(1.e-6_r2, casapool%nsoilmin)
     !    casabal%cplantlast  = casapool%cplant
     !    casabal%clitterlast = casapool%clitter
     !    casabal%csoillast   = casapool%csoil
     !    casabal%clabilelast = casapool%clabile
     ! endif
     ! if (icycle > 2) then
-    !    casapool%pplant       = MAX(1.e-7_r_2, casapool%pplant)
-    !    casapool%plitter      = MAX(1.e-7_r_2, casapool%plitter)
-    !    casapool%psoil        = MAX(1.e-7_r_2, casapool%psoil)
-    !    casapool%Psoillab     = MAX(1.e-7_r_2, casapool%psoillab)
-    !    casapool%psoilsorb    = MAX(1.e-7_r_2, casapool%psoilsorb)
-    !    casapool%psoilocc     = MAX(1.e-7_r_2, casapool%psoilocc)
+    !    casapool%pplant       = MAX(1.e-7_r2, casapool%pplant)
+    !    casapool%plitter      = MAX(1.e-7_r2, casapool%plitter)
+    !    casapool%psoil        = MAX(1.e-7_r2, casapool%psoil)
+    !    casapool%Psoillab     = MAX(1.e-7_r2, casapool%psoillab)
+    !    casapool%psoilsorb    = MAX(1.e-7_r2, casapool%psoilsorb)
+    !    casapool%psoilocc     = MAX(1.e-7_r2, casapool%psoilocc)
     !    casabal%pplantlast    = casapool%pplant
     !    casabal%plitterlast   = casapool%plitter
     !    casabal%psoillast     = casapool%psoil
@@ -739,8 +739,8 @@ contains
        write(*,*) 'casa_init: not using restart file!'
        write(*,*) 'Using input from readbiome.!!!'
        write(*,*) 'initialising frac_sapwood=1 and sapwood_area = 0)'
-       casaflux%frac_sapwood(:) = 1.0_r_2
-       casaflux%sapwood_area(:) = 0.0_r_2
+       casaflux%frac_sapwood(:) = 1.0_r2
+       casaflux%sapwood_area(:) = 0.0_r2
 #ifndef UM_BUILD
     else if ((initcasa == 1) .and. (.not. cable_user%casa_fromzero)) then
        call read_casa_restart_nc(casabiome, casamet, casapool, casaflux, &
@@ -749,84 +749,84 @@ contains
 #endif
     else
        do npt=1, mp
-          casamet%lon(npt) = real(patch(npt)%longitude, r_2)
-          casamet%lat(npt) = real(patch(npt)%latitude, r_2)
+          casamet%lon(npt) = real(patch(npt)%longitude, r2)
+          casamet%lat(npt) = real(patch(npt)%latitude, r2)
        enddo
     endif
 
     !MC - remove zeroing because done in load_parameters before
-    ! where(casamet%lnonwood==1) casapool%cplant(:,WOOD) = 0.0_r_2
-    ! where(casamet%lnonwood==1) casapool%nplant(:,WOOD) = 0.0_r_2
-    ! where(casamet%lnonwood==1) casapool%pplant(:,WOOD) = 0.0_r_2
+    ! where(casamet%lnonwood==1) casapool%cplant(:,WOOD) = 0.0_r2
+    ! where(casamet%lnonwood==1) casapool%nplant(:,WOOD) = 0.0_r2
+    ! where(casamet%lnonwood==1) casapool%pplant(:,WOOD) = 0.0_r2
 
     ! ! reset labile C pool, comment out by Q.Zhang 10/09/2011: casapool%clabile = 0.0
     ! ! check pool sizes
-    ! casapool%Ctot_0     = 0.0_r_2
-    ! casapool%Ctot       = 0.0_r_2
-    ! casapool%cplant     = MAX(0.0_r_2, casapool%cplant)
-    ! casapool%clitter    = MAX(0.0_r_2, casapool%clitter)
-    ! casapool%csoil      = MAX(0.0_r_2, casapool%csoil)
+    ! casapool%Ctot_0     = 0.0_r2
+    ! casapool%Ctot       = 0.0_r2
+    ! casapool%cplant     = MAX(0.0_r2, casapool%cplant)
+    ! casapool%clitter    = MAX(0.0_r2, casapool%clitter)
+    ! casapool%csoil      = MAX(0.0_r2, casapool%csoil)
     ! casabal%cplantlast  = casapool%cplant
     ! casabal%clitterlast = casapool%clitter
     ! casabal%csoillast   = casapool%csoil
     ! casabal%clabilelast = casapool%clabile
-    ! casabal%sumcbal     = 0.0_r_2
-    ! casabal%FCgppyear   = 0.0_r_2
-    ! casabal%FCrpyear    = 0.0_r_2
-    ! casabal%FCnppyear   = 0.0_r_2
-    ! casabal%FCrsyear    = 0.0_r_2
-    ! casabal%FCneeyear   = 0.0_r_2
+    ! casabal%sumcbal     = 0.0_r2
+    ! casabal%FCgppyear   = 0.0_r2
+    ! casabal%FCrpyear    = 0.0_r2
+    ! casabal%FCnppyear   = 0.0_r2
+    ! casabal%FCrsyear    = 0.0_r2
+    ! casabal%FCneeyear   = 0.0_r2
     ! ! vh !
-    ! WHERE (casamet%lnonwood==1) casapool%cplant(:,WOOD) = 0.0_r_2
+    ! WHERE (casamet%lnonwood==1) casapool%cplant(:,WOOD) = 0.0_r2
     ! IF (icycle == 1) THEN
     !    casapool%Nplant(:,:) = casapool%cplant(:,:) * casapool%ratioNCplant(:,:)
     !    casapool%Nsoil(:,:)  = casapool%ratioNCsoil(:,:) * casapool%Csoil(:,:)
     !    casapool%Psoil(:,:)  = casapool%Nsoil(:,:) / casapool%ratioNPsoil(:,:)
-    !    casapool%Nsoilmin(:) = 2.5_r_2
+    !    casapool%Nsoilmin(:) = 2.5_r2
     ! ENDIF
 
     ! IF (icycle >= 1) THEN
-    !    casapool%nplant     = MAX(1.0e-6_r_2, casapool%nplant)
-    !    casapool%nlitter    = MAX(1.0e-6_r_2, casapool%nlitter)
-    !    casapool%nsoil      = MAX(1.0e-6_r_2, casapool%nsoil)
-    !    casapool%nsoilmin   = MAX(1.0e-6_r_2, casapool%nsoilmin)
+    !    casapool%nplant     = MAX(1.0e-6_r2, casapool%nplant)
+    !    casapool%nlitter    = MAX(1.0e-6_r2, casapool%nlitter)
+    !    casapool%nsoil      = MAX(1.0e-6_r2, casapool%nsoil)
+    !    casapool%nsoilmin   = MAX(1.0e-6_r2, casapool%nsoilmin)
     !    casabal%nplantlast  = casapool%nplant
     !    casabal%nlitterlast = casapool%nlitter
     !    casabal%nsoillast   = casapool%nsoil
     !    casabal%nsoilminlast= casapool%nsoilmin
-    !    casabal%sumnbal     = 0.0_r_2
-    !    casabal%FNdepyear   = 0.0_r_2
-    !    casabal%FNfixyear   = 0.0_r_2
-    !    casabal%FNsnetyear  = 0.0_r_2
-    !    casabal%FNupyear    = 0.0_r_2
-    !    casabal%FNleachyear = 0.0_r_2
-    !    casabal%FNlossyear  = 0.0_r_2
+    !    casabal%sumnbal     = 0.0_r2
+    !    casabal%FNdepyear   = 0.0_r2
+    !    casabal%FNfixyear   = 0.0_r2
+    !    casabal%FNsnetyear  = 0.0_r2
+    !    casabal%FNupyear    = 0.0_r2
+    !    casabal%FNleachyear = 0.0_r2
+    !    casabal%FNlossyear  = 0.0_r2
     !    ! vh !
-    !    WHERE(casamet%lnonwood==1) casapool%nplant(:,WOOD) = 0.0_r_2
+    !    WHERE(casamet%lnonwood==1) casapool%nplant(:,WOOD) = 0.0_r2
     ! ENDIF
 
     ! IF (icycle >=1 ) THEN
-    !    casapool%pplant       = MAX(1.0e-7_r_2, casapool%pplant)
-    !    casapool%plitter      = MAX(1.0e-7_r_2, casapool%plitter)
-    !    casapool%psoil        = MAX(1.0e-7_r_2, casapool%psoil)
-    !    casapool%Psoillab     = MAX(1.0e-7_r_2, casapool%psoillab)  ! was 2.0, changed according to  YP
-    !    casapool%psoilsorb    = MAX(1.0e-7_r_2, casapool%psoilsorb) ! was 10.0, -
-    !    casapool%psoilocc     = MAX(1.0e-7_r_2, casapool%psoilocc)  ! was 50.0, -
+    !    casapool%pplant       = MAX(1.0e-7_r2, casapool%pplant)
+    !    casapool%plitter      = MAX(1.0e-7_r2, casapool%plitter)
+    !    casapool%psoil        = MAX(1.0e-7_r2, casapool%psoil)
+    !    casapool%Psoillab     = MAX(1.0e-7_r2, casapool%psoillab)  ! was 2.0, changed according to  YP
+    !    casapool%psoilsorb    = MAX(1.0e-7_r2, casapool%psoilsorb) ! was 10.0, -
+    !    casapool%psoilocc     = MAX(1.0e-7_r2, casapool%psoilocc)  ! was 50.0, -
     !    casabal%pplantlast    = casapool%pplant
     !    casabal%plitterlast   = casapool%plitter
     !    casabal%psoillast     = casapool%psoil
     !    casabal%psoillablast  = casapool%psoillab
     !    casabal%psoilsorblast = casapool%psoilsorb
     !    casabal%psoilocclast  = casapool%psoilocc
-    !    casabal%sumpbal       = 0.0_r_2
-    !    casabal%FPweayear     = 0.0_r_2
-    !    casabal%FPdustyear    = 0.0_r_2
-    !    casabal%FPsnetyear    = 0.0_r_2
-    !    casabal%FPupyear      = 0.0_r_2
-    !    casabal%FPleachyear   = 0.0_r_2
-    !    casabal%FPlossyear    = 0.0_r_2
+    !    casabal%sumpbal       = 0.0_r2
+    !    casabal%FPweayear     = 0.0_r2
+    !    casabal%FPdustyear    = 0.0_r2
+    !    casabal%FPsnetyear    = 0.0_r2
+    !    casabal%FPupyear      = 0.0_r2
+    !    casabal%FPleachyear   = 0.0_r2
+    !    casabal%FPlossyear    = 0.0_r2
     !    ! vh !
-    !    WHERE(casamet%lnonwood==1) casapool%pplant(:,WOOD) = 0.0_r_2
+    !    WHERE(casamet%lnonwood==1) casapool%pplant(:,WOOD) = 0.0_r2
     ! ENDIF
 
   END SUBROUTINE casa_init
@@ -856,9 +856,9 @@ contains
     TYPE(phen_variable),       INTENT(INOUT) :: phen
 
     ! local variables
-    REAL(r_2), DIMENSION(mso) :: Psorder, xPsoil50 ! , Pweasoil
-    REAL(r_2), DIMENSION(mso) :: fracPlab, fracPocc ! , fracPsorb, fracPorg
-    REAL(r_2), DIMENSION(mp)  :: totPsoil
+    REAL(r2), DIMENSION(mso) :: Psorder, xPsoil50 ! , Pweasoil
+    REAL(r2), DIMENSION(mso) :: fracPlab, fracPocc ! , fracPsorb, fracPorg
+    REAL(r2), DIMENSION(mp)  :: totPsoil
     INTEGER :: npt, nout, nso
 
     ! Soiltype     soilnumber soil P(g P/m2)
@@ -874,20 +874,20 @@ contains
     ! Spodosol    10      41.0
     ! Ultisol     11      51.5
     ! Vertisol    12      190.6
-    DATA Psorder/61.3_r_2, 103.9_r_2, 92.8_r_2, 136.9_r_2, 98.2_r_2, 107.6_r_2, 84.1_r_2, &
-         110.1_r_2, 35.4_r_2, 41.0_r_2, 51.5_r_2, 190.6_r_2/
-    ! DATA Pweasoil/0.05_r_2, 0.04_r_2, 0.03_r_2, 0.02_r_2, 0.01_r_2, 0.009_r_2, 0.008_r_2, &
-    !      0.007_r_2, 0.006_r_2, 0.005_r_2, 0.004_r_2, 0.003_r_2/
-    DATA fracPlab/0.08_r_2, 0.08_r_2, 0.10_r_2, 0.02_r_2, 0.08_r_2, 0.08_r_2, 0.08_r_2, &
-         0.06_r_2, 0.02_r_2, 0.05_r_2, 0.09_r_2, 0.05_r_2/
-    ! DATA fracPsorb/0.32_r_2, 0.37_r_2, 0.57_r_2, 0.67_r_2, 0.37_r_2, 0.37_r_2, 0.37_r_2, &
-    !      0.32_r_2, 0.24_r_2, 0.22_r_2, 0.21_r_2, 0.38_r_2/
-    DATA fracPocc/0.36_r_2, 0.38_r_2, 0.25_r_2, 0.26_r_2, 0.38_r_2, 0.38_r_2, 0.38_r_2, &
-         0.44_r_2, 0.38_r_2, 0.38_r_2, 0.37_r_2, 0.45_r_2/
-    ! DATA fracPorg/0.25_r_2, 0.17_r_2, 0.08_r_2, 0.05_r_2, 0.17_r_2, 0.17_r_2, 0.17_r_2, &
-    !      0.18_r_2, 0.36_r_2, 0.35_r_2, 0.34_r_2, 0.12_r_2/
-    DATA xPsoil50/7.6_r_2, 4.1_r_2, 4.2_r_2, 3.4_r_2, 4.1_r_2, 4.1_r_2, 4.8_r_2, 4.1_r_2, &
-         6.9_r_2, 6.9_r_2, 6.9_r_2, 1.7_r_2/
+    DATA Psorder/61.3_r2, 103.9_r2, 92.8_r2, 136.9_r2, 98.2_r2, 107.6_r2, 84.1_r2, &
+         110.1_r2, 35.4_r2, 41.0_r2, 51.5_r2, 190.6_r2/
+    ! DATA Pweasoil/0.05_r2, 0.04_r2, 0.03_r2, 0.02_r2, 0.01_r2, 0.009_r2, 0.008_r2, &
+    !      0.007_r2, 0.006_r2, 0.005_r2, 0.004_r2, 0.003_r2/
+    DATA fracPlab/0.08_r2, 0.08_r2, 0.10_r2, 0.02_r2, 0.08_r2, 0.08_r2, 0.08_r2, &
+         0.06_r2, 0.02_r2, 0.05_r2, 0.09_r2, 0.05_r2/
+    ! DATA fracPsorb/0.32_r2, 0.37_r2, 0.57_r2, 0.67_r2, 0.37_r2, 0.37_r2, 0.37_r2, &
+    !      0.32_r2, 0.24_r2, 0.22_r2, 0.21_r2, 0.38_r2/
+    DATA fracPocc/0.36_r2, 0.38_r2, 0.25_r2, 0.26_r2, 0.38_r2, 0.38_r2, 0.38_r2, &
+         0.44_r2, 0.38_r2, 0.38_r2, 0.37_r2, 0.45_r2/
+    ! DATA fracPorg/0.25_r2, 0.17_r2, 0.08_r2, 0.05_r2, 0.17_r2, 0.17_r2, 0.17_r2, &
+    !      0.18_r2, 0.36_r2, 0.35_r2, 0.34_r2, 0.12_r2/
+    DATA xPsoil50/7.6_r2, 4.1_r2, 4.2_r2, 3.4_r2, 4.1_r2, 4.1_r2, 4.8_r2, 4.1_r2, &
+         6.9_r2, 6.9_r2, 6.9_r2, 1.7_r2/
     !
     ! estimated based on Yang, Post and Jain (2013)
     !   Soiltype     soilnumber soil P(g P/m2  top 50 cm)
@@ -916,9 +916,9 @@ contains
     OPEN(NEWUNIT=nout,file=casafile%cnpepool)
     write(*,*) 'Opened file ', casafile%cnpepool
 
-    casabal%sumcbal = MIN(9999.0_r_2, MAX(-9999.0_r_2, casabal%sumcbal))
-    casabal%sumnbal = MIN(9999.0_r_2, MAX(-9999.0_r_2, casabal%sumnbal))
-    casabal%sumpbal = MIN(9999.0_r_2, MAX(-9999.0_r_2, casabal%sumpbal))
+    casabal%sumcbal = MIN(9999.0_r2, MAX(-9999.0_r2, casabal%sumcbal))
+    casabal%sumnbal = MIN(9999.0_r2, MAX(-9999.0_r2, casabal%sumnbal))
+    casabal%sumpbal = MIN(9999.0_r2, MAX(-9999.0_r2, casabal%sumpbal))
 
     DO npt =1, mp
        nso = casamet%isorder(npt)
@@ -931,53 +931,53 @@ contains
                   * casapool%clitter(npt,:)
              casapool%Nsoil(npt,:)  = casapool%ratioNCsoil(npt,:)   &
                   * casapool%Csoil(npt,:)
-             casapool%nsoilmin(npt) = 2.0_r_2
-             casabal%sumnbal(npt)   = 0.0_r_2
+             casapool%nsoilmin(npt) = 2.0_r2
+             casabal%sumnbal(npt)   = 0.0_r2
              if(casamet%iveg2(npt)==grass) then
-                casapool%nplant(npt,wood) = 0.0_r_2
-                casapool%nlitter(npt,cwd) = 0.0_r_2
+                casapool%nplant(npt,wood) = 0.0_r2
+                casapool%nlitter(npt,cwd) = 0.0_r2
              endif
           ENDIF
 
           IF (icycle<3) THEN
-             casabal%sumpbal(npt)    = 0.0_r_2
+             casabal%sumpbal(npt)    = 0.0_r2
              casapool%pplant(npt,:)  = casapool%Nplant(npt,:)/casapool%ratioNPplant(npt,:)
-             casapool%plitter(npt,:) = casapool%Nlitter(npt,:)/(casapool%ratioNPlitter(npt,:) + 1.e-10_r_2)
+             casapool%plitter(npt,:) = casapool%Nlitter(npt,:)/(casapool%ratioNPlitter(npt,:) + 1.e-10_r2)
              casapool%psoil(npt,:)   = casapool%Nsoil(npt,:)/casapool%ratioNPsoil(npt,:)
              casapool%psoillab(npt)  = totpsoil(npt) *fracpLab(nso)
              casapool%psoilsorb(npt) = casaflux%psorbmax(npt) * casapool%psoillab(npt) &
                   / (casaflux%kmlabp(npt)+casapool%psoillab(npt))
              casapool%psoilocc(npt) = totpsoil(npt) *fracPocc(nso)
              if(casamet%iveg2(npt)==grass) then
-                casapool%pplant(npt,wood) = 0.0_r_2
-                casapool%plitter(npt,cwd) = 0.0_r_2
+                casapool%pplant(npt,wood) = 0.0_r2
+                casapool%plitter(npt,cwd) = 0.0_r2
              endif
           ENDIF
        else
-          casapool%cplant(npt,:)  = 0.0_r_2
-          casapool%clitter(npt,:) = 0.0_r_2
-          casapool%csoil(npt,:)   = 0.0_r_2
-          casapool%clabile(npt)   = 0.0_r_2
-          casapool%nplant(npt,:)  = 0.0_r_2
-          casapool%nlitter(npt,:) = 0.0_r_2
-          casapool%nsoil(npt,:)   = 0.0_r_2
-          casapool%nsoilmin(npt)  = 0.0_r_2
-          casapool%pplant(npt,:)  = 0.0_r_2
-          casapool%plitter(npt,:) = 0.0_r_2
-          casapool%psoil(npt,:)   = 0.0_r_2
-          casapool%psoillab(npt)  = 0.0_r_2
-          casapool%psoilsorb(npt) = 0.0_r_2
-          casapool%psoilocc(npt)  = 0.0_r_2
-          casabal%sumcbal(npt)    = 0.0_r_2
-          casabal%sumnbal(npt)    = 0.0_r_2
-          casabal%sumpbal(npt)    = 0.0_r_2
+          casapool%cplant(npt,:)  = 0.0_r2
+          casapool%clitter(npt,:) = 0.0_r2
+          casapool%csoil(npt,:)   = 0.0_r2
+          casapool%clabile(npt)   = 0.0_r2
+          casapool%nplant(npt,:)  = 0.0_r2
+          casapool%nlitter(npt,:) = 0.0_r2
+          casapool%nsoil(npt,:)   = 0.0_r2
+          casapool%nsoilmin(npt)  = 0.0_r2
+          casapool%pplant(npt,:)  = 0.0_r2
+          casapool%plitter(npt,:) = 0.0_r2
+          casapool%psoil(npt,:)   = 0.0_r2
+          casapool%psoillab(npt)  = 0.0_r2
+          casapool%psoilsorb(npt) = 0.0_r2
+          casapool%psoilocc(npt)  = 0.0_r2
+          casabal%sumcbal(npt)    = 0.0_r2
+          casabal%sumnbal(npt)    = 0.0_r2
+          casabal%sumpbal(npt)    = 0.0_r2
        endif
 
        !! vh_js  !!
        IF (cable_user%CALL_POP) THEN
           WRITE(nout,92) ktau,npt,veg%iveg(npt),soil%isoilm(npt) ,     &
                casamet%isorder(npt),casamet%lat(npt),casamet%lon(npt), &
-               casamet%areacell(npt)*(1.0e-9_r_2),casamet%glai(npt),       &
+               casamet%areacell(npt)*(1.0e-9_r2),casamet%glai(npt),       &
                casabiome%sla(veg%iveg(npt)), phen%phase(npt), &
                phen%doyphase(npt,3), phen%phen(npt), phen%aphen(npt), &
                casapool%clabile(npt), &
@@ -991,7 +991,7 @@ contains
        ELSE
           WRITE(nout,92) ktau,npt,veg%iveg(npt),soil%isoilm(npt),     &
                casamet%isorder(npt),casamet%lat(npt),casamet%lon(npt), &
-               casamet%areacell(npt)*(1.0e-9_r_2),casamet%glai(npt),       &
+               casamet%areacell(npt)*(1.0e-9_r2),casamet%glai(npt),       &
                casabiome%sla(veg%iveg(npt)), phen%phase(npt), &
                phen%doyphase(npt,3), phen%phen(npt), phen%aphen(npt), &
                casapool%clabile(npt), &
@@ -1031,16 +1031,16 @@ contains
     TYPE (soil_parameter_type), INTENT(INOUT) :: soil ! soil parameters
     TYPE (casa_met),            INTENT(INOUT) :: casamet
     TYPE (casa_balance),        INTENT(INOUT) :: casabal
-    !  REAL(r_2),    INTENT(IN) :: clitterinput(mp,3),csoilinput(mp,3)
+    !  REAL(r2),    INTENT(IN) :: clitterinput(mp,3),csoilinput(mp,3)
 
     ! local variables
     INTEGER ::  npt,nout
-    REAL(r_2) :: xyear, totGPP, totNPP
+    REAL(r2) :: xyear, totGPP, totNPP
 
-    totGPP = 0.0_r_2
-    totNPP = 0.0_r_2
+    totGPP = 0.0_r2
+    totNPP = 0.0_r2
     nout   = 104
-    xyear  = 1.0_r_2/real(myear,r_2)
+    xyear  = 1.0_r2/real(myear,r2)
     casabal%FCgppyear    = casabal%FCgppyear    * xyear
     casabal%FCnppyear    = casabal%FCnppyear    * xyear
     casabal%FCrmleafyear = casabal%FCrmleafyear * xyear
@@ -1071,7 +1071,7 @@ contains
        CASE(1)
           WRITE(nout,*) myear,npt,veg%iveg(npt),soil%isoilm(npt),    &
                casamet%isorder(npt),casamet%lat(npt),casamet%lon(npt), &
-               casamet%areacell(npt)*(1.0e-9_r_2),casabal%Fcgppyear(npt),  &
+               casamet%areacell(npt)*(1.0e-9_r2),casabal%Fcgppyear(npt),  &
                casabal%Fcnppyear(npt),  &
                casabal%Fcrmleafyear(npt),casabal%Fcrmwoodyear(npt),     &
                casabal%Fcrmrootyear(npt),casabal%Fcrgrowyear(npt),     &
@@ -1081,7 +1081,7 @@ contains
           WRITE(nout,*) myear,npt,veg%iveg(npt),soil%isoilm(npt),    &
                casamet%isorder(npt),casamet%lat(npt),casamet%lon(npt), &
                                 !MC - casamet%areacell is different between MPI and serial
-               casamet%areacell(npt)*(1.0e-9_r_2),casabal%Fcgppyear(npt),  &
+               casamet%areacell(npt)*(1.0e-9_r2),casabal%Fcgppyear(npt),  &
                casabal%FCnppyear(npt),                                 &
                casabal%Fcrmleafyear(npt),casabal%Fcrmwoodyear(npt),     &
                casabal%Fcrmrootyear(npt),casabal%Fcrgrowyear(npt),     &
@@ -1092,7 +1092,7 @@ contains
        CASE(3)
           WRITE(nout,*) myear,npt,veg%iveg(npt),soil%isoilm(npt), &
                casamet%isorder(npt),casamet%lat(npt),casamet%lon(npt),  &
-               casamet%areacell(npt)*(1.0e-9_r_2),casabal%Fcgppyear(npt), &
+               casamet%areacell(npt)*(1.0e-9_r2),casabal%Fcgppyear(npt), &
                casabal%FCnppyear(npt),                                  &
                casabal%Fcrmleafyear(npt),casabal%Fcrmwoodyear(npt),     &
                casabal%Fcrmrootyear(npt),casabal%Fcrgrowyear(npt),     &
@@ -1107,8 +1107,8 @@ contains
        totNPP = totNPP+casabal%Fcnppyear(npt)* casamet%areacell(npt)
     ENDDO
 
-    write(*,*) 'totGPP global = ', totGPP * (1.0e-15_r_2)
-    write(*,*) 'totNPP global = ', totNPP * (1.0e-15_r_2)
+    write(*,*) 'totGPP global = ', totGPP * (1.0e-15_r2)
+    write(*,*) 'totNPP global = ', totNPP * (1.0e-15_r2)
 
     CLOSE(nout)
 
@@ -1132,43 +1132,43 @@ contains
     LOGICAL,            intent(in)    :: zeroflux
 
     IF (zeroflux) THEN
-       casabal%FCgppyear    = 0.0_r_2
-       casabal%FCrpyear     = 0.0_r_2
-       casabal%FCrmleafyear = 0.0_r_2
-       casabal%FCrmwoodyear = 0.0_r_2
-       casabal%FCrmrootyear = 0.0_r_2
-       casabal%FCrgrowyear  = 0.0_r_2
-       casabal%FCnppyear    = 0.0_r_2
-       casabal%FCrsyear     = 0.0_r_2
-       casabal%FCneeyear    = 0.0_r_2
-       casabal%dCdtyear     = 0.0_r_2
+       casabal%FCgppyear    = 0.0_r2
+       casabal%FCrpyear     = 0.0_r2
+       casabal%FCrmleafyear = 0.0_r2
+       casabal%FCrmwoodyear = 0.0_r2
+       casabal%FCrmrootyear = 0.0_r2
+       casabal%FCrgrowyear  = 0.0_r2
+       casabal%FCnppyear    = 0.0_r2
+       casabal%FCrsyear     = 0.0_r2
+       casabal%FCneeyear    = 0.0_r2
+       casabal%dCdtyear     = 0.0_r2
 
-       casabal%FNdepyear   = 0.0_r_2
-       casabal%FNfixyear   = 0.0_r_2
-       casabal%FNsnetyear  = 0.0_r_2
-       casabal%FNupyear    = 0.0_r_2
-       casabal%FNleachyear = 0.0_r_2
-       casabal%FNlossyear  = 0.0_r_2
+       casabal%FNdepyear   = 0.0_r2
+       casabal%FNfixyear   = 0.0_r2
+       casabal%FNsnetyear  = 0.0_r2
+       casabal%FNupyear    = 0.0_r2
+       casabal%FNleachyear = 0.0_r2
+       casabal%FNlossyear  = 0.0_r2
 
-       casabal%FPweayear   = 0.0_r_2
-       casabal%FPdustyear  = 0.0_r_2
-       casabal%FPsnetyear  = 0.0_r_2
-       casabal%FPupyear    = 0.0_r_2
-       casabal%FPleachyear = 0.0_r_2
-       casabal%FPlossyear  = 0.0_r_2
+       casabal%FPweayear   = 0.0_r2
+       casabal%FPdustyear  = 0.0_r2
+       casabal%FPsnetyear  = 0.0_r2
+       casabal%FPupyear    = 0.0_r2
+       casabal%FPleachyear = 0.0_r2
+       casabal%FPlossyear  = 0.0_r2
 
-       casaflux%FluxCtohwp   = 0.0_r_2
-       casaflux%FluxNtohwp   = 0.0_r_2
-       casaflux%FluxPtohwp   = 0.0_r_2
-       casaflux%FluxCtoclear = 0.0_r_2
-       casaflux%FluxNtoclear = 0.0_r_2
-       casaflux%FluxPtoclear = 0.0_r_2
-       casaflux%CtransferLUC = 0.0_r_2
+       casaflux%FluxCtohwp   = 0.0_r2
+       casaflux%FluxNtohwp   = 0.0_r2
+       casaflux%FluxPtohwp   = 0.0_r2
+       casaflux%FluxCtoclear = 0.0_r2
+       casaflux%FluxNtoclear = 0.0_r2
+       casaflux%FluxPtoclear = 0.0_r2
+       casaflux%CtransferLUC = 0.0_r2
 
        !MC - commented because otherwise serial and MPI versions different
-       ! casaflux%Cplant_turnover_disturbance         = 0.0_r_2
-       ! casaflux%Cplant_turnover_crowding            = 0.0_r_2
-       ! casaflux%Cplant_turnover_resource_limitation = 0.0_r_2
+       ! casaflux%Cplant_turnover_disturbance         = 0.0_r2
+       ! casaflux%Cplant_turnover_crowding            = 0.0_r2
+       ! casaflux%Cplant_turnover_resource_limitation = 0.0_r2
 
     ELSE
 
@@ -1241,22 +1241,22 @@ contains
     TYPE(phen_variable),       INTENT(INOUT) :: phen
     TYPE(POP_TYPE),            INTENT(IN)    :: POP
     TYPE(climate_TYPE),        INTENT(IN)    :: climate
-    real(r_2), dimension(mp),  intent(out)   :: xnplimit
-    real(r_2), dimension(mp),  intent(out)   :: xkNlimiting
-    real(r_2), dimension(mp),  intent(out)   :: xklitter, xksoil
-    real(r_2), dimension(mp),  intent(out)   :: xkleafcold, xkleafdry, xkleaf
+    real(r2), dimension(mp),  intent(out)   :: xnplimit
+    real(r2), dimension(mp),  intent(out)   :: xkNlimiting
+    real(r2), dimension(mp),  intent(out)   :: xklitter, xksoil
+    real(r2), dimension(mp),  intent(out)   :: xkleafcold, xkleafdry, xkleaf
     ! added by ypwang following Chris Lu 5/nov/2012
-    real(r_2), dimension(mp),  intent(out)   :: &
+    real(r2), dimension(mp),  intent(out)   :: &
          cleaf2met, cleaf2str, croot2met, croot2str, cwood2cwd, &
          nleaf2met, nleaf2str, nroot2met, nroot2str, nwood2cwd, &
          pleaf2met, pleaf2str, proot2met, proot2str, pwood2cwd
 
     ! local variables
-    REAL(r_2), DIMENSION(mp) :: xNuptake, xPuptake, xNPuptake
+    REAL(r2), DIMENSION(mp) :: xNuptake, xPuptake, xNPuptake
     INTEGER :: j
-    REAL(r_2), ALLOCATABLE :: tmp(:)
+    REAL(r2), ALLOCATABLE :: tmp(:)
 
-    xKNlimiting = 1.0_r_2
+    xKNlimiting = 1.0_r2
 
     ! zero annual sums
     if (idoy==1) CALL casa_cnpflux(casaflux, casapool, casabal, .true.)
@@ -1282,42 +1282,42 @@ contains
     IF (cable_user%CALL_POP) THEN
 
        call casa_allocation(veg,soil,casabiome,casaflux,casapool,casamet,phen,LALLOC)
-       WHERE (pop%pop_grid(:)%cmass_sum_old.gt.0.001_r_2 .and. pop%pop_grid(:)%cmass_sum.gt.0.001_r_2 )
+       WHERE (pop%pop_grid(:)%cmass_sum_old.gt.0.001_r2 .and. pop%pop_grid(:)%cmass_sum.gt.0.001_r2 )
           casaflux%frac_sapwood(POP%Iwood) = POP%pop_grid(:)%csapwood_sum / POP%pop_grid(:)%cmass_sum
-          casaflux%sapwood_area(POP%Iwood) = max(POP%pop_grid(:)%sapwood_area/10000._r_2, 1.0e-6_r_2)
+          casaflux%sapwood_area(POP%Iwood) = max(POP%pop_grid(:)%sapwood_area/10000._r2, 1.0e-6_r2)
           veg%hc(POP%Iwood) = real(POP%pop_grid(:)%height_max)
 
           WHERE (pop%pop_grid(:)%LU ==2)
-             casaflux%kplant(POP%Iwood,2) = 1.0_r_2 -  &
-                  (1.0_r_2 -  max( min((POP%pop_grid(:)%stress_mortality + &
+             casaflux%kplant(POP%Iwood,2) = 1.0_r2 -  &
+                  (1.0_r2 -  max( min((POP%pop_grid(:)%stress_mortality + &
                   POP%pop_grid(:)%crowding_mortality ) &
                   /(POP%pop_grid(:)%cmass_sum+POP%pop_grid(:)%growth) + &
-                  1.0_r_2/veg%disturbance_interval(POP%Iwood,1), 0.99_r_2), &
-                  0.0_r_2))**(1.0_r_2/365.0_r_2)
+                  1.0_r2/veg%disturbance_interval(POP%Iwood,1), 0.99_r2), &
+                  0.0_r2))**(1.0_r2/365.0_r2)
           ELSEWHERE
-             casaflux%kplant(POP%Iwood,2) =  1.0_r_2 -  &
-                  (1.0_r_2 -  max( min((POP%pop_grid(:)%stress_mortality + &
+             casaflux%kplant(POP%Iwood,2) =  1.0_r2 -  &
+                  (1.0_r2 -  max( min((POP%pop_grid(:)%stress_mortality + &
                   POP%pop_grid(:)%crowding_mortality + &
                   POP%pop_grid(:)%cat_mortality  ) &
-                  /(POP%pop_grid(:)%cmass_sum+POP%pop_grid(:)%growth), 0.99_r_2), &
-                  0.0_r_2))**(1.0_r_2/365.0_r_2)
+                  /(POP%pop_grid(:)%cmass_sum+POP%pop_grid(:)%growth), 0.99_r2), &
+                  0.0_r2))**(1.0_r2/365.0_r2)
           ENDWHERE
           veg%hc(POP%Iwood) = real(POP%pop_grid(:)%height_max)
        ELSEWHERE
-          casaflux%frac_sapwood(POP%Iwood) = 1.0_r_2
-          casaflux%sapwood_area(POP%Iwood) = max(POP%pop_grid(:)%sapwood_area/10000._r_2, 1e-6_r_2)
-          casaflux%kplant(POP%Iwood,2) = 0.0_r_2
+          casaflux%frac_sapwood(POP%Iwood) = 1.0_r2
+          casaflux%sapwood_area(POP%Iwood) = max(POP%pop_grid(:)%sapwood_area/10000._r2, 1e-6_r2)
+          casaflux%kplant(POP%Iwood,2) = 0.0_r2
           veg%hc(POP%Iwood) = real(POP%pop_grid(:)%height_max)
        ENDWHERE
-       if (any(casaflux%kplant(:,leaf) < 0.0_r_2)) then
+       if (any(casaflux%kplant(:,leaf) < 0.0_r2)) then
           do j=1, mp
-             if (casaflux%kplant(j,leaf) < 0.0_r_2) then
+             if (casaflux%kplant(j,leaf) < 0.0_r2) then
                 print*, 'ERR KK20 ', j, casaflux%kplant(j,leaf)
              endif
           enddo
        endif
        casaflux%kplant_tot(POP%Iwood,2) = casaflux%kplant(POP%Iwood,2) + &
-            (1.0_r_2 -casaflux%kplant(POP%Iwood,2)) * casaflux%kplant_fire(POP%Iwood,2)
+            (1.0_r2 -casaflux%kplant(POP%Iwood,2)) * casaflux%kplant_fire(POP%Iwood,2)
     ENDIF
 
     call casa_xratesoil(xklitter,xksoil,veg,soil,casamet,casabiome)
@@ -1331,7 +1331,7 @@ contains
           casaflux%klitter(:,j) = casaflux%klitter(:,j)* xkNlimiting(:)
           ! MC - have to update klitter_tot as well, otherwise no C balance
           casaflux%klitter_tot(:,j) = casaflux%klitter(:,j) + &
-               (1.0_r_2 -casaflux%klitter(:,j)) * casaflux%klitter_fire(:,j)
+               (1.0_r2 -casaflux%klitter(:,j)) * casaflux%klitter_fire(:,j)
        ENDDO
        call casa_nuptake(veg,xNuptake,casabiome,casapool,casaflux,casamet)
        IF (icycle >2) call casa_puptake(veg,xPuptake,casabiome, &
@@ -1344,9 +1344,9 @@ contains
          nleaf2met,nleaf2str,nroot2met,nroot2str,nwood2cwd, &
          pleaf2met,pleaf2str,proot2met,proot2str,pwood2cwd)
 
-    casaflux%Cplant_turnover_disturbance         = 0.0_r_2
-    casaflux%Cplant_turnover_crowding            = 0.0_r_2
-    casaflux%Cplant_turnover_resource_limitation = 0.0_r_2
+    casaflux%Cplant_turnover_disturbance         = 0.0_r2
+    casaflux%Cplant_turnover_crowding            = 0.0_r2
+    casaflux%Cplant_turnover_resource_limitation = 0.0_r2
 
     if (cable_user%CALL_POP) THEN
        if (.not.allocated(tmp)) allocate(tmp(size(POP%pop_grid)))
@@ -1354,8 +1354,8 @@ contains
             + POP%pop_grid(:)%crowding_mortality &
             + POP%pop_grid(:)%cat_mortality &
             + POP%pop_grid(:)%fire_mortality
-       ! where (tmp .gt. 1.e-12_r_2)
-       where (tmp > real(epsilon(1.0),r_2))
+       ! where (tmp .gt. 1.e-12_r2)
+       where (tmp > real(epsilon(1.0),r2))
           casaflux%Cplant_turnover_disturbance(POP%Iwood(:)) =  &
                casaflux%Cplant_turnover(POP%Iwood(:),2) * &
                (POP%pop_grid(:)%cat_mortality + POP%pop_grid(:)%fire_mortality) / tmp(:)
@@ -1383,8 +1383,8 @@ contains
 
     ! for spinning up only
     IF (cable_user%limit_labile) THEN
-       casapool%Nsoilmin = max(casapool%Nsoilmin, 5.0_r_2)
-       casapool%Psoillab = max(casapool%Psoillab, 1.0_r_2)
+       casapool%Nsoilmin = max(casapool%Nsoilmin, 5.0_r2)
+       casapool%Psoillab = max(casapool%Psoillab, 1.0_r2)
     ENDIF
 
   END SUBROUTINE biogeochem
@@ -1518,12 +1518,14 @@ contains
   !! old routine used before 2023. Replaced by write_casa_output_land_nc and write_casa_output_grid_nc
   subroutine write_casa_output_nc(veg, casamet, casapool, casabal, casaflux, casaonly, ctime, lfinal)
 
+    use, intrinsic :: iso_c_binding, only: c_float
+
     use casadimension,        only: mplant, mlitter, msoil, icycle
     use casavariable,         only: casa_met, casa_pool, casa_balance, casa_flux, &
          casafile, casa_timeunits
     use cable_common_module,  only: cable_user, filename, handle_err
     use cable_def_types_mod,  only: veg_parameter_type, mp
-    ! use cable_def_types_mod,  only: sp => r_2
+    ! use cable_def_types_mod,  only: sp => r2
     !use netcdf,               only: nf90_noerr, &
     !     nf90_put_var, nf90_clobber, nf90_create, nf90_global, nf90_put_att, &
 !#ifdef __NETCDF3__
@@ -1549,7 +1551,7 @@ contains
     character(len=99) :: fname
     character(len=50) :: dum
     logical, save :: call1 = .true.
-    integer, parameter :: sp = kind(1.0)
+    integer, parameter :: r1 = c_float
 
     ! 1 dim arrays (mp)
     character(len=21), dimension(2)  :: a0
@@ -1853,10 +1855,10 @@ contains
        if (status /= nf90_noerr) call handle_err(status)
 
        ! put lat / lon ( mp )
-       status = nf90_put_var(file_id, vid0(1), real(casamet%lat,sp))
+       status = nf90_put_var(file_id, vid0(1), real(casamet%lat,r1))
        if(status /= nf90_noerr) call handle_err(status)
 
-       status = nf90_put_var(file_id, vid0(2), real(casamet%lon,sp))
+       status = nf90_put_var(file_id, vid0(2), real(casamet%lon,r1))
        if(status /= nf90_noerr) call handle_err(status)
 
        call1 = .false.
@@ -1869,227 +1871,227 @@ contains
     if(status /= nf90_noerr) call handle_err(status)
 
     ! patchfrac and area
-    status = nf90_put_var(file_id, vid1(1), real(patch(:)%frac,sp),         start=(/1,cnt/), count=(/mp,1/) )
+    status = nf90_put_var(file_id, vid1(1), real(patch(:)%frac,r1),         start=(/1,cnt/), count=(/mp,1/) )
     if(status /= nf90_noerr) call handle_err(status)
     !status = nf90_put_att(file_id, vid1(52), 'units', '-')
     !if(status /= nf90_noerr) call handle_err(status)
-    status = nf90_put_var(file_id, vid1(2), real(casamet%areacell,sp),      start=(/1,cnt/), count=(/mp,1/) )
+    status = nf90_put_var(file_id, vid1(2), real(casamet%areacell,r1),      start=(/1,cnt/), count=(/mp,1/) )
     if(status /= nf90_noerr) call handle_err(status)
     
     ! C
-    status = nf90_put_var(file_id, vid1(3),  real(casamet%glai,sp),         start=(/1,cnt/), count=(/mp,1/) )
+    status = nf90_put_var(file_id, vid1(3),  real(casamet%glai,r1),         start=(/1,cnt/), count=(/mp,1/) )
     if(status /= nf90_noerr) call handle_err(status)
-    status = nf90_put_var(file_id, vid1(4),  real(casapool%clabile,sp),     start=(/1,cnt/), count=(/mp,1/) )
+    status = nf90_put_var(file_id, vid1(4),  real(casapool%clabile,r1),     start=(/1,cnt/), count=(/mp,1/) )
     if(status /= nf90_noerr) call handle_err(status)
-    status = nf90_put_var(file_id, vid1(5),  real(casabal%sumcbal,sp),      start=(/1,cnt/), count=(/mp,1/) )
+    status = nf90_put_var(file_id, vid1(5),  real(casabal%sumcbal,r1),      start=(/1,cnt/), count=(/mp,1/) )
     if(status /= nf90_noerr) call handle_err(status)
-    status = nf90_put_var(file_id, vid1(6),  real(casaflux%cgpp,sp),        start=(/1,cnt/), count=(/mp,1/) )
+    status = nf90_put_var(file_id, vid1(6),  real(casaflux%cgpp,r1),        start=(/1,cnt/), count=(/mp,1/) )
     if(status /= nf90_noerr) call handle_err(status)
-    status = nf90_put_var(file_id, vid1(7),  real(casaflux%cnpp,sp),        start=(/1,cnt/), count=(/mp,1/) )
+    status = nf90_put_var(file_id, vid1(7),  real(casaflux%cnpp,r1),        start=(/1,cnt/), count=(/mp,1/) )
     if(status /= nf90_noerr) call handle_err(status)
-    status = nf90_put_var(file_id, vid1(8),  real(casaflux%stemnpp,sp),     start=(/1,cnt/), count=(/mp,1/) )
+    status = nf90_put_var(file_id, vid1(8),  real(casaflux%stemnpp,r1),     start=(/1,cnt/), count=(/mp,1/) )
     if(status /= nf90_noerr) call handle_err(status)
-    status = nf90_put_var(file_id, vid1(9),  real(casaflux%crp,sp),         start=(/1,cnt/), count=(/mp,1/) )
+    status = nf90_put_var(file_id, vid1(9),  real(casaflux%crp,r1),         start=(/1,cnt/), count=(/mp,1/) )
     if(status /= nf90_noerr) call handle_err(status)
-    status = nf90_put_var(file_id, vid1(10),  real(casaflux%crgplant,sp),    start=(/1,cnt/), count=(/mp,1/) )
+    status = nf90_put_var(file_id, vid1(10),  real(casaflux%crgplant,r1),    start=(/1,cnt/), count=(/mp,1/) )
     if(status /= nf90_noerr) call handle_err(status)
-    status = nf90_put_var(file_id, vid1(11),  real(casaflux%clabloss,sp),    start=(/1,cnt/), count=(/mp,1/) )
+    status = nf90_put_var(file_id, vid1(11),  real(casaflux%clabloss,r1),    start=(/1,cnt/), count=(/mp,1/) )
     if(status /= nf90_noerr) call handle_err(status)
-    status = nf90_put_var(file_id, vid1(12), real(casaflux%fracclabile,sp), start=(/1,cnt/), count=(/mp,1/) )
+    status = nf90_put_var(file_id, vid1(12), real(casaflux%fracclabile,r1), start=(/1,cnt/), count=(/mp,1/) )
     if(status /= nf90_noerr) call handle_err(status)
-    status = nf90_put_var(file_id, vid1(13), real(casaflux%cnep,sp),        start=(/1,cnt/), count=(/mp,1/) )
+    status = nf90_put_var(file_id, vid1(13), real(casaflux%cnep,r1),        start=(/1,cnt/), count=(/mp,1/) )
     if(status /= nf90_noerr) call handle_err(status)
-    status = nf90_put_var(file_id, vid1(14), real(casaflux%crsoil,sp),      start=(/1,cnt/), count=(/mp,1/) )
+    status = nf90_put_var(file_id, vid1(14), real(casaflux%crsoil,r1),      start=(/1,cnt/), count=(/mp,1/) )
     if(status /= nf90_noerr) call handle_err(status)
-    status = nf90_put_var(file_id, vid1(15), real(casaflux%fluxctoco2,sp),  start=(/1,cnt/), count=(/mp,1/) )
+    status = nf90_put_var(file_id, vid1(15), real(casaflux%fluxctoco2,r1),  start=(/1,cnt/), count=(/mp,1/) )
     if(status /= nf90_noerr) call handle_err(status)
-    status = nf90_put_var(file_id, vid1(16), real(casabal%fcgppyear,sp),    start=(/1,cnt/), count=(/mp,1/) )
+    status = nf90_put_var(file_id, vid1(16), real(casabal%fcgppyear,r1),    start=(/1,cnt/), count=(/mp,1/) )
     if(status /= nf90_noerr) call handle_err(status)
-    status = nf90_put_var(file_id, vid1(17), real(casabal%fcrpyear,sp),     start=(/1,cnt/), count=(/mp,1/) )
+    status = nf90_put_var(file_id, vid1(17), real(casabal%fcrpyear,r1),     start=(/1,cnt/), count=(/mp,1/) )
     if(status /= nf90_noerr) call handle_err(status)
-    status = nf90_put_var(file_id, vid1(18), real(casabal%fcnppyear,sp),    start=(/1,cnt/), count=(/mp,1/) )
+    status = nf90_put_var(file_id, vid1(18), real(casabal%fcnppyear,r1),    start=(/1,cnt/), count=(/mp,1/) )
     if(status /= nf90_noerr) call handle_err(status)
-    status = nf90_put_var(file_id, vid1(19), real(casabal%fcrsyear,sp),     start=(/1,cnt/), count=(/mp,1/) )
+    status = nf90_put_var(file_id, vid1(19), real(casabal%fcrsyear,r1),     start=(/1,cnt/), count=(/mp,1/) )
     if(status /= nf90_noerr) call handle_err(status)
-    status = nf90_put_var(file_id, vid1(20), real(casabal%fcneeyear,sp),    start=(/1,cnt/), count=(/mp,1/) )
+    status = nf90_put_var(file_id, vid1(20), real(casabal%fcneeyear,r1),    start=(/1,cnt/), count=(/mp,1/) )
     if(status /= nf90_noerr) call handle_err(status)
-    status = nf90_put_var(file_id, vid1(21), real(veg%vcmax,sp),            start=(/1,cnt/), count=(/mp,1/) )
+    status = nf90_put_var(file_id, vid1(21), real(veg%vcmax,r1),            start=(/1,cnt/), count=(/mp,1/) )
     if(status /= nf90_noerr) call handle_err(status)
-    status = nf90_put_var(file_id, vid1(22), real(casaflux%CallocLeaf,sp),     start=(/1,cnt/), count=(/mp,1/) )
+    status = nf90_put_var(file_id, vid1(22), real(casaflux%CallocLeaf,r1),     start=(/1,cnt/), count=(/mp,1/) )
     if(status /= nf90_noerr) call handle_err(status)
-    status = nf90_put_var(file_id, vid1(23), real(casaflux%CallocWood,sp),     start=(/1,cnt/), count=(/mp,1/) )
+    status = nf90_put_var(file_id, vid1(23), real(casaflux%CallocWood,r1),     start=(/1,cnt/), count=(/mp,1/) )
     if(status /= nf90_noerr) call handle_err(status)
-    status = nf90_put_var(file_id, vid1(24), real(casaflux%CallocFineRoot,sp), start=(/1,cnt/), count=(/mp,1/) )
+    status = nf90_put_var(file_id, vid1(24), real(casaflux%CallocFineRoot,r1), start=(/1,cnt/), count=(/mp,1/) )
     if(status /= nf90_noerr) call handle_err(status)
     ! N
     if (icycle > 1) then
-       status = nf90_put_var(file_id, vid1(25), real(casabal%sumnbal,sp),      start=(/1,cnt/), count=(/mp,1/) )
+       status = nf90_put_var(file_id, vid1(25), real(casabal%sumnbal,r1),      start=(/1,cnt/), count=(/mp,1/) )
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vid1(26), real(casaflux%nminfix,sp),     start=(/1,cnt/), count=(/mp,1/) )
+       status = nf90_put_var(file_id, vid1(26), real(casaflux%nminfix,r1),     start=(/1,cnt/), count=(/mp,1/) )
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vid1(27), real(casaflux%nmindep,sp),     start=(/1,cnt/), count=(/mp,1/) )
+       status = nf90_put_var(file_id, vid1(27), real(casaflux%nmindep,r1),     start=(/1,cnt/), count=(/mp,1/) )
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vid1(28), real(casaflux%nminloss,sp),    start=(/1,cnt/), count=(/mp,1/) )
+       status = nf90_put_var(file_id, vid1(28), real(casaflux%nminloss,r1),    start=(/1,cnt/), count=(/mp,1/) )
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vid1(29), real(casaflux%nminleach,sp),   start=(/1,cnt/), count=(/mp,1/) )
+       status = nf90_put_var(file_id, vid1(29), real(casaflux%nminleach,r1),   start=(/1,cnt/), count=(/mp,1/) )
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vid1(30), real(casaflux%nupland,sp),     start=(/1,cnt/), count=(/mp,1/) )
+       status = nf90_put_var(file_id, vid1(30), real(casaflux%nupland,r1),     start=(/1,cnt/), count=(/mp,1/) )
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vid1(31), real(casaflux%nlittermin,sp),  start=(/1,cnt/), count=(/mp,1/) )
+       status = nf90_put_var(file_id, vid1(31), real(casaflux%nlittermin,r1),  start=(/1,cnt/), count=(/mp,1/) )
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vid1(32), real(casaflux%nsmin,sp),       start=(/1,cnt/), count=(/mp,1/) )
+       status = nf90_put_var(file_id, vid1(32), real(casaflux%nsmin,r1),       start=(/1,cnt/), count=(/mp,1/) )
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vid1(33), real(casaflux%nsimm,sp),       start=(/1,cnt/), count=(/mp,1/) )
+       status = nf90_put_var(file_id, vid1(33), real(casaflux%nsimm,r1),       start=(/1,cnt/), count=(/mp,1/) )
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vid1(34), real(casaflux%nsnet,sp),       start=(/1,cnt/), count=(/mp,1/) )
+       status = nf90_put_var(file_id, vid1(34), real(casaflux%nsnet,r1),       start=(/1,cnt/), count=(/mp,1/) )
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vid1(35), real(casaflux%fnminloss,sp),   start=(/1,cnt/), count=(/mp,1/) )
+       status = nf90_put_var(file_id, vid1(35), real(casaflux%fnminloss,r1),   start=(/1,cnt/), count=(/mp,1/) )
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vid1(36), real(casapool%nsoilmin,sp),    start=(/1,cnt/), count=(/mp,1/) )
+       status = nf90_put_var(file_id, vid1(36), real(casapool%nsoilmin,r1),    start=(/1,cnt/), count=(/mp,1/) )
        if(status /= nf90_noerr) call handle_err(status)
     endif
     ! P
     if (icycle > 2) then
-       status = nf90_put_var(file_id, vid1(37), real(casapool%psoillab,sp),    start=(/1,cnt/), count=(/mp,1/) )
+       status = nf90_put_var(file_id, vid1(37), real(casapool%psoillab,r1),    start=(/1,cnt/), count=(/mp,1/) )
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vid1(38), real(casapool%psoilsorb,sp),   start=(/1,cnt/), count=(/mp,1/) )
+       status = nf90_put_var(file_id, vid1(38), real(casapool%psoilsorb,r1),   start=(/1,cnt/), count=(/mp,1/) )
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vid1(39), real(casapool%psoilocc,sp),    start=(/1,cnt/), count=(/mp,1/) )
+       status = nf90_put_var(file_id, vid1(39), real(casapool%psoilocc,r1),    start=(/1,cnt/), count=(/mp,1/) )
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vid1(40), real(casabal%sumpbal,sp),      start=(/1,cnt/), count=(/mp,1/) )
+       status = nf90_put_var(file_id, vid1(40), real(casabal%sumpbal,r1),      start=(/1,cnt/), count=(/mp,1/) )
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vid1(41), real(casaflux%plabuptake,sp),  start=(/1,cnt/), count=(/mp,1/) )
+       status = nf90_put_var(file_id, vid1(41), real(casaflux%plabuptake,r1),  start=(/1,cnt/), count=(/mp,1/) )
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vid1(42), real(casaflux%pdep,sp),        start=(/1,cnt/), count=(/mp,1/) )
+       status = nf90_put_var(file_id, vid1(42), real(casaflux%pdep,r1),        start=(/1,cnt/), count=(/mp,1/) )
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vid1(43), real(casaflux%pwea,sp),        start=(/1,cnt/), count=(/mp,1/) )
+       status = nf90_put_var(file_id, vid1(43), real(casaflux%pwea,r1),        start=(/1,cnt/), count=(/mp,1/) )
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vid1(44), real(casaflux%pleach,sp),      start=(/1,cnt/), count=(/mp,1/) )
+       status = nf90_put_var(file_id, vid1(44), real(casaflux%pleach,r1),      start=(/1,cnt/), count=(/mp,1/) )
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vid1(45), real(casaflux%ploss,sp),       start=(/1,cnt/), count=(/mp,1/) )
+       status = nf90_put_var(file_id, vid1(45), real(casaflux%ploss,r1),       start=(/1,cnt/), count=(/mp,1/) )
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vid1(46), real(casaflux%pupland,sp),     start=(/1,cnt/), count=(/mp,1/) )
+       status = nf90_put_var(file_id, vid1(46), real(casaflux%pupland,r1),     start=(/1,cnt/), count=(/mp,1/) )
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vid1(47), real(casaflux%plittermin,sp),  start=(/1,cnt/), count=(/mp,1/) )
+       status = nf90_put_var(file_id, vid1(47), real(casaflux%plittermin,r1),  start=(/1,cnt/), count=(/mp,1/) )
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vid1(48), real(casaflux%psmin,sp),       start=(/1,cnt/), count=(/mp,1/) )
+       status = nf90_put_var(file_id, vid1(48), real(casaflux%psmin,r1),       start=(/1,cnt/), count=(/mp,1/) )
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vid1(49), real(casaflux%psimm,sp),       start=(/1,cnt/), count=(/mp,1/) )
+       status = nf90_put_var(file_id, vid1(49), real(casaflux%psimm,r1),       start=(/1,cnt/), count=(/mp,1/) )
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vid1(50), real(casaflux%psnet,sp),       start=(/1,cnt/), count=(/mp,1/) )
+       status = nf90_put_var(file_id, vid1(50), real(casaflux%psnet,r1),       start=(/1,cnt/), count=(/mp,1/) )
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vid1(51), real(casaflux%fpleach,sp),     start=(/1,cnt/), count=(/mp,1/) )
+       status = nf90_put_var(file_id, vid1(51), real(casaflux%fpleach,r1),     start=(/1,cnt/), count=(/mp,1/) )
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vid1(52), real(casaflux%kplab,sp),       start=(/1,cnt/), count=(/mp,1/) )
+       status = nf90_put_var(file_id, vid1(52), real(casaflux%kplab,r1),       start=(/1,cnt/), count=(/mp,1/) )
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vid1(53), real(casaflux%kpsorb,sp),      start=(/1,cnt/), count=(/mp,1/) )
+       status = nf90_put_var(file_id, vid1(53), real(casaflux%kpsorb,r1),      start=(/1,cnt/), count=(/mp,1/) )
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vid1(54), real(casaflux%kpocc,sp),       start=(/1,cnt/), count=(/mp,1/) )
+       status = nf90_put_var(file_id, vid1(54), real(casaflux%kpocc,r1),       start=(/1,cnt/), count=(/mp,1/) )
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vid1(55), real(casaflux%kmlabp,sp),      start=(/1,cnt/), count=(/mp,1/) )
+       status = nf90_put_var(file_id, vid1(55), real(casaflux%kmlabp,r1),      start=(/1,cnt/), count=(/mp,1/) )
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vid1(56), real(casaflux%psorbmax,sp),    start=(/1,cnt/), count=(/mp,1/) )
+       status = nf90_put_var(file_id, vid1(56), real(casaflux%psorbmax,r1),    start=(/1,cnt/), count=(/mp,1/) )
        if(status /= nf90_noerr) call handle_err(status)
     endif
 
     ! put 3d vars ( mp, mplant, t )
     ! C
-    status = nf90_put_var(file_id, vid2(1), real(casapool%cplant,sp),      start=(/1,1,cnt/), count=(/mp,mplant,1/))
+    status = nf90_put_var(file_id, vid2(1), real(casapool%cplant,r1),      start=(/1,1,cnt/), count=(/mp,mplant,1/))
     if(status /= nf90_noerr) call handle_err(status)
-    status = nf90_put_var(file_id, vid2(2), real(casaflux%fracCalloc,sp),  start=(/1,1,cnt/), count=(/mp,mplant,1/))
+    status = nf90_put_var(file_id, vid2(2), real(casaflux%fracCalloc,r1),  start=(/1,1,cnt/), count=(/mp,mplant,1/))
     if(status /= nf90_noerr) call handle_err(status)
-    status = nf90_put_var(file_id, vid2(3), real(casaflux%kplant,sp),      start=(/1,1,cnt/), count=(/mp,mplant,1/))
+    status = nf90_put_var(file_id, vid2(3), real(casaflux%kplant,r1),      start=(/1,1,cnt/), count=(/mp,mplant,1/))
     if(status /= nf90_noerr) call handle_err(status)
-    status = nf90_put_var(file_id, vid2(4), real(casaflux%crmplant,sp),    start=(/1,1,cnt/), count=(/mp,mplant,1/))
+    status = nf90_put_var(file_id, vid2(4), real(casaflux%crmplant,r1),    start=(/1,1,cnt/), count=(/mp,mplant,1/))
     if(status /= nf90_noerr) call handle_err(status)
-    status = nf90_put_var(file_id, vid2(5), real(casaflux%kplant_fire,sp), start=(/1,1,cnt/), count=(/mp,mplant,1/))
+    status = nf90_put_var(file_id, vid2(5), real(casaflux%kplant_fire,r1), start=(/1,1,cnt/), count=(/mp,mplant,1/))
     if(status /= nf90_noerr) call handle_err(status)
     ! N
     if (icycle > 1) then
-       status = nf90_put_var(file_id, vid2(6), real(casapool%nplant,sp),     start=(/1,1,cnt/), count=(/mp,mplant,1/))
+       status = nf90_put_var(file_id, vid2(6), real(casapool%nplant,r1),     start=(/1,1,cnt/), count=(/mp,mplant,1/))
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vid2(7), real(casaflux%fracnalloc,sp), start=(/1,1,cnt/), count=(/mp,mplant,1/))
+       status = nf90_put_var(file_id, vid2(7), real(casaflux%fracnalloc,r1), start=(/1,1,cnt/), count=(/mp,mplant,1/))
        if(status /= nf90_noerr) call handle_err(status)
     endif
     ! P
     if (icycle > 2) then
-       status = nf90_put_var(file_id, vid2(8), real(casapool%pplant,sp),     start=(/1,1,cnt/), count=(/mp,mplant,1/))
+       status = nf90_put_var(file_id, vid2(8), real(casapool%pplant,r1),     start=(/1,1,cnt/), count=(/mp,mplant,1/))
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vid2(9), real(casaflux%fracpalloc,sp), start=(/1,1,cnt/), count=(/mp,mplant,1/))
+       status = nf90_put_var(file_id, vid2(9), real(casaflux%fracpalloc,r1), start=(/1,1,cnt/), count=(/mp,mplant,1/))
        if(status /= nf90_noerr) call handle_err(status)
     endif
 
     ! put 3d vars ( mp, mlitter, t )
     ! C
-    status = nf90_put_var(file_id, vid3(1), real(casapool%clitter,sp),       start=(/1,1,cnt/), count=(/mp,mlitter,1/))
+    status = nf90_put_var(file_id, vid3(1), real(casapool%clitter,r1),       start=(/1,1,cnt/), count=(/mp,mlitter,1/))
     if(status /= nf90_noerr) call handle_err(status)
-    status = nf90_put_var(file_id, vid3(2), real(casaflux%klitter,sp),       start=(/1,1,cnt/), count=(/mp,mlitter,1/))
+    status = nf90_put_var(file_id, vid3(2), real(casaflux%klitter,r1),       start=(/1,1,cnt/), count=(/mp,mlitter,1/))
     if(status /= nf90_noerr) call handle_err(status)
-    status = nf90_put_var(file_id, vid3(3), real(casaflux%fromltoco2,sp),    start=(/1,1,cnt/), count=(/mp,mlitter,1/))
+    status = nf90_put_var(file_id, vid3(3), real(casaflux%fromltoco2,r1),    start=(/1,1,cnt/), count=(/mp,mlitter,1/))
     if(status /= nf90_noerr) call handle_err(status)
-    status = nf90_put_var(file_id, vid3(4), real(casaflux%fluxctolitter,sp), start=(/1,1,cnt/), count=(/mp,mlitter,1/))
+    status = nf90_put_var(file_id, vid3(4), real(casaflux%fluxctolitter,r1), start=(/1,1,cnt/), count=(/mp,mlitter,1/))
     if(status /= nf90_noerr) call handle_err(status)
-    status = nf90_put_var(file_id, vid3(5), real(casaflux%fluxcleaftolitter,sp), start=(/1,1,cnt/), count=(/mp,mlitter,1/))
+    status = nf90_put_var(file_id, vid3(5), real(casaflux%fluxcleaftolitter,r1), start=(/1,1,cnt/), count=(/mp,mlitter,1/))
     if(status /= nf90_noerr) call handle_err(status)
-    status = nf90_put_var(file_id, vid3(6), real(casaflux%fluxcwoodtolitter,sp), start=(/1,1,cnt/), count=(/mp,mlitter,1/))
+    status = nf90_put_var(file_id, vid3(6), real(casaflux%fluxcwoodtolitter,r1), start=(/1,1,cnt/), count=(/mp,mlitter,1/))
     if(status /= nf90_noerr) call handle_err(status)
-    status = nf90_put_var(file_id, vid3(7), real(casaflux%fluxcfineroottolitter,sp), start=(/1,1,cnt/), count=(/mp,mlitter,1/))
+    status = nf90_put_var(file_id, vid3(7), real(casaflux%fluxcfineroottolitter,r1), start=(/1,1,cnt/), count=(/mp,mlitter,1/))
     if(status /= nf90_noerr) call handle_err(status)
-    status = nf90_put_var(file_id, vid3(8), real(casaflux%klitter_fire,sp),  start=(/1,1,cnt/), count=(/mp,mlitter,1/))
+    status = nf90_put_var(file_id, vid3(8), real(casaflux%klitter_fire,r1),  start=(/1,1,cnt/), count=(/mp,mlitter,1/))
     if(status /= nf90_noerr) call handle_err(status)
     ! N
     if (icycle > 1) then
-       status = nf90_put_var(file_id, vid3(9), real(casapool%nlitter,sp),       start=(/1,1,cnt/), count=(/mp,mlitter,1/))
+       status = nf90_put_var(file_id, vid3(9), real(casapool%nlitter,r1),       start=(/1,1,cnt/), count=(/mp,mlitter,1/))
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vid3(10), real(casaflux%fluxntolitter,sp), start=(/1,1,cnt/), count=(/mp,mlitter,1/))
+       status = nf90_put_var(file_id, vid3(10), real(casaflux%fluxntolitter,r1), start=(/1,1,cnt/), count=(/mp,mlitter,1/))
        if(status /= nf90_noerr) call handle_err(status)
     endif
     ! P
     if (icycle > 2) then
-       status = nf90_put_var(file_id, vid3(11), real(casapool%plitter,sp),       start=(/1,1,cnt/), count=(/mp,mlitter,1/))
+       status = nf90_put_var(file_id, vid3(11), real(casapool%plitter,r1),       start=(/1,1,cnt/), count=(/mp,mlitter,1/))
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vid3(12), real(casaflux%fluxptolitter,sp), start=(/1,1,cnt/), count=(/mp,mlitter,1/))
+       status = nf90_put_var(file_id, vid3(12), real(casaflux%fluxptolitter,r1), start=(/1,1,cnt/), count=(/mp,mlitter,1/))
        if(status /= nf90_noerr) call handle_err(status)
     endif
 
     ! put 3d vars ( mp, msoil, t )
     ! C
-    status = nf90_put_var(file_id, vid4(1), real(casapool%csoil,sp),       start=(/1,1,cnt/), count=(/mp,msoil,1/))
+    status = nf90_put_var(file_id, vid4(1), real(casapool%csoil,r1),       start=(/1,1,cnt/), count=(/mp,msoil,1/))
     if(status /= nf90_noerr) call handle_err(status)
-    status = nf90_put_var(file_id, vid4(2), real(casaflux%ksoil,sp),       start=(/1,1,cnt/), count=(/mp,msoil,1/))
+    status = nf90_put_var(file_id, vid4(2), real(casaflux%ksoil,r1),       start=(/1,1,cnt/), count=(/mp,msoil,1/))
     if(status /= nf90_noerr) call handle_err(status)
-    status = nf90_put_var(file_id, vid4(3), real(casaflux%fromstoco2,sp),  start=(/1,1,cnt/), count=(/mp,msoil,1/))
+    status = nf90_put_var(file_id, vid4(3), real(casaflux%fromstoco2,r1),  start=(/1,1,cnt/), count=(/mp,msoil,1/))
     if(status /= nf90_noerr) call handle_err(status)
-    status = nf90_put_var(file_id, vid4(4), real(casaflux%fluxctosoil,sp), start=(/1,1,cnt/), count=(/mp,msoil,1/))
+    status = nf90_put_var(file_id, vid4(4), real(casaflux%fluxctosoil,r1), start=(/1,1,cnt/), count=(/mp,msoil,1/))
     if(status /= nf90_noerr) call handle_err(status)
     ! N
     if (icycle > 1) then
-       status = nf90_put_var(file_id, vid4(5), real(casapool%nsoil,sp),       start=(/1,1,cnt/), count=(/mp,msoil,1/))
+       status = nf90_put_var(file_id, vid4(5), real(casapool%nsoil,r1),       start=(/1,1,cnt/), count=(/mp,msoil,1/))
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vid4(6), real(casaflux%fluxntosoil,sp), start=(/1,1,cnt/), count=(/mp,msoil,1/))
+       status = nf90_put_var(file_id, vid4(6), real(casaflux%fluxntosoil,r1), start=(/1,1,cnt/), count=(/mp,msoil,1/))
        if(status /= nf90_noerr) call handle_err(status)
     endif
     ! P
     if (icycle > 2) then
-       status = nf90_put_var(file_id, vid4(7), real(casapool%psoil,sp),       start=(/1,1,cnt/), count=(/mp,msoil,1/))
+       status = nf90_put_var(file_id, vid4(7), real(casapool%psoil,r1),       start=(/1,1,cnt/), count=(/mp,msoil,1/))
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vid4(8), real(casaflux%fluxptosoil,sp), start=(/1,1,cnt/), count=(/mp,msoil,1/))
+       status = nf90_put_var(file_id, vid4(8), real(casaflux%fluxptosoil,r1), start=(/1,1,cnt/), count=(/mp,msoil,1/))
        if(status /= nf90_noerr) call handle_err(status)
     endif
 
     ! put 4d vars ( mp, mlitter,mplant, t )
     ! C
-    status = nf90_put_var(file_id, vid5(1), real(casaflux%fromptol,sp), start=(/1,1,1,cnt/), count=(/mp,mlitter,mplant,1/))
+    status = nf90_put_var(file_id, vid5(1), real(casaflux%fromptol,r1), start=(/1,1,1,cnt/), count=(/mp,mlitter,mplant,1/))
     if(status /= nf90_noerr) call handle_err(status)
 
     ! put 4d vars ( mp, msoil, mlitter, t )
     ! C
-    status = nf90_put_var(file_id, vid6(1), real(casaflux%fromltos,sp), start=(/1,1,1,cnt/), count=(/mp,msoil,mlitter,1/))
+    status = nf90_put_var(file_id, vid6(1), real(casaflux%fromltos,r1), start=(/1,1,1,cnt/), count=(/mp,msoil,mlitter,1/))
     if(status /= nf90_noerr) call handle_err(status)
 
     ! put 4d vars ( mp, msoil, msoil, t )
     ! C
-    status = nf90_put_var(file_id, vid7(1), real(casaflux%fromstos,sp), start=(/1,1,1,cnt/), count=(/mp,msoil,msoil,1/))
+    status = nf90_put_var(file_id, vid7(1), real(casaflux%fromstos,r1), start=(/1,1,1,cnt/), count=(/mp,msoil,msoil,1/))
     if(status /= nf90_noerr) call handle_err(status)
 
     if ( lfinal ) then
@@ -2109,6 +2111,8 @@ contains
    ! Note: only works for 4D casa variables. Higher dimensions are not supported at the moment 
    !       -> variables fromLtoS, fromPtoL, and fromStoS currently not considered
    !       -> variables with additional dimensions (mplant, mlitter, msoil) are averaged over patches to avoid 5D outputs
+
+    use, intrinsic :: iso_c_binding, only: c_float
 
     use casadimension,        only: mplant, mlitter, msoil, icycle
     use casavariable,         only: casa_met, casa_pool, casa_balance, casa_flux, &
@@ -2140,7 +2144,7 @@ contains
     character(len=99) :: fname
     character(len=50) :: dum
     logical, save :: call1 = .true.
-    integer, parameter :: sp = kind(1.0)
+    integer, parameter :: r1 = c_float
 
     ! 2 dim arrays (x,y)
     character(len=21), dimension(2)  :: a0
@@ -2522,7 +2526,7 @@ contains
           if (status /= nf90_noerr) call handle_err(status)
           status = nf90_put_att(file_id, vid1(i), 'units', trim(u1(i)))
           if (status /= nf90_noerr) call handle_err(status)
-          status = nf90_put_att(file_id, vid1(i), '_FillValue', real(ncmissingr,sp))
+          status = nf90_put_att(file_id, vid1(i), '_FillValue', real(ncmissingr,r1))
           if (status /= nf90_noerr) call handle_err(status)
        end do
 
@@ -2535,7 +2539,7 @@ contains
           if (status /= nf90_noerr) call handle_err(status)
           status = nf90_put_att(file_id, vid2(i), 'units', trim(u2(i)))
           if (status /= nf90_noerr) call handle_err(status)
-          status = nf90_put_att(file_id, vid2(i), '_FillValue', real(ncmissingr,sp))
+          status = nf90_put_att(file_id, vid2(i), '_FillValue', real(ncmissingr,r1))
           if (status /= nf90_noerr) call handle_err(status)
        end do
 
@@ -2548,7 +2552,7 @@ contains
           if (status /= nf90_noerr) call handle_err(status)
           status = nf90_put_att(file_id, vid3(i), 'units', trim(u3(i)))
           if (status /= nf90_noerr) call handle_err(status)
-          status = nf90_put_att(file_id, vid3(i), '_FillValue', real(ncmissingr,sp))
+          status = nf90_put_att(file_id, vid3(i), '_FillValue', real(ncmissingr,r1))
           if (status /= nf90_noerr) call handle_err(status)
        end do
 
@@ -2561,7 +2565,7 @@ contains
           if (status /= nf90_noerr) call handle_err(status)
           status = nf90_put_att(file_id, vid4(i), 'units', trim(u4(i)))
           if (status /= nf90_noerr) call handle_err(status)
-          status = nf90_put_att(file_id, vid4(i), '_FillValue', real(ncmissingr,sp))
+          status = nf90_put_att(file_id, vid4(i), '_FillValue', real(ncmissingr,r1))
           if (status /= nf90_noerr) call handle_err(status)
        end do
 
@@ -2570,15 +2574,15 @@ contains
        if (status /= nf90_noerr) call handle_err(status)
 
        ! put y and x (note this is necessary to get the correct output grid!)
-       status = nf90_put_var(file_id, vidy, real(lat_all(1,:),sp))
+       status = nf90_put_var(file_id, vidy, real(lat_all(1,:),r1))
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vidx, real(lon_all(:,1),sp))
+       status = nf90_put_var(file_id, vidx, real(lon_all(:,1),r1))
        if(status /= nf90_noerr) call handle_err(status)
 
        ! put longitude and latitude
-       status = nf90_put_var(file_id, vid0(1), real(latitude,sp))
+       status = nf90_put_var(file_id, vid0(1), real(latitude,r1))
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vid0(2), real(longitude,sp))
+       status = nf90_put_var(file_id, vid0(2), real(longitude,r1))
        if(status /= nf90_noerr) call handle_err(status)
 
        ! allocate temporary array
@@ -2602,149 +2606,149 @@ contains
     if(status /= nf90_noerr) call handle_err(status)
 
     ! patchfrac and area
-    call put_casa_var_grid_patch(file_id,vid1(1), real(patch(:)%frac,sp), cnt, otmp4patch)
-    call put_casa_var_grid_patch(file_id,vid1(2), real(casamet%areacell,sp), cnt, otmp4patch)
+    call put_casa_var_grid_patch(file_id,vid1(1), real(patch(:)%frac,r1), cnt, otmp4patch)
+    call put_casa_var_grid_patch(file_id,vid1(2), real(casamet%areacell,r1), cnt, otmp4patch)
     
     ! 4D vars (x,y,patch,t)
     ! C
-    call put_casa_var_grid_patch(file_id, vid1(3), real(casamet%glai,sp), cnt, otmp4patch)
-    call put_casa_var_grid_patch(file_id, vid1(4), real(casapool%clabile,sp), cnt, otmp4patch)
-    call put_casa_var_grid_patch(file_id, vid1(5), real(casabal%sumcbal,sp), cnt, otmp4patch)
-    call put_casa_var_grid_patch(file_id, vid1(6), real(casaflux%cgpp,sp), cnt, otmp4patch)
-    call put_casa_var_grid_patch(file_id, vid1(7), real(casaflux%cnpp,sp), cnt, otmp4patch)
-    call put_casa_var_grid_patch(file_id, vid1(8), real(casaflux%stemnpp,sp), cnt, otmp4patch)
-    call put_casa_var_grid_patch(file_id, vid1(9), real(casaflux%crp,sp), cnt, otmp4patch)
-    call put_casa_var_grid_patch(file_id, vid1(10), real(casaflux%crgplant,sp), cnt, otmp4patch)
-    call put_casa_var_grid_patch(file_id, vid1(11), real(casaflux%clabloss,sp), cnt, otmp4patch)
-    call put_casa_var_grid_patch(file_id, vid1(12), real(casaflux%fracclabile,sp), cnt, otmp4patch )
-    call put_casa_var_grid_patch(file_id, vid1(13), real(casaflux%cnep,sp), cnt, otmp4patch)
-    call put_casa_var_grid_patch(file_id, vid1(14), real(casaflux%crsoil,sp), cnt, otmp4patch)
-    call put_casa_var_grid_patch(file_id, vid1(15), real(casaflux%fluxctoco2,sp), cnt, otmp4patch)
-    call put_casa_var_grid_patch(file_id, vid1(16), real(casabal%fcgppyear,sp), cnt, otmp4patch)
-    call put_casa_var_grid_patch(file_id, vid1(17), real(casabal%fcrpyear,sp), cnt, otmp4patch)
-    call put_casa_var_grid_patch(file_id, vid1(18), real(casabal%fcnppyear,sp), cnt, otmp4patch)
-    call put_casa_var_grid_patch(file_id, vid1(19), real(casabal%fcrsyear,sp), cnt, otmp4patch)
-    call put_casa_var_grid_patch(file_id, vid1(20), real(casabal%fcneeyear,sp), cnt, otmp4patch)
-    call put_casa_var_grid_patch(file_id, vid1(21), real(veg%vcmax,sp), cnt, otmp4patch)
-    call put_casa_var_grid_patch(file_id, vid1(22), real(casaflux%CallocLeaf,sp), cnt, otmp4patch)
-    call put_casa_var_grid_patch(file_id, vid1(23), real(casaflux%CallocWood,sp), cnt, otmp4patch)
-    call put_casa_var_grid_patch(file_id, vid1(24), real(casaflux%CallocFineRoot,sp), cnt, otmp4patch)
+    call put_casa_var_grid_patch(file_id, vid1(3), real(casamet%glai,r1), cnt, otmp4patch)
+    call put_casa_var_grid_patch(file_id, vid1(4), real(casapool%clabile,r1), cnt, otmp4patch)
+    call put_casa_var_grid_patch(file_id, vid1(5), real(casabal%sumcbal,r1), cnt, otmp4patch)
+    call put_casa_var_grid_patch(file_id, vid1(6), real(casaflux%cgpp,r1), cnt, otmp4patch)
+    call put_casa_var_grid_patch(file_id, vid1(7), real(casaflux%cnpp,r1), cnt, otmp4patch)
+    call put_casa_var_grid_patch(file_id, vid1(8), real(casaflux%stemnpp,r1), cnt, otmp4patch)
+    call put_casa_var_grid_patch(file_id, vid1(9), real(casaflux%crp,r1), cnt, otmp4patch)
+    call put_casa_var_grid_patch(file_id, vid1(10), real(casaflux%crgplant,r1), cnt, otmp4patch)
+    call put_casa_var_grid_patch(file_id, vid1(11), real(casaflux%clabloss,r1), cnt, otmp4patch)
+    call put_casa_var_grid_patch(file_id, vid1(12), real(casaflux%fracclabile,r1), cnt, otmp4patch )
+    call put_casa_var_grid_patch(file_id, vid1(13), real(casaflux%cnep,r1), cnt, otmp4patch)
+    call put_casa_var_grid_patch(file_id, vid1(14), real(casaflux%crsoil,r1), cnt, otmp4patch)
+    call put_casa_var_grid_patch(file_id, vid1(15), real(casaflux%fluxctoco2,r1), cnt, otmp4patch)
+    call put_casa_var_grid_patch(file_id, vid1(16), real(casabal%fcgppyear,r1), cnt, otmp4patch)
+    call put_casa_var_grid_patch(file_id, vid1(17), real(casabal%fcrpyear,r1), cnt, otmp4patch)
+    call put_casa_var_grid_patch(file_id, vid1(18), real(casabal%fcnppyear,r1), cnt, otmp4patch)
+    call put_casa_var_grid_patch(file_id, vid1(19), real(casabal%fcrsyear,r1), cnt, otmp4patch)
+    call put_casa_var_grid_patch(file_id, vid1(20), real(casabal%fcneeyear,r1), cnt, otmp4patch)
+    call put_casa_var_grid_patch(file_id, vid1(21), real(veg%vcmax,r1), cnt, otmp4patch)
+    call put_casa_var_grid_patch(file_id, vid1(22), real(casaflux%CallocLeaf,r1), cnt, otmp4patch)
+    call put_casa_var_grid_patch(file_id, vid1(23), real(casaflux%CallocWood,r1), cnt, otmp4patch)
+    call put_casa_var_grid_patch(file_id, vid1(24), real(casaflux%CallocFineRoot,r1), cnt, otmp4patch)
 
     ! N
     if (icycle > 1) then
-       call put_casa_var_grid_patch(file_id, vid1(25), real(casabal%sumnbal,sp), cnt, otmp4patch )
-       call put_casa_var_grid_patch(file_id, vid1(26), real(casaflux%nminfix,sp), cnt, otmp4patch )
-       call put_casa_var_grid_patch(file_id, vid1(27), real(casaflux%nmindep,sp), cnt, otmp4patch )
-       call put_casa_var_grid_patch(file_id, vid1(28), real(casaflux%nminloss,sp), cnt, otmp4patch )
-       call put_casa_var_grid_patch(file_id, vid1(29), real(casaflux%nminleach,sp), cnt, otmp4patch )
-       call put_casa_var_grid_patch(file_id, vid1(30), real(casaflux%nupland,sp), cnt, otmp4patch )
-       call put_casa_var_grid_patch(file_id, vid1(31), real(casaflux%nlittermin,sp), cnt, otmp4patch )
-       call put_casa_var_grid_patch(file_id, vid1(32), real(casaflux%nsmin,sp), cnt, otmp4patch )
-       call put_casa_var_grid_patch(file_id, vid1(33), real(casaflux%nsimm,sp), cnt, otmp4patch )
-       call put_casa_var_grid_patch(file_id, vid1(34), real(casaflux%nsnet,sp), cnt, otmp4patch )
-       call put_casa_var_grid_patch(file_id, vid1(35), real(casaflux%fnminloss,sp), cnt, otmp4patch )
-       call put_casa_var_grid_patch(file_id, vid1(36), real(casapool%nsoilmin,sp), cnt, otmp4patch )
+       call put_casa_var_grid_patch(file_id, vid1(25), real(casabal%sumnbal,r1), cnt, otmp4patch )
+       call put_casa_var_grid_patch(file_id, vid1(26), real(casaflux%nminfix,r1), cnt, otmp4patch )
+       call put_casa_var_grid_patch(file_id, vid1(27), real(casaflux%nmindep,r1), cnt, otmp4patch )
+       call put_casa_var_grid_patch(file_id, vid1(28), real(casaflux%nminloss,r1), cnt, otmp4patch )
+       call put_casa_var_grid_patch(file_id, vid1(29), real(casaflux%nminleach,r1), cnt, otmp4patch )
+       call put_casa_var_grid_patch(file_id, vid1(30), real(casaflux%nupland,r1), cnt, otmp4patch )
+       call put_casa_var_grid_patch(file_id, vid1(31), real(casaflux%nlittermin,r1), cnt, otmp4patch )
+       call put_casa_var_grid_patch(file_id, vid1(32), real(casaflux%nsmin,r1), cnt, otmp4patch )
+       call put_casa_var_grid_patch(file_id, vid1(33), real(casaflux%nsimm,r1), cnt, otmp4patch )
+       call put_casa_var_grid_patch(file_id, vid1(34), real(casaflux%nsnet,r1), cnt, otmp4patch )
+       call put_casa_var_grid_patch(file_id, vid1(35), real(casaflux%fnminloss,r1), cnt, otmp4patch )
+       call put_casa_var_grid_patch(file_id, vid1(36), real(casapool%nsoilmin,r1), cnt, otmp4patch )
     endif
 
     ! P
     if (icycle > 2) then
-       call put_casa_var_grid_patch(file_id, vid1(37), real(casapool%psoillab,sp), cnt, otmp4patch )
-       call put_casa_var_grid_patch(file_id, vid1(38), real(casapool%psoilsorb,sp), cnt, otmp4patch )
-       call put_casa_var_grid_patch(file_id, vid1(39), real(casapool%psoilocc,sp), cnt, otmp4patch )
-       call put_casa_var_grid_patch(file_id, vid1(40), real(casabal%sumpbal,sp), cnt, otmp4patch )
-       call put_casa_var_grid_patch(file_id, vid1(41), real(casaflux%plabuptake,sp), cnt, otmp4patch )
-       call put_casa_var_grid_patch(file_id, vid1(42), real(casaflux%pdep,sp), cnt, otmp4patch )
-       call put_casa_var_grid_patch(file_id, vid1(43), real(casaflux%pwea,sp), cnt, otmp4patch )
-       call put_casa_var_grid_patch(file_id, vid1(44), real(casaflux%pleach,sp), cnt, otmp4patch )
-       call put_casa_var_grid_patch(file_id, vid1(45), real(casaflux%ploss,sp), cnt, otmp4patch )
-       call put_casa_var_grid_patch(file_id, vid1(46), real(casaflux%pupland,sp), cnt, otmp4patch )
-       call put_casa_var_grid_patch(file_id, vid1(47), real(casaflux%plittermin,sp), cnt, otmp4patch )
-       call put_casa_var_grid_patch(file_id, vid1(48), real(casaflux%psmin,sp), cnt, otmp4patch )
-       call put_casa_var_grid_patch(file_id, vid1(49), real(casaflux%psimm,sp), cnt, otmp4patch )
-       call put_casa_var_grid_patch(file_id, vid1(50), real(casaflux%psnet,sp), cnt, otmp4patch )
-       call put_casa_var_grid_patch(file_id, vid1(51), real(casaflux%fpleach,sp), cnt, otmp4patch )
-       call put_casa_var_grid_patch(file_id, vid1(52), real(casaflux%kplab,sp), cnt, otmp4patch )
-       call put_casa_var_grid_patch(file_id, vid1(53), real(casaflux%kpsorb,sp), cnt, otmp4patch )
-       call put_casa_var_grid_patch(file_id, vid1(54), real(casaflux%kpocc,sp), cnt, otmp4patch )
-       call put_casa_var_grid_patch(file_id, vid1(55), real(casaflux%kmlabp,sp), cnt, otmp4patch )
-       call put_casa_var_grid_patch(file_id, vid1(56), real(casaflux%psorbmax,sp), cnt, otmp4patch )
+       call put_casa_var_grid_patch(file_id, vid1(37), real(casapool%psoillab,r1), cnt, otmp4patch )
+       call put_casa_var_grid_patch(file_id, vid1(38), real(casapool%psoilsorb,r1), cnt, otmp4patch )
+       call put_casa_var_grid_patch(file_id, vid1(39), real(casapool%psoilocc,r1), cnt, otmp4patch )
+       call put_casa_var_grid_patch(file_id, vid1(40), real(casabal%sumpbal,r1), cnt, otmp4patch )
+       call put_casa_var_grid_patch(file_id, vid1(41), real(casaflux%plabuptake,r1), cnt, otmp4patch )
+       call put_casa_var_grid_patch(file_id, vid1(42), real(casaflux%pdep,r1), cnt, otmp4patch )
+       call put_casa_var_grid_patch(file_id, vid1(43), real(casaflux%pwea,r1), cnt, otmp4patch )
+       call put_casa_var_grid_patch(file_id, vid1(44), real(casaflux%pleach,r1), cnt, otmp4patch )
+       call put_casa_var_grid_patch(file_id, vid1(45), real(casaflux%ploss,r1), cnt, otmp4patch )
+       call put_casa_var_grid_patch(file_id, vid1(46), real(casaflux%pupland,r1), cnt, otmp4patch )
+       call put_casa_var_grid_patch(file_id, vid1(47), real(casaflux%plittermin,r1), cnt, otmp4patch )
+       call put_casa_var_grid_patch(file_id, vid1(48), real(casaflux%psmin,r1), cnt, otmp4patch )
+       call put_casa_var_grid_patch(file_id, vid1(49), real(casaflux%psimm,r1), cnt, otmp4patch )
+       call put_casa_var_grid_patch(file_id, vid1(50), real(casaflux%psnet,r1), cnt, otmp4patch )
+       call put_casa_var_grid_patch(file_id, vid1(51), real(casaflux%fpleach,r1), cnt, otmp4patch )
+       call put_casa_var_grid_patch(file_id, vid1(52), real(casaflux%kplab,r1), cnt, otmp4patch )
+       call put_casa_var_grid_patch(file_id, vid1(53), real(casaflux%kpsorb,r1), cnt, otmp4patch )
+       call put_casa_var_grid_patch(file_id, vid1(54), real(casaflux%kpocc,r1), cnt, otmp4patch )
+       call put_casa_var_grid_patch(file_id, vid1(55), real(casaflux%kmlabp,r1), cnt, otmp4patch )
+       call put_casa_var_grid_patch(file_id, vid1(56), real(casaflux%psorbmax,r1), cnt, otmp4patch )
     endif
 
     ! 4D vars (x,y,mplant,t)
     ! C
-    call put_casa_var_grid_patch_average(file_id, vid2(1), real(casapool%cplant,sp),      "mplant", cnt, otmp4plant)
-    call put_casa_var_grid_patch_average(file_id, vid2(2), real(casaflux%fracCalloc,sp),  "mplant", cnt, otmp4plant)
-    call put_casa_var_grid_patch_average(file_id, vid2(3), real(casaflux%kplant,sp),      "mplant", cnt, otmp4plant)
-    call put_casa_var_grid_patch_average(file_id, vid2(4), real(casaflux%crmplant,sp),    "mplant", cnt, otmp4plant)
-    call put_casa_var_grid_patch_average(file_id, vid2(5), real(casaflux%kplant_fire,sp), "mplant", cnt, otmp4plant)
+    call put_casa_var_grid_patch_average(file_id, vid2(1), real(casapool%cplant,r1),      "mplant", cnt, otmp4plant)
+    call put_casa_var_grid_patch_average(file_id, vid2(2), real(casaflux%fracCalloc,r1),  "mplant", cnt, otmp4plant)
+    call put_casa_var_grid_patch_average(file_id, vid2(3), real(casaflux%kplant,r1),      "mplant", cnt, otmp4plant)
+    call put_casa_var_grid_patch_average(file_id, vid2(4), real(casaflux%crmplant,r1),    "mplant", cnt, otmp4plant)
+    call put_casa_var_grid_patch_average(file_id, vid2(5), real(casaflux%kplant_fire,r1), "mplant", cnt, otmp4plant)
 
     ! N
     if (icycle > 1) then
-      call put_casa_var_grid_patch_average(file_id, vid2(6), real(casapool%nplant,sp),     "mplant", cnt, otmp4plant)
-      call put_casa_var_grid_patch_average(file_id, vid2(7), real(casaflux%fracnalloc,sp), "mplant", cnt, otmp4plant)
+      call put_casa_var_grid_patch_average(file_id, vid2(6), real(casapool%nplant,r1),     "mplant", cnt, otmp4plant)
+      call put_casa_var_grid_patch_average(file_id, vid2(7), real(casaflux%fracnalloc,r1), "mplant", cnt, otmp4plant)
     endif
 
     ! P
     if (icycle > 2) then
-       call put_casa_var_grid_patch_average(file_id, vid2(8), real(casapool%pplant,sp),     "mplant", cnt, otmp4plant)
-       call put_casa_var_grid_patch_average(file_id, vid2(9), real(casaflux%fracpalloc,sp), "mplant", cnt, otmp4plant)
+       call put_casa_var_grid_patch_average(file_id, vid2(8), real(casapool%pplant,r1),     "mplant", cnt, otmp4plant)
+       call put_casa_var_grid_patch_average(file_id, vid2(9), real(casaflux%fracpalloc,r1), "mplant", cnt, otmp4plant)
     endif
 
     ! 4D vars (x,y,mlitter,t)
     ! C
-    call put_casa_var_grid_patch_average(file_id, vid3(1), real(casapool%clitter,sp),              "mlitter", cnt, otmp4litter)
-    call put_casa_var_grid_patch_average(file_id, vid3(2), real(casaflux%klitter,sp),              "mlitter", cnt, otmp4litter)
-    call put_casa_var_grid_patch_average(file_id, vid3(3), real(casaflux%fromltoco2,sp),           "mlitter", cnt, otmp4litter)
-    call put_casa_var_grid_patch_average(file_id, vid3(4), real(casaflux%fluxctolitter,sp),        "mlitter", cnt, otmp4litter)
-    call put_casa_var_grid_patch_average(file_id, vid3(5), real(casaflux%fluxcleaftolitter,sp),     "mlitter", cnt, otmp4litter)
-    call put_casa_var_grid_patch_average(file_id, vid3(6), real(casaflux%fluxcwoodtolitter,sp),     "mlitter", cnt, otmp4litter)
-    call put_casa_var_grid_patch_average(file_id, vid3(7), real(casaflux%fluxcfineroottolitter,sp), "mlitter", cnt, otmp4litter)
-    call put_casa_var_grid_patch_average(file_id, vid3(8), real(casaflux%klitter_fire,sp),         "mlitter", cnt, otmp4litter)
+    call put_casa_var_grid_patch_average(file_id, vid3(1), real(casapool%clitter,r1),              "mlitter", cnt, otmp4litter)
+    call put_casa_var_grid_patch_average(file_id, vid3(2), real(casaflux%klitter,r1),              "mlitter", cnt, otmp4litter)
+    call put_casa_var_grid_patch_average(file_id, vid3(3), real(casaflux%fromltoco2,r1),           "mlitter", cnt, otmp4litter)
+    call put_casa_var_grid_patch_average(file_id, vid3(4), real(casaflux%fluxctolitter,r1),        "mlitter", cnt, otmp4litter)
+    call put_casa_var_grid_patch_average(file_id, vid3(5), real(casaflux%fluxcleaftolitter,r1),     "mlitter", cnt, otmp4litter)
+    call put_casa_var_grid_patch_average(file_id, vid3(6), real(casaflux%fluxcwoodtolitter,r1),     "mlitter", cnt, otmp4litter)
+    call put_casa_var_grid_patch_average(file_id, vid3(7), real(casaflux%fluxcfineroottolitter,r1), "mlitter", cnt, otmp4litter)
+    call put_casa_var_grid_patch_average(file_id, vid3(8), real(casaflux%klitter_fire,r1),         "mlitter", cnt, otmp4litter)
 
     ! N
     if (icycle > 1) then
-       call put_casa_var_grid_patch_average(file_id, vid3(9), real(casapool%nlitter,sp),       "mlitter", cnt, otmp4litter)
-       call put_casa_var_grid_patch_average(file_id, vid3(10), real(casaflux%fluxntolitter,sp), "mlitter", cnt, otmp4litter)
+       call put_casa_var_grid_patch_average(file_id, vid3(9), real(casapool%nlitter,r1),       "mlitter", cnt, otmp4litter)
+       call put_casa_var_grid_patch_average(file_id, vid3(10), real(casaflux%fluxntolitter,r1), "mlitter", cnt, otmp4litter)
     endif
 
     ! P
     if (icycle > 2) then
-       call put_casa_var_grid_patch_average(file_id, vid3(11), real(casapool%plitter,sp),       "mlitter", cnt, otmp4litter)
-       call put_casa_var_grid_patch_average(file_id, vid3(12), real(casaflux%fluxptolitter,sp), "mlitter", cnt, otmp4litter)
+       call put_casa_var_grid_patch_average(file_id, vid3(11), real(casapool%plitter,r1),       "mlitter", cnt, otmp4litter)
+       call put_casa_var_grid_patch_average(file_id, vid3(12), real(casaflux%fluxptolitter,r1), "mlitter", cnt, otmp4litter)
     endif
 
     ! 4d vars (x,y,msoil,t)
     ! C
-    call put_casa_var_grid_patch_average(file_id, vid4(1), real(casapool%csoil,sp),       "msoil", cnt, otmp4soil)
-    call put_casa_var_grid_patch_average(file_id, vid4(2), real(casaflux%ksoil,sp),       "msoil", cnt, otmp4soil)
-    call put_casa_var_grid_patch_average(file_id, vid4(3), real(casaflux%fromstoco2,sp),  "msoil", cnt, otmp4soil)
-    call put_casa_var_grid_patch_average(file_id, vid4(4), real(casaflux%fluxctosoil,sp), "msoil", cnt, otmp4soil)
+    call put_casa_var_grid_patch_average(file_id, vid4(1), real(casapool%csoil,r1),       "msoil", cnt, otmp4soil)
+    call put_casa_var_grid_patch_average(file_id, vid4(2), real(casaflux%ksoil,r1),       "msoil", cnt, otmp4soil)
+    call put_casa_var_grid_patch_average(file_id, vid4(3), real(casaflux%fromstoco2,r1),  "msoil", cnt, otmp4soil)
+    call put_casa_var_grid_patch_average(file_id, vid4(4), real(casaflux%fluxctosoil,r1), "msoil", cnt, otmp4soil)
 
     ! N
     if (icycle > 1) then
-       call put_casa_var_grid_patch_average(file_id, vid4(5), real(casapool%nsoil,sp),       "msoil", cnt, otmp4soil)
-       call put_casa_var_grid_patch_average(file_id, vid4(6), real(casaflux%fluxntosoil,sp), "msoil", cnt, otmp4soil)
+       call put_casa_var_grid_patch_average(file_id, vid4(5), real(casapool%nsoil,r1),       "msoil", cnt, otmp4soil)
+       call put_casa_var_grid_patch_average(file_id, vid4(6), real(casaflux%fluxntosoil,r1), "msoil", cnt, otmp4soil)
     endif
 
     ! P
     if (icycle > 2) then
-       call put_casa_var_grid_patch_average(file_id, vid4(7), real(casapool%psoil,sp),       "msoil", cnt, otmp4soil)
-       call put_casa_var_grid_patch_average(file_id, vid4(8), real(casaflux%fluxptosoil,sp), "msoil", cnt, otmp4soil)
+       call put_casa_var_grid_patch_average(file_id, vid4(7), real(casapool%psoil,r1),       "msoil", cnt, otmp4soil)
+       call put_casa_var_grid_patch_average(file_id, vid4(8), real(casaflux%fluxptosoil,r1), "msoil", cnt, otmp4soil)
     endif
 
     ! put 4d vars ( mp, mlitter,mplant, t )
     ! C
-    !status = nf90_put_var(file_id, vid5(1), real(casaflux%fromptol,sp), start=(/1,1,1,cnt/), count=(/mp,mlitter,mplant,1/))
+    !status = nf90_put_var(file_id, vid5(1), real(casaflux%fromptol,r1), start=(/1,1,1,cnt/), count=(/mp,mlitter,mplant,1/))
     !if(status /= nf90_noerr) call handle_err(status)
 
     ! put 4d vars ( mp, msoil, mlitter, t )
     ! C
-    !status = nf90_put_var(file_id, vid6(1), real(casaflux%fromltos,sp), start=(/1,1,1,cnt/), count=(/mp,msoil,mlitter,1/))
+    !status = nf90_put_var(file_id, vid6(1), real(casaflux%fromltos,r1), start=(/1,1,1,cnt/), count=(/mp,msoil,mlitter,1/))
     !if(status /= nf90_noerr) call handle_err(status)
 
     ! put 4d vars ( mp, msoil, msoil, t )
     ! C
-    !status = nf90_put_var(file_id, vid7(1), real(casaflux%fromstos,sp), start=(/1,1,1,cnt/), count=(/mp,msoil,msoil,1/))
+    !status = nf90_put_var(file_id, vid7(1), real(casaflux%fromstos,r1), start=(/1,1,1,cnt/), count=(/mp,msoil,msoil,1/))
     !if(status /= nf90_noerr) call handle_err(status)
 
     if ( lfinal ) then
@@ -2774,9 +2778,9 @@ contains
 
    INTEGER, INTENT(IN) :: file_id                               ! netcdf file ID 
    INTEGER, INTENT(IN) :: var_id                                ! variable's netcdf ID
-   REAL(KIND=r_1), DIMENSION(:), INTENT(IN) :: var_vals           ! variable values
+   REAL(KIND=r1), DIMENSION(:), INTENT(IN) :: var_vals           ! variable values
    INTEGER, INTENT(IN) :: cnt                                   ! current time step #
-   REAL(KIND=r_1), DIMENSION(:,:,:,:), INTENT(INOUT) :: tmp_array ! temporary array   
+   REAL(KIND=r1), DIMENSION(:,:,:,:), INTENT(INOUT) :: tmp_array ! temporary array   
 
    ! Local variables
    INTEGER                                       :: i, j   ! counters
@@ -2819,10 +2823,10 @@ SUBROUTINE put_casa_var_grid_patch_average(file_id,var_id,var_vals,outdim,cnt,tm
 
    INTEGER, INTENT(IN) :: file_id                               ! netcdf file ID 
    INTEGER, INTENT(IN) :: var_id                                ! variable's netcdf ID
-   REAL(KIND=r_1), DIMENSION(:,:), INTENT(IN) :: var_vals         ! variable values
+   REAL(KIND=r1), DIMENSION(:,:), INTENT(IN) :: var_vals         ! variable values
    CHARACTER(LEN=*), INTENT(IN) :: outdim                       ! 3rd dimension of output ('mplant','mlitter','msoil') 
    INTEGER, INTENT(IN) :: cnt                                   ! current time step #
-   REAL(KIND=r_1), DIMENSION(:,:,:,:), INTENT(INOUT) :: tmp_array ! temporary array   
+   REAL(KIND=r1), DIMENSION(:,:,:,:), INTENT(INOUT) :: tmp_array ! temporary array   
 
    ! Local variables
    INTEGER                                       :: ndim3  ! size of 3rd dimension
@@ -2864,6 +2868,8 @@ END SUBROUTINE put_casa_var_grid_patch_average
    ! see r9609 for a grid level output, which is overwritten here.
    ! see r9610 for code that allows 4D casa outputs (e.g. land,patch,mplant,time)
 
+    use, intrinsic :: iso_c_binding, only: c_float
+
     use casadimension,        only: mplant, mlitter, msoil, icycle
     use casavariable,         only: casa_met, casa_pool, casa_balance, casa_flux, &
          casafile, casa_timeunits
@@ -2895,7 +2901,7 @@ END SUBROUTINE put_casa_var_grid_patch_average
     character(len=99) :: fname
     character(len=50) :: dum
     logical, save :: call1 = .true.
-    integer, parameter :: sp = kind(1.0)
+    integer, parameter :: r1 = c_float
 
     ! 1 dim arrays (land)
     character(len=21), dimension(2)  :: a0
@@ -3276,7 +3282,7 @@ END SUBROUTINE put_casa_var_grid_patch_average
          if (status /= nf90_noerr) call handle_err(status)
          status = nf90_put_att(file_id, vid0(i), 'units', trim(u0(i)))
          if (status /= nf90_noerr) call handle_err(status)
-         status = nf90_put_att(file_id, vid0(i), '_FillValue', real(ncmissingr,sp))
+         status = nf90_put_att(file_id, vid0(i), '_FillValue', real(ncmissingr,r1))
          if (status /= nf90_noerr) call handle_err(status)
       end do
 
@@ -3289,7 +3295,7 @@ END SUBROUTINE put_casa_var_grid_patch_average
           if (status /= nf90_noerr) call handle_err(status)
           status = nf90_put_att(file_id, vid1(i), 'units', trim(u1(i)))
           if (status /= nf90_noerr) call handle_err(status)
-          status = nf90_put_att(file_id, vid1(i), '_FillValue', real(ncmissingr,sp))
+          status = nf90_put_att(file_id, vid1(i), '_FillValue', real(ncmissingr,r1))
           if (status /= nf90_noerr) call handle_err(status)
        end do
 
@@ -3302,7 +3308,7 @@ END SUBROUTINE put_casa_var_grid_patch_average
           if (status /= nf90_noerr) call handle_err(status)
           status = nf90_put_att(file_id, vid2(i), 'units', trim(u2(i)))
           if (status /= nf90_noerr) call handle_err(status)
-          status = nf90_put_att(file_id, vid2(i), '_FillValue', real(ncmissingr,sp))
+          status = nf90_put_att(file_id, vid2(i), '_FillValue', real(ncmissingr,r1))
           if (status /= nf90_noerr) call handle_err(status)
        end do
 
@@ -3315,7 +3321,7 @@ END SUBROUTINE put_casa_var_grid_patch_average
           if (status /= nf90_noerr) call handle_err(status)
           status = nf90_put_att(file_id, vid3(i), 'units', trim(u3(i)))
           if (status /= nf90_noerr) call handle_err(status)
-          status = nf90_put_att(file_id, vid3(i), '_FillValue', real(ncmissingr,sp))
+          status = nf90_put_att(file_id, vid3(i), '_FillValue', real(ncmissingr,r1))
           if (status /= nf90_noerr) call handle_err(status)
        end do
 
@@ -3328,7 +3334,7 @@ END SUBROUTINE put_casa_var_grid_patch_average
           if (status /= nf90_noerr) call handle_err(status)
           status = nf90_put_att(file_id, vid4(i), 'units', trim(u4(i)))
           if (status /= nf90_noerr) call handle_err(status)
-          status = nf90_put_att(file_id, vid4(i), '_FillValue', real(ncmissingr,sp))
+          status = nf90_put_att(file_id, vid4(i), '_FillValue', real(ncmissingr,r1))
           if (status /= nf90_noerr) call handle_err(status)
        end do
 
@@ -3337,14 +3343,14 @@ END SUBROUTINE put_casa_var_grid_patch_average
        if (status /= nf90_noerr) call handle_err(status)
 
        ! put y and x and local lat and lon
-       status = nf90_put_var(file_id, vidy, real(lat_all(1,:),sp))
+       status = nf90_put_var(file_id, vidy, real(lat_all(1,:),r1))
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, vidx, real(lon_all(:,1),sp))
+       status = nf90_put_var(file_id, vidx, real(lon_all(:,1),r1))
        if(status /= nf90_noerr) call handle_err(status)
 
-       status = nf90_put_var(file_id, llat_id, real(latitude,sp))
+       status = nf90_put_var(file_id, llat_id, real(latitude,r1))
        if(status /= nf90_noerr) call handle_err(status)
-       status = nf90_put_var(file_id, llon_id, real(longitude,sp))
+       status = nf90_put_var(file_id, llon_id, real(longitude,r1))
        if(status /= nf90_noerr) call handle_err(status)
 
        ! put longitude and latitude
@@ -3375,144 +3381,144 @@ END SUBROUTINE put_casa_var_grid_patch_average
     if(status /= nf90_noerr) call handle_err(status)
 
     ! patchfrac and area
-    call put_casa_var_patch(file_id,vid1(1), real(patch(:)%frac,sp), cnt, otmp3patch)
-    call put_casa_var_patch(file_id,vid1(2), real(casamet%areacell,sp), cnt, otmp3patch)
+    call put_casa_var_patch(file_id,vid1(1), real(patch(:)%frac,r1), cnt, otmp3patch)
+    call put_casa_var_patch(file_id,vid1(2), real(casamet%areacell,r1), cnt, otmp3patch)
     ! 4D vars (land,patch,t)
     ! C
-    call put_casa_var_patch(file_id, vid1(3), real(casamet%glai,sp), cnt, otmp3patch)
-    call put_casa_var_patch(file_id, vid1(4), real(casapool%clabile,sp), cnt, otmp3patch)
-    call put_casa_var_patch(file_id, vid1(5), real(casabal%sumcbal,sp), cnt, otmp3patch)
-    call put_casa_var_patch(file_id, vid1(6), real(casaflux%cgpp,sp), cnt, otmp3patch)
-    call put_casa_var_patch(file_id, vid1(7), real(casaflux%cnpp,sp), cnt, otmp3patch)
-    call put_casa_var_patch(file_id, vid1(8), real(casaflux%stemnpp,sp), cnt, otmp3patch)
-    call put_casa_var_patch(file_id, vid1(9), real(casaflux%crp,sp), cnt, otmp3patch)
-    call put_casa_var_patch(file_id, vid1(10), real(casaflux%crgplant,sp), cnt, otmp3patch)
-    call put_casa_var_patch(file_id, vid1(11), real(casaflux%clabloss,sp), cnt, otmp3patch)
-    call put_casa_var_patch(file_id, vid1(12), real(casaflux%fracclabile,sp), cnt, otmp3patch )
-    call put_casa_var_patch(file_id, vid1(13), real(casaflux%cnep,sp), cnt, otmp3patch)
-    call put_casa_var_patch(file_id, vid1(14), real(casaflux%crsoil,sp), cnt, otmp3patch)
-    call put_casa_var_patch(file_id, vid1(15), real(casaflux%fluxctoco2,sp), cnt, otmp3patch)
-    call put_casa_var_patch(file_id, vid1(16), real(casabal%fcgppyear,sp), cnt, otmp3patch)
-    call put_casa_var_patch(file_id, vid1(17), real(casabal%fcrpyear,sp), cnt, otmp3patch)
-    call put_casa_var_patch(file_id, vid1(18), real(casabal%fcnppyear,sp), cnt, otmp3patch)
-    call put_casa_var_patch(file_id, vid1(19), real(casabal%fcrsyear,sp), cnt, otmp3patch)
-    call put_casa_var_patch(file_id, vid1(20), real(casabal%fcneeyear,sp), cnt, otmp3patch)
-    call put_casa_var_patch(file_id, vid1(21), real(veg%vcmax,sp), cnt, otmp3patch)
-    call put_casa_var_patch(file_id, vid1(22), real(casaflux%CallocLeaf,sp), cnt, otmp3patch)
-    call put_casa_var_patch(file_id, vid1(23), real(casaflux%CallocWood,sp), cnt, otmp3patch)
-    call put_casa_var_patch(file_id, vid1(24), real(casaflux%CallocFineRoot,sp), cnt, otmp3patch)
+    call put_casa_var_patch(file_id, vid1(3), real(casamet%glai,r1), cnt, otmp3patch)
+    call put_casa_var_patch(file_id, vid1(4), real(casapool%clabile,r1), cnt, otmp3patch)
+    call put_casa_var_patch(file_id, vid1(5), real(casabal%sumcbal,r1), cnt, otmp3patch)
+    call put_casa_var_patch(file_id, vid1(6), real(casaflux%cgpp,r1), cnt, otmp3patch)
+    call put_casa_var_patch(file_id, vid1(7), real(casaflux%cnpp,r1), cnt, otmp3patch)
+    call put_casa_var_patch(file_id, vid1(8), real(casaflux%stemnpp,r1), cnt, otmp3patch)
+    call put_casa_var_patch(file_id, vid1(9), real(casaflux%crp,r1), cnt, otmp3patch)
+    call put_casa_var_patch(file_id, vid1(10), real(casaflux%crgplant,r1), cnt, otmp3patch)
+    call put_casa_var_patch(file_id, vid1(11), real(casaflux%clabloss,r1), cnt, otmp3patch)
+    call put_casa_var_patch(file_id, vid1(12), real(casaflux%fracclabile,r1), cnt, otmp3patch )
+    call put_casa_var_patch(file_id, vid1(13), real(casaflux%cnep,r1), cnt, otmp3patch)
+    call put_casa_var_patch(file_id, vid1(14), real(casaflux%crsoil,r1), cnt, otmp3patch)
+    call put_casa_var_patch(file_id, vid1(15), real(casaflux%fluxctoco2,r1), cnt, otmp3patch)
+    call put_casa_var_patch(file_id, vid1(16), real(casabal%fcgppyear,r1), cnt, otmp3patch)
+    call put_casa_var_patch(file_id, vid1(17), real(casabal%fcrpyear,r1), cnt, otmp3patch)
+    call put_casa_var_patch(file_id, vid1(18), real(casabal%fcnppyear,r1), cnt, otmp3patch)
+    call put_casa_var_patch(file_id, vid1(19), real(casabal%fcrsyear,r1), cnt, otmp3patch)
+    call put_casa_var_patch(file_id, vid1(20), real(casabal%fcneeyear,r1), cnt, otmp3patch)
+    call put_casa_var_patch(file_id, vid1(21), real(veg%vcmax,r1), cnt, otmp3patch)
+    call put_casa_var_patch(file_id, vid1(22), real(casaflux%CallocLeaf,r1), cnt, otmp3patch)
+    call put_casa_var_patch(file_id, vid1(23), real(casaflux%CallocWood,r1), cnt, otmp3patch)
+    call put_casa_var_patch(file_id, vid1(24), real(casaflux%CallocFineRoot,r1), cnt, otmp3patch)
 
     ! N
     if (icycle > 1) then
-       call put_casa_var_patch(file_id, vid1(25), real(casabal%sumnbal,sp), cnt, otmp3patch )
-       call put_casa_var_patch(file_id, vid1(26), real(casaflux%nminfix,sp), cnt, otmp3patch )
-       call put_casa_var_patch(file_id, vid1(27), real(casaflux%nmindep,sp), cnt, otmp3patch )
-       call put_casa_var_patch(file_id, vid1(28), real(casaflux%nminloss,sp), cnt, otmp3patch )
-       call put_casa_var_patch(file_id, vid1(29), real(casaflux%nminleach,sp), cnt, otmp3patch )
-       call put_casa_var_patch(file_id, vid1(30), real(casaflux%nupland,sp), cnt, otmp3patch )
-       call put_casa_var_patch(file_id, vid1(31), real(casaflux%nlittermin,sp), cnt, otmp3patch )
-       call put_casa_var_patch(file_id, vid1(32), real(casaflux%nsmin,sp), cnt, otmp3patch )
-       call put_casa_var_patch(file_id, vid1(33), real(casaflux%nsimm,sp), cnt, otmp3patch )
-       call put_casa_var_patch(file_id, vid1(34), real(casaflux%nsnet,sp), cnt, otmp3patch )
-       call put_casa_var_patch(file_id, vid1(35), real(casaflux%fnminloss,sp), cnt, otmp3patch )
-       call put_casa_var_patch(file_id, vid1(36), real(casapool%nsoilmin,sp), cnt, otmp3patch )
+       call put_casa_var_patch(file_id, vid1(25), real(casabal%sumnbal,r1), cnt, otmp3patch )
+       call put_casa_var_patch(file_id, vid1(26), real(casaflux%nminfix,r1), cnt, otmp3patch )
+       call put_casa_var_patch(file_id, vid1(27), real(casaflux%nmindep,r1), cnt, otmp3patch )
+       call put_casa_var_patch(file_id, vid1(28), real(casaflux%nminloss,r1), cnt, otmp3patch )
+       call put_casa_var_patch(file_id, vid1(29), real(casaflux%nminleach,r1), cnt, otmp3patch )
+       call put_casa_var_patch(file_id, vid1(30), real(casaflux%nupland,r1), cnt, otmp3patch )
+       call put_casa_var_patch(file_id, vid1(31), real(casaflux%nlittermin,r1), cnt, otmp3patch )
+       call put_casa_var_patch(file_id, vid1(32), real(casaflux%nsmin,r1), cnt, otmp3patch )
+       call put_casa_var_patch(file_id, vid1(33), real(casaflux%nsimm,r1), cnt, otmp3patch )
+       call put_casa_var_patch(file_id, vid1(34), real(casaflux%nsnet,r1), cnt, otmp3patch )
+       call put_casa_var_patch(file_id, vid1(35), real(casaflux%fnminloss,r1), cnt, otmp3patch )
+       call put_casa_var_patch(file_id, vid1(36), real(casapool%nsoilmin,r1), cnt, otmp3patch )
     endif
     ! P
     if (icycle > 2) then
-       call put_casa_var_patch(file_id, vid1(37), real(casapool%psoillab,sp), cnt, otmp3patch )
-       call put_casa_var_patch(file_id, vid1(38), real(casapool%psoilsorb,sp), cnt, otmp3patch )
-       call put_casa_var_patch(file_id, vid1(39), real(casapool%psoilocc,sp), cnt, otmp3patch )
-       call put_casa_var_patch(file_id, vid1(40), real(casabal%sumpbal,sp), cnt, otmp3patch )
-       call put_casa_var_patch(file_id, vid1(41), real(casaflux%plabuptake,sp), cnt, otmp3patch )
-       call put_casa_var_patch(file_id, vid1(42), real(casaflux%pdep,sp), cnt, otmp3patch )
-       call put_casa_var_patch(file_id, vid1(43), real(casaflux%pwea,sp), cnt, otmp3patch )
-       call put_casa_var_patch(file_id, vid1(44), real(casaflux%pleach,sp), cnt, otmp3patch )
-       call put_casa_var_patch(file_id, vid1(45), real(casaflux%ploss,sp), cnt, otmp3patch )
-       call put_casa_var_patch(file_id, vid1(46), real(casaflux%pupland,sp), cnt, otmp3patch )
-       call put_casa_var_patch(file_id, vid1(47), real(casaflux%plittermin,sp), cnt, otmp3patch )
-       call put_casa_var_patch(file_id, vid1(48), real(casaflux%psmin,sp), cnt, otmp3patch )
-       call put_casa_var_patch(file_id, vid1(49), real(casaflux%psimm,sp), cnt, otmp3patch )
-       call put_casa_var_patch(file_id, vid1(50), real(casaflux%psnet,sp), cnt, otmp3patch )
-       call put_casa_var_patch(file_id, vid1(51), real(casaflux%fpleach,sp), cnt, otmp3patch )
-       call put_casa_var_patch(file_id, vid1(52), real(casaflux%kplab,sp), cnt, otmp3patch )
-       call put_casa_var_patch(file_id, vid1(53), real(casaflux%kpsorb,sp), cnt, otmp3patch )
-       call put_casa_var_patch(file_id, vid1(54), real(casaflux%kpocc,sp), cnt, otmp3patch )
-       call put_casa_var_patch(file_id, vid1(55), real(casaflux%kmlabp,sp), cnt, otmp3patch )
-       call put_casa_var_patch(file_id, vid1(56), real(casaflux%psorbmax,sp), cnt, otmp3patch )
+       call put_casa_var_patch(file_id, vid1(37), real(casapool%psoillab,r1), cnt, otmp3patch )
+       call put_casa_var_patch(file_id, vid1(38), real(casapool%psoilsorb,r1), cnt, otmp3patch )
+       call put_casa_var_patch(file_id, vid1(39), real(casapool%psoilocc,r1), cnt, otmp3patch )
+       call put_casa_var_patch(file_id, vid1(40), real(casabal%sumpbal,r1), cnt, otmp3patch )
+       call put_casa_var_patch(file_id, vid1(41), real(casaflux%plabuptake,r1), cnt, otmp3patch )
+       call put_casa_var_patch(file_id, vid1(42), real(casaflux%pdep,r1), cnt, otmp3patch )
+       call put_casa_var_patch(file_id, vid1(43), real(casaflux%pwea,r1), cnt, otmp3patch )
+       call put_casa_var_patch(file_id, vid1(44), real(casaflux%pleach,r1), cnt, otmp3patch )
+       call put_casa_var_patch(file_id, vid1(45), real(casaflux%ploss,r1), cnt, otmp3patch )
+       call put_casa_var_patch(file_id, vid1(46), real(casaflux%pupland,r1), cnt, otmp3patch )
+       call put_casa_var_patch(file_id, vid1(47), real(casaflux%plittermin,r1), cnt, otmp3patch )
+       call put_casa_var_patch(file_id, vid1(48), real(casaflux%psmin,r1), cnt, otmp3patch )
+       call put_casa_var_patch(file_id, vid1(49), real(casaflux%psimm,r1), cnt, otmp3patch )
+       call put_casa_var_patch(file_id, vid1(50), real(casaflux%psnet,r1), cnt, otmp3patch )
+       call put_casa_var_patch(file_id, vid1(51), real(casaflux%fpleach,r1), cnt, otmp3patch )
+       call put_casa_var_patch(file_id, vid1(52), real(casaflux%kplab,r1), cnt, otmp3patch )
+       call put_casa_var_patch(file_id, vid1(53), real(casaflux%kpsorb,r1), cnt, otmp3patch )
+       call put_casa_var_patch(file_id, vid1(54), real(casaflux%kpocc,r1), cnt, otmp3patch )
+       call put_casa_var_patch(file_id, vid1(55), real(casaflux%kmlabp,r1), cnt, otmp3patch )
+       call put_casa_var_patch(file_id, vid1(56), real(casaflux%psorbmax,r1), cnt, otmp3patch )
     endif
     ! 4D vars (land,patch,mplant,t)
     ! C
-    call put_casa_var_patch_average(file_id, vid2(1), real(casapool%cplant,sp),      "mplant", cnt, otmp3plant)
-    call put_casa_var_patch_average(file_id, vid2(2), real(casaflux%fracCalloc,sp),  "mplant", cnt, otmp3plant)
-    call put_casa_var_patch_average(file_id, vid2(3), real(casaflux%kplant,sp),      "mplant", cnt, otmp3plant)
-    call put_casa_var_patch_average(file_id, vid2(4), real(casaflux%crmplant,sp),    "mplant", cnt, otmp3plant)
-    call put_casa_var_patch_average(file_id, vid2(5), real(casaflux%kplant_fire,sp), "mplant", cnt, otmp3plant)
+    call put_casa_var_patch_average(file_id, vid2(1), real(casapool%cplant,r1),      "mplant", cnt, otmp3plant)
+    call put_casa_var_patch_average(file_id, vid2(2), real(casaflux%fracCalloc,r1),  "mplant", cnt, otmp3plant)
+    call put_casa_var_patch_average(file_id, vid2(3), real(casaflux%kplant,r1),      "mplant", cnt, otmp3plant)
+    call put_casa_var_patch_average(file_id, vid2(4), real(casaflux%crmplant,r1),    "mplant", cnt, otmp3plant)
+    call put_casa_var_patch_average(file_id, vid2(5), real(casaflux%kplant_fire,r1), "mplant", cnt, otmp3plant)
 
     ! N
     if (icycle > 1) then
-      call put_casa_var_patch_average(file_id, vid2(6), real(casapool%nplant,sp),     "mplant", cnt, otmp3plant)
-      call put_casa_var_patch_average(file_id, vid2(7), real(casaflux%fracnalloc,sp), "mplant", cnt, otmp3plant)
+      call put_casa_var_patch_average(file_id, vid2(6), real(casapool%nplant,r1),     "mplant", cnt, otmp3plant)
+      call put_casa_var_patch_average(file_id, vid2(7), real(casaflux%fracnalloc,r1), "mplant", cnt, otmp3plant)
     endif
 
     ! P
     if (icycle > 2) then
-       call put_casa_var_patch_average(file_id, vid2(8), real(casapool%pplant,sp),     "mplant", cnt, otmp3plant)
-       call put_casa_var_patch_average(file_id, vid2(9), real(casaflux%fracpalloc,sp), "mplant", cnt, otmp3plant)
+       call put_casa_var_patch_average(file_id, vid2(8), real(casapool%pplant,r1),     "mplant", cnt, otmp3plant)
+       call put_casa_var_patch_average(file_id, vid2(9), real(casaflux%fracpalloc,r1), "mplant", cnt, otmp3plant)
     endif
 
     ! 4D vars (land,patch,mlitter,t)
     ! C
-    call put_casa_var_patch_average(file_id, vid3(1), real(casapool%clitter,sp),               "mlitter", cnt, otmp3litter)
-    call put_casa_var_patch_average(file_id, vid3(2), real(casaflux%klitter,sp),               "mlitter", cnt, otmp3litter)
-    call put_casa_var_patch_average(file_id, vid3(3), real(casaflux%fromltoco2,sp),            "mlitter", cnt, otmp3litter)
-    call put_casa_var_patch_average(file_id, vid3(4), real(casaflux%fluxctolitter,sp),         "mlitter", cnt, otmp3litter)
-    call put_casa_var_patch_average(file_id, vid3(5), real(casaflux%fluxcleaftolitter,sp),     "mlitter", cnt, otmp3litter)
-    call put_casa_var_patch_average(file_id, vid3(6), real(casaflux%fluxcwoodtolitter,sp),     "mlitter", cnt, otmp3litter)
-    call put_casa_var_patch_average(file_id, vid3(7), real(casaflux%fluxcfineroottolitter,sp), "mlitter", cnt, otmp3litter)
-    call put_casa_var_patch_average(file_id, vid3(8), real(casaflux%klitter_fire,sp),          "mlitter", cnt, otmp3litter)
+    call put_casa_var_patch_average(file_id, vid3(1), real(casapool%clitter,r1),               "mlitter", cnt, otmp3litter)
+    call put_casa_var_patch_average(file_id, vid3(2), real(casaflux%klitter,r1),               "mlitter", cnt, otmp3litter)
+    call put_casa_var_patch_average(file_id, vid3(3), real(casaflux%fromltoco2,r1),            "mlitter", cnt, otmp3litter)
+    call put_casa_var_patch_average(file_id, vid3(4), real(casaflux%fluxctolitter,r1),         "mlitter", cnt, otmp3litter)
+    call put_casa_var_patch_average(file_id, vid3(5), real(casaflux%fluxcleaftolitter,r1),     "mlitter", cnt, otmp3litter)
+    call put_casa_var_patch_average(file_id, vid3(6), real(casaflux%fluxcwoodtolitter,r1),     "mlitter", cnt, otmp3litter)
+    call put_casa_var_patch_average(file_id, vid3(7), real(casaflux%fluxcfineroottolitter,r1), "mlitter", cnt, otmp3litter)
+    call put_casa_var_patch_average(file_id, vid3(8), real(casaflux%klitter_fire,r1),          "mlitter", cnt, otmp3litter)
     ! N
     if (icycle > 1) then
-       call put_casa_var_patch_average(file_id, vid3(9), real(casapool%nlitter,sp),       "mlitter", cnt, otmp3litter)
-       call put_casa_var_patch_average(file_id, vid3(10), real(casaflux%fluxntolitter,sp), "mlitter", cnt, otmp3litter)
+       call put_casa_var_patch_average(file_id, vid3(9), real(casapool%nlitter,r1),       "mlitter", cnt, otmp3litter)
+       call put_casa_var_patch_average(file_id, vid3(10), real(casaflux%fluxntolitter,r1), "mlitter", cnt, otmp3litter)
     endif
 
     ! P
     if (icycle > 2) then
-       call put_casa_var_patch_average(file_id, vid3(11), real(casapool%plitter,sp),       "mlitter", cnt, otmp3litter)
-       call put_casa_var_patch_average(file_id, vid3(12), real(casaflux%fluxptolitter,sp), "mlitter", cnt, otmp3litter)
+       call put_casa_var_patch_average(file_id, vid3(11), real(casapool%plitter,r1),       "mlitter", cnt, otmp3litter)
+       call put_casa_var_patch_average(file_id, vid3(12), real(casaflux%fluxptolitter,r1), "mlitter", cnt, otmp3litter)
     endif
 
     ! 4d vars (land,patch,msoil,t)
     ! C
-    call put_casa_var_patch_average(file_id, vid4(1), real(casapool%csoil,sp),       "msoil", cnt, otmp3soil)
-    call put_casa_var_patch_average(file_id, vid4(2), real(casaflux%ksoil,sp),       "msoil", cnt, otmp3soil)
-    call put_casa_var_patch_average(file_id, vid4(3), real(casaflux%fromstoco2,sp),  "msoil", cnt, otmp3soil)
-    call put_casa_var_patch_average(file_id, vid4(4), real(casaflux%fluxctosoil,sp), "msoil", cnt, otmp3soil)
+    call put_casa_var_patch_average(file_id, vid4(1), real(casapool%csoil,r1),       "msoil", cnt, otmp3soil)
+    call put_casa_var_patch_average(file_id, vid4(2), real(casaflux%ksoil,r1),       "msoil", cnt, otmp3soil)
+    call put_casa_var_patch_average(file_id, vid4(3), real(casaflux%fromstoco2,r1),  "msoil", cnt, otmp3soil)
+    call put_casa_var_patch_average(file_id, vid4(4), real(casaflux%fluxctosoil,r1), "msoil", cnt, otmp3soil)
 
     ! N
     if (icycle > 1) then
-       call put_casa_var_patch_average(file_id, vid4(5), real(casapool%nsoil,sp),       "msoil", cnt, otmp3soil)
-       call put_casa_var_patch_average(file_id, vid4(6), real(casaflux%fluxntosoil,sp), "msoil", cnt, otmp3soil)
+       call put_casa_var_patch_average(file_id, vid4(5), real(casapool%nsoil,r1),       "msoil", cnt, otmp3soil)
+       call put_casa_var_patch_average(file_id, vid4(6), real(casaflux%fluxntosoil,r1), "msoil", cnt, otmp3soil)
     endif
 
     ! P
     if (icycle > 2) then
-       call put_casa_var_patch_average(file_id, vid4(7), real(casapool%psoil,sp),       "msoil", cnt, otmp3soil)
-       call put_casa_var_patch_average(file_id, vid4(8), real(casaflux%fluxptosoil,sp), "msoil", cnt, otmp3soil)
+       call put_casa_var_patch_average(file_id, vid4(7), real(casapool%psoil,r1),       "msoil", cnt, otmp3soil)
+       call put_casa_var_patch_average(file_id, vid4(8), real(casaflux%fluxptosoil,r1), "msoil", cnt, otmp3soil)
     endif
     ! put 4d vars ( mp, mlitter,mplant, t )
     ! C
-    !status = nf90_put_var(file_id, vid5(1), real(casaflux%fromptol,sp), start=(/1,1,1,cnt/), count=(/mp,mlitter,mplant,1/))
+    !status = nf90_put_var(file_id, vid5(1), real(casaflux%fromptol,r1), start=(/1,1,1,cnt/), count=(/mp,mlitter,mplant,1/))
     !if(status /= nf90_noerr) call handle_err(status)
 
     ! put 4d vars ( mp, msoil, mlitter, t )
     ! C
-    !status = nf90_put_var(file_id, vid6(1), real(casaflux%fromltos,sp), start=(/1,1,1,cnt/), count=(/mp,msoil,mlitter,1/))
+    !status = nf90_put_var(file_id, vid6(1), real(casaflux%fromltos,r1), start=(/1,1,1,cnt/), count=(/mp,msoil,mlitter,1/))
     !if(status /= nf90_noerr) call handle_err(status)
 
     ! put 4d vars ( mp, msoil, msoil, t )
     ! C
-    !status = nf90_put_var(file_id, vid7(1), real(casaflux%fromstos,sp), start=(/1,1,1,cnt/), count=(/mp,msoil,msoil,1/))
+    !status = nf90_put_var(file_id, vid7(1), real(casaflux%fromstos,r1), start=(/1,1,1,cnt/), count=(/mp,msoil,msoil,1/))
     !if(status /= nf90_noerr) call handle_err(status)
 
     if ( lfinal ) then
@@ -3542,9 +3548,9 @@ END SUBROUTINE put_casa_var_grid_patch_average
 
    INTEGER, INTENT(IN) :: file_id                              ! netcdf file ID 
    INTEGER, INTENT(IN) :: var_id                               ! variable's netcdf ID
-   REAL(KIND=r_1), DIMENSION(:), INTENT(IN) :: var_vals          ! variable values
+   REAL(KIND=r1), DIMENSION(:), INTENT(IN) :: var_vals          ! variable values
    INTEGER, INTENT(IN) :: cnt                                  ! current time step #
-   REAL(KIND=r_1), DIMENSION(:,:,:), INTENT(INOUT) :: tmp_array  ! temporary array   
+   REAL(KIND=r1), DIMENSION(:,:,:), INTENT(INOUT) :: tmp_array  ! temporary array   
 
    ! Local variables
    INTEGER   :: i      ! counter
@@ -3580,10 +3586,10 @@ SUBROUTINE put_casa_var_patch_average(file_id,var_id,var_vals,outdim,cnt,tmp_arr
 
    INTEGER, INTENT(IN) :: file_id                               ! netcdf file ID 
    INTEGER, INTENT(IN) :: var_id                                ! variable's netcdf ID
-   REAL(KIND=r_1), DIMENSION(:,:), INTENT(IN) :: var_vals         ! variable values
+   REAL(KIND=r1), DIMENSION(:,:), INTENT(IN) :: var_vals         ! variable values
    CHARACTER(LEN=*), INTENT(IN) :: outdim                       ! 2nd dimension of output ('mplant','mlitter','msoil') 
    INTEGER, INTENT(IN) :: cnt                                   ! current time step #
-   REAL(KIND=r_1), DIMENSION(:,:,:), INTENT(INOUT) :: tmp_array   ! temporary array   
+   REAL(KIND=r1), DIMENSION(:,:,:), INTENT(INOUT) :: tmp_array   ! temporary array   
 
    ! Local variables
    INTEGER  :: ndim2  ! size of 2nd dimension

--- a/core/biogeochem/casa_variable.F90
+++ b/core/biogeochem/casa_variable.F90
@@ -28,7 +28,7 @@
 
 module casadimension
 
-  use cable_def_types_mod, only: r_2
+  use cable_def_types_mod, only: r2
 
   implicit none
 
@@ -52,8 +52,8 @@ module casadimension
   ! INTEGER, PARAMETER :: icycle=3    ! =1 for C, =2 for C+N; =3 for C+N+P
   integer, parameter :: mstart = 1    ! starting time step
   integer, parameter :: mphase = 4    ! phen. phases
-  real(r_2), parameter :: deltcasa = 1.0_r_2/365.0_r_2 ! fraction 1 day of year
-  real(r_2), parameter :: deltpool = 1.0_r_2           ! pool delt(1day)
+  real(r2), parameter :: deltcasa = 1.0_r2/365.0_r2 ! fraction 1 day of year
+  real(r2), parameter :: deltpool = 1.0_r2           ! pool delt(1day)
 
 end module casadimension
 
@@ -63,7 +63,7 @@ end module casadimension
 
 module casaparm
 
-  use cable_def_types_mod, only: r_2
+  use cable_def_types_mod, only: r2
   ! use casadimension, only: deltcasa
 
   implicit none
@@ -93,23 +93,23 @@ module casaparm
   integer, parameter :: POCC    = 3
   !! vh_js !! LALLOC moved to bgcdriver to allow for value to be switchable
   ! integer, parameter :: LALLOC = 0  ! 0 constant; 1 variable
-  real(r_2), parameter :: z30 = 0.3_r_2
-  real(r_2), parameter :: R0 = 0.3_r_2
-  real(r_2), parameter :: S0 = 0.3_r_2
-  real(r_2), parameter :: fixed_stem = 1.0_r_2 / 3.0_r_2
-  real(r_2), parameter :: Q10alloc = 2.0_r_2
-  real(r_2), parameter :: ratioNCstrfix = 1.0_r_2 / 150.0_r_2
-  real(r_2), parameter :: ratioNPstrfix = 25.0_r_2
-  real(r_2), parameter :: fracCbiomass = 0.50_r_2
-  real(r_2), parameter :: tsoilrefc = 25.0_r_2
-  real(r_2), parameter :: tkzeroc = 273.15_r_2
-  real(r_2), parameter :: frootparma = 0.3192_r_2
-  real(r_2), parameter :: frootparmb =-0.0485_r_2
-  real(r_2), parameter :: frootparmc = 0.1755_r_2
-  real(r_2), parameter :: xweightalloc = 0.2_r_2
-  !  real(r_2), parameter :: xkplab  = 0.5_r_2 * deltcasa
-  !  real(r_2), parameter :: xkpsorb = 0.01_r_2 * deltcasa
-  !  real(r_2), parameter :: xkpocc  = 0.01_r_2 * deltcasa
+  real(r2), parameter :: z30 = 0.3_r2
+  real(r2), parameter :: R0 = 0.3_r2
+  real(r2), parameter :: S0 = 0.3_r2
+  real(r2), parameter :: fixed_stem = 1.0_r2 / 3.0_r2
+  real(r2), parameter :: Q10alloc = 2.0_r2
+  real(r2), parameter :: ratioNCstrfix = 1.0_r2 / 150.0_r2
+  real(r2), parameter :: ratioNPstrfix = 25.0_r2
+  real(r2), parameter :: fracCbiomass = 0.50_r2
+  real(r2), parameter :: tsoilrefc = 25.0_r2
+  real(r2), parameter :: tkzeroc = 273.15_r2
+  real(r2), parameter :: frootparma = 0.3192_r2
+  real(r2), parameter :: frootparmb =-0.0485_r2
+  real(r2), parameter :: frootparmc = 0.1755_r2
+  real(r2), parameter :: xweightalloc = 0.2_r2
+  !  real(r2), parameter :: xkplab  = 0.5_r2 * deltcasa
+  !  real(r2), parameter :: xkpsorb = 0.01_r2 * deltcasa
+  !  real(r2), parameter :: xkpocc  = 0.01_r2 * deltcasa
 
 end module casaparm
 
@@ -119,7 +119,7 @@ end module casaparm
 
 module casavariable
 
-  use cable_def_types_mod, only: r_2
+  use cable_def_types_mod, only: r2
 
   implicit none
 
@@ -164,7 +164,7 @@ module casavariable
   type casa_biome
      integer, dimension(:), pointer :: &
           ivt2 => null()
-     real(r_2), dimension(:), pointer :: &
+     real(r2), dimension(:), pointer :: &
           xkleafcoldmax => null(), &
           xkleafcoldexp => null(), &
           xkleafdrymax => null(), &
@@ -201,7 +201,7 @@ module casavariable
           DAMM_KMcp => null(), &
           DAMM_Ea => null(), &
           DAMM_alpha => null()
-     real(r_2), dimension(:,:), pointer :: &
+     real(r2), dimension(:,:), pointer :: &
           plantrate => null(), &
           rmplant => null(), &
           fracnpptoP => null(), &
@@ -217,18 +217,18 @@ module casavariable
           litterrate => null(), &
           ratioPcplantmin => null(), &
           ratioPcplantmax => null()
-     real(r_2), dimension(:,:), pointer :: &
+     real(r2), dimension(:,:), pointer :: &
           soilrate => null()
   end type casa_biome
 
 
   type casa_pool
-     real(r_2), dimension(:), pointer :: &
+     real(r2), dimension(:), pointer :: &
           Clabile => null(), &
           dClabiledt => null(), &
           Ctot => null(), &          !! vh_js !!
           Ctot_0 => null()
-     real(r_2), dimension(:,:), pointer :: &
+     real(r2), dimension(:,:), pointer :: &
           Cplant => null(), &
           Nplant => null(), &
           Pplant => null(), &
@@ -237,7 +237,7 @@ module casavariable
           dPplantdt => null(), &
           ratioNCplant => null(), &
           ratioNPplant => null()
-     real(r_2), dimension(:), pointer :: &
+     real(r2), dimension(:), pointer :: &
           Nsoilmin => null(), &
           Psoillab => null(), &
           Psoilsorb => null(), &
@@ -246,7 +246,7 @@ module casavariable
           dPsoillabdt => null(), &
           dPsoilsorbdt => null(), &
           dPsoiloccdt => null()
-     real(r_2), dimension(:,:), pointer :: &
+     real(r2), dimension(:,:), pointer :: &
           Clitter => null(), &
           Nlitter => null(), &
           Plitter => null(), &
@@ -255,7 +255,7 @@ module casavariable
           dPlitterdt => null(), &
           ratioNClitter => null(), &
           ratioNPlitter => null()
-     real(r_2), dimension(:,:), pointer :: &
+     real(r2), dimension(:,:), pointer :: &
           Csoil => null(), &
           Nsoil => null(), &
           Psoil => null(), &
@@ -274,7 +274,7 @@ module casavariable
 
 
   type casa_flux
-     real(r_2), dimension(:), pointer :: &
+     real(r2), dimension(:), pointer :: &
           Cgpp => null(), &
           Cnpp => null(), &
           Crp => null(), &
@@ -301,7 +301,7 @@ module casavariable
           CallocLeaf => null(), &  ! C allocation to leaves 
           CallocWood => null(), &  ! C allocation to wood
           CallocFineRoot => null() ! C allocation to fine roots
-     real(r_2), dimension(:,:), pointer :: &
+     real(r2), dimension(:,:), pointer :: &
           fracCalloc => null(), &
           fracNalloc => null(), &
           fracPalloc => null(), &
@@ -309,9 +309,9 @@ module casavariable
           kplant => null(), &
           !! vh_js !! additional diagnostic
           Cplant_turnover => null()
-     real(r_2), dimension(:,:,:), pointer :: &
+     real(r2), dimension(:,:,:), pointer :: &
           fromPtoL => null()
-     real(r_2), dimension(:),pointer :: &
+     real(r2), dimension(:),pointer :: &
           Cnep => null(), &
           Crsoil => null(), &
           Nmindep => null(), &
@@ -343,59 +343,59 @@ module casavariable
           Cplant_turnover_disturbance => null(), &
           Cplant_turnover_crowding  => null(), &
           Cplant_turnover_resource_limitation => null()
-     real(r_2), dimension(:,:),   pointer :: klitter => null()
-     real(r_2), dimension(:,:),   pointer :: ksoil => null()
-     real(r_2), dimension(:,:,:), pointer :: fromLtoS => null()
-     real(r_2), dimension(:,:,:), pointer :: fromStoS => null()
-     real(r_2), dimension(:,:),   pointer :: fromLtoCO2 => null()
-     real(r_2), dimension(:,:),   pointer :: fromStoCO2 => null()
-     real(r_2), dimension(:,:),   pointer :: FluxCtolitter => null()
-     real(r_2), dimension(:,:),   pointer :: FluxCLeaftoLitter => null()
-     real(r_2), dimension(:,:),   pointer :: FluxCWoodtoLitter => null()
-     real(r_2), dimension(:,:),   pointer :: FluxCFineRoottoLitter => null()
-     real(r_2), dimension(:,:),   pointer :: FluxNtolitter => null()
-     real(r_2), dimension(:,:),   pointer :: FluxPtolitter => null()
-     real(r_2), dimension(:,:),   pointer :: FluxCtosoil => null()
-     real(r_2), dimension(:,:),   pointer :: FluxNtosoil => null()
-     real(r_2), dimension(:,:),   pointer :: FluxPtosoil => null()
-     real(r_2), dimension(:),     pointer :: FluxCtoCO2 => null()
-     real(r_2), dimension(:),     pointer :: FluxCtohwp => null()
-     real(r_2), dimension(:),     pointer :: FluxNtohwp => null()
-     real(r_2), dimension(:),     pointer :: FluxPtohwp => null()
-     real(r_2), dimension(:),     pointer :: FluxCtoclear => null()
-     real(r_2), dimension(:),     pointer :: FluxNtoclear => null()
-     real(r_2), dimension(:),     pointer :: FluxPtoclear => null()
-     real(r_2), dimension(:),     pointer :: CtransferLUC => null()
+     real(r2), dimension(:,:),   pointer :: klitter => null()
+     real(r2), dimension(:,:),   pointer :: ksoil => null()
+     real(r2), dimension(:,:,:), pointer :: fromLtoS => null()
+     real(r2), dimension(:,:,:), pointer :: fromStoS => null()
+     real(r2), dimension(:,:),   pointer :: fromLtoCO2 => null()
+     real(r2), dimension(:,:),   pointer :: fromStoCO2 => null()
+     real(r2), dimension(:,:),   pointer :: FluxCtolitter => null()
+     real(r2), dimension(:,:),   pointer :: FluxCLeaftoLitter => null()
+     real(r2), dimension(:,:),   pointer :: FluxCWoodtoLitter => null()
+     real(r2), dimension(:,:),   pointer :: FluxCFineRoottoLitter => null()
+     real(r2), dimension(:,:),   pointer :: FluxNtolitter => null()
+     real(r2), dimension(:,:),   pointer :: FluxPtolitter => null()
+     real(r2), dimension(:,:),   pointer :: FluxCtosoil => null()
+     real(r2), dimension(:,:),   pointer :: FluxNtosoil => null()
+     real(r2), dimension(:,:),   pointer :: FluxPtosoil => null()
+     real(r2), dimension(:),     pointer :: FluxCtoCO2 => null()
+     real(r2), dimension(:),     pointer :: FluxCtohwp => null()
+     real(r2), dimension(:),     pointer :: FluxNtohwp => null()
+     real(r2), dimension(:),     pointer :: FluxPtohwp => null()
+     real(r2), dimension(:),     pointer :: FluxCtoclear => null()
+     real(r2), dimension(:),     pointer :: FluxNtoclear => null()
+     real(r2), dimension(:),     pointer :: FluxPtoclear => null()
+     real(r2), dimension(:),     pointer :: CtransferLUC => null()
      !CVH variables inherited from BLAZE
-     real(r_2), dimension(:,:,:), pointer :: fromPtoL_fire => null()
-     real(r_2), dimension(:,:), pointer   :: klitter_fire => null()
+     real(r2), dimension(:,:,:), pointer :: fromPtoL_fire => null()
+     real(r2), dimension(:,:), pointer   :: klitter_fire => null()
      ! sum of fire turnover and non-fire turnover (litter)
-     real(r_2), dimension(:,:), pointer   :: klitter_tot => null()
-     real(r_2), dimension(:,:), pointer   :: kplant_fire => null()
+     real(r2), dimension(:,:), pointer   :: klitter_tot => null()
+     real(r2), dimension(:,:), pointer   :: kplant_fire => null()
      ! sum of fire turnover and non-fire turnover (plants)
-     real(r_2), dimension(:,:), pointer   :: kplant_tot => null()
+     real(r2), dimension(:,:), pointer   :: kplant_tot => null()
      !CVH diagnostic: CO2 emissions from fire
-     real(r_2), dimension(:), pointer     :: fluxCtoCO2_plant_fire => null()
-     real(r_2), dimension(:), pointer     :: fluxCtoCO2_litter_fire => null()
+     real(r2), dimension(:), pointer     :: fluxCtoCO2_plant_fire => null()
+     real(r2), dimension(:), pointer     :: fluxCtoCO2_litter_fire => null()
      ! contribution to fire emissions from individual plant pools
-     real(r_2), dimension(:,:), pointer   :: fluxfromPtoCO2_fire => null()
+     real(r2), dimension(:,:), pointer   :: fluxfromPtoCO2_fire => null()
      ! contribution to fire emissions from individual litter pools
-     real(r_2), dimension(:,:), pointer   :: fluxfromLtoCO2_fire => null()
-     real(r_2), dimension(:), pointer     :: fluxNtoAtm_fire => null()
-     ! real(r_2), dimension(:,:,:),pointer  :: fire_mortality_vs_height => null()
+     real(r2), dimension(:,:), pointer   :: fluxfromLtoCO2_fire => null()
+     real(r2), dimension(:), pointer     :: fluxNtoAtm_fire => null()
+     ! real(r2), dimension(:,:,:),pointer  :: fire_mortality_vs_height => null()
      ! Diagnostic fluxes for use in 13C
-     real(r_2), dimension(:,:,:), pointer :: FluxFromPtoL => null()
-     real(r_2), dimension(:,:,:), pointer :: FluxFromLtoS => null()
-     real(r_2), dimension(:,:,:), pointer :: FluxFromStoS => null()
-     real(r_2), dimension(:,:),   pointer :: FluxFromPtoCO2 => null()
-     real(r_2), dimension(:,:),   pointer :: FluxFromLtoCO2 => null()
-     real(r_2), dimension(:,:),   pointer :: FluxFromStoCO2 => null()
-     real(r_2), dimension(:),     pointer :: FluxFromPtoHarvest => null()
+     real(r2), dimension(:,:,:), pointer :: FluxFromPtoL => null()
+     real(r2), dimension(:,:,:), pointer :: FluxFromLtoS => null()
+     real(r2), dimension(:,:,:), pointer :: FluxFromStoS => null()
+     real(r2), dimension(:,:),   pointer :: FluxFromPtoCO2 => null()
+     real(r2), dimension(:,:),   pointer :: FluxFromLtoCO2 => null()
+     real(r2), dimension(:,:),   pointer :: FluxFromStoCO2 => null()
+     real(r2), dimension(:),     pointer :: FluxFromPtoHarvest => null()
   end type casa_flux
 
 
   type casa_met
-     real(r_2), dimension(:), pointer :: &
+     real(r2), dimension(:), pointer :: &
           glai => null(), &
           Tairk => null(), &
           precip => null(), &
@@ -404,19 +404,19 @@ module casavariable
           btran => null()
      integer, dimension(:), pointer :: &
           lnonwood => null()
-     real(r_2), dimension(:,:), pointer :: &
+     real(r2), dimension(:,:), pointer :: &
           Tsoil => null(), &
           moist => null()
      integer, dimension(:), pointer :: &
           iveg2 => null(), &
           ijgcm => null(), &
           isorder => null()
-     real(r_2), dimension(:), pointer :: &
+     real(r2), dimension(:), pointer :: &
           lat => null(), &
           lon => null(), &
           areacell => null()
      ! added yp wang 5/nov/2012
-     real(r_2), dimension(:,:), pointer :: &
+     real(r2), dimension(:,:), pointer :: &
           Tairkspin => null(), &
           cgppspin => null(), &
           crmplantspin_1 => null(), &
@@ -437,14 +437,14 @@ module casavariable
           mtempspin => null(), &
           frecspin => null()
      ! 13C
-     real(r_2), dimension(:,:), pointer :: &
+     real(r2), dimension(:,:), pointer :: &
           ! daily cumulated total 12CO2 net assimilation in [g(C)/m2]
           cAn12spin => null()
-     real(r_2), dimension(:,:), pointer :: &
+     real(r2), dimension(:,:), pointer :: &
           ! daily cumulated total 13CO2 net assimilation in [g(13C)/m2]
           cAn13spin => null()
      ! BLAZE
-     real(r_2), dimension(:,:), pointer :: &
+     real(r2), dimension(:,:), pointer :: &
           dprecip_spin => null(), &
           aprecip_av20_spin => null(), &
           du10_max_spin     => null(), &
@@ -461,7 +461,7 @@ module casavariable
 
 
   type casa_balance
-     real(r_2), dimension(:), pointer :: &
+     real(r2), dimension(:), pointer :: &
           FCgppyear => null(), &
           FCnppyear => null(), &
           FCrmleafyear => null(), &
@@ -487,22 +487,22 @@ module casavariable
           FPupyear => null(), &
           FPleachyear => null(), &
           FPlossyear => null()
-     real(r_2), dimension(:,:),pointer :: &
+     real(r2), dimension(:,:),pointer :: &
           glaimon => null(), &
           glaimonx => null()
-     real(r_2), dimension(:,:), pointer :: &
+     real(r2), dimension(:,:), pointer :: &
           cplantlast => null(), &
           nplantlast => null(), &
           pplantlast => null()
-     real(r_2), dimension(:,:), pointer :: &
+     real(r2), dimension(:,:), pointer :: &
           clitterlast => null(), &
           nlitterlast => null(), &
           plitterlast => null()
-     real(r_2), dimension(:,:), pointer :: &
+     real(r2), dimension(:,:), pointer :: &
           csoillast => null(), &
           nsoillast => null(), &
           psoillast => null()
-     real(r_2), dimension(:), pointer :: &
+     real(r2), dimension(:), pointer :: &
           nsoilminlast => null(), &
           psoillablast => null(), &
           psoilsorblast => null(), &
@@ -513,7 +513,7 @@ module casavariable
           sumcbal => null(), &
           sumnbal => null(), &
           sumpbal => null()
-     real(r_2), dimension(:), pointer :: &
+     real(r2), dimension(:), pointer :: &
           clabilelast => null()
   end type casa_balance
 
@@ -984,292 +984,292 @@ contains
 
   subroutine zero_casabiome(casabiome)
 
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
     type(casa_biome), intent(inout) :: casabiome
 
     casabiome%ivt2 = 0
-    casabiome%xkleafcoldmax = 0.0_r_2
-    casabiome%xkleafcoldexp = 0.0_r_2
-    casabiome%xkleafdrymax = 0.0_r_2
-    casabiome%xkleafdryexp = 0.0_r_2
-    casabiome%glaimax = 0.0_r_2
-    casabiome%glaimin = 0.0_r_2
-    casabiome%sla = 0.0_r_2
-    casabiome%ratiofrootleaf = 0.0_r_2
-    casabiome%kroot = 0.0_r_2
-    casabiome%krootlen = 0.0_r_2
-    casabiome%rootdepth = 0.0_r_2
-    casabiome%kuptake = 0.0_r_2
-    casabiome%kminN = 0.0_r_2
-    casabiome%kuplabP = 0.0_r_2
-    casabiome%kclabrate = 0.0_r_2
-    casabiome%xnpmax = 0.0_r_2
-    casabiome%q10soil = 0.0_r_2
-    casabiome%xkoptlitter = 0.0_r_2
-    casabiome%xkoptsoil = 0.0_r_2
-    casabiome%xkplab = 0.0_r_2
-    casabiome%xkpsorb = 0.0_r_2
-    casabiome%xkpocc = 0.0_r_2
-    casabiome%prodptase = 0.0_r_2
-    casabiome%costnpup = 0.0_r_2
-    casabiome%maxfinelitter = 0.0_r_2
-    casabiome%maxcwd = 0.0_r_2
-    casabiome%nintercept = 0.0_r_2
-    casabiome%nslope = 0.0_r_2
-    casabiome%la_to_sa = 0.0_r_2
-    casabiome%vcmax_scalar = 0.0_r_2
-    casabiome%disturbance_interval = 0.0_r_2
-    casabiome%DAMM_EnzPool = 0.0_r_2
-    casabiome%DAMM_KMO2 = 0.0_r_2
-    casabiome%DAMM_KMcp = 0.0_r_2
-    casabiome%DAMM_Ea = 0.0_r_2
-    casabiome%DAMM_alpha = 0.0_r_2
-    casabiome%plantrate = 0.0_r_2
-    casabiome%rmplant = 0.0_r_2
-    casabiome%fracnpptoP = 0.0_r_2
-    casabiome%fraclignin = 0.0_r_2
-    casabiome%fraclabile = 0.0_r_2
-    casabiome%ratioNCplantmin = 0.0_r_2
-    casabiome%ratioNCplantmax = 0.0_r_2
-    casabiome%ratioNPplantmin = 0.0_r_2
-    casabiome%ratioNPplantmax = 0.0_r_2
-    casabiome%fracLigninplant = 0.0_r_2
-    casabiome%ftransNPtoL = 0.0_r_2
-    casabiome%ftransPPtoL = 0.0_r_2
-    casabiome%litterrate = 0.0_r_2
-    casabiome%ratioPcplantmin = 0.0_r_2
-    casabiome%ratioPcplantmax = 0.0_r_2
-    casabiome%soilrate = 0.0_r_2
+    casabiome%xkleafcoldmax = 0.0_r2
+    casabiome%xkleafcoldexp = 0.0_r2
+    casabiome%xkleafdrymax = 0.0_r2
+    casabiome%xkleafdryexp = 0.0_r2
+    casabiome%glaimax = 0.0_r2
+    casabiome%glaimin = 0.0_r2
+    casabiome%sla = 0.0_r2
+    casabiome%ratiofrootleaf = 0.0_r2
+    casabiome%kroot = 0.0_r2
+    casabiome%krootlen = 0.0_r2
+    casabiome%rootdepth = 0.0_r2
+    casabiome%kuptake = 0.0_r2
+    casabiome%kminN = 0.0_r2
+    casabiome%kuplabP = 0.0_r2
+    casabiome%kclabrate = 0.0_r2
+    casabiome%xnpmax = 0.0_r2
+    casabiome%q10soil = 0.0_r2
+    casabiome%xkoptlitter = 0.0_r2
+    casabiome%xkoptsoil = 0.0_r2
+    casabiome%xkplab = 0.0_r2
+    casabiome%xkpsorb = 0.0_r2
+    casabiome%xkpocc = 0.0_r2
+    casabiome%prodptase = 0.0_r2
+    casabiome%costnpup = 0.0_r2
+    casabiome%maxfinelitter = 0.0_r2
+    casabiome%maxcwd = 0.0_r2
+    casabiome%nintercept = 0.0_r2
+    casabiome%nslope = 0.0_r2
+    casabiome%la_to_sa = 0.0_r2
+    casabiome%vcmax_scalar = 0.0_r2
+    casabiome%disturbance_interval = 0.0_r2
+    casabiome%DAMM_EnzPool = 0.0_r2
+    casabiome%DAMM_KMO2 = 0.0_r2
+    casabiome%DAMM_KMcp = 0.0_r2
+    casabiome%DAMM_Ea = 0.0_r2
+    casabiome%DAMM_alpha = 0.0_r2
+    casabiome%plantrate = 0.0_r2
+    casabiome%rmplant = 0.0_r2
+    casabiome%fracnpptoP = 0.0_r2
+    casabiome%fraclignin = 0.0_r2
+    casabiome%fraclabile = 0.0_r2
+    casabiome%ratioNCplantmin = 0.0_r2
+    casabiome%ratioNCplantmax = 0.0_r2
+    casabiome%ratioNPplantmin = 0.0_r2
+    casabiome%ratioNPplantmax = 0.0_r2
+    casabiome%fracLigninplant = 0.0_r2
+    casabiome%ftransNPtoL = 0.0_r2
+    casabiome%ftransPPtoL = 0.0_r2
+    casabiome%litterrate = 0.0_r2
+    casabiome%ratioPcplantmin = 0.0_r2
+    casabiome%ratioPcplantmax = 0.0_r2
+    casabiome%soilrate = 0.0_r2
 
   end subroutine zero_casabiome
 
 
   subroutine zero_casapool(casapool)
 
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
     type(casa_pool), intent(inout) :: casapool
 
-    casapool%Clabile = 0.0_r_2
-    casapool%dClabiledt = 0.0_r_2
-    casapool%Ctot = 0.0_r_2
-    casapool%Ctot_0 = 0.0_r_2
-    casapool%Cplant = 0.0_r_2
-    casapool%Nplant = 0.0_r_2
-    casapool%Pplant = 0.0_r_2
-    casapool%dCplantdt = 0.0_r_2
-    casapool%dNplantdt = 0.0_r_2
-    casapool%dPplantdt = 0.0_r_2
-    casapool%ratioNCplant = 0.0_r_2
-    casapool%ratioNPplant = 0.0_r_2
-    casapool%Nsoilmin = 0.0_r_2
-    casapool%Psoillab = 0.0_r_2
-    casapool%Psoilsorb = 0.0_r_2
-    casapool%Psoilocc = 0.0_r_2
-    casapool%dNsoilmindt = 0.0_r_2
-    casapool%dPsoillabdt = 0.0_r_2
-    casapool%dPsoilsorbdt = 0.0_r_2
-    casapool%dPsoiloccdt = 0.0_r_2
-    casapool%Clitter = 0.0_r_2
-    casapool%Nlitter = 0.0_r_2
-    casapool%Plitter = 0.0_r_2
-    casapool%dClitterdt = 0.0_r_2
-    casapool%dNlitterdt = 0.0_r_2
-    casapool%dPlitterdt = 0.0_r_2
-    casapool%ratioNClitter = 0.0_r_2
-    casapool%ratioNPlitter = 0.0_r_2
-    casapool%Csoil = 0.0_r_2
-    casapool%Nsoil = 0.0_r_2
-    casapool%Psoil = 0.0_r_2
-    casapool%dCsoildt = 0.0_r_2
-    casapool%dNsoildt = 0.0_r_2
-    casapool%dPsoildt = 0.0_r_2
-    casapool%ratioNCsoil = 0.0_r_2
-    casapool%ratioNCsoilnew = 0.0_r_2
-    casapool%ratioNPsoil = 0.0_r_2
-    casapool%ratioNCsoilmin = 0.0_r_2
-    casapool%ratioNCsoilmax = 0.0_r_2
-    casapool%ratioPCsoil = 0.0_r_2
-    casapool%ratioPCplant = 0.0_r_2
-    casapool%ratioPClitter = 0.0_r_2
+    casapool%Clabile = 0.0_r2
+    casapool%dClabiledt = 0.0_r2
+    casapool%Ctot = 0.0_r2
+    casapool%Ctot_0 = 0.0_r2
+    casapool%Cplant = 0.0_r2
+    casapool%Nplant = 0.0_r2
+    casapool%Pplant = 0.0_r2
+    casapool%dCplantdt = 0.0_r2
+    casapool%dNplantdt = 0.0_r2
+    casapool%dPplantdt = 0.0_r2
+    casapool%ratioNCplant = 0.0_r2
+    casapool%ratioNPplant = 0.0_r2
+    casapool%Nsoilmin = 0.0_r2
+    casapool%Psoillab = 0.0_r2
+    casapool%Psoilsorb = 0.0_r2
+    casapool%Psoilocc = 0.0_r2
+    casapool%dNsoilmindt = 0.0_r2
+    casapool%dPsoillabdt = 0.0_r2
+    casapool%dPsoilsorbdt = 0.0_r2
+    casapool%dPsoiloccdt = 0.0_r2
+    casapool%Clitter = 0.0_r2
+    casapool%Nlitter = 0.0_r2
+    casapool%Plitter = 0.0_r2
+    casapool%dClitterdt = 0.0_r2
+    casapool%dNlitterdt = 0.0_r2
+    casapool%dPlitterdt = 0.0_r2
+    casapool%ratioNClitter = 0.0_r2
+    casapool%ratioNPlitter = 0.0_r2
+    casapool%Csoil = 0.0_r2
+    casapool%Nsoil = 0.0_r2
+    casapool%Psoil = 0.0_r2
+    casapool%dCsoildt = 0.0_r2
+    casapool%dNsoildt = 0.0_r2
+    casapool%dPsoildt = 0.0_r2
+    casapool%ratioNCsoil = 0.0_r2
+    casapool%ratioNCsoilnew = 0.0_r2
+    casapool%ratioNPsoil = 0.0_r2
+    casapool%ratioNCsoilmin = 0.0_r2
+    casapool%ratioNCsoilmax = 0.0_r2
+    casapool%ratioPCsoil = 0.0_r2
+    casapool%ratioPCplant = 0.0_r2
+    casapool%ratioPClitter = 0.0_r2
 
   end subroutine zero_casapool
 
 
   subroutine zero_casaflux(casaflux)
 
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
     type(casa_flux), intent(inout) :: casaflux
 
-    casaflux%Cgpp = 0.0_r_2
-    casaflux%Cnpp = 0.0_r_2
-    casaflux%Crp = 0.0_r_2
-    casaflux%Crgplant = 0.0_r_2
-    casaflux%Nminfix = 0.0_r_2
-    casaflux%Nminuptake = 0.0_r_2
-    casaflux%Plabuptake = 0.0_r_2
-    casaflux%Clabloss = 0.0_r_2
-    casaflux%fracClabile = 0.0_r_2
-    casaflux%stemnpp = 0.0_r_2
-    casaflux%potstemnpp = 0.0_r_2
-    casaflux%frac_sapwood = 0.0_r_2
-    casaflux%sapwood_area = 0.0_r_2
-    casaflux%Charvest = 0.0_r_2
-    casaflux%CharvestPast = 0.0_r_2
-    casaflux%CharvestCrop = 0.0_r_2
-    casaflux%Nharvest = 0.0_r_2
-    casaflux%Pharvest = 0.0_r_2
-    casaflux%fHarvest = 0.0_r_2
-    casaflux%fHarvestPast = 0.0_r_2
-    casaflux%fHarvestCrop = 0.0_r_2
-    casaflux%fcrop = 0.0_r_2
-    casaflux%CallocLeaf = 0.0_r_2
-    casaflux%CallocWood = 0.0_r_2
-    casaflux%CallocFineRoot = 0.0_r_2
-    casaflux%fracCalloc = 0.0_r_2
-    casaflux%fracNalloc = 0.0_r_2
-    casaflux%fracPalloc = 0.0_r_2
-    casaflux%Crmplant = 0.0_r_2
-    casaflux%kplant = 0.0_r_2
-    casaflux%Cplant_turnover = 0.0_r_2
-    casaflux%fromPtoL = 0.0_r_2
-    casaflux%Cnep = 0.0_r_2
-    casaflux%Crsoil = 0.0_r_2
-    casaflux%Nmindep = 0.0_r_2
-    casaflux%Nminloss = 0.0_r_2
-    casaflux%Nminleach = 0.0_r_2
-    casaflux%Nupland = 0.0_r_2
-    casaflux%Nlittermin = 0.0_r_2
-    casaflux%Nsmin = 0.0_r_2
-    casaflux%Nsimm = 0.0_r_2
-    casaflux%Nsnet = 0.0_r_2
-    casaflux%fNminloss = 0.0_r_2
-    casaflux%fNminleach = 0.0_r_2
-    casaflux%Pdep = 0.0_r_2
-    casaflux%Pwea = 0.0_r_2
-    casaflux%Pleach = 0.0_r_2
-    casaflux%Ploss = 0.0_r_2
-    casaflux%Pupland = 0.0_r_2
-    casaflux%Plittermin = 0.0_r_2
-    casaflux%Psmin = 0.0_r_2
-    casaflux%Psimm = 0.0_r_2
-    casaflux%Psnet = 0.0_r_2
-    casaflux%fPleach = 0.0_r_2
-    casaflux%kplab = 0.0_r_2
-    casaflux%kpsorb = 0.0_r_2
-    casaflux%kpocc = 0.0_r_2
-    casaflux%kmlabp = 0.0_r_2
-    casaflux%Psorbmax = 0.0_r_2
-    casaflux%Cplant_turnover_disturbance = 0.0_r_2
-    casaflux%Cplant_turnover_crowding  = 0.0_r_2
-    casaflux%Cplant_turnover_resource_limitation = 0.0_r_2
-    casaflux%klitter = 0.0_r_2
-    casaflux%ksoil = 0.0_r_2
-    casaflux%fromLtoS = 0.0_r_2
-    casaflux%fromStoS = 0.0_r_2
-    casaflux%fromLtoCO2 = 0.0_r_2
-    casaflux%fromStoCO2 = 0.0_r_2
-    casaflux%FluxCtolitter = 0.0_r_2
-    casaflux%FluxCLeaftoLitter = 0.0_r_2
-    casaflux%FluxCWoodtoLitter = 0.0_r_2
-    casaflux%FluxCFineRoottoLitter = 0.0_r_2
-    casaflux%FluxNtolitter = 0.0_r_2
-    casaflux%FluxPtolitter = 0.0_r_2
-    casaflux%FluxCtosoil = 0.0_r_2
-    casaflux%FluxNtosoil = 0.0_r_2
-    casaflux%FluxPtosoil = 0.0_r_2
-    casaflux%FluxCtoCO2 = 0.0_r_2
-    casaflux%FluxCtohwp = 0.0_r_2
-    casaflux%FluxNtohwp = 0.0_r_2
-    casaflux%FluxPtohwp = 0.0_r_2
-    casaflux%FluxCtoclear = 0.0_r_2
-    casaflux%FluxNtoclear = 0.0_r_2
-    casaflux%FluxPtoclear = 0.0_r_2
-    casaflux%CtransferLUC = 0.0_r_2
-    casaflux%fromPtoL_fire = 0.0_r_2
-    casaflux%klitter_fire = 0.0_r_2
-    casaflux%klitter_tot = 0.0_r_2
-    casaflux%kplant_fire = 0.0_r_2
-    casaflux%kplant_tot = 0.0_r_2
-    casaflux%fluxCtoCO2_plant_fire = 0.0_r_2
-    casaflux%fluxCtoCO2_litter_fire = 0.0_r_2
-    casaflux%fluxfromPtoCO2_fire = 0.0_r_2
-    casaflux%fluxfromLtoCO2_fire = 0.0_r_2
-    casaflux%fluxNtoAtm_fire = 0.0_r_2
-    ! casaflux%fire_mortality_vs_height = 0.0_r_2
-    casaflux%FluxFromPtoL = 0.0_r_2
-    casaflux%FluxFromLtoS = 0.0_r_2
-    casaflux%FluxFromStoS = 0.0_r_2
-    casaflux%FluxFromPtoCO2 = 0.0_r_2
-    casaflux%FluxFromLtoCO2 = 0.0_r_2
-    casaflux%FluxFromStoCO2 = 0.0_r_2
-    casaflux%FluxFromPtoHarvest = 0.0_r_2
+    casaflux%Cgpp = 0.0_r2
+    casaflux%Cnpp = 0.0_r2
+    casaflux%Crp = 0.0_r2
+    casaflux%Crgplant = 0.0_r2
+    casaflux%Nminfix = 0.0_r2
+    casaflux%Nminuptake = 0.0_r2
+    casaflux%Plabuptake = 0.0_r2
+    casaflux%Clabloss = 0.0_r2
+    casaflux%fracClabile = 0.0_r2
+    casaflux%stemnpp = 0.0_r2
+    casaflux%potstemnpp = 0.0_r2
+    casaflux%frac_sapwood = 0.0_r2
+    casaflux%sapwood_area = 0.0_r2
+    casaflux%Charvest = 0.0_r2
+    casaflux%CharvestPast = 0.0_r2
+    casaflux%CharvestCrop = 0.0_r2
+    casaflux%Nharvest = 0.0_r2
+    casaflux%Pharvest = 0.0_r2
+    casaflux%fHarvest = 0.0_r2
+    casaflux%fHarvestPast = 0.0_r2
+    casaflux%fHarvestCrop = 0.0_r2
+    casaflux%fcrop = 0.0_r2
+    casaflux%CallocLeaf = 0.0_r2
+    casaflux%CallocWood = 0.0_r2
+    casaflux%CallocFineRoot = 0.0_r2
+    casaflux%fracCalloc = 0.0_r2
+    casaflux%fracNalloc = 0.0_r2
+    casaflux%fracPalloc = 0.0_r2
+    casaflux%Crmplant = 0.0_r2
+    casaflux%kplant = 0.0_r2
+    casaflux%Cplant_turnover = 0.0_r2
+    casaflux%fromPtoL = 0.0_r2
+    casaflux%Cnep = 0.0_r2
+    casaflux%Crsoil = 0.0_r2
+    casaflux%Nmindep = 0.0_r2
+    casaflux%Nminloss = 0.0_r2
+    casaflux%Nminleach = 0.0_r2
+    casaflux%Nupland = 0.0_r2
+    casaflux%Nlittermin = 0.0_r2
+    casaflux%Nsmin = 0.0_r2
+    casaflux%Nsimm = 0.0_r2
+    casaflux%Nsnet = 0.0_r2
+    casaflux%fNminloss = 0.0_r2
+    casaflux%fNminleach = 0.0_r2
+    casaflux%Pdep = 0.0_r2
+    casaflux%Pwea = 0.0_r2
+    casaflux%Pleach = 0.0_r2
+    casaflux%Ploss = 0.0_r2
+    casaflux%Pupland = 0.0_r2
+    casaflux%Plittermin = 0.0_r2
+    casaflux%Psmin = 0.0_r2
+    casaflux%Psimm = 0.0_r2
+    casaflux%Psnet = 0.0_r2
+    casaflux%fPleach = 0.0_r2
+    casaflux%kplab = 0.0_r2
+    casaflux%kpsorb = 0.0_r2
+    casaflux%kpocc = 0.0_r2
+    casaflux%kmlabp = 0.0_r2
+    casaflux%Psorbmax = 0.0_r2
+    casaflux%Cplant_turnover_disturbance = 0.0_r2
+    casaflux%Cplant_turnover_crowding  = 0.0_r2
+    casaflux%Cplant_turnover_resource_limitation = 0.0_r2
+    casaflux%klitter = 0.0_r2
+    casaflux%ksoil = 0.0_r2
+    casaflux%fromLtoS = 0.0_r2
+    casaflux%fromStoS = 0.0_r2
+    casaflux%fromLtoCO2 = 0.0_r2
+    casaflux%fromStoCO2 = 0.0_r2
+    casaflux%FluxCtolitter = 0.0_r2
+    casaflux%FluxCLeaftoLitter = 0.0_r2
+    casaflux%FluxCWoodtoLitter = 0.0_r2
+    casaflux%FluxCFineRoottoLitter = 0.0_r2
+    casaflux%FluxNtolitter = 0.0_r2
+    casaflux%FluxPtolitter = 0.0_r2
+    casaflux%FluxCtosoil = 0.0_r2
+    casaflux%FluxNtosoil = 0.0_r2
+    casaflux%FluxPtosoil = 0.0_r2
+    casaflux%FluxCtoCO2 = 0.0_r2
+    casaflux%FluxCtohwp = 0.0_r2
+    casaflux%FluxNtohwp = 0.0_r2
+    casaflux%FluxPtohwp = 0.0_r2
+    casaflux%FluxCtoclear = 0.0_r2
+    casaflux%FluxNtoclear = 0.0_r2
+    casaflux%FluxPtoclear = 0.0_r2
+    casaflux%CtransferLUC = 0.0_r2
+    casaflux%fromPtoL_fire = 0.0_r2
+    casaflux%klitter_fire = 0.0_r2
+    casaflux%klitter_tot = 0.0_r2
+    casaflux%kplant_fire = 0.0_r2
+    casaflux%kplant_tot = 0.0_r2
+    casaflux%fluxCtoCO2_plant_fire = 0.0_r2
+    casaflux%fluxCtoCO2_litter_fire = 0.0_r2
+    casaflux%fluxfromPtoCO2_fire = 0.0_r2
+    casaflux%fluxfromLtoCO2_fire = 0.0_r2
+    casaflux%fluxNtoAtm_fire = 0.0_r2
+    ! casaflux%fire_mortality_vs_height = 0.0_r2
+    casaflux%FluxFromPtoL = 0.0_r2
+    casaflux%FluxFromLtoS = 0.0_r2
+    casaflux%FluxFromStoS = 0.0_r2
+    casaflux%FluxFromPtoCO2 = 0.0_r2
+    casaflux%FluxFromLtoCO2 = 0.0_r2
+    casaflux%FluxFromStoCO2 = 0.0_r2
+    casaflux%FluxFromPtoHarvest = 0.0_r2
 
   end subroutine zero_casaflux
 
 
   subroutine zero_casamet(casamet)
 
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
     type(casa_met), intent(inout) :: casamet
 
-    casamet%glai = 0.0_r_2
-    casamet%Tairk = 0.0_r_2
-    casamet%precip = 0.0_r_2
-    casamet%tsoilavg = 0.0_r_2
-    casamet%moistavg = 0.0_r_2
-    casamet%btran = 0.0_r_2
+    casamet%glai = 0.0_r2
+    casamet%Tairk = 0.0_r2
+    casamet%precip = 0.0_r2
+    casamet%tsoilavg = 0.0_r2
+    casamet%moistavg = 0.0_r2
+    casamet%btran = 0.0_r2
     casamet%lnonwood = 0
-    casamet%Tsoil = 0.0_r_2
-    casamet%moist = 0.0_r_2
+    casamet%Tsoil = 0.0_r2
+    casamet%moist = 0.0_r2
     casamet%iveg2 = 0
     casamet%ijgcm = 0
     casamet%isorder = 0
-    casamet%lat = 0.0_r_2
-    casamet%lon = 0.0_r_2
-    casamet%areacell = 0.0_r_2
-    casamet%Tairkspin = 0.0_r_2
-    casamet%cgppspin = 0.0_r_2
-    casamet%crmplantspin_1 = 0.0_r_2
-    casamet%crmplantspin_2 = 0.0_r_2
-    casamet%crmplantspin_3 = 0.0_r_2
-    casamet%Tsoilspin_1 = 0.0_r_2
-    casamet%Tsoilspin_2 = 0.0_r_2
-    casamet%Tsoilspin_3 = 0.0_r_2
-    casamet%Tsoilspin_4 = 0.0_r_2
-    casamet%Tsoilspin_5 = 0.0_r_2
-    casamet%Tsoilspin_6 = 0.0_r_2
-    casamet%moistspin_1 = 0.0_r_2
-    casamet%moistspin_2 = 0.0_r_2
-    casamet%moistspin_3 = 0.0_r_2
-    casamet%moistspin_4 = 0.0_r_2
-    casamet%moistspin_5 = 0.0_r_2
-    casamet%moistspin_6 = 0.0_r_2
-    casamet%mtempspin = 0.0_r_2
-    casamet%frecspin = 0.0_r_2
-    casamet%cAn12spin = 0.0_r_2
-    casamet%cAn13spin = 0.0_r_2
-    casamet%dprecip_spin = 0.0_r_2
-    casamet%aprecip_av20_spin = 0.0_r_2
-    casamet%du10_max_spin     = 0.0_r_2
-    casamet%drhum_spin        = 0.0_r_2
-    casamet%dtemp_max_spin    = 0.0_r_2
-    casamet%dtemp_min_spin    = 0.0_r_2
-    casamet%KBDI_spin         = 0.0_r_2
-    casamet%D_MacArthur_spin  = 0.0_r_2
-    casamet%FFDI_spin         = 0.0_r_2
-    casamet%last_precip_spin  = 0.0_r_2
+    casamet%lat = 0.0_r2
+    casamet%lon = 0.0_r2
+    casamet%areacell = 0.0_r2
+    casamet%Tairkspin = 0.0_r2
+    casamet%cgppspin = 0.0_r2
+    casamet%crmplantspin_1 = 0.0_r2
+    casamet%crmplantspin_2 = 0.0_r2
+    casamet%crmplantspin_3 = 0.0_r2
+    casamet%Tsoilspin_1 = 0.0_r2
+    casamet%Tsoilspin_2 = 0.0_r2
+    casamet%Tsoilspin_3 = 0.0_r2
+    casamet%Tsoilspin_4 = 0.0_r2
+    casamet%Tsoilspin_5 = 0.0_r2
+    casamet%Tsoilspin_6 = 0.0_r2
+    casamet%moistspin_1 = 0.0_r2
+    casamet%moistspin_2 = 0.0_r2
+    casamet%moistspin_3 = 0.0_r2
+    casamet%moistspin_4 = 0.0_r2
+    casamet%moistspin_5 = 0.0_r2
+    casamet%moistspin_6 = 0.0_r2
+    casamet%mtempspin = 0.0_r2
+    casamet%frecspin = 0.0_r2
+    casamet%cAn12spin = 0.0_r2
+    casamet%cAn13spin = 0.0_r2
+    casamet%dprecip_spin = 0.0_r2
+    casamet%aprecip_av20_spin = 0.0_r2
+    casamet%du10_max_spin     = 0.0_r2
+    casamet%drhum_spin        = 0.0_r2
+    casamet%dtemp_max_spin    = 0.0_r2
+    casamet%dtemp_min_spin    = 0.0_r2
+    casamet%KBDI_spin         = 0.0_r2
+    casamet%D_MacArthur_spin  = 0.0_r2
+    casamet%FFDI_spin         = 0.0_r2
+    casamet%last_precip_spin  = 0.0_r2
     casamet%DSLR_spin = 0
 
   end subroutine zero_casamet
@@ -1277,59 +1277,59 @@ contains
 
   subroutine zero_casabal(casabal)
 
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
     type(casa_balance), intent(inout) :: casabal
 
-    casabal%FCgppyear = 0.0_r_2
-    casabal%FCnppyear = 0.0_r_2
-    casabal%FCrmleafyear = 0.0_r_2
-    casabal%FCrmwoodyear = 0.0_r_2
-    casabal%FCrmrootyear = 0.0_r_2
-    casabal%FCrgrowyear = 0.0_r_2
-    casabal%FCrpyear = 0.0_r_2
-    casabal%FCrsyear = 0.0_r_2
-    casabal%FCneeyear = 0.0_r_2
-    casabal%dCdtyear = 0.0_r_2
-    casabal%LAImax = 0.0_r_2
-    casabal%Cleafmean = 0.0_r_2
-    casabal%Crootmean = 0.0_r_2
-    casabal%FNdepyear = 0.0_r_2
-    casabal%FNfixyear = 0.0_r_2
-    casabal%FNsnetyear = 0.0_r_2
-    casabal%FNupyear = 0.0_r_2
-    casabal%FNleachyear = 0.0_r_2
-    casabal%FNlossyear = 0.0_r_2
-    casabal%FPweayear = 0.0_r_2
-    casabal%FPdustyear = 0.0_r_2
-    casabal%FPsnetyear = 0.0_r_2
-    casabal%FPupyear = 0.0_r_2
-    casabal%FPleachyear = 0.0_r_2
-    casabal%FPlossyear = 0.0_r_2
-    casabal%glaimon = 0.0_r_2
-    casabal%glaimonx = 0.0_r_2
-    casabal%cplantlast = 0.0_r_2
-    casabal%nplantlast = 0.0_r_2
-    casabal%pplantlast = 0.0_r_2
-    casabal%clitterlast = 0.0_r_2
-    casabal%nlitterlast = 0.0_r_2
-    casabal%plitterlast = 0.0_r_2
-    casabal%csoillast = 0.0_r_2
-    casabal%nsoillast = 0.0_r_2
-    casabal%psoillast = 0.0_r_2
-    casabal%nsoilminlast = 0.0_r_2
-    casabal%psoillablast = 0.0_r_2
-    casabal%psoilsorblast = 0.0_r_2
-    casabal%psoilocclast = 0.0_r_2
-    casabal%cbalance = 0.0_r_2
-    casabal%nbalance = 0.0_r_2
-    casabal%pbalance = 0.0_r_2
-    casabal%sumcbal = 0.0_r_2
-    casabal%sumnbal = 0.0_r_2
-    casabal%sumpbal = 0.0_r_2
-    casabal%clabilelast = 0.0_r_2
+    casabal%FCgppyear = 0.0_r2
+    casabal%FCnppyear = 0.0_r2
+    casabal%FCrmleafyear = 0.0_r2
+    casabal%FCrmwoodyear = 0.0_r2
+    casabal%FCrmrootyear = 0.0_r2
+    casabal%FCrgrowyear = 0.0_r2
+    casabal%FCrpyear = 0.0_r2
+    casabal%FCrsyear = 0.0_r2
+    casabal%FCneeyear = 0.0_r2
+    casabal%dCdtyear = 0.0_r2
+    casabal%LAImax = 0.0_r2
+    casabal%Cleafmean = 0.0_r2
+    casabal%Crootmean = 0.0_r2
+    casabal%FNdepyear = 0.0_r2
+    casabal%FNfixyear = 0.0_r2
+    casabal%FNsnetyear = 0.0_r2
+    casabal%FNupyear = 0.0_r2
+    casabal%FNleachyear = 0.0_r2
+    casabal%FNlossyear = 0.0_r2
+    casabal%FPweayear = 0.0_r2
+    casabal%FPdustyear = 0.0_r2
+    casabal%FPsnetyear = 0.0_r2
+    casabal%FPupyear = 0.0_r2
+    casabal%FPleachyear = 0.0_r2
+    casabal%FPlossyear = 0.0_r2
+    casabal%glaimon = 0.0_r2
+    casabal%glaimonx = 0.0_r2
+    casabal%cplantlast = 0.0_r2
+    casabal%nplantlast = 0.0_r2
+    casabal%pplantlast = 0.0_r2
+    casabal%clitterlast = 0.0_r2
+    casabal%nlitterlast = 0.0_r2
+    casabal%plitterlast = 0.0_r2
+    casabal%csoillast = 0.0_r2
+    casabal%nsoillast = 0.0_r2
+    casabal%psoillast = 0.0_r2
+    casabal%nsoilminlast = 0.0_r2
+    casabal%psoillablast = 0.0_r2
+    casabal%psoilsorblast = 0.0_r2
+    casabal%psoilocclast = 0.0_r2
+    casabal%cbalance = 0.0_r2
+    casabal%nbalance = 0.0_r2
+    casabal%pbalance = 0.0_r2
+    casabal%sumcbal = 0.0_r2
+    casabal%sumnbal = 0.0_r2
+    casabal%sumpbal = 0.0_r2
+    casabal%clabilelast = 0.0_r2
 
   end subroutine zero_casabal
 
@@ -1693,7 +1693,7 @@ contains
 
   subroutine update_sum_casa(sum_casapool, sum_casaflux, casapool, casaflux, sum_now, average_now, nsteps)
 
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
@@ -1704,9 +1704,9 @@ contains
     logical,         intent(in)    :: sum_now, average_now
     integer,         intent(in)    :: nsteps
 
-    real(r_2) :: rnsteps
+    real(r2) :: rnsteps
 
-    rnsteps = 1.0 / real(nsteps, r_2)
+    rnsteps = 1.0 / real(nsteps, r2)
 
     if (sum_now) then
        sum_casapool%Clabile        = sum_casapool%Clabile        + casapool%Clabile
@@ -1862,20 +1862,20 @@ contains
 
     if (average_now) then
        ! sum_casaflux%fracCalloc = sum_casaflux%fracCalloc * rnsteps
-       where (sum_casaflux%Cnpp > 1.e-12_r_2)
+       where (sum_casaflux%Cnpp > 1.e-12_r2)
           sum_casaflux%fracCalloc(:,1) = sum_casaflux%fracCalloc(:,1) / sum_casaflux%Cnpp
           sum_casaflux%fracCalloc(:,2) = sum_casaflux%fracCalloc(:,2) / sum_casaflux%Cnpp
           sum_casaflux%fracCalloc(:,3) = sum_casaflux%fracCalloc(:,3) / sum_casaflux%Cnpp
        elsewhere
-          sum_casaflux%fracCalloc(:,1) = 0.0_r_2
-          sum_casaflux%fracCalloc(:,2) = 0.0_r_2
-          sum_casaflux%fracCalloc(:,3) = 0.0_r_2
+          sum_casaflux%fracCalloc(:,1) = 0.0_r2
+          sum_casaflux%fracCalloc(:,2) = 0.0_r2
+          sum_casaflux%fracCalloc(:,3) = 0.0_r2
        endwhere
        ! sum_casaflux%kplant = sum_casaflux%kplant * rnsteps
-       where (sum_casapool%Cplant > 1.e-12_r_2)
+       where (sum_casapool%Cplant > 1.e-12_r2)
           sum_casaflux%kplant = sum_casaflux%kplant / sum_casapool%Cplant
        elsewhere
-          sum_casaflux%kplant = 0.0_r_2
+          sum_casaflux%kplant = 0.0_r2
        endwhere
        sum_casapool%Clabile    = sum_casapool%Clabile * rnsteps
        sum_casapool%dClabiledt = sum_casapool%Clabile * rnsteps
@@ -3977,7 +3977,7 @@ end module casavariable
 
 module phenvariable
 
-  use cable_def_types_mod, only: mvtype, r_2
+  use cable_def_types_mod, only: mvtype, r2
   use casadimension, only: mdyear, mphase
 
   implicit none
@@ -4001,7 +4001,7 @@ module phenvariable
 
   type phen_variable
      integer,   dimension(:),   pointer :: phase => null()
-     real(r_2), dimension(:),   pointer :: TKshed => null()
+     real(r2), dimension(:),   pointer :: TKshed => null()
      integer,   dimension(:,:), pointer :: doyphase => null()
      ! fraction of max LAI
      real,      dimension(:),   pointer :: phen => null()
@@ -4083,14 +4083,14 @@ contains
 
   subroutine zero_phenvariable(phen)
 
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
     type(phen_variable), intent(inout) :: phen
 
     phen%phase          = 0
-    phen%Tkshed         = 0.0_r_2
+    phen%Tkshed         = 0.0_r2
     phen%doyphase       = 0
     phen%phen           = 0.0
     phen%aphen          = 0.0

--- a/core/biogeochem/pop_io.F90
+++ b/core/biogeochem/pop_io.F90
@@ -137,7 +137,7 @@ contains
     INTEGER, SAVE :: FILE_ID, EPI_CNT = 0
 
     ! TEMPORARY ARRAYS
-    INTEGER,  ALLOCATABLE :: I1(:), I2(:,:), I3(:,:,:), I4(:,:,:,:)
+    INTEGER,  ALLOCATABLE :: I11(:), I22(:,:), I33(:,:,:), I44(:,:,:,:)
     REAL(dp), ALLOCATABLE :: R1(:), R2(:,:), R3(:,:,:), R4(:,:,:,:)
 #ifdef __MPI__
     integer :: ierr
@@ -771,12 +771,12 @@ contains
 
        ! PUT 3D VARS ( mp,ndisturb, t )
 
-       ALLOCATE ( I2( mp, ndisturb ) )
+       ALLOCATE ( I22( mp, ndisturb ) )
        DO i = 1, SIZE(VIDI4)
           DO m = 1, mp
              SELECT CASE (i)
              CASE(1)
-                I2( m,: ) = POP%pop_grid(m)%n_age
+                I22( m,: ) = POP%pop_grid(m)%n_age
              CASE default
                 write(*,*) "Parameter not assigned in pop_io.F90!"
 #ifdef __MPI__
@@ -786,20 +786,20 @@ contains
 #endif
              END SELECT
           END DO
-          STATUS = NF90_PUT_VAR(FILE_ID, VIDI4( i), I2,         &
+          STATUS = NF90_PUT_VAR(FILE_ID, VIDI4( i), I22,         &
                start=(/ 1, 1, CNT /), count=(/ mp, ndisturb, 1 /) )
           IF(STATUS /= NF90_NoErr) CALL handle_err(STATUS)
        END DO
-       DEALLOCATE( I2 )
+       DEALLOCATE( I22 )
 
        ! PUT 3D VARS ( mp,npatch2d, t )
 
-       ALLOCATE ( I2( mp, npatch2d ) )
+       ALLOCATE ( I22( mp, npatch2d ) )
        DO i = 1, SIZE(VIDI5)
           DO m = 1, mp
              SELECT CASE (i)
              CASE( 1)
-                I2( m,: ) = POP%pop_grid(m)%patch(:)%id
+                I22( m,: ) = POP%pop_grid(m)%patch(:)%id
              CASE default
                 write(*,*) "Parameter not assigned in pop_io.F90!"
 #ifdef __MPI__
@@ -809,11 +809,11 @@ contains
 #endif
              END SELECT
           END DO
-          STATUS = NF90_PUT_VAR(FILE_ID, VIDI5( i), I2,         &
+          STATUS = NF90_PUT_VAR(FILE_ID, VIDI5( i), I22,         &
                start=(/ 1, 1, CNT /), count=(/ mp, npatch2d, 1 /) )
           IF(STATUS /= NF90_NoErr) CALL handle_err(STATUS)
        END DO
-       DEALLOCATE( I2 )
+       DEALLOCATE( I22 )
 
        ALLOCATE( R2( mp, npatch2d ) )
        DO i = 1, SIZE(VIDR5)
@@ -883,19 +883,19 @@ contains
        DEALLOCATE( R2 )
 
        ! PUT 4D VARS ( mp,npatch2d, ndisturb,t )
-       ALLOCATE( I3( mp, npatch2d, ndisturb ) )
+       ALLOCATE( I33( mp, npatch2d, ndisturb ) )
        DO i = 1, SIZE(VIDI7)
           DO p = 1, npatch2d
              DO m = 1, mp
                 SELECT CASE ( i )
                 CASE( 1)
-                   I3(m,p,:)= POP%pop_grid(m)%patch(p)%disturbance_interval
+                   I33(m,p,:)= POP%pop_grid(m)%patch(p)%disturbance_interval
                 CASE( 2)
-                   I3(m,p,:)= POP%pop_grid(m)%patch(p)%first_disturbance_year
+                   I33(m,p,:)= POP%pop_grid(m)%patch(p)%first_disturbance_year
                 CASE( 3)
-                   I3(m,p,:)= POP%pop_grid(m)%patch(p)%age
+                   I33(m,p,:)= POP%pop_grid(m)%patch(p)%age
                 CASE( 4)
-                   I3(m,p,:)= POP%pop_grid(m)%ranked_age_unique(p,:)
+                   I33(m,p,:)= POP%pop_grid(m)%ranked_age_unique(p,:)
                 CASE default
                    write(*,*) "Parameter not assigned in pop_io.F90!"
 #ifdef __MPI__
@@ -906,11 +906,11 @@ contains
                 END SELECT
              END DO
           END DO
-          STATUS = NF90_PUT_VAR(FILE_ID, VIDI7( i), I3,         &
+          STATUS = NF90_PUT_VAR(FILE_ID, VIDI7( i), I33,         &
                start=(/1, 1, 1, CNT /), count=(/ mp, npatch2d,ndisturb, 1 /) )
           IF(STATUS /= NF90_NoErr) CALL handle_err(STATUS)
        END DO
-       DEALLOCATE( I3 )
+       DEALLOCATE( I33 )
 
        ALLOCATE( R3( mp, npatch2d, ndisturb ) )
        DO i = 1, SIZE(VIDR7)
@@ -936,13 +936,13 @@ contains
        DEALLOCATE( R3 )
 
        !PUT 4D VARS ( mp,npatch2d, nlayer,t )
-       ALLOCATE( I3( mp, npatch2d, nlayer ) )
+       ALLOCATE( I33( mp, npatch2d, nlayer ) )
        DO i = 1, SIZE(VIDI8)
           DO p = 1, npatch2d
              DO m = 1, mp
                 SELECT CASE ( i )
                 CASE( 1)
-                   I3(m,p,:) =  POP%pop_grid(m)%patch(p)%layer(:)%ncohort
+                   I33(m,p,:) =  POP%pop_grid(m)%patch(p)%layer(:)%ncohort
                 CASE default
                    write(*,*) "Parameter not assigned in pop_io.F90!"
 #ifdef __MPI__
@@ -953,11 +953,11 @@ contains
                 END SELECT
              END DO
           END DO
-          STATUS = NF90_PUT_VAR(FILE_ID, VIDI8( i), I3,         &
+          STATUS = NF90_PUT_VAR(FILE_ID, VIDI8( i), I33,         &
                start=(/1, 1, 1, CNT /), count=(/ mp, npatch2d,nlayer, 1 /) )
           IF(STATUS /= NF90_NoErr) CALL handle_err(STATUS)
        END DO
-       DEALLOCATE( I3 )
+       DEALLOCATE( I33 )
 
        ALLOCATE( R3( mp, npatch2d, nlayer ) )
        DO i = 1, SIZE(VIDR8)
@@ -989,16 +989,16 @@ contains
        DEALLOCATE( R3 )
 
        ! PUT 5D VARS ( mp,npatch2d, nlayer,ncohort_max,t )
-       ALLOCATE( I4( mp, npatch2d, nlayer, ncohort_max ) )
+       ALLOCATE( I44( mp, npatch2d, nlayer, ncohort_max ) )
        DO i = 1, SIZE(VIDI9)
           DO l = 1, nlayer
              DO p = 1, npatch2d
                 DO m = 1, mp
                    SELECT CASE ( i )
                    CASE( 1)
-                      I4(m,p,l,:) = POP%pop_grid(m)%patch(p)%layer(l)%cohort(:)%age
+                      I44(m,p,l,:) = POP%pop_grid(m)%patch(p)%layer(l)%cohort(:)%age
                    CASE( 2)
-                      I4(m,p,l,:) = POP%pop_grid(m)%patch(p)%layer(l)%cohort(:)%id
+                      I44(m,p,l,:) = POP%pop_grid(m)%patch(p)%layer(l)%cohort(:)%id
                    CASE default
                       write(*,*) "Parameter not assigned in pop_io.F90!"
 #ifdef __MPI__
@@ -1010,12 +1010,12 @@ contains
                 END DO
              END DO
           END DO
-          STATUS = NF90_PUT_VAR(FILE_ID, VIDI9( i), I4,         &
+          STATUS = NF90_PUT_VAR(FILE_ID, VIDI9( i), I44,         &
                start=(/ 1, 1,1,1, CNT /), count=(/ mp, npatch2d,nlayer,ncohort_max,1 /) )
           IF(STATUS /= NF90_NoErr) CALL handle_err(STATUS)
 
        ENDDO
-       DEALLOCATE(I4)
+       DEALLOCATE(I44)
 
        ALLOCATE( R4( mp, npatch2d, nlayer, ncohort_max ) )
        DO i = 1, SIZE(VIDR9)
@@ -1185,16 +1185,16 @@ contains
        STATUS = NF90_INQ_VARID( FILE_ID, 'Time', t_ID )
        IF (STATUS /= NF90_noerr) CALL handle_err(STATUS)
 
-       ALLOCATE( I1 (t_dim) )
-       STATUS = NF90_GET_VAR( FILE_ID, t_ID, I1 )
+       ALLOCATE( I11 (t_dim) )
+       STATUS = NF90_GET_VAR( FILE_ID, t_ID, I11 )
        IF ( STATUS /= NF90_noerr ) CALL handle_err(STATUS)
        DO i = 1, t_dim
-          IF ( YEAR .EQ. I1(i)+1 ) THEN ! DATA FROM PRECEDING YEAR !
+          IF ( YEAR .EQ. I11(i)+1 ) THEN ! DATA FROM PRECEDING YEAR !
              tx = i
              EXIT
           END IF
        END DO
-       DEALLOCATE( I1 )
+       DEALLOCATE( I11 )
 
        IF ( tx .LE. 0 ) THEN
           WRITE(*,*) 'FILE '//TRIM(fname)//" doesn't contain specific data for ",YEAR
@@ -1379,28 +1379,28 @@ contains
        DEALLOCATE( R2 )
 
        ! GET 2D VARS ( mp,ndisturb)
-       ALLOCATE ( I2( mp, ndisturb ) )
+       ALLOCATE ( I22( mp, ndisturb ) )
        STATUS = NF90_INQ_VARID( FILE_ID, TRIM(AI4(1)), dID )
        IF (STATUS /= NF90_noerr) CALL handle_err(STATUS)
-       STATUS = NF90_GET_VAR  ( FILE_ID, dID, I2, &
+       STATUS = NF90_GET_VAR  ( FILE_ID, dID, I22, &
             start=(/ 1, 1, tx /), count=(/ mp, ndisturb, 1 /) )
        IF (STATUS /= NF90_noerr) CALL handle_err(STATUS)
        DO m = 1, mp
-          POP%pop_grid(m)%n_age = I2( m,: )
+          POP%pop_grid(m)%n_age = I22( m,: )
        END DO
-       DEALLOCATE( I2 )
+       DEALLOCATE( I22 )
 
        ! GET 2D VARS ( mp,npatch2d)
-       ALLOCATE ( I2( mp,npatch2d ) )
+       ALLOCATE ( I22( mp,npatch2d ) )
        STATUS = NF90_INQ_VARID( FILE_ID, TRIM(AI5(1)), dID )
        IF (STATUS /= NF90_noerr) CALL handle_err(STATUS)
-       STATUS = NF90_GET_VAR  ( FILE_ID, dID, I2, &
+       STATUS = NF90_GET_VAR  ( FILE_ID, dID, I22, &
             start=(/ 1, 1, tx /), count=(/ mp, npatch2d, 1 /) )
        IF (STATUS /= NF90_noerr) CALL handle_err(STATUS)
        DO m = 1, mp
-          POP%pop_grid(m)%patch(:)%id = I2( m,: )
+          POP%pop_grid(m)%patch(:)%id = I22( m,: )
        END DO
-       DEALLOCATE( I2 )
+       DEALLOCATE( I22 )
 
        ! PATCH STRUCTURE
        ! GET 2D VARS ( mp,npatch2d )
@@ -1474,24 +1474,24 @@ contains
        DEALLOCATE( R2 )
 
        ! GET 3D VARS ( mp,npatch2d,ndisturb )
-       ALLOCATE( I3( mp, npatch2d, ndisturb ) )
+       ALLOCATE( I33( mp, npatch2d, ndisturb ) )
        DO i = 1, SIZE(AI7)
           STATUS = NF90_INQ_VARID( FILE_ID, TRIM(AI7(i)), dID )
           IF (STATUS /= NF90_noerr) CALL handle_err(STATUS)
-          STATUS = NF90_GET_VAR  ( FILE_ID, dID, I3, &
+          STATUS = NF90_GET_VAR  ( FILE_ID, dID, I33, &
                start=(/ 1, 1, 1, tx /), count=(/ mp, npatch2d, ndisturb, 1 /) )
           IF (STATUS /= NF90_noerr) CALL handle_err(STATUS)
           DO p = 1, npatch2d
              DO m = 1, mp
                 SELECT CASE ( i )
                 CASE( 1)
-                   POP%pop_grid(m)%patch(p)%disturbance_interval   = I3(m,p,:)
+                   POP%pop_grid(m)%patch(p)%disturbance_interval   = I33(m,p,:)
                 CASE( 2)
-                   POP%pop_grid(m)%patch(p)%first_disturbance_year = I3(m,p,:)
+                   POP%pop_grid(m)%patch(p)%first_disturbance_year = I33(m,p,:)
                 CASE( 3)
-                   POP%pop_grid(m)%patch(p)%age                    = I3(m,p,:)
+                   POP%pop_grid(m)%patch(p)%age                    = I33(m,p,:)
                 CASE( 4)
-                   POP%pop_grid(m)%ranked_age_unique(p,:)          = I3(m,p,:)
+                   POP%pop_grid(m)%ranked_age_unique(p,:)          = I33(m,p,:)
                 CASE default
                    write(*,*) "Parameter not assigned in pop_io.F90!"
 #ifdef __MPI__
@@ -1503,7 +1503,7 @@ contains
              END DO
           END DO
        END DO
-       DEALLOCATE( I3 )
+       DEALLOCATE( I33 )
 
        ALLOCATE( R3( mp, npatch2d,ndisturb ) )
        STATUS = NF90_INQ_VARID( FILE_ID, TRIM(AR7(1)), dID )
@@ -1518,18 +1518,18 @@ contains
 
        ! LAYER STRUCTURE
        ! GET 3D VARS ( mp,npatch2d,nlayer )
-       ALLOCATE( I3( mp, npatch2d, nlayer ) )
+       ALLOCATE( I33( mp, npatch2d, nlayer ) )
        DO i = 1, SIZE(AI8)
           STATUS = NF90_INQ_VARID( FILE_ID, TRIM(AI8(i)), dID )
           IF (STATUS /= NF90_noerr) CALL handle_err(STATUS)
-          STATUS = NF90_GET_VAR  ( FILE_ID, dID, I3, &
+          STATUS = NF90_GET_VAR  ( FILE_ID, dID, I33, &
                start=(/ 1, 1, 1, tx /), count=(/ mp, npatch2d, nlayer, 1 /) )
           IF (STATUS /= NF90_noerr) CALL handle_err(STATUS)
           DO p = 1, npatch2d
              DO m = 1, mp
                 SELECT CASE ( i )
                 CASE( 1)
-                   POP%pop_grid(m)%patch(p)%layer(:)%ncohort = I3(m,p,:)
+                   POP%pop_grid(m)%patch(p)%layer(:)%ncohort = I33(m,p,:)
                 CASE default
                    write(*,*) "Parameter not assigned in pop_io.F90!"
 #ifdef __MPI__
@@ -1541,7 +1541,7 @@ contains
              END DO
           END DO
        END DO
-       DEALLOCATE( I3 )
+       DEALLOCATE( I33 )
 
        ALLOCATE( R3( mp, npatch2d, nlayer ) )
        DO i = 1, SIZE(AR8)
@@ -1576,11 +1576,11 @@ contains
 
        ! COHORT STRUCTURE
        ! GET 4D VARS ( mp,npatch2d,nlayer,ncohort_max )
-       ALLOCATE( I4( mp, npatch2d, nlayer, ncohort_max ) )
+       ALLOCATE( I44( mp, npatch2d, nlayer, ncohort_max ) )
        DO i = 1, SIZE(AI9)
           STATUS = NF90_INQ_VARID( FILE_ID, TRIM(AI9(i)), dID )
           IF (STATUS /= NF90_noerr) CALL handle_err(STATUS)
-          STATUS = NF90_GET_VAR  ( FILE_ID, dID, I4, start=(/ 1, 1, 1, 1, tx /), &
+          STATUS = NF90_GET_VAR  ( FILE_ID, dID, I44, start=(/ 1, 1, 1, 1, tx /), &
                count=(/ mp,npatch2d,nlayer,ncohort_max,1 /) )
           IF (STATUS /= NF90_noerr) CALL handle_err(STATUS)
           DO l = 1, nlayer
@@ -1588,9 +1588,9 @@ contains
                 DO m = 1, mp
                    SELECT CASE ( i )
                    CASE( 1)
-                      POP%pop_grid(m)%patch(p)%layer(l)%cohort(:)%age = I4(m,p,l,:)
+                      POP%pop_grid(m)%patch(p)%layer(l)%cohort(:)%age = I44(m,p,l,:)
                    CASE( 2)
-                      POP%pop_grid(m)%patch(p)%layer(l)%cohort(:)%id  = I4(m,p,l,:)
+                      POP%pop_grid(m)%patch(p)%layer(l)%cohort(:)%id  = I44(m,p,l,:)
                    CASE default
                       write(*,*) "Parameter not assigned in pop_io.F90!"
 #ifdef __MPI__
@@ -1603,7 +1603,7 @@ contains
              END DO
           END DO
        END DO
-       DEALLOCATE( I4 )
+       DEALLOCATE( I44 )
 
        ALLOCATE( R4( mp, npatch2d, nlayer, ncohort_max ) )
        DO i = 1, SIZE(AR9)

--- a/core/biogeochem/spincasacnp.F90
+++ b/core/biogeochem/spincasacnp.F90
@@ -22,7 +22,6 @@ contains
     use casa_cable,          only: POPdriver, read_casa_dump, analyticpool
     use casa_inout,          only: casa_fluxout, biogeochem, write_casa_output_patch_nc, &
                                    write_casa_output_grid_nc
-    use TypeDef,             only: dp
     ! 13C
     use cable_c13o2_def,     only: c13o2_pool, c13o2_flux
     use cable_c13o2,         only: c13o2_save_casapool, c13o2_update_pools, &
@@ -61,38 +60,38 @@ contains
     ! type(casa_met) :: casaspin
 
     ! local variables
-    real(r_2), dimension(:), allocatable, save  :: avg_cleaf2met, avg_cleaf2str, avg_croot2met, avg_croot2str, avg_cwood2cwd
-    real(r_2), dimension(:), allocatable, save  :: avg_nleaf2met, avg_nleaf2str, avg_nroot2met, avg_nroot2str, avg_nwood2cwd
-    real(r_2), dimension(:), allocatable, save  :: avg_pleaf2met, avg_pleaf2str, avg_proot2met, avg_proot2str, avg_pwood2cwd
-    real(r_2), dimension(:), allocatable, save  :: avg_cgpp,      avg_cnpp,      avg_nuptake,   avg_puptake
-    real(r_2), dimension(:), allocatable, save  :: avg_nsoilmin,  avg_psoillab,  avg_psoilsorb, avg_psoilocc
+    real(r2), dimension(:), allocatable, save  :: avg_cleaf2met, avg_cleaf2str, avg_croot2met, avg_croot2str, avg_cwood2cwd
+    real(r2), dimension(:), allocatable, save  :: avg_nleaf2met, avg_nleaf2str, avg_nroot2met, avg_nroot2str, avg_nwood2cwd
+    real(r2), dimension(:), allocatable, save  :: avg_pleaf2met, avg_pleaf2str, avg_proot2met, avg_proot2str, avg_pwood2cwd
+    real(r2), dimension(:), allocatable, save  :: avg_cgpp,      avg_cnpp,      avg_nuptake,   avg_puptake
+    real(r2), dimension(:), allocatable, save  :: avg_nsoilmin,  avg_psoillab,  avg_psoilsorb, avg_psoilocc
     !chris 12/oct/2012 for spin up casa
-    real(r_2), dimension(:), allocatable, save  :: avg_ratioNCsoilmic,  avg_ratioNCsoilslow,  avg_ratioNCsoilpass
-    real(r_2), dimension(:), allocatable, save  :: avg_xnplimit,  avg_xkNlimiting,avg_xklitter, avg_xksoil
+    real(r2), dimension(:), allocatable, save  :: avg_ratioNCsoilmic,  avg_ratioNCsoilslow,  avg_ratioNCsoilpass
+    real(r2), dimension(:), allocatable, save  :: avg_xnplimit,  avg_xkNlimiting,avg_xklitter, avg_xksoil
 
     ! local variables
     integer                  :: myearspin, nyear, nloop1
     character(len=99)        :: ncfile
     character(len=4)         :: cyear
     integer                  :: ktau, ktauday, nday, idoy, ktauy, nloop, LOY, YYYY
-    real(r_2), dimension(mp) :: cleaf2met, cleaf2str, croot2met, croot2str, cwood2cwd
-    real(r_2), dimension(mp) :: nleaf2met, nleaf2str, nroot2met, nroot2str, nwood2cwd
-    real(r_2), dimension(mp) :: pleaf2met, pleaf2str, proot2met, proot2str, pwood2cwd
-    real(r_2), dimension(mp) :: xnplimit,  xkNlimiting, xklitter, xksoil, xkleaf, xkleafcold, xkleafdry
+    real(r2), dimension(mp) :: cleaf2met, cleaf2str, croot2met, croot2str, cwood2cwd
+    real(r2), dimension(mp) :: nleaf2met, nleaf2str, nroot2met, nroot2str, nwood2cwd
+    real(r2), dimension(mp) :: pleaf2met, pleaf2str, proot2met, proot2str, pwood2cwd
+    real(r2), dimension(mp) :: xnplimit,  xkNlimiting, xklitter, xksoil, xkleaf, xkleafcold, xkleafdry
 
     ! more variables to store the spinup pool size over the last 10 loops. Added by Yp Wang 30 Nov 2012
-    real(dp), allocatable, save :: LAImax(:), Cleafmean(:), Crootmean(:)
-    real(dp), allocatable :: NPPtoGPP(:)
+    real(r2), allocatable, save :: LAImax(:), Cleafmean(:), Crootmean(:)
+    real(r2), allocatable :: NPPtoGPP(:)
     integer,  allocatable :: Iw(:) ! array of indices corresponding to woody (shrub or forest) tiles
     integer :: ctime
-    real(dp) :: rday
+    real(r2) :: rday
 
     ! 13C
-    real(dp), dimension(c13o2pools%ntile,c13o2pools%npools) :: casasave
+    real(r2), dimension(c13o2pools%ntile,c13o2pools%npools) :: casasave
     integer :: c13o2_file_id
     character(len=40), dimension(c13o2_nvars_output) :: c13o2_vars
     integer,           dimension(c13o2_nvars_output) :: c13o2_var_ids
-    real(r_2), dimension(:), allocatable :: avg_c13leaf2met, avg_c13leaf2str, avg_c13root2met, &
+    real(r2), dimension(:), allocatable :: avg_c13leaf2met, avg_c13leaf2str, avg_c13root2met, &
          avg_c13root2str, avg_c13wood2cwd
 
     if (.not. allocated(LAIMax))    allocate(LAIMax(mp))
@@ -130,43 +129,43 @@ contains
     myearspin = CABLE_USER%CASA_SPIN_ENDYEAR - CABLE_USER%CASA_SPIN_STARTYEAR + 1
 
     ! compute the mean fluxes and residence time of each carbon pool
-    avg_cleaf2met       = 0.0_dp
-    avg_cleaf2str       = 0.0_dp
-    avg_croot2met       = 0.0_dp
-    avg_croot2str       = 0.0_dp
-    avg_cwood2cwd       = 0.0_dp
-    avg_nleaf2met       = 0.0_dp
-    avg_nleaf2str       = 0.0_dp
-    avg_nroot2met       = 0.0_dp
-    avg_nroot2str       = 0.0_dp
-    avg_nwood2cwd       = 0.0_dp
-    avg_pleaf2met       = 0.0_dp
-    avg_pleaf2str       = 0.0_dp
-    avg_proot2met       = 0.0_dp
-    avg_proot2str       = 0.0_dp
-    avg_pwood2cwd       = 0.0_dp
-    avg_cgpp            = 0.0_dp
-    avg_cnpp            = 0.0_dp
-    avg_nuptake         = 0.0_dp
-    avg_puptake         = 0.0_dp
-    avg_xnplimit        = 0.0_dp
-    avg_xkNlimiting     = 0.0_dp
-    avg_xklitter        = 0.0_dp
-    avg_xksoil          = 0.0_dp
-    avg_nsoilmin        = 0.0_dp
-    avg_psoillab        = 0.0_dp
-    avg_psoilsorb       = 0.0_dp
-    avg_psoilocc        = 0.0_dp
-    avg_rationcsoilmic  = 0.0_dp
-    avg_rationcsoilslow = 0.0_dp
-    avg_rationcsoilpass = 0.0_dp
+    avg_cleaf2met       = 0.0_r2
+    avg_cleaf2str       = 0.0_r2
+    avg_croot2met       = 0.0_r2
+    avg_croot2str       = 0.0_r2
+    avg_cwood2cwd       = 0.0_r2
+    avg_nleaf2met       = 0.0_r2
+    avg_nleaf2str       = 0.0_r2
+    avg_nroot2met       = 0.0_r2
+    avg_nroot2str       = 0.0_r2
+    avg_nwood2cwd       = 0.0_r2
+    avg_pleaf2met       = 0.0_r2
+    avg_pleaf2str       = 0.0_r2
+    avg_proot2met       = 0.0_r2
+    avg_proot2str       = 0.0_r2
+    avg_pwood2cwd       = 0.0_r2
+    avg_cgpp            = 0.0_r2
+    avg_cnpp            = 0.0_r2
+    avg_nuptake         = 0.0_r2
+    avg_puptake         = 0.0_r2
+    avg_xnplimit        = 0.0_r2
+    avg_xkNlimiting     = 0.0_r2
+    avg_xklitter        = 0.0_r2
+    avg_xksoil          = 0.0_r2
+    avg_nsoilmin        = 0.0_r2
+    avg_psoillab        = 0.0_r2
+    avg_psoilsorb       = 0.0_r2
+    avg_psoilocc        = 0.0_r2
+    avg_rationcsoilmic  = 0.0_r2
+    avg_rationcsoilslow = 0.0_r2
+    avg_rationcsoilpass = 0.0_r2
     ! 13C
     if (cable_user%c13o2) then
-       avg_c13leaf2met = 0.0_dp
-       avg_c13leaf2str = 0.0_dp
-       avg_c13root2met = 0.0_dp
-       avg_c13root2str = 0.0_dp
-       avg_c13wood2cwd = 0.0_dp
+       avg_c13leaf2met = 0.0_r2
+       avg_c13leaf2str = 0.0_r2
+       avg_c13root2met = 0.0_r2
+       avg_c13root2str = 0.0_r2
+       avg_c13wood2cwd = 0.0_r2
     endif
 
     !   write(600,*) 'csoil3 init: ', casapool%csoil(3,:)
@@ -222,15 +221,15 @@ contains
           ! 13C
           if (cable_user%c13o2) then
              avg_c13leaf2met(:) = avg_c13leaf2met(:) + &
-                  cleaf2met(:) * isoratio(c13o2pools%cplant(:,leaf), casasave(:,leaf), 0.0_dp, tiny(1.0_dp)) ! 1.0_dp
+                  cleaf2met(:) * isoratio(c13o2pools%cplant(:,leaf), casasave(:,leaf), 0.0_r2, tiny(1.0_r2)) ! 1.0_r2
              avg_c13leaf2str(:) = avg_c13leaf2str(:) + &
-                  cleaf2str(:) * isoratio(c13o2pools%cplant(:,leaf), casasave(:,leaf), 0.0_dp, tiny(1.0_dp))
+                  cleaf2str(:) * isoratio(c13o2pools%cplant(:,leaf), casasave(:,leaf), 0.0_r2, tiny(1.0_r2))
              avg_c13root2met(:) = avg_c13root2met(:) + &
-                  croot2met(:) * isoratio(c13o2pools%cplant(:,froot), casasave(:,froot), 0.0_dp, tiny(1.0_dp))
+                  croot2met(:) * isoratio(c13o2pools%cplant(:,froot), casasave(:,froot), 0.0_r2, tiny(1.0_r2))
              avg_c13root2str(:) = avg_c13root2str(:) + &
-                  croot2str(:) * isoratio(c13o2pools%cplant(:,froot), casasave(:,froot), 0.0_dp, tiny(1.0_dp))
+                  croot2str(:) * isoratio(c13o2pools%cplant(:,froot), casasave(:,froot), 0.0_r2, tiny(1.0_r2))
              avg_c13wood2cwd(:) = avg_c13wood2cwd(:) + &
-                  cwood2cwd(:) * isoratio(c13o2pools%cplant(:,wood), casasave(:,wood), 0.0_dp, tiny(1.0_dp))
+                  cwood2cwd(:) * isoratio(c13o2pools%cplant(:,wood), casasave(:,wood), 0.0_r2, tiny(1.0_r2))
              call c13o2_update_pools(casasave, casaflux, c13o2flux, c13o2pools)
              call c13o2_sanity_pools(casapool, casaflux, c13o2pools)
           endif
@@ -250,22 +249,22 @@ contains
                 ! accumulate annual variables for use in POP
                 if (mod(ktau/ktauday,LOY) == 1) then
                    ! (assumes 70% of wood NPP is allocated above ground)
-                   casaflux%stemnpp  = casaflux%cnpp * casaflux%fracCalloc(:,2) * 0.7_dp
+                   casaflux%stemnpp  = casaflux%cnpp * casaflux%fracCalloc(:,2) * 0.7_r2
                    casaflux%potstemnpp = casaflux%stemnpp + (casaflux%fracClabile * casaflux%cgpp)
                    casabal%LAImax    = casamet%glai
-                   casabal%Cleafmean = casapool%cplant(:,1) / real(LOY,dp) / 1000._dp
-                   casabal%Crootmean = casapool%cplant(:,3) / real(LOY,dp) / 1000._dp
+                   casabal%Cleafmean = casapool%cplant(:,1) / real(LOY,r2) / 1000._r2
+                   casabal%Crootmean = casapool%cplant(:,3) / real(LOY,r2) / 1000._r2
                 else
-                   casaflux%stemnpp  = casaflux%stemnpp + casaflux%cnpp * casaflux%fracCalloc(:,2) * 0.7_dp
-                   casaflux%potstemnpp = casaflux%potstemnpp + (casaflux%cnpp * casaflux%fracCalloc(:,2) * 0.7_dp + &
+                   casaflux%stemnpp  = casaflux%stemnpp + casaflux%cnpp * casaflux%fracCalloc(:,2) * 0.7_r2
+                   casaflux%potstemnpp = casaflux%potstemnpp + (casaflux%cnpp * casaflux%fracCalloc(:,2) * 0.7_r2 + &
                                                                 casaflux%fracClabile * casaflux%cgpp)
                    casabal%LAImax    = max(casamet%glai, casabal%LAImax)
-                   casabal%Cleafmean = casabal%Cleafmean + casapool%cplant(:,1) / real(LOY,dp) / 1000.0_dp
-                   casabal%Crootmean = casabal%Crootmean + casapool%cplant(:,3) / real(LOY,dp) / 1000.0_dp
+                   casabal%Cleafmean = casabal%Cleafmean + casapool%cplant(:,1) / real(LOY,r2) / 1000.0_r2
+                   casabal%Crootmean = casabal%Crootmean + casapool%cplant(:,3) / real(LOY,r2) / 1000.0_r2
                 endif
              else
-                casaflux%stemnpp = 0.0_dp
-                casaflux%potstemnpp = 0.0_dp
+                casaflux%stemnpp = 0.0_r2
+                casaflux%potstemnpp = 0.0_r2
              endif ! CALL_POP
 
              !CALL WRITE_CASA_OUTPUT_NC (veg, casamet, casapool, casabal, casaflux, &
@@ -287,8 +286,8 @@ contains
              !    ! call write_casa_output_nc(veg, casamet, casapool, casabal, casaflux, .true., ctime, .false.)
              !    ctime = ctime + 1
              ! endif  ! end of year
-             casaflux%stemnpp = 0.0_dp
-             casaflux%potstemnpp = 0.0_dp
+             casaflux%stemnpp = 0.0_r2
+             casaflux%potstemnpp = 0.0_r2
 
           endif ! (cable_user%CALL_POP .and. (POP%np.gt.0))
 
@@ -338,7 +337,7 @@ contains
 
     !!CLN    CLOSE(91)
     ! average
-    rday = 1.0_dp / real(nday*myearspin, dp)
+    rday = 1.0_r2 / real(nday*myearspin, r2)
 
     avg_cleaf2met       = avg_cleaf2met       * rday
     avg_cleaf2str       = avg_cleaf2str       * rday
@@ -540,22 +539,22 @@ contains
                    ! accumulate annual variables for use in POP
                    IF (MOD(ktau/ktauday,LOY) == 1) THEN
                       ! (assumes 70% of wood NPP is allocated above ground)
-                      casaflux%stemnpp  = casaflux%cnpp * casaflux%fracCalloc(:,2) * 0.7_dp
+                      casaflux%stemnpp  = casaflux%cnpp * casaflux%fracCalloc(:,2) * 0.7_r2
                       casaflux%potstemnpp = casaflux%stemnpp + (casaflux%fracClabile * casaflux%cgpp)
                       casabal%LAImax    = casamet%glai
-                      casabal%Cleafmean = casapool%cplant(:,1) / real(LOY,dp) / 1000.0_dp
-                      casabal%Crootmean = casapool%cplant(:,3) / real(LOY,dp) / 1000.0_dp
+                      casabal%Cleafmean = casapool%cplant(:,1) / real(LOY,r2) / 1000.0_r2
+                      casabal%Crootmean = casapool%cplant(:,3) / real(LOY,r2) / 1000.0_r2
                    ELSE
-                      casaflux%stemnpp  = casaflux%stemnpp + casaflux%cnpp * casaflux%fracCalloc(:,2) * 0.7_dp
-                      casaflux%potstemnpp = casaflux%potstemnpp + (casaflux%cnpp * casaflux%fracCalloc(:,2) * 0.7_dp + &
+                      casaflux%stemnpp  = casaflux%stemnpp + casaflux%cnpp * casaflux%fracCalloc(:,2) * 0.7_r2
+                      casaflux%potstemnpp = casaflux%potstemnpp + (casaflux%cnpp * casaflux%fracCalloc(:,2) * 0.7_r2 + &
                                                                    casaflux%fracClabile * casaflux%cgpp)
                       casabal%LAImax    = max(casamet%glai, casabal%LAImax)
-                      casabal%Cleafmean = casabal%Cleafmean + casapool%cplant(:,1) / real(LOY,dp) / 1000.0_dp
-                      casabal%Crootmean = casabal%Crootmean + casapool%cplant(:,3) / real(LOY,dp) / 1000.0_dp
+                      casabal%Cleafmean = casabal%Cleafmean + casapool%cplant(:,1) / real(LOY,r2) / 1000.0_r2
+                      casabal%Crootmean = casabal%Crootmean + casapool%cplant(:,3) / real(LOY,r2) / 1000.0_r2
                    ENDIF
                 ELSE
-                   casaflux%stemnpp = 0.0_dp
-                   casaflux%potstemnpp = 0.0_dp
+                   casaflux%stemnpp = 0.0_r2
+                   casaflux%potstemnpp = 0.0_r2
                 ENDIF ! CALL_POP
 
                 IF (idoy==mdyear) THEN ! end of year
@@ -575,8 +574,8 @@ contains
                 !         (nloop.eq.mloop .and. nyear.eq.myearspin.and.idoy.eq.mdyear)  )
                 !     ctime = ctime+1
                 ! ENDIF ! end of year
-                casaflux%stemnpp = 0.0_dp
-                casaflux%potstemnpp = 0.0_dp
+                casaflux%stemnpp = 0.0_r2
+                casaflux%potstemnpp = 0.0_r2
              ENDIF ! CALL_POP
 
           ENDDO ! end of idoy

--- a/core/biogeophys/cable_albedo.F90
+++ b/core/biogeophys/cable_albedo.F90
@@ -43,7 +43,7 @@ SUBROUTINE surface_albedo(ssnow, veg, met, rad, soil, canopy)
    USE cable_common_module
    USE cable_def_types_mod, ONLY : veg_parameter_type, soil_parameter_type, &
                                    canopy_type, met_type, radiation_type,   &
-                                   soil_snow_type, mp, r_2, nrb
+                                   soil_snow_type, mp, r2, nrb
 
    implicit none
 
@@ -54,7 +54,7 @@ SUBROUTINE surface_albedo(ssnow, veg, met, rad, soil, canopy)
    TYPE(soil_parameter_type), INTENT(INOUT) :: soil
    TYPE(canopy_type),         INTENT(IN)    :: canopy
 
-   REAL(r_2), DIMENSION(mp) :: dummy2, dummy
+   REAL(r2), DIMENSION(mp) :: dummy2, dummy
    REAL, DIMENSION(:,:), ALLOCATABLE, SAVE :: c1, rhoch
    LOGICAL, DIMENSION(mp)  :: mask ! select points for calculation
    INTEGER :: b    !rad. band 1=visible, 2=near-infrared, 3=long-wave
@@ -353,7 +353,7 @@ END SUBROUTINE calc_rhoch
 ! subr to calc soil albedo based on colour - Ticket #27
 SUBROUTINE soilcol_albedo(ssnow, soil)
 
-   USE cable_def_types_mod, ONLY: soil_snow_type, soil_parameter_type, r_2, mp, nrb
+   USE cable_def_types_mod, ONLY: soil_snow_type, soil_parameter_type, r2, mp, nrb
 
    implicit none
 
@@ -363,47 +363,47 @@ SUBROUTINE soilcol_albedo(ssnow, soil)
 
    ! Local Variables
    INTEGER   :: ib
-   REAL(r_2), DIMENSION(mp)      :: inc
-   REAL(r_2), DIMENSION(mp, nrb) :: albsod, & ! soil albedo (direct)
+   REAL(r2), DIMENSION(mp)      :: inc
+   REAL(r2), DIMENSION(mp, nrb) :: albsod, & ! soil albedo (direct)
                                     albsoi    ! soil albedo (indirect)
    ! Look-up tables for soil albedo
    ! saturated soil albedos for 20 color classes and 2 wavebands (1=vis, 2=nir)
-   REAL(r_2), DIMENSION(20,nrb) :: &
+   REAL(r2), DIMENSION(20,nrb) :: &
       albsat, &
       albdry
-   REAL(r_2), PARAMETER, DIMENSION(20*nrb) :: albsat1D = (/ &
-        0.25_r_2,0.23_r_2,0.21_r_2,0.20_r_2,0.19_r_2,0.18_r_2, &
-        0.17_r_2,0.16_r_2,0.15_r_2,0.14_r_2,0.13_r_2,0.12_r_2, &
-        0.11_r_2,0.10_r_2,0.09_r_2,0.08_r_2,0.07_r_2,0.06_r_2, &
-        0.05_r_2,0.04_r_2,0.50_r_2,0.46_r_2,0.42_r_2,0.40_r_2, &
-        0.38_r_2,0.36_r_2,0.34_r_2,0.32_r_2,0.30_r_2,0.28_r_2, &
-        0.26_r_2,0.24_r_2,0.22_r_2,0.20_r_2,0.18_r_2,0.16_r_2, &
-        0.14_r_2,0.12_r_2,0.10_r_2,0.08_r_2, 0.0_r_2, 0.0_r_2, &
-        0.0_r_2, 0.0_r_2, 0.0_r_2, 0.0_r_2, 0.0_r_2, 0.0_r_2, &
-        0.0_r_2, 0.0_r_2, 0.0_r_2, 0.0_r_2, 0.0_r_2, 0.0_r_2, &
-        0.0_r_2, 0.0_r_2, 0.0_r_2, 0.0_r_2, 0.0_r_2, 0.0_r_2 /)
+   REAL(r2), PARAMETER, DIMENSION(20*nrb) :: albsat1D = (/ &
+        0.25_r2,0.23_r2,0.21_r2,0.20_r2,0.19_r2,0.18_r2, &
+        0.17_r2,0.16_r2,0.15_r2,0.14_r2,0.13_r2,0.12_r2, &
+        0.11_r2,0.10_r2,0.09_r2,0.08_r2,0.07_r2,0.06_r2, &
+        0.05_r2,0.04_r2,0.50_r2,0.46_r2,0.42_r2,0.40_r2, &
+        0.38_r2,0.36_r2,0.34_r2,0.32_r2,0.30_r2,0.28_r2, &
+        0.26_r2,0.24_r2,0.22_r2,0.20_r2,0.18_r2,0.16_r2, &
+        0.14_r2,0.12_r2,0.10_r2,0.08_r2, 0.0_r2, 0.0_r2, &
+        0.0_r2, 0.0_r2, 0.0_r2, 0.0_r2, 0.0_r2, 0.0_r2, &
+        0.0_r2, 0.0_r2, 0.0_r2, 0.0_r2, 0.0_r2, 0.0_r2, &
+        0.0_r2, 0.0_r2, 0.0_r2, 0.0_r2, 0.0_r2, 0.0_r2 /)
    ! dry soil albedos for 20 color classes and 2 wavebands (1=vis, 2=nir)
-   REAL(r_2), PARAMETER, DIMENSION(20*nrb) :: albdry1D = (/ &
-        0.36_r_2,0.34_r_2,0.32_r_2,0.31_r_2,0.30_r_2,0.29_r_2, &
-        0.28_r_2,0.27_r_2,0.26_r_2,0.25_r_2,0.24_r_2,0.23_r_2, &
-        0.22_r_2,0.20_r_2,0.18_r_2,0.16_r_2,0.14_r_2,0.12_r_2, &
-        0.10_r_2,0.08_r_2,0.61_r_2,0.57_r_2,0.53_r_2,0.51_r_2, &
-        0.49_r_2,0.48_r_2,0.45_r_2,0.43_r_2,0.41_r_2,0.39_r_2, &
-        0.37_r_2,0.35_r_2,0.33_r_2,0.31_r_2,0.29_r_2,0.27_r_2, &
-        0.25_r_2,0.23_r_2,0.21_r_2,0.16_r_2, 0.0_r_2, 0.0_r_2, &
-        0.0_r_2, 0.0_r_2, 0.0_r_2, 0.0_r_2, 0.0_r_2, 0.0_r_2, &
-        0.0_r_2, 0.0_r_2, 0.0_r_2, 0.0_r_2, 0.0_r_2, 0.0_r_2, &
-        0.0_r_2, 0.0_r_2, 0.0_r_2, 0.0_r_2, 0.0_r_2, 0.0_r_2 /)
+   REAL(r2), PARAMETER, DIMENSION(20*nrb) :: albdry1D = (/ &
+        0.36_r2,0.34_r2,0.32_r2,0.31_r2,0.30_r2,0.29_r2, &
+        0.28_r2,0.27_r2,0.26_r2,0.25_r2,0.24_r2,0.23_r2, &
+        0.22_r2,0.20_r2,0.18_r2,0.16_r2,0.14_r2,0.12_r2, &
+        0.10_r2,0.08_r2,0.61_r2,0.57_r2,0.53_r2,0.51_r2, &
+        0.49_r2,0.48_r2,0.45_r2,0.43_r2,0.41_r2,0.39_r2, &
+        0.37_r2,0.35_r2,0.33_r2,0.31_r2,0.29_r2,0.27_r2, &
+        0.25_r2,0.23_r2,0.21_r2,0.16_r2, 0.0_r2, 0.0_r2, &
+        0.0_r2, 0.0_r2, 0.0_r2, 0.0_r2, 0.0_r2, 0.0_r2, &
+        0.0_r2, 0.0_r2, 0.0_r2, 0.0_r2, 0.0_r2, 0.0_r2, &
+        0.0_r2, 0.0_r2, 0.0_r2, 0.0_r2, 0.0_r2, 0.0_r2 /)
 
    albsat = RESHAPE( albsat1D, (/20, nrb/) )
    albdry = RESHAPE( albdry1D, (/20, nrb/) )
 
    DO ib = 1,2 ! Number of wavebands (vis, nir)
-      inc = MAX(0.11_r_2-0.40_r_2*ssnow%wb(:,1), 0._r_2)
+      inc = MAX(0.11_r2-0.40_r2*ssnow%wb(:,1), 0._r2)
       albsod(:,ib) = MIN(albsat(INT(soil%soilcol),ib)+inc, albdry(INT(soil%soilcol),ib))
       albsoi(:,ib) = albsod(:,ib)
    END DO
-   ssnow%albsoilsn = real(0.5_r_2*(albsod + albsoi))
+   ssnow%albsoilsn = real(0.5_r2*(albsod + albsoi))
 
 END SUBROUTINE soilcol_albedo
 

--- a/core/biogeophys/cable_c13o2_def.F90
+++ b/core/biogeophys/cable_c13o2_def.F90
@@ -9,7 +9,7 @@
 
 MODULE cable_c13o2_def
 
-  use cable_def_types_mod, only: dp => r_2
+  use cable_def_types_mod, only: r2
 
   implicit none
 
@@ -32,47 +32,47 @@ MODULE cable_c13o2_def
   public :: c13o2_update_sum_pools
 
   ! variables
-  real(dp), dimension(:), allocatable :: c13o2_delta_atm
+  real(r2), dimension(:), allocatable :: c13o2_delta_atm
 
   ! types
   type c13o2_flux ! all fluxes in units mol(13CO2)/m2s
      integer                           :: ntile, nleaf
      ! atmospheric 13CO2 concentration [mol(13CO2)/mol(air)]
-     real(dp), dimension(:),   pointer :: ca => null()
+     real(r2), dimension(:),   pointer :: ca => null()
      ! net assimilation 13CO2 flux divided by VPDB [mol(CO2)/m2s]
-     real(dp), dimension(:,:), pointer :: An => null()
+     real(r2), dimension(:,:), pointer :: An => null()
      ! leaf discrimination: 1-A13/A12/Ca
-     real(dp), dimension(:,:), pointer :: Disc => null()
+     real(r2), dimension(:,:), pointer :: Disc => null()
      ! daily cumulated total 12CO2 net assimilation in [mol(CO2)/m2]
-     real(dp), dimension(:),   pointer :: cAn12 => null()
+     real(r2), dimension(:),   pointer :: cAn12 => null()
      ! daily cumulated total 13CO2 net assimilation divided by VPDB in [mol(CO2)/m2]
-     real(dp), dimension(:),   pointer :: cAn => null()
+     real(r2), dimension(:),   pointer :: cAn => null()
      ! isotope ratio of daily cumulated total 13CO2 net assimilation over 12CO2 net assimilation divided by VPDB
-     real(dp), dimension(:),   pointer :: RAn => null()
+     real(r2), dimension(:),   pointer :: RAn => null()
      ! Transitory starch concentration in leaf [mol(CO2)/m2] - One pool for sun and shade leaves
-     real(dp), dimension(:),   pointer :: Vstarch => null()
+     real(r2), dimension(:),   pointer :: Vstarch => null()
      ! Isotopic composition of transitory starch
-     real(dp), dimension(:),   pointer :: Rstarch => null()
+     real(r2), dimension(:),   pointer :: Rstarch => null()
      ! Isotopic composition of leaf sucrose
-     real(dp), dimension(:,:), pointer :: Rsucrose => null()
+     real(r2), dimension(:,:), pointer :: Rsucrose => null()
      ! Isotopic composition of pool used for photorespiration
-     real(dp), dimension(:,:), pointer :: Rphoto => null()
+     real(r2), dimension(:,:), pointer :: Rphoto => null()
   end type c13o2_flux
 
   type c13o2_pool ! all pools in units g(C)/m2
      integer                           :: ntile, nplant, nlitter, nsoil, npools
-     real(dp), dimension(:,:), pointer :: cplant => null()   ! 13C content in plants: leaves, wood, fine roots
-     real(dp), dimension(:,:), pointer :: clitter => null()  ! 13C content in litter: metabolic, fine structural, coarse woody debris
-     real(dp), dimension(:,:), pointer :: csoil => null()    ! 13C content in soils: fast, medium, slow
-     real(dp), dimension(:),   pointer :: clabile => null()  ! 13C content in excess pool
-     real(dp), dimension(:),   pointer :: charvest => null() ! 13C content in agricultural harvest products
+     real(r2), dimension(:,:), pointer :: cplant => null()   ! 13C content in plants: leaves, wood, fine roots
+     real(r2), dimension(:,:), pointer :: clitter => null()  ! 13C content in litter: metabolic, fine structural, coarse woody debris
+     real(r2), dimension(:,:), pointer :: csoil => null()    ! 13C content in soils: fast, medium, slow
+     real(r2), dimension(:),   pointer :: clabile => null()  ! 13C content in excess pool
+     real(r2), dimension(:),   pointer :: charvest => null() ! 13C content in agricultural harvest products
   end type c13o2_pool
 
   type c13o2_luc  ! all pools in units g(C)/m2
      integer                           :: nland, nharvest, nclearance, npools
-     real(dp), dimension(:,:), pointer :: charvest => null()   ! 13C content in harvest products
-     real(dp), dimension(:,:), pointer :: cclearance => null() ! 13C content in clearance products
-     real(dp), dimension(:),   pointer :: cagric => null()     ! 13C content in agricultural products
+     real(r2), dimension(:,:), pointer :: charvest => null()   ! 13C content in harvest products
+     real(r2), dimension(:,:), pointer :: cclearance => null() ! 13C content in clearance products
+     real(r2), dimension(:),   pointer :: cagric => null()     ! 13C content in agricultural products
   end type c13o2_luc
 
   ! ------------------------------------------------------------------
@@ -158,22 +158,22 @@ contains
   ! Zero all 13C fluxes
   subroutine c13o2_zero_flux(c13o2flux)
 
-    use cable_def_types_mod, only: dp => r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
     type(c13o2_flux), intent(inout) :: c13o2flux
 
-    c13o2flux%ca       =  0.0_dp
-    c13o2flux%An       =  0.0_dp
-    c13o2flux%Disc     = -1.0_dp
-    c13o2flux%cAn12    =  0.0_dp
-    c13o2flux%cAn      =  0.0_dp
-    c13o2flux%RAn      =  0.0_dp
-    c13o2flux%Vstarch  =  0.0_dp
-    c13o2flux%Rstarch  =  1.0_dp
-    c13o2flux%Rsucrose =  1.0_dp
-    c13o2flux%Rphoto   =  1.0_dp
+    c13o2flux%ca       =  0.0_r2
+    c13o2flux%An       =  0.0_r2
+    c13o2flux%Disc     = -1.0_r2
+    c13o2flux%cAn12    =  0.0_r2
+    c13o2flux%cAn      =  0.0_r2
+    c13o2flux%RAn      =  0.0_r2
+    c13o2flux%Vstarch  =  0.0_r2
+    c13o2flux%Rstarch  =  1.0_r2
+    c13o2flux%Rsucrose =  1.0_r2
+    c13o2flux%Rphoto   =  1.0_r2
 
   end subroutine c13o2_zero_flux
 
@@ -182,17 +182,17 @@ contains
   ! Zero all 13C Casa pools
   subroutine c13o2_zero_pools(c13o2pools)
 
-    use cable_def_types_mod, only: dp => r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
     type(c13o2_pool), intent(inout) :: c13o2pools
 
-    c13o2pools%cplant   = 0.0_dp
-    c13o2pools%clitter  = 0.0_dp
-    c13o2pools%csoil    = 0.0_dp
-    c13o2pools%clabile  = 0.0_dp
-    c13o2pools%charvest = 0.0_dp
+    c13o2pools%cplant   = 0.0_r2
+    c13o2pools%clitter  = 0.0_r2
+    c13o2pools%csoil    = 0.0_r2
+    c13o2pools%clabile  = 0.0_r2
+    c13o2pools%charvest = 0.0_r2
 
   end subroutine c13o2_zero_pools
 
@@ -201,15 +201,15 @@ contains
   ! Zero all 13C LUC pools
   subroutine c13o2_zero_luc(c13o2luc)
 
-    use cable_def_types_mod, only: dp => r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
     type(c13o2_luc), intent(inout) :: c13o2luc
 
-    c13o2luc%charvest   = 0.0_dp
-    c13o2luc%cclearance = 0.0_dp
-    c13o2luc%cagric     = 0.0_dp
+    c13o2luc%charvest   = 0.0_r2
+    c13o2luc%cclearance = 0.0_r2
+    c13o2luc%cagric     = 0.0_r2
 
   end subroutine c13o2_zero_luc
 
@@ -218,16 +218,16 @@ contains
   ! Zero the accumulated output for 13CO2
   subroutine c13o2_zero_sum_pools(sum_c13o2pools)
 
-    use cable_def_types_mod, only: dp => r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
     type(c13o2_pool), intent(inout) :: sum_c13o2pools
 
-    sum_c13o2pools%cplant   = 0.0_dp
-    sum_c13o2pools%clitter  = 0.0_dp
-    sum_c13o2pools%csoil    = 0.0_dp
-    sum_c13o2pools%clabile  = 0.0_dp
+    sum_c13o2pools%cplant   = 0.0_r2
+    sum_c13o2pools%clitter  = 0.0_r2
+    sum_c13o2pools%csoil    = 0.0_r2
+    sum_c13o2pools%clabile  = 0.0_r2
 
   end subroutine c13o2_zero_sum_pools
 
@@ -237,6 +237,8 @@ contains
   ! or divide at end by number of time steps
   subroutine c13o2_update_sum_pools(sum_c13o2pools, c13o2pools, sum_now, average_now, nsteps)
 
+    use cable_def_types_mod, only: r2
+
     implicit none
 
     type(c13o2_pool), intent(inout) :: sum_c13o2pools
@@ -244,7 +246,7 @@ contains
     logical,          intent(in)    :: sum_now, average_now
     integer,          intent(in)    :: nsteps
 
-    real(dp) :: rsteps ! 1/real(nsteps)
+    real(r2) :: rsteps ! 1/real(nsteps)
 
     if (sum_now) then
        sum_c13o2pools%cplant  =  sum_c13o2pools%cplant   + c13o2pools%cplant
@@ -253,7 +255,7 @@ contains
        sum_c13o2pools%clabile  = sum_c13o2pools%clabile  + c13o2pools%clabile
     endif
     if (average_now) then
-       rsteps = 1.0_dp / real(nsteps,dp)
+       rsteps = 1.0_r2 / real(nsteps,r2)
        sum_c13o2pools%cplant   = sum_c13o2pools%cplant  * rsteps
        sum_c13o2pools%clitter  = sum_c13o2pools%clitter * rsteps
        sum_c13o2pools%csoil    = sum_c13o2pools%csoil   * rsteps

--- a/core/biogeophys/cable_canopy.F90
+++ b/core/biogeophys/cable_canopy.F90
@@ -115,16 +115,16 @@ CONTAINS
          tlfx => null(),          & ! leaf temp prev. iter (K)
          tlfy => null()             ! leaf temp (K)
 
-    REAL(r_2), DIMENSION(mp) :: &
+    REAL(r2), DIMENSION(mp) :: &
          gbvtop                   ! bnd layer cond. top leaf
 
-    REAL(r_2), DIMENSION(:), POINTER :: &
+    REAL(r2), DIMENSION(:), POINTER :: &
          ecy => null(),           & ! lat heat fl dry big leaf
          hcy => null(),           & ! veg. sens heat
          rny => null(),           & ! net rad
          ghwet => null()            ! cond for heat for a wet canopy
 
-    REAL(r_2), DIMENSION(:,:), POINTER :: &
+    REAL(r2), DIMENSION(:,:), POINTER :: &
          gbhu => null(),          & ! forcedConvectionBndryLayerCond
          gbhf => null(),          & ! freeConvectionBndryLayerCond
          csx => null()              ! leaf surface CO2 concentration
@@ -173,53 +173,53 @@ CONTAINS
 
     canopy%fevw_pot = 0.0
     canopy%gswx     = 1.0e-3     ! default stomatal conuctance
-    gbhf            = 1.0e-3_r_2 ! default free convection boundary layer conductance
-    gbhu            = 1.0e-3_r_2 ! default forced convection boundary layer conductance
+    gbhf            = 1.0e-3_r2 ! default free convection boundary layer conductance
+    gbhu            = 1.0e-3_r2 ! default forced convection boundary layer conductance
     ssnow%evapfbl   = 0.0
-    ssnow%rex       = 0.0_r_2
+    ssnow%rex       = 0.0_r2
     ! Initialise in-canopy temperatures and humidity:
-    csx = SPREAD(real(met%ca,r_2), 2, mf) ! initialise leaf surface CO2 concentration
+    csx = SPREAD(real(met%ca,r2), 2, mf) ! initialise leaf surface CO2 concentration
     met%tvair = met%tk
     met%qvair = met%qv
     canopy%tv = met%tvair
 
     ! Initialise sunlit and shaded Ac and Aj diagnostics
-    canopy%A_sh           = 0.0_r_2
-    canopy%A_sl           = 0.0_r_2
-    canopy%A_shC          = 0.0_r_2
-    canopy%A_slC          = 0.0_r_2
-    canopy%A_shJ          = 0.0_r_2
-    canopy%A_slJ          = 0.0_r_2
-    canopy%GPP_sh         = 0.0_r_2
-    canopy%GPP_sl         = 0.0_r_2
-    canopy%fevc_sh        = 0.0_r_2
-    canopy%fevc_sl        = 0.0_r_2
-    canopy%eta_A_cs       = 0.0_r_2
-    canopy%eta_GPP_cs     = 0.0_r_2
-    canopy%eta_fevc_cs    = 0.0_r_2
-    canopy%eta_A_cs_sh    = 0.0_r_2
-    canopy%eta_A_cs_sl    = 0.0_r_2
-    canopy%eta_fevc_cs_sh = 0.0_r_2
-    canopy%eta_fevc_cs_sl = 0.0_r_2
+    canopy%A_sh           = 0.0_r2
+    canopy%A_sl           = 0.0_r2
+    canopy%A_shC          = 0.0_r2
+    canopy%A_slC          = 0.0_r2
+    canopy%A_shJ          = 0.0_r2
+    canopy%A_slJ          = 0.0_r2
+    canopy%GPP_sh         = 0.0_r2
+    canopy%GPP_sl         = 0.0_r2
+    canopy%fevc_sh        = 0.0_r2
+    canopy%fevc_sl        = 0.0_r2
+    canopy%eta_A_cs       = 0.0_r2
+    canopy%eta_GPP_cs     = 0.0_r2
+    canopy%eta_fevc_cs    = 0.0_r2
+    canopy%eta_A_cs_sh    = 0.0_r2
+    canopy%eta_A_cs_sl    = 0.0_r2
+    canopy%eta_fevc_cs_sh = 0.0_r2
+    canopy%eta_fevc_cs_sl = 0.0_r2
 
-    canopy%dAdcs   = 0.0_r_2
-    canopy%cs      = 0.0_r_2
-    canopy%cs_sl   = 0.0_r_2
-    canopy%cs_sh   = 0.0_r_2
-    canopy%tlf     = 0.0_r_2
-    canopy%dlf     = 0.0_r_2
-    canopy%evapfbl = 0.0_r_2
+    canopy%dAdcs   = 0.0_r2
+    canopy%cs      = 0.0_r2
+    canopy%cs_sl   = 0.0_r2
+    canopy%cs_sh   = 0.0_r2
+    canopy%tlf     = 0.0_r2
+    canopy%dlf     = 0.0_r2
+    canopy%evapfbl = 0.0_r2
 
     ! 13C
-    canopy%An        = 0.0_r_2
-    canopy%Rd        = 0.0_r_2
+    canopy%An        = 0.0_r2
+    canopy%Rd        = 0.0_r2
     canopy%isc3      = .true.
-    canopy%vcmax     = 0.0_r_2
-    canopy%gammastar = 0.0_r_2
-    canopy%gsc       = 0.0_r_2
-    canopy%gbc       = 0.0_r_2
-    canopy%gac       = 0.0_r_2
-    canopy%ci        = 0.0_r_2
+    canopy%vcmax     = 0.0_r2
+    canopy%gammastar = 0.0_r2
+    canopy%gsc       = 0.0_r2
+    canopy%gbc       = 0.0_r2
+    canopy%gac       = 0.0_r2
+    canopy%ci        = 0.0_r2
 
     CALL define_air(met, air)
 
@@ -241,9 +241,9 @@ CONTAINS
        ssnow%tss = real(ssnow%Tsurface) + C%tfrz
     endif
     tss4 = ssnow%tss**4
-    canopy%fes  = 0.0_r_2
-    canopy%fess = 0.0_r_2
-    canopy%fesp = 0.0_r_2
+    canopy%fes  = 0.0_r2
+    canopy%fess = 0.0_r2
+    canopy%fesp = 0.0_r2
     ssnow%potev = 0.0
     canopy%fevw_pot = 0.0
 
@@ -352,8 +352,8 @@ CONTAINS
              ! Mathews (2006), A process-based model of offine fuel moisture,
              !                 International Journal of Wildland Fire 15,155-168
              ! assuming here u=1.0 ms-1, bulk litter density 63.5 kgm-3
-             canopy%kthLitt = 0.3_r_2 ! ~ 0.2992125984251969 = 0.2+0.14*0.045*1000.0/63.5
-             canopy%DvLitt = 3.1415841138194147e-05_r_2 ! = 2.17e-5*exp(1.0*2.6)*exp(-0.5*(2.08+(1.0*2.38)))
+             canopy%kthLitt = 0.3_r2 ! ~ 0.2992125984251969 = 0.2+0.14*0.045*1000.0/63.5
+             canopy%DvLitt = 3.1415841138194147e-05_r2 ! = 2.17e-5*exp(1.0*2.6)*exp(-0.5*(2.08+(1.0*2.38)))
           ENDIF
 
        ENDIF
@@ -391,22 +391,22 @@ CONTAINS
              gbvtop(j) = real( air%cmolar(j)*C%APOL * air%visc(j) / C%prandt / &
                   veg%dleaf(j) * (canopy%us(j) / MAX(rough%usuh(j),1.e-6) &
                   * veg%dleaf(j) / air%visc(j) )**0.5 &
-                  * C%prandt**(1.0/3.0) / veg%shelrb(j), r_2 )
-             gbvtop(j) = MAX(0.05_r_2, gbvtop(j)) ! for testing (BP aug2010)
+                  * C%prandt**(1.0/3.0) / veg%shelrb(j), r2 )
+             gbvtop(j) = MAX(0.05_r2, gbvtop(j)) ! for testing (BP aug2010)
 
              ! Forced convection boundary layer conductance
              ! (see Wang & Leuning 1998, AFM):
              !vh! inserted 'min' to avoid floating underflow
-             gbhu(j,1) = gbvtop(j)*(1.0_r_2 - EXP(-real( min(canopy%vlaiw(j) * &
-                  (0.5*rough%coexp(j)+rad%extkb(j)), 20.0), r_2))) / &
-                  real(rad%extkb(j)+0.5*rough%coexp(j), r_2)
-             gbhu(j,2) = 2.0_r_2 / real(rough%coexp(j),r_2) * gbvtop(j) * &
-                  (1.0_r_2-EXP(-real( min(0.5*rough%coexp(j)*canopy%vlaiw(j), 20.0), r_2))) &
+             gbhu(j,1) = gbvtop(j)*(1.0_r2 - EXP(-real( min(canopy%vlaiw(j) * &
+                  (0.5*rough%coexp(j)+rad%extkb(j)), 20.0), r2))) / &
+                  real(rad%extkb(j)+0.5*rough%coexp(j), r2)
+             gbhu(j,2) = 2.0_r2 / real(rough%coexp(j),r2) * gbvtop(j) * &
+                  (1.0_r2-EXP(-real( min(0.5*rough%coexp(j)*canopy%vlaiw(j), 20.0), r2))) &
                   - gbhu(j,1)
 
              if (cable_user%amphistomatous) then
-                gbhu(j,1) = gbhu(j,1) * 2.0_r_2
-                gbhu(j,2) = gbhu(j,2) * 2.0_r_2
+                gbhu(j,1) = gbhu(j,1) * 2.0_r2
+                gbhu(j,2) = gbhu(j,2) * 2.0_r2
              endif
 
           ENDIF ! canopy%vlaiw(j) > C%LAI_THRESH
@@ -421,8 +421,8 @@ CONTAINS
        ! print*, 'RR25 ', rough%coexp
        ! print*, 'RR26 ', rad%extkb
 
-       rny = sum(real(rad%rniso,r_2), 2) ! init current estimate net rad
-       hcy = 0.0_r_2          ! init current estimate sensible heat
+       rny = sum(real(rad%rniso,r2), 2) ! init current estimate net rad
+       hcy = 0.0_r2          ! init current estimate sensible heat
        ecy = rny - hcy        ! init current estimate latent heat
 
        sum_rad_rniso = sum(rad%rniso,2)
@@ -518,7 +518,7 @@ CONTAINS
              !! vh_js !! account for additional litter resistance to sensible heat transfer
              canopy%fhs = air%rho * C%CAPP * (ssnow%tss - met%tk) / &
                   ( ssnow%rtsoil + real(1-ssnow%isflag) * &
-                  real(veg%clitt*0.003_r_2/canopy%kthLitt) / (air%rho*C%CAPP) )
+                  real(veg%clitt*0.003_r2/canopy%kthLitt) / (air%rho*C%CAPP) )
           ELSE
              canopy%fhs = air%rho * C%CAPP * (ssnow%tss - met%tk) / ssnow%rtsoil
           ENDIF
@@ -579,7 +579,7 @@ CONTAINS
              !! vh_js !! account for additional litter resistance to sensible heat transfer
              canopy%fhs =  air%rho *C%CAPP *(ssnow%tss - met%tvair) / &
                   ( ssnow%rtsoil +  real(1-ssnow%isflag) * &
-                  real(veg%clitt*0.003_r_2/canopy%kthLitt) / (air%rho*C%CAPP) )
+                  real(veg%clitt*0.003_r2/canopy%kthLitt) / (air%rho*C%CAPP) )
           else
              canopy%fhs = air%rho*C%CAPP*(ssnow%tss - met%tvair) /ssnow%rtsoil
           ENDIF
@@ -807,11 +807,11 @@ CONTAINS
        IF (cable_user%litter) THEN
           !!vh_js!!
           ssnow%dfh_dtg = air%rho * C%CAPP / ( ssnow%rtsoil + &
-               real(1-ssnow%isflag) * real(veg%clitt*0.003_r_2/canopy%kthLitt) / &
+               real(1-ssnow%isflag) * real(veg%clitt*0.003_r2/canopy%kthLitt) / &
                (air%rho*C%CAPP) )
           ssnow%dfe_ddq = ssnow%wetfac * air%rho * air%rlam * ssnow%cls/ &
                ( ssnow%rtsoil + real(1-ssnow%isflag) * &
-               real(veg%clitt*0.003_r_2/canopy%DvLitt) )
+               real(veg%clitt*0.003_r2/canopy%DvLitt) )
        ELSE
           ssnow%dfh_dtg = air%rho * C%CAPP / ssnow%rtsoil
           ssnow%dfe_ddq = ssnow%wetfac * air%rho * air%rlam * ssnow%cls / ssnow%rtsoil
@@ -821,7 +821,7 @@ CONTAINS
             / ( ( C%TETENC + ssnow%tss-C%tfrz )**2 )*EXP( C%TETENB * &
             ( ssnow%tss-C%tfrz ) / ( C%TETENC + ssnow%tss-C%tfrz ) )
        canopy%dgdtg = real(ssnow%dfn_dtg - ssnow%dfh_dtg - ssnow%dfe_ddq * &
-            ssnow%ddq_dtg, r_2)
+            ssnow%ddq_dtg, r2)
     ENDIF
 
     bal%drybal = REAL(ecy+hcy) - SUM(rad%rniso,2) &
@@ -896,7 +896,7 @@ CONTAINS
          ssnowpotev = cc1 * (canopy%fns - ground_H_flux) + &
               cc2 * air%rho * air%rlam * (qsatfvar - met%qvair) / &
               (ssnow%rtsoil + real(1-ssnow%isflag) * &
-              real(veg%clitt*0.003_r_2/canopy%DvLitt))
+              real(veg%clitt*0.003_r2/canopy%DvLitt))
       else
          ssnowpotev = cc1 * (canopy%fns - ground_H_flux) + &
               cc2 * air%rho * air%rlam * (qsatfvar - met%qvair) / ssnow%rtsoil
@@ -936,7 +936,7 @@ CONTAINS
       if (cable_user%litter) then
          !! vh_js !!
          ssnowpotev = air%rho * air%rlam * idq / &
-              (ssnow%rtsoil + real(1-ssnow%isflag) * real(veg%clitt*0.003_r_2/canopy%DvLitt))
+              (ssnow%rtsoil + real(1-ssnow%isflag) * real(veg%clitt*0.003_r2/canopy%DvLitt))
       else
          ssnowpotev = air%rho * air%rlam * idq / ssnow%rtsoil
       endif
@@ -952,37 +952,37 @@ CONTAINS
 
       implicit none
 
-      real(r_2), dimension(mp) :: frescale, flower_limit, fupper_limit, pwet
+      real(r2), dimension(mp) :: frescale, flower_limit, fupper_limit, pwet
 
       integer :: j
 
       ! Soil latent heat:
-      canopy%fess = real(ssnow%wetfac * ssnow%potev, r_2)
-      where (ssnow%potev < 0.0) canopy%fess = real(ssnow%potev, r_2)
+      canopy%fess = real(ssnow%wetfac * ssnow%potev, r2)
+      where (ssnow%potev < 0.0) canopy%fess = real(ssnow%potev, r2)
 
       ! Reduce soil evap due to presence of puddle
-      pwet = max(0.0_r_2, min(0.2_r_2, &
-           real(ssnow%pudsto,r_2) / max(1.0_r_2, real(ssnow%pudsmx,r_2)) ) )
-      canopy%fess = canopy%fess * (1.0_r_2-pwet)
+      pwet = max(0.0_r2, min(0.2_r2, &
+           real(ssnow%pudsto,r2) / max(1.0_r2, real(ssnow%pudsmx,r2)) ) )
+      canopy%fess = canopy%fess * (1.0_r2-pwet)
 
-      frescale = real(soil%zse(1) * 1000. * air%rlam / dels, r_2)
+      frescale = real(soil%zse(1) * 1000. * air%rlam / dels, r2)
 
       do j=1, mp
 
-         if ((ssnow%snowd(j) < 0.1) .and. (canopy%fess(j) > 0.0_r_2)) then
+         if ((ssnow%snowd(j) < 0.1) .and. (canopy%fess(j) > 0.0_r2)) then
             if (.not. cable_user%l_new_reduce_soilevp) then
-               flower_limit(j) = ssnow%wb(j,1) - real(soil%swilt(j),r_2)/2.0_r_2
+               flower_limit(j) = ssnow%wb(j,1) - real(soil%swilt(j),r2)/2.0_r2
             else
                ! E.Kowalczyk 2014 - reduces the soil evaporation
-               flower_limit(j) = ssnow%wb(j,1) - real(soil%swilt(j),r_2)
+               flower_limit(j) = ssnow%wb(j,1) - real(soil%swilt(j),r2)
             endif
 
-            fupper_limit(j) = max(0.0_r_2, &
+            fupper_limit(j) = max(0.0_r2, &
                  flower_limit(j) * frescale(j) &
-                 - real(ssnow%evapfbl(j,1)*air%rlam(j)/dels, r_2))
+                 - real(ssnow%evapfbl(j,1)*air%rlam(j)/dels, r2))
             canopy%fess(j) = min(canopy%fess(j), fupper_limit(j))
 
-            fupper_limit(j) = (ssnow%wb(j,1) - real(ssnow%wbice(j,1),r_2)) * frescale(j)
+            fupper_limit(j) = (ssnow%wb(j,1) - real(ssnow%wbice(j,1),r2)) * frescale(j)
             canopy%fess(j) = min(canopy%fess(j), fupper_limit(j))
          end if
 
@@ -991,14 +991,14 @@ CONTAINS
          if ((ssnow%snowd(j) >= 0.1) .and. (ssnow%potev(j) > 0.0)) then
             ssnow%cls(j) = 1.1335
             canopy%fess(j) = real(min( (ssnow%wetfac(j)*ssnow%potev(j))*ssnow%cls(j), &
-                 ssnow%snowd(j)/dels*air%rlam(j)*ssnow%cls(j) ), r_2)
+                 ssnow%snowd(j)/dels*air%rlam(j)*ssnow%cls(j) ), r2)
          endif
 
       enddo
 
       ! Evaporation from soil puddle
-      canopy%fesp = min(real(ssnow%pudsto/dels*air%rlam, r_2), &
-           max(pwet*real(ssnow%potev,r_2), 0.0_r_2))
+      canopy%fesp = min(real(ssnow%pudsto/dels*air%rlam, r2), &
+           max(pwet*real(ssnow%potev,r2), 0.0_r2))
       canopy%fes  = canopy%fess + canopy%fesp
 
     END SUBROUTINE latent_heat_flux
@@ -1007,10 +1007,10 @@ CONTAINS
 
     SUBROUTINE within_canopy(gbhu, gbhf)
 
-      USE cable_def_types_mod, only: mp, r_2
+      USE cable_def_types_mod, only: mp, r2
       use mo_utils,            only: eq
 
-      REAL(r_2), INTENT(IN), DIMENSION(:,:) :: &
+      REAL(r2), INTENT(IN), DIMENSION(:,:) :: &
            gbhu, & ! forcedConvectionBndryLayerCond
            gbhf    ! freeConvectionBndryLayerCond
 
@@ -1231,7 +1231,7 @@ CONTAINS
       ! for momentum, using the businger-dyer form for unstable cases
       ! and the Beljaars and Holtslag (1991) form for stable cases.
 
-      use mo_constants, only: pi => pi_sp
+      use mo_constants, only: pi => pi_r1
 
       implicit none
 
@@ -1337,10 +1337,10 @@ CONTAINS
            cansat, & ! max canopy intercept. (mm)
            tlfy      ! leaf temp (K) - assC%UMINg the temperature of
       ! wet leaf is equal that of dry leaf ="tlfy"
-      REAL(r_2), INTENT(IN), DIMENSION(:,:) :: &
+      REAL(r2), INTENT(IN), DIMENSION(:,:) :: &
            gbhu,          & ! forcedConvectionBndryLayerCond
            gbhf             ! freeConvectionBndryLayerCond
-      REAL(r_2), INTENT(OUT), DIMENSION(:) :: &
+      REAL(r2), INTENT(OUT), DIMENSION(:) :: &
            ghwet            ! cond for heat for a wet canopy
 
       ! local variables
@@ -1355,7 +1355,7 @@ CONTAINS
 
       ! END header
 
-      ghwet = 1.0e-3_r_2
+      ghwet = 1.0e-3_r2
       gwwet = 1.0e-3
       ghrwet= 1.0e-3
       canopy%fevw = 0.0
@@ -1376,7 +1376,7 @@ CONTAINS
 
             ! VEG SENSIBLE & LATENT HEAT FLUXES fevw, fhvw (W/m2) for a wet canopy
             ! calculate total thermal resistance, rthv in s/m
-            ghwet(j)  = 2.0_r_2 * real(sum_gbh(j), r_2)
+            ghwet(j)  = 2.0_r2 * real(sum_gbh(j), r2)
             gwwet(j)  = 1.075 * sum_gbh(j)
             ghrwet(j) = sum_rad_gradis(j) + real(ghwet(j))
 
@@ -1467,8 +1467,8 @@ CONTAINS
          / ( soil%sfc - soil%swilt/2.0 ) ) )
 
     DO j=1,mp
-       IF ( ssnow%wbice(j,1) > real(tiny(1.0),r_2) ) &
-            ssnow%wetfac(j) = ssnow%wetfac(j) * real(MAX( 0.5_r_2, 1._r_2 - MIN( 0.2_r_2, &
+       IF ( ssnow%wbice(j,1) > real(tiny(1.0),r2) ) &
+            ssnow%wetfac(j) = ssnow%wetfac(j) * real(MAX( 0.5_r2, 1._r2 - MIN( 0.2_r2, &
             ( ssnow%wbice(j,1) / ssnow%wb(j,1) )**2 ) ) )
 
        IF( ssnow%snowd(j) > 0.1) ssnow%wetfac(j) = 0.9
@@ -1518,16 +1518,16 @@ CONTAINS
          fwsoil,     & ! soil water modifier of stom. cond
          tlfx,       & ! leaf temp prev. iter (K)
          tlfy          ! leaf temp (K)
-    real(r_2), dimension(:),   intent(inout) :: &
+    real(r2), dimension(:),   intent(inout) :: &
          ecy,        & ! lat heat fl dry big leaf
          hcy,        & ! veg. sens heat
          rny         !& !
-    real(r_2), dimension(:,:), intent(inout) :: &
+    real(r2), dimension(:,:), intent(inout) :: &
          gbhu,       & ! forcedConvectionBndryLayerCond
          gbhf,       & ! freeConvectionBndryLayerCond
          csx           ! leaf surface CO2 concentration
     real,      dimension(:),   intent(in)    :: cansat
-    real(r_2), dimension(:),   intent(out)   :: ghwet  ! cond for heat for a wet canopy
+    real(r2), dimension(:),   intent(out)   :: ghwet  ! cond for heat for a wet canopy
     integer,                   intent(in)    :: iter
     type(climate_type),        intent(in)    :: climate
 
@@ -1560,7 +1560,7 @@ CONTAINS
          temp_sun_c4,   & !
          temp_shade_c4    !
 
-    real(r_2), dimension(mp)  :: &
+    real(r2), dimension(mp)  :: &
          ecx,        & ! lat. hflux big leaf
          hcx,        & ! sens heat fl big leaf prev iteration
          rnx           ! net rad prev timestep
@@ -1599,7 +1599,7 @@ CONTAINS
          kc4,        & ! An-Ci slope in Collatz 1992 model
          gmes          ! mesophyll conductance of big leaf
 
-    real(r_2), dimension(mp,mf)  ::  dAnrubiscox, & ! CO2 elasticity of net photosynthesis (rubisco limited)
+    real(r2), dimension(mp,mf)  ::  dAnrubiscox, & ! CO2 elasticity of net photosynthesis (rubisco limited)
          dAnrubpx, &   !  (rubp limited)
          dAnsinkx, &  ! (sink limited)
          dAnx, & !(actual rate)
@@ -1653,7 +1653,7 @@ CONTAINS
              stop 126
 #endif
           endif
-          canopy%fwsoil = real(fwsoil, r_2)
+          canopy%fwsoil = real(fwsoil, r2)
        elseif ((cable_user%soil_struc=='sli') .or. (cable_user%fwsoil_switch=='Haverd2013')) then
           fwsoil = real(canopy%fwsoil)
        endif
@@ -1677,12 +1677,12 @@ CONTAINS
     anrubiscox  = 0.0
     anrubpx     = 0.0
     ansinkx     = 0.0
-    dAnrubiscox = 0.0_r_2
-    dAnrubpx    = 0.0_r_2
-    dAnsinkx    = 0.0_r_2
+    dAnrubiscox = 0.0_r2
+    dAnrubpx    = 0.0_r2
+    dAnsinkx    = 0.0_r2
     dAnx        = 0.0
-    eta_x       = 0.0_r_2
-    rnx         = SUM(real(rad%rniso,r_2),2)
+    eta_x       = 0.0_r2
+    rnx         = SUM(real(rad%rniso,r2),2)
     abs_deltlf  = 999.0
     vcmxt3      = 0.0
     vcmxt4      = 0.0
@@ -1690,16 +1690,16 @@ CONTAINS
 
     gras  = 1.0e-6
     an_y  = 0.0
-    hcx   = 0.0_r_2              ! init sens heat iteration memory variable
-    hcy   = 0.0_r_2
+    hcx   = 0.0_r2              ! init sens heat iteration memory variable
+    hcy   = 0.0_r2
     rdy   = 0.0
-    ecx   = SUM(real(rad%rniso,r_2),2) ! init lat heat iteration memory variable
+    ecx   = SUM(real(rad%rniso,r2),2) ! init lat heat iteration memory variable
     tlfxx = tlfx
     psycst(:,:)   = SPREAD(air%psyc,2,mf)
-    canopy%fevc   = 0.0_r_2
+    canopy%fevc   = 0.0_r2
     ssnow%evapfbl = 0.0
 
-    ghwet = 1.0e-3_r_2
+    ghwet = 1.0e-3_r2
     gwwet = 1.0e-3
     ghrwet= 1.0e-3
     canopy%fevw = 0.0
@@ -1729,8 +1729,8 @@ CONTAINS
     DO kk=1,mp
 
        IF(canopy%vlaiw(kk) <= C%LAI_THRESH) THEN
-          rnx(kk) = 0.0_r_2 ! intialise
-          ecx(kk) = 0.0_r_2 ! intialise
+          rnx(kk) = 0.0_r2 ! intialise
+          ecx(kk) = 0.0_r2 ! intialise
           ecy(kk) = ecx(kk) ! store initial values
           abs_deltlf(kk) = 0.0
           rny(kk) = rnx(kk) ! store initial values
@@ -1770,7 +1770,7 @@ CONTAINS
 
           IF (canopy%vlaiw(i) > C%LAI_THRESH .AND. abs_deltlf(i) > 0.1) THEN
 
-             ghwet(i)  = 2.0_r_2 * real(sum_gbh(i),r_2)
+             ghwet(i)  = 2.0_r2 * real(sum_gbh(i),r2)
              gwwet(i)  = 1.075 * sum_gbh(i)
              ghrwet(i) = sum_rad_gradis(i) + real(ghwet(i))
 
@@ -1789,16 +1789,16 @@ CONTAINS
 
              ! See Appendix E in (Leuning et al, 1995):
              gbhf(i,1) = real( rad%fvlai(i,1) * air%cmolar(i) * 0.5*C%dheat &
-                  * ( gras(i)**0.25 ) / veg%dleaf(i), r_2)
+                  * ( gras(i)**0.25 ) / veg%dleaf(i), r2)
              gbhf(i,2) = real( rad%fvlai(i,2) * air%cmolar(i) * 0.5 * C%dheat &
-                  * ( gras(i)**0.25 ) / veg%dleaf(i), r_2)
-             gbhf(i,:) = max(1.e-6_r_2, gbhf(i,:))
+                  * ( gras(i)**0.25 ) / veg%dleaf(i), r2)
+             gbhf(i,:) = max(1.e-6_r2, gbhf(i,:))
 
              ! Conductance for heat:
-             gh(i,:) = real(2.0_r_2 * (gbhu(i,:) + gbhf(i,:)))
+             gh(i,:) = real(2.0_r2 * (gbhu(i,:) + gbhf(i,:)))
 
              if (cable_user%amphistomatous) then
-                gbhf(i,:) = 2.0_r_2 * gbhf(i,:)
+                gbhf(i,:) = 2.0_r2 * gbhf(i,:)
                 gh(i,:)   = real(gbhu(i,:) + gbhf(i,:))
              endif
 
@@ -2025,8 +2025,8 @@ CONTAINS
                 gmes(i,1) = veg%gm(i) * rad%scalex(i,1) * xgmesT(tlfx(i)) * max(0.15,fwsoil(i)**qm)
                 gmes(i,2) = veg%gm(i) * rad%scalex(i,2) * xgmesT(tlfx(i)) * max(0.15,fwsoil(i)**qm)
 
-                !gmes(i,1) = gmes(i,1) * MAX(0.15_r_2,real(fwsoil(i)**qm,r_2))
-                !gmes(i,2) = gmes(i,2) * MAX(0.15_r_2,real(fwsoil(i)**qm,r_2))
+                !gmes(i,1) = gmes(i,1) * MAX(0.15_r2,real(fwsoil(i)**qm,r2))
+                !gmes(i,2) = gmes(i,2) * MAX(0.15_r2,real(fwsoil(i)**qm,r2))
              else ! gmes = 0.0 easier to debug than inf
                 gmes(i,1) = 0.0
                 gmes(i,2) = 0.0
@@ -2149,9 +2149,9 @@ CONTAINS
 
                 IF (rad%fvlai(i,kk)>C%LAI_THRESH) THEN
 
-                   csx(i,kk) = real(met%ca(i),r_2) - real(C%RGBWC*anx(i,kk),r_2) / &
+                   csx(i,kk) = real(met%ca(i),r2) - real(C%RGBWC*anx(i,kk),r2) / &
                         (gbhu(i,kk) + gbhf(i,kk))
-                   csx(i,kk) = max(1.0e-4_r_2, csx(i,kk))
+                   csx(i,kk) = max(1.0e-4_r2, csx(i,kk))
 
                    ! Ticket #56, xleuning replaced with gs_coeff here
                    if (cable_user%g0_switch == 'default') then
@@ -2187,39 +2187,39 @@ CONTAINS
                   * ( rad%rniso(i,2) - C%capp * C%rmair * ( met%tvair(i) - &
                   met%tk(i) ) * rad%gradis(i,2) ) + C%capp * C%rmair * &
                   met%dva(i) * ghr(i,2) ) / &
-                  ( air%dsatdk(i) + psycst(i,2) ), r_2)
+                  ( air%dsatdk(i) + psycst(i,2) ), r2)
 
              IF (cable_user%fwsoil_switch=='Haverd2013') then
                 ! avoid root-water extraction when fwsoil is zero
                 if (fwsoil(i) < 1e-6) then
                    anx(i,:) = -rdx(i,:)
-                   ecx(i)   = 0.0_r_2
+                   ecx(i)   = 0.0_r2
                 endif
 
-                canopy%fevc(i) = ecx(i) * (1.0_r_2-real(canopy%fwet(i),r_2))
+                canopy%fevc(i) = ecx(i) * (1.0_r2-real(canopy%fwet(i),r2))
 
-                call getrex_1d(ssnow%wb(i,:)-real(ssnow%wbice(i,:),r_2), ssnow%rex(i,:), &
+                call getrex_1d(ssnow%wb(i,:)-real(ssnow%wbice(i,:),r2), ssnow%rex(i,:), &
                      canopy%fwsoil(i), &
-                     real(veg%froot(i,:),r_2), SPREAD(real(soil%ssat(i),r_2),1,ms), &
-                     SPREAD(real(soil%swilt(i),r_2),1,ms), &
-                     max(canopy%fevc(i)/real(air%rlam(i),r_2)/1000.0_r_2, 0.0_r_2), &
+                     real(veg%froot(i,:),r2), SPREAD(real(soil%ssat(i),r2),1,ms), &
+                     SPREAD(real(soil%swilt(i),r2),1,ms), &
+                     max(canopy%fevc(i)/real(air%rlam(i),r2)/1000.0_r2, 0.0_r2), &
                      veg%gamma(i), &
-                     real(soil%zse, r_2), real(dels,r_2), veg%zr(i))
+                     real(soil%zse, r2), real(dels,r2), veg%zr(i))
 
                 fwsoil(i) = real(canopy%fwsoil(i))
 
-                where (ssnow%rex(i,:) > tiny(1.0_r_2)) &
+                where (ssnow%rex(i,:) > tiny(1.0_r2)) &
                      ssnow%evapfbl(i,:) = real(ssnow%rex(i,:))*dels*1000. ! mm water &
                 !(root water extraction) per time step
 
                 if (cable_user%Cumberland_soil) then
-                   canopy%fwsoil(i) = max(canopy%fwsoil(i), 0.6_r_2)
+                   canopy%fwsoil(i) = max(canopy%fwsoil(i), 0.6_r2)
                    fwsoil(i) = real(canopy%fwsoil(i))
                 endif
 
              ELSE
 
-                if (ecx(i) > 0.0_r_2 .and. canopy%fwet(i) < 1.0) then
+                if (ecx(i) > 0.0_r2 .and. canopy%fwet(i) < 1.0) then
                    evapfb(i) = ( 1.0 - canopy%fwet(i)) * real(ecx(i)) *dels &
                         / air%rlam(i)
 
@@ -2232,20 +2232,20 @@ CONTAINS
 
                    ENDDO
                    IF (cable_user%soil_struc=='default') then
-                      canopy%fevc(i) = real(sum(ssnow%evapfbl(i,:))*air%rlam(i)/dels, r_2)
-                      ecx(i) = canopy%fevc(i) / (1.0_r_2-real(canopy%fwet(i),r_2))
+                      canopy%fevc(i) = real(sum(ssnow%evapfbl(i,:))*air%rlam(i)/dels, r2)
+                      ecx(i) = canopy%fevc(i) / (1.0_r2-real(canopy%fwet(i),r2))
                    ELSEIF (cable_user%soil_struc=='sli') then
-                      canopy%fevc(i) = ecx(i) * (1.0_r_2-real(canopy%fwet(i),r_2))
+                      canopy%fevc(i) = ecx(i) * (1.0_r2-real(canopy%fwet(i),r2))
                    ENDIF
 
                 ENDIF
 
              ENDIF
              ! Update canopy sensible heat flux:
-             hcx(i) = ( SUM(real(rad%rniso(i,:),r_2)) - ecx(i) &
-                  - real(C%capp*C%rmair*(met%tvair(i)-met%tk(i)), r_2) &
-                  * SUM(real(rad%gradis(i,:),r_2)) ) &
-                  * SUM(real(gh(i,:),r_2))/ SUM(real(ghr(i,:),r_2))
+             hcx(i) = ( SUM(real(rad%rniso(i,:),r2)) - ecx(i) &
+                  - real(C%capp*C%rmair*(met%tvair(i)-met%tk(i)), r2) &
+                  * SUM(real(rad%gradis(i,:),r2)) ) &
+                  * SUM(real(gh(i,:),r2))/ SUM(real(ghr(i,:),r2))
 
              ! Update leaf temperature:
              tlfx(i) = met%tvair(i)+REAL(hcx(i))/(C%capp*C%rmair*SUM(gh(i,:)))
@@ -2253,7 +2253,7 @@ CONTAINS
              ! Update net radiation for canopy:
              rnx(i) = real( SUM( rad%rniso(i,:)) - &
                   C%CAPP * C%rmair *( tlfx(i)-met%tk(i) ) * &
-                  SUM( rad%gradis(i,:) ), r_2)
+                  SUM( rad%gradis(i,:) ), r2)
 
              ! Update leaf surface vapour pressure deficit:
              dsx(i) = met%dva(i) + air%dsatdk(i) * (tlfx(i)-met%tvair(i))
@@ -2328,7 +2328,7 @@ CONTAINS
     END DO  ! DO WHILE (ANY(abs_deltlf > 0.1) .AND.  k < C%MAXITER)
 
     ! dry canopy flux
-    canopy%fevc = (1.0_r_2-real(canopy%fwet,r_2)) * ecy
+    canopy%fevc = (1.0_r2-real(canopy%fwet,r2)) * ecy
 
     ! print*, 'DD45 ', canopy%fwet
     ! print*, 'DD46 ', canopy%fevc
@@ -2340,12 +2340,12 @@ CONTAINS
        ! ** ssnow%evapfbl(i,:) = ssnow%evapfbl(i,:) * ecy(i) / ecx(i) **
        DO i = 1, mp
 
-          IF( ecy(i) > 0.0_r_2 .AND. canopy%fwet(i) < 1.0 ) THEN
+          IF( ecy(i) > 0.0_r2 .AND. canopy%fwet(i) < 1.0 ) THEN
 
-             IF( ABS( ecy(i) - ecx(i) ) > 1.0e-6_r_2 ) THEN
+             IF( ABS( ecy(i) - ecx(i) ) > 1.0e-6_r2 ) THEN
 
                 IF( ABS( canopy%fevc(i) - real(SUM(oldevapfbl(i,:)) * air%rlam(i) &
-                     /dels, r_2) ) > 1.0e-4_r_2 ) THEN
+                     /dels, r2) ) > 1.0e-4_r2 ) THEN
 
                    WRITE(*,*) 'ERROR! oldevapfbl not right.', ktau_gl, i
                    WRITE(*,*) 'ecx, ecy = ', ecx(i), ecy(i)
@@ -2382,83 +2382,83 @@ CONTAINS
 
     ! additional diagnostic variables for assessing contributions of rubisco and rubp limited photosynthesis to
     ! net photosynthesis in sunlit and shaded leaves.
-    canopy%A_sh = real(an_y(:,2), r_2)
-    canopy%A_sl = real(an_y(:,1), r_2)
+    canopy%A_sh = real(an_y(:,2), r2)
+    canopy%A_sl = real(an_y(:,1), r2)
 
-    canopy%GPP_sh = real(an_y(:,2) + rdy(:,2), r_2)
-    canopy%GPP_sl = real(an_y(:,1) + rdy(:,1), r_2)
+    canopy%GPP_sh = real(an_y(:,2) + rdy(:,2), r2)
+    canopy%GPP_sl = real(an_y(:,1) + rdy(:,1), r2)
 
-    canopy%A_shC = real(anrubiscoy(:,2), r_2)
-    canopy%A_shJ = real(anrubpy(:,2), r_2)
+    canopy%A_shC = real(anrubiscoy(:,2), r2)
+    canopy%A_shJ = real(anrubpy(:,2), r2)
 
-    where (anrubiscoy(:,2) > an_y(:,2)) canopy%A_shC = 0.0_r_2
-    where (anrubpy(:,2) > an_y(:,2))    canopy%A_shJ = 0.0_r_2
+    where (anrubiscoy(:,2) > an_y(:,2)) canopy%A_shC = 0.0_r2
+    where (anrubpy(:,2) > an_y(:,2))    canopy%A_shJ = 0.0_r2
 
-    canopy%A_slC = real(anrubiscoy(:,1), r_2)
-    canopy%A_slJ = real(anrubpy(:,1), r_2)
+    canopy%A_slC = real(anrubiscoy(:,1), r2)
+    canopy%A_slJ = real(anrubpy(:,1), r2)
 
-    where (anrubiscoy(:,1) > an_y(:,1)) canopy%A_slC = 0.0_r_2
-    where (anrubpy(:,1)    > an_y(:,1)) canopy%A_slJ = 0.0_r_2
+    where (anrubiscoy(:,1) > an_y(:,1)) canopy%A_slC = 0.0_r2
+    where (anrubpy(:,1)    > an_y(:,1)) canopy%A_slJ = 0.0_r2
 
-    canopy%eta_A_cs = canopy%A_sh * min(eta_y(:,2),5.0_r_2) + canopy%A_sl * min(eta_y(:,1),5.0_r_2)
-    where ((canopy%A_sl > 0.0_r_2) .and. (canopy%A_sh > 0.0_r_2))
-       canopy%eta_GPP_cs = canopy%GPP_sh  * min(eta_y(:,2),5.0_r_2) * canopy%GPP_sh/canopy%A_sh + &
-            canopy%GPP_sl * min(eta_y(:,1),5.0_r_2)* canopy%GPP_sl/canopy%A_sl
-    elsewhere ((canopy%A_sl .le. 0.0_r_2) .and. (canopy%A_sh > 0.0_r_2))
-       canopy%eta_GPP_cs = canopy%GPP_sh * min(eta_y(:,2),5.0_r_2) * canopy%GPP_sh/canopy%A_sh
+    canopy%eta_A_cs = canopy%A_sh * min(eta_y(:,2),5.0_r2) + canopy%A_sl * min(eta_y(:,1),5.0_r2)
+    where ((canopy%A_sl > 0.0_r2) .and. (canopy%A_sh > 0.0_r2))
+       canopy%eta_GPP_cs = canopy%GPP_sh  * min(eta_y(:,2),5.0_r2) * canopy%GPP_sh/canopy%A_sh + &
+            canopy%GPP_sl * min(eta_y(:,1),5.0_r2)* canopy%GPP_sl/canopy%A_sl
+    elsewhere ((canopy%A_sl .le. 0.0_r2) .and. (canopy%A_sh > 0.0_r2))
+       canopy%eta_GPP_cs = canopy%GPP_sh * min(eta_y(:,2),5.0_r2) * canopy%GPP_sh/canopy%A_sh
     elsewhere
        canopy%eta_GPP_cs = canopy%eta_A_cs
     end where
 
-    where (canopy%A_sl > 0.0_r_2)
-       canopy%eta_A_cs_sl    =  min(eta_y(:,1),5.0_r_2)
-       canopy%eta_fevc_cs_sl = (min(eta_y(:,1),5.0_r_2) - 1.0_r_2) * &
-            real(max(0.0, gs_coeff(:,1)*an_y(:,1)), r_2) / real(canopy%gswx(:,1), r_2)
+    where (canopy%A_sl > 0.0_r2)
+       canopy%eta_A_cs_sl    =  min(eta_y(:,1),5.0_r2)
+       canopy%eta_fevc_cs_sl = (min(eta_y(:,1),5.0_r2) - 1.0_r2) * &
+            real(max(0.0, gs_coeff(:,1)*an_y(:,1)), r2) / real(canopy%gswx(:,1), r2)
     elsewhere
-       canopy%eta_A_cs_sl    = 0.0_r_2
-       canopy%eta_fevc_cs_sl = 0.0_r_2
+       canopy%eta_A_cs_sl    = 0.0_r2
+       canopy%eta_fevc_cs_sl = 0.0_r2
     endwhere
 
-    where (canopy%A_sh > 0.0_r_2)
-       canopy%eta_A_cs_sh    =  min(eta_y(:,2),5.0_r_2)
-       canopy%eta_fevc_cs_sh = (min(eta_y(:,2),5.0_r_2) - 1.0_r_2) * &
-            real(max(0.0, gs_coeff(:,2)*an_y(:,2)), r_2) / real(canopy%gswx(:,2), r_2)
+    where (canopy%A_sh > 0.0_r2)
+       canopy%eta_A_cs_sh    =  min(eta_y(:,2),5.0_r2)
+       canopy%eta_fevc_cs_sh = (min(eta_y(:,2),5.0_r2) - 1.0_r2) * &
+            real(max(0.0, gs_coeff(:,2)*an_y(:,2)), r2) / real(canopy%gswx(:,2), r2)
     elsewhere
-       canopy%eta_A_cs_sh    = 0.0_r_2
-       canopy%eta_fevc_cs_sh = 0.0_r_2
+       canopy%eta_A_cs_sh    = 0.0_r2
+       canopy%eta_fevc_cs_sh = 0.0_r2
     endwhere
 
     where ((rad%fvlai(:,1)+rad%fvlai(:,2)) > 0.01)
-       canopy%eta_fevc_cs = ( canopy%eta_fevc_cs_sl *  real(rad%fvlai(:,1), r_2) + &
-            canopy%eta_fevc_cs_sh * real(rad%fvlai(:,2), r_2) ) * canopy%fevc / &
-            real(rad%fvlai(:,1)+rad%fvlai(:,2), r_2)
+       canopy%eta_fevc_cs = ( canopy%eta_fevc_cs_sl *  real(rad%fvlai(:,1), r2) + &
+            canopy%eta_fevc_cs_sh * real(rad%fvlai(:,2), r2) ) * canopy%fevc / &
+            real(rad%fvlai(:,1)+rad%fvlai(:,2), r2)
     elsewhere
-       canopy%eta_fevc_cs = 0.0_r_2
+       canopy%eta_fevc_cs = 0.0_r2
     endwhere
 
     canopy%dAdcs = canopy%A_sl * dAn_y(:,1) + canopy%A_sh * dAn_y(:,2)
-    canopy%cs    = canopy%A_sl * csx(:,1) * 1.0e6_r_2 + canopy%A_sh * csx(:,2) * 1.0e6_r_2
-    canopy%cs_sl = csx(:,1) * 1.0e6_r_2
-    canopy%cs_sh = csx(:,2) * 1.0e6_r_2
-    canopy%tlf   = real(tlfy, r_2)
-    canopy%dlf   = real(dsx, r_2)
+    canopy%cs    = canopy%A_sl * csx(:,1) * 1.0e6_r2 + canopy%A_sh * csx(:,2) * 1.0e6_r2
+    canopy%cs_sl = csx(:,1) * 1.0e6_r2
+    canopy%cs_sh = csx(:,2) * 1.0e6_r2
+    canopy%tlf   = real(tlfy, r2)
+    canopy%dlf   = real(dsx, r2)
 
     ! print*, 'DD47 ', ssnow%evapfbl
     canopy%evapfbl = ssnow%evapfbl
 
     ! 13C
-    canopy%An        = real(an_y, r_2)
-    canopy%Rd        = real(rdy, r_2)
+    canopy%An        = real(an_y, r2)
+    canopy%Rd        = real(rdy, r2)
     canopy%isc3      = (1.0-veg%frac4) > epsilon(1.0)
-    canopy%vcmax     = real(merge(vcmxt3, vcmxt4, spread(canopy%isc3,2,mf)), r_2)
-    canopy%gammastar = real(spread(cx2*0.5,2,mf), r_2)
-    canopy%gsc       = real(canopy%gswx / C%rgswc, r_2)
-    canopy%gbc       = (gbhu + gbhf) / real(C%rgbwc, r_2)
-    canopy%gac       = huge(1.0_r_2)
-    ! replace 1.0_r_2/canopy%gac by tiny(1.0_r_2) to avoid underflow
-    canopy%ci        = real(spread(met%ca, 2, mf), r_2) - &
+    canopy%vcmax     = real(merge(vcmxt3, vcmxt4, spread(canopy%isc3,2,mf)), r2)
+    canopy%gammastar = real(spread(cx2*0.5,2,mf), r2)
+    canopy%gsc       = real(canopy%gswx / C%rgswc, r2)
+    canopy%gbc       = (gbhu + gbhf) / real(C%rgbwc, r2)
+    canopy%gac       = huge(1.0_r2)
+    ! replace 1.0_r2/canopy%gac by tiny(1.0_r2) to avoid underflow
+    canopy%ci        = real(spread(met%ca, 2, mf), r2) - &
          canopy%An / &
-         (1.0_r_2 / (1.0_r_2/canopy%gbc + 1.0_r_2/canopy%gsc + tiny(1.0_r_2)))
+         (1.0_r2 / (1.0_r2/canopy%gbc + 1.0_r2/canopy%gsc + tiny(1.0_r2)))
 
     ! deallocate( gswmin )
 
@@ -2474,12 +2474,12 @@ CONTAINS
        vx4z, gs_coeffz, vlaiz, deltlfz, anxz, fwsoilz, qs, &
        gmes, kc4, anrubiscoz, anrubpz, ansinkz, eta, dA )
 
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
     use cable_common_module, only: cable_user
 
     implicit none
 
-    real(r_2), dimension(:, :), intent(in) :: csxz
+    real(r2), dimension(:, :), intent(in) :: csxz
     real,      dimension(:, :), intent(in) :: gmes
     real,      dimension(:, :), intent(in) :: &
          cx1z,       & !
@@ -2497,18 +2497,18 @@ CONTAINS
     real,                       intent(in)    :: qs
     real,      dimension(:, :), intent(inout) :: gswminz
     real,      dimension(:, :), intent(inout) :: anxz, anrubiscoz, anrubpz, ansinkz
-    real(r_2), dimension(:, :), intent(out)   :: eta, dA
+    real(r2), dimension(:, :), intent(out)   :: eta, dA
 
     ! local variables
-    real(r_2), dimension(size(csxz, 1), size(csxz, 2)) :: dAmp, dAme, dAmc, eta_p, eta_e, eta_c
+    real(r2), dimension(size(csxz, 1), size(csxz, 2)) :: dAmp, dAme, dAmc, eta_p, eta_e, eta_c
     !real, dimension(mp) :: fwsoilz  ! why was this local??
-    real(r_2) :: gamma, beta, gammast, gm, g0, X, Rd, cs
-    real(r_2) :: cc, gsm
-    real(r_2) :: Am
+    real(r2) :: gamma, beta, gammast, gm, g0, X, Rd, cs
+    real(r2) :: cc, gsm
+    real(r2) :: Am
     integer :: i, j, mp, mf
     ! for minimum of 3 rates and corresponding elasticities
     real,      dimension(3) :: tmp3
-    real(r_2), dimension(3) :: dtmp3
+    real(r2), dimension(3) :: dtmp3
     integer,   dimension(1) :: ii
 
     mp = size(csxz, 1)
@@ -2526,24 +2526,24 @@ CONTAINS
                 anrubiscoz(i,j) = -rdxz(i,j)
                 anrubpz(i,j)    = -rdxz(i,j)
                 ansinkz(i,j)    = -rdxz(i,j)
-                dAmc(i,j)       = 0.0_r_2
-                dAme(i,j)       = 0.0_r_2
-                dAmp(i,j)       = 0.0_r_2
-                dA(i,j)         = 0.0_r_2
-                eta_c(i,j)      = 0.0_r_2
-                eta_e(i,j)      = 0.0_r_2
-                eta_p(i,j)      = 0.0_r_2
-                eta(i,j)        = 0.0_r_2
+                dAmc(i,j)       = 0.0_r2
+                dAme(i,j)       = 0.0_r2
+                dAmp(i,j)       = 0.0_r2
+                dA(i,j)         = 0.0_r2
+                eta_c(i,j)      = 0.0_r2
+                eta_e(i,j)      = 0.0_r2
+                eta_p(i,j)      = 0.0_r2
+                eta(i,j)        = 0.0_r2
 
                 ! C3, Rubisco limited, accounting for explicit mesophyll conductance
                 if ((vcmxt3z(i,j) > 1.0e-8) .and. (gs_coeffz(i,j) > 100.)) then
                    cs      = csxz(i,j)
-                   g0      = real(gswminz(i,j) * fwsoilz(i)**qs / C%RGSWC, r_2)
-                   X       = real(gs_coeffz(i,j), r_2)
-                   gamma   = real(vcmxt3z(i,j), r_2)
-                   beta    = real(cx1z(i,j), r_2)
-                   gammast = real(cx2z(i,j) / 2.0, r_2)
-                   Rd      = real(rdxz(i,j), r_2)
+                   g0      = real(gswminz(i,j) * fwsoilz(i)**qs / C%RGSWC, r2)
+                   X       = real(gs_coeffz(i,j), r2)
+                   gamma   = real(vcmxt3z(i,j), r2)
+                   beta    = real(cx1z(i,j), r2)
+                   gammast = real(cx2z(i,j) / 2.0, r2)
+                   Rd      = real(rdxz(i,j), r2)
                    gm      = gmes(i,j)
 
                    if (trim(cable_user%g0_switch) == 'default') then
@@ -2558,17 +2558,17 @@ CONTAINS
                    elseif (trim(cable_user%g0_switch) == 'maximum') then
                       ! set g0 to zero initially
                       if (cable_user%explicit_gm) then
-                         call fAmdAm_c3(cs, 0.0_r_2, X*cs, gamma, beta, gammast, Rd, &
+                         call fAmdAm_c3(cs, 0.0_r2, X*cs, gamma, beta, gammast, Rd, &
                               gm, Am, dAmc(i,j))
                          if (g0 > Am*X) then ! repeat calculation if g0 > A*X
-                            call fAmdAm_c3(cs, g0, 0.1e-4_r_2, gamma, beta, gammast, Rd, &
+                            call fAmdAm_c3(cs, g0, 0.1e-4_r2, gamma, beta, gammast, Rd, &
                                  gm, Am, dAmc(i,j))
                          endif
                       else
-                         call fAndAn_c3(cs, 0.0_r_2, X*cs, gamma, beta, gammast, Rd, &
+                         call fAndAn_c3(cs, 0.0_r2, X*cs, gamma, beta, gammast, Rd, &
                               Am, dAmc(i,j))
                          if (g0 > Am*X) then ! repeat calculation if g0 > A*X
-                            call fAndAn_c3(cs, g0, 0.1e-4_r_2, gamma, beta, gammast, Rd, &
+                            call fAndAn_c3(cs, g0, 0.1e-4_r2, gamma, beta, gammast, Rd, &
                               Am, dAmc(i,j))
                          endif
                       endif
@@ -2577,28 +2577,28 @@ CONTAINS
 
                    if (cable_user%explicit_gm) then
                       gsm = (gm * (g0+X*Am)) / (gm + (g0+X*Am))
-                      cc  = cs - Am / max(gsm, 1.0e-4_r_2)
+                      cc  = cs - Am / max(gsm, 1.0e-4_r2)
                    endif
-                   if (Am > 0.0_r_2) eta_c(i,j) = dAmc(i,j) * cs / Am
+                   if (Am > 0.0_r2) eta_c(i,j) = dAmc(i,j) * cs / Am
                 endif  ! C3
 
                 ! C4, Rubisco limited, accounting for explicit mesophyll conductance
                 if (vcmxt4z(i,j) > 1.0e-8) then
                    anrubiscoz(i,j) = vcmxt4z(i,j)- rdxz(i,j)
-                   dAmc(i,j)  = 0.0_r_2
-                   eta_c(i,j) = 0.0_r_2
+                   dAmc(i,j)  = 0.0_r2
+                   eta_c(i,j) = 0.0_r2
                 endif
 
                 ! C3, RuBP regeneration-limited, accounting for explicit mesophyll conductance
                 if ( (vcmxt3z(i,j) > 0.0) .and. (gs_coeffz(i,j) > 100.) .and. &
                      (vx3z(i,j) > 1.0e-8) ) then
                    cs      = csxz(i,j)
-                   g0      = real(gswminz(i,j) * fwsoilz(i)**qs / C%RGSWC, r_2)
-                   X       = real(gs_coeffz(i,j), r_2)
-                   gamma   = real(vx3z(i,j), r_2)
-                   beta    = real(cx2z(i,j), r_2)
-                   gammast = real(cx2z(i,j) / 2.0, r_2)
-                   Rd      = real(rdxz(i,j), r_2)
+                   g0      = real(gswminz(i,j) * fwsoilz(i)**qs / C%RGSWC, r2)
+                   X       = real(gs_coeffz(i,j), r2)
+                   gamma   = real(vx3z(i,j), r2)
+                   beta    = real(cx2z(i,j), r2)
+                   gammast = real(cx2z(i,j) / 2.0, r2)
+                   Rd      = real(rdxz(i,j), r2)
                    gm      = gmes(i,j)
 
                    if (trim(cable_user%g0_switch) == 'default') then
@@ -2611,19 +2611,19 @@ CONTAINS
                       endif
                    elseif (trim(cable_user%g0_switch) == 'maximum') then
                       if (cable_user%explicit_gm) then
-                         call fAmdAm_c3(cs, 0.0_r_2, X*cs, gamma, beta, gammast, Rd, &
+                         call fAmdAm_c3(cs, 0.0_r2, X*cs, gamma, beta, gammast, Rd, &
                               gm, Am, dAme(i,j))
                          ! repeat calculation if g0 > A*X
                          if (g0 > Am*X) then
-                            call fAmdAm_c3(cs, g0, 0.1e-4_r_2, gamma, beta, gammast, Rd, &
+                            call fAmdAm_c3(cs, g0, 0.1e-4_r2, gamma, beta, gammast, Rd, &
                                  gm, Am, dAme(i,j))
                          endif
                       else
-                         call fAndAn_c3(cs, 0.0_r_2, X*cs, gamma, beta, gammast, Rd, &
+                         call fAndAn_c3(cs, 0.0_r2, X*cs, gamma, beta, gammast, Rd, &
                               Am, dAme(i,j))
                          ! repeat calculation if g0 > A*X
                          if (g0 > Am*X) then
-                            call fAndAn_c3(cs, g0, 0.1e-4_r_2, gamma, beta, gammast, Rd, &
+                            call fAndAn_c3(cs, g0, 0.1e-4_r2, gamma, beta, gammast, Rd, &
                                  Am, dAme(i,j))
                          endif
                       endif
@@ -2632,33 +2632,33 @@ CONTAINS
 
                    if (cable_user%explicit_gm) then
                       gsm = (gm * (g0+X*Am)) / (gm + (g0+X*Am))
-                      cc  = cs - Am / max(gsm, 1.0e-4_r_2)
+                      cc  = cs - Am / max(gsm, 1.0e-4_r2)
                    endif
-                   if (Am > 0.0_r_2) eta_e(i,j) = dAme(i,j) * cs / Am
+                   if (Am > 0.0_r2) eta_e(i,j) = dAme(i,j) * cs / Am
                 endif  ! C3
 
                 ! C4, RuBP limited, accounting for explicit mesophyll conductance
                 if (vx4z(i,j) > 1.0e-8) then
                    anrubpz(i,j) = vx4z(i,j) - rdxz(i,j)
-                   dAme(i,j)  = 0.0_r_2
-                   eta_e(i,j) = 0.0_r_2
+                   dAme(i,j)  = 0.0_r2
+                   eta_e(i,j) = 0.0_r2
                 endif
 
                 ! Sink limited, accounting for explicit mesophyll conductance
                 if (vcmxt3z(i,j) > 1.0e-10) then ! C3
 
                    ansinkz(i,j) = 0.5 * vcmxt3z(i,j) - rdxz(i,j)
-                   dAmp(i,j)  = 0.0_r_2
-                   eta_p(i,j) = 0.0_r_2
+                   dAmp(i,j)  = 0.0_r2
+                   eta_p(i,j) = 0.0_r2
 
                 elseif ((vcmxt4z(i,j) > 1.0e-10) .and. (gs_coeffz(i,j) > 100.)) then ! C4
                    cs         = csxz(i,j)
-                   g0         = real(gswminz(i,j) * fwsoilz(i)**qs / C%RGSWC, r_2)
-                   X          = real(gs_coeffz(i,j), r_2)
-                   gamma      = real(kc4(i,j),r_2) ! k in Collatz 1992
-                   beta       = 0.0_r_2
-                   gammast    = 0.0_r_2
-                   Rd         = real(rdxz(i,j), r_2)
+                   g0         = real(gswminz(i,j) * fwsoilz(i)**qs / C%RGSWC, r2)
+                   X          = real(gs_coeffz(i,j), r2)
+                   gamma      = real(kc4(i,j),r2) ! k in Collatz 1992
+                   beta       = 0.0_r2
+                   gammast    = 0.0_r2
+                   Rd         = real(rdxz(i,j), r2)
                    gm         = gmes(i,j)
 
                    if (trim(cable_user%g0_switch) == 'default') then
@@ -2671,26 +2671,26 @@ CONTAINS
                       endif
                    elseif (trim(cable_user%g0_switch) == 'maximum') then
                       if (cable_user%explicit_gm) then
-                         call fAmdAm_c4(cs, 0.0_r_2, X*cs, gamma, beta, gammast, Rd, gm, &
+                         call fAmdAm_c4(cs, 0.0_r2, X*cs, gamma, beta, gammast, Rd, gm, &
                               Am, dAmp(i,j))
                          if (g0 > Am*X) then
-                            call fAmdAm_c4(cs, g0, 0.1e-4_r_2, gamma, beta, gammast, Rd, gm, &
+                            call fAmdAm_c4(cs, g0, 0.1e-4_r2, gamma, beta, gammast, Rd, gm, &
                                  Am, dAmp(i,j))
                          endif
                       else
-                         call fAndAn_c4(cs, 0.0_r_2, X*cs, gamma, beta, gammast, Rd, &
+                         call fAndAn_c4(cs, 0.0_r2, X*cs, gamma, beta, gammast, Rd, &
                               Am, dAmp(i,j))
                          if (g0 > Am*X) then
-                            call fAndAn_c4(cs, g0, 0.1e-4_r_2, gamma, beta, gammast, Rd, &
+                            call fAndAn_c4(cs, g0, 0.1e-4_r2, gamma, beta, gammast, Rd, &
                                  Am, dAmp(i,j))
                          endif
                       endif
                    endif
                    ansinkz(i,j) = real(Am)
 
-                   dAmp(i,j)  = 0.0_r_2
-                   eta_p(i,j) = 0.0_r_2
-                   if (Am > 0.0_r_2) eta_p(i,j) = dAmp(i,j) * cs / Am
+                   dAmp(i,j)  = 0.0_r2
+                   eta_p(i,j) = 0.0_r2
+                   if (Am > 0.0_r2) eta_p(i,j) = dAmp(i,j) * cs / Am
                 endif ! C3/C4
 
              endif ! deltlfz > 0.1
@@ -2710,14 +2710,14 @@ CONTAINS
              anrubiscoz(i,:) = 0.0
              anrubpz(i,:)    = 0.0
              ansinkz(i,:)    = 0.0
-             dAmc(i,:)       = 0.0_r_2
-             dAme(i,:)       = 0.0_r_2
-             dAmp(i,:)       = 0.0_r_2
-             dA(i,:)         = 0.0_r_2
-             eta_c(i,:)      = 0.0_r_2
-             eta_e(i,:)      = 0.0_r_2
-             eta_p(i,:)      = 0.0_r_2
-             eta(i,:)        = 0.0_r_2
+             dAmc(i,:)       = 0.0_r2
+             dAme(i,:)       = 0.0_r2
+             dAmp(i,:)       = 0.0_r2
+             dA(i,:)         = 0.0_r2
+             eta_c(i,:)      = 0.0_r2
+             eta_e(i,:)      = 0.0_r2
+             eta_p(i,:)      = 0.0_r2
+             eta(i,:)        = 0.0_r2
 
           endif ! vlaiz(i,j) > C%lai_thresh
 
@@ -2882,9 +2882,9 @@ CONTAINS
     !real, parameter :: q10c4 = 2.0
     ! parameter values from Massad et al. 2007, PCE 30, 1191-1204, slightly adjusted to
     ! get optimum at ~36degC as in Yamori et al. 2014
-    real, parameter :: EHa    = 66000.0  ! 67.29e3_r_2   ! J/mol
-    real, parameter :: EHd    = 145000.0 ! 144.57e3_r_2  ! J/mol
-    real, parameter :: Entrop = 469.4217 ! 0.472e3_r_2   ! J/mol/K
+    real, parameter :: EHa    = 66000.0  ! 67.29e3_r2   ! J/mol
+    real, parameter :: EHd    = 145000.0 ! 144.57e3_r2  ! J/mol
+    real, parameter :: Entrop = 469.4217 ! 0.472e3_r2   ! J/mol/K
 
     ! Q10 function replaced with Arrhenius function for the sake of parameter
     ! identifiability/interpretability
@@ -3178,22 +3178,22 @@ CONTAINS
   !   type(soil_snow_type),      intent(inout) :: ssnow
   !   type(veg_parameter_type),  intent(inout) :: veg
 
-  !   real(r_2), dimension(mp,ms) :: tmp1, tmp2, delta_root, alpha2a_root, alpha2_root
+  !   real(r2), dimension(mp,ms) :: tmp1, tmp2, delta_root, alpha2a_root, alpha2_root
 
   !   ! Lai and Katul formulation for root efficiency function - vh 17/07/09
-  !   alpha2a_root = max(ssnow%wb-soil%swilt_vec, 0.001_r_2) / (soil%ssat_vec)
+  !   alpha2a_root = max(ssnow%wb-soil%swilt_vec, 0.001_r2) / (soil%ssat_vec)
   !   tmp1         = ssnow%wb - soil%swilt_vec
   !   tmp2         = spread(veg%gamma,2,ms) / tmp1 * log(alpha2a_root)
-  !   where ((tmp1 > 0.001_r_2) .and. (tmp2 > -10.0_r_2))
+  !   where ((tmp1 > 0.001_r2) .and. (tmp2 > -10.0_r2))
   !      alpha2_root = exp(tmp2)
   !   elsewhere
-  !      alpha2_root = 0.0_r_2
+  !      alpha2_root = 0.0_r2
   !   endwhere
 
   !   WHERE (veg%froot > 0.0)
-  !      delta_root = 1.0_r_2
+  !      delta_root = 1.0_r2
   !   ELSEWHERE
-  !      delta_root = 0.0_r_2
+  !      delta_root = 0.0_r2
   !   ENDWHERE
 
   !   fwsoil  = maxval(real(alpha2_root*delta_root), dim=2)
@@ -3208,34 +3208,34 @@ CONTAINS
   SUBROUTINE getrex_1d(theta, rex, fws, Fs, thetaS, thetaw, Etrans, gamma, dx, dt, zr)
 
     ! root extraction : Haverd et al. 2013
-    USE cable_def_types_mod, only: r_2
+    USE cable_def_types_mod, only: r2
 
     IMPLICIT NONE
 
-    REAL(r_2), DIMENSION(:), INTENT(IN)    :: theta  ! volumetric soil moisture
-    REAL(r_2), DIMENSION(:), INTENT(INOUT) :: rex    ! water extraction per layer
-    REAL(r_2),               INTENT(INOUT) :: fws    ! stomatal limitation factor
-    REAL(r_2), DIMENSION(:), INTENT(IN)    :: Fs     ! root length density
-    REAL(r_2), DIMENSION(:), INTENT(IN)    :: thetaS ! saturation soil moisture
-    REAL(r_2), DIMENSION(:), INTENT(IN)    :: thetaw ! soil moisture at wiliting point
-    REAL(r_2),               INTENT(IN)    :: Etrans ! total transpiration
-    REAL(r_2),               INTENT(IN)    :: gamma  ! skew of Li & Katul alpha2 function
-    REAL(r_2), DIMENSION(:), INTENT(IN)    :: dx     ! layer thicknesses (m)
-    REAL(r_2),               INTENT(IN)    :: dt
-    REAL(r_2),               INTENT(IN)    :: zr
+    REAL(r2), DIMENSION(:), INTENT(IN)    :: theta  ! volumetric soil moisture
+    REAL(r2), DIMENSION(:), INTENT(INOUT) :: rex    ! water extraction per layer
+    REAL(r2),               INTENT(INOUT) :: fws    ! stomatal limitation factor
+    REAL(r2), DIMENSION(:), INTENT(IN)    :: Fs     ! root length density
+    REAL(r2), DIMENSION(:), INTENT(IN)    :: thetaS ! saturation soil moisture
+    REAL(r2), DIMENSION(:), INTENT(IN)    :: thetaw ! soil moisture at wiliting point
+    REAL(r2),               INTENT(IN)    :: Etrans ! total transpiration
+    REAL(r2),               INTENT(IN)    :: gamma  ! skew of Li & Katul alpha2 function
+    REAL(r2), DIMENSION(:), INTENT(IN)    :: dx     ! layer thicknesses (m)
+    REAL(r2),               INTENT(IN)    :: dt
+    REAL(r2),               INTENT(IN)    :: zr
 
     ! Gets rate of water extraction compatible with CABLE stomatal conductance model
     ! theta(:) - soil moisture(m3 m-3)
     ! rex(:)   - rate of water extraction by roots from layers (cm/h).
-    REAL(r_2), DIMENSION(1:size(theta)) :: lthetar, alpha_root, delta_root, layer_depth
-    REAL(r_2)                           :: trex, e3, one, zero
+    REAL(r2), DIMENSION(1:size(theta)) :: lthetar, alpha_root, delta_root, layer_depth
+    REAL(r2)                           :: trex, e3, one, zero
     INTEGER :: k
 
-    e3   = 0.001_r_2
-    one  = 1.0_r_2
-    zero = 0.0_r_2
+    e3   = 0.001_r2
+    one  = 1.0_r2
+    zero = 0.0_r2
 
-    layer_depth(1) = 0.0_r_2
+    layer_depth(1) = 0.0_r2
     do k=2, size(theta)
        layer_depth(k) = sum(dx(1:k-1))
     enddo
@@ -3267,7 +3267,7 @@ CONTAINS
 
     ! reduce extraction efficiency where total extraction depletes soil moisture below wilting point
     where (((rex*dt) > (theta(:)-thetaw(:))*dx(:)) .and. ((rex*dt) > zero))
-       alpha_root = alpha_root*(theta(:)-thetaw(:))*dx(:)/(1.1_r_2*rex*dt)
+       alpha_root = alpha_root*(theta(:)-thetaw(:))*dx(:)/(1.1_r2*rex*dt)
     endwhere
     rex(:) = alpha_root(:)*Fs(:)
 
@@ -3280,7 +3280,7 @@ CONTAINS
     rex(:) = Etrans*rex(:)
 
     ! check that the water available in each layer exceeds the extraction
-    !if (any((rex*dt) > (theta(:)-0.01_r_2)*dx(:))) then
+    !if (any((rex*dt) > (theta(:)-0.01_r2)*dx(:))) then
     if (any(((rex*dt) > max((theta(:)-thetaw(:)),zero)*dx(:)) .and. (Etrans > zero))) then
        !MC - ask Vanessa why fwsoil=0. if any (not all) demand exceeds water in layer.
        !     Should it be in else clause of trex>zero?
@@ -3288,7 +3288,7 @@ CONTAINS
        !     Should it be fws=one here and fws=zero in else clause of trex>zero?
        fws = zero
        ! distribute extraction according to available water
-       ! rex(:) = (theta(:)-0.01_r_2)*dx(:)
+       ! rex(:) = (theta(:)-0.01_r2)*dx(:)
        rex(:) = max((theta(:)-thetaw(:))*dx(:),zero)
        trex = sum(rex(:))
        if (trex > zero) then
@@ -3311,12 +3311,12 @@ CONTAINS
 
   ! SUBROUTINE cubic_root_solver(a0,a1,a2,x1,x2,x3)
 
-  !   USE cable_def_types_mod, only: r_2
+  !   USE cable_def_types_mod, only: r2
 
-  !   REAL(r_2), INTENT(IN) :: a0,a1,a2
-  !   REAL(r_2), INTENT(OUT) :: x1,x2,x3
+  !   REAL(r2), INTENT(IN) :: a0,a1,a2
+  !   REAL(r2), INTENT(OUT) :: x1,x2,x3
 
-  !   REAL(r_2) :: Q, R, theta, a, b, c
+  !   REAL(r2) :: Q, R, theta, a, b, c
   !   real :: pi_c = 3.1415927
 
   !   a = a2
@@ -3346,15 +3346,15 @@ CONTAINS
   ! functions for implicit mesophyll conductance
   elemental pure subroutine fabc(Cs, g0, x, gamma, beta, Gammastar, Rd, a, b, c)
 
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
-    real(r_2), intent(in)  :: Cs, g0, x, gamma, beta, Gammastar, Rd
-    real(r_2), intent(out) :: a, b, c
+    real(r2), intent(in)  :: Cs, g0, x, gamma, beta, Gammastar, Rd
+    real(r2), intent(out) :: a, b, c
 
-    a = (1.0_r_2-x)*Cs - x*beta
-    b = -g0*Cs**2 + ((1.0_r_2-x)*(Rd-gamma)-g0*beta)*Cs - x*(gamma*Gammastar+Rd*beta)
+    a = (1.0_r2-x)*Cs - x*beta
+    b = -g0*Cs**2 + ((1.0_r2-x)*(Rd-gamma)-g0*beta)*Cs - x*(gamma*Gammastar+Rd*beta)
     c = -g0*(Rd-gamma)*Cs**2 - g0*(gamma*Gammastar+Rd*beta)*Cs
 
   end subroutine fabc
@@ -3362,15 +3362,15 @@ CONTAINS
 
   elemental pure subroutine fabc_c4(Cs, g0, x, gamma, beta, Gammastar, Rd, a, b, c)
 
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
-    real(r_2), intent(in)  :: Cs, g0, x, gamma, beta, Gammastar, Rd
-    real(r_2), intent(out) :: a, b, c
+    real(r2), intent(in)  :: Cs, g0, x, gamma, beta, Gammastar, Rd
+    real(r2), intent(out) :: a, b, c
 
     a = x
-    b = (g0+gamma*(1.0_r_2-x))*Cs - x*(beta-Rd)
+    b = (g0+gamma*(1.0_r2-x))*Cs - x*(beta-Rd)
     c =  -gamma*g0*Cs**2 - g0*(beta-Rd)*Cs
 
   end subroutine fabc_c4
@@ -3378,116 +3378,116 @@ CONTAINS
 
   elemental pure subroutine fAn_c3(a, b, c, A2)
 
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
-    real(r_2), intent(in) :: a,b,c
-    real(r_2), intent(out) :: A2
+    real(r2), intent(in) :: a,b,c
+    real(r2), intent(out) :: A2
 
-    real(r_2) :: s2
+    real(r2) :: s2
 
-    s2 = b**2 - 4.0_r_2*a*c
-    A2 = (-b - sqrt(s2))/(2.0_r_2*a)
+    s2 = b**2 - 4.0_r2*a*c
+    A2 = (-b - sqrt(s2))/(2.0_r2*a)
 
   end subroutine fAn_c3
 
 
   elemental pure subroutine fAn_c4(a, b, c, A2)
 
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
-    real(r_2), intent(in)  :: a, b, c
-    real(r_2), intent(out) :: A2
+    real(r2), intent(in)  :: a, b, c
+    real(r2), intent(out) :: A2
 
-    real(r_2) :: s2
+    real(r2) :: s2
 
-    s2 = b**2 - 4.0_r_2*a*c
-    A2 = (-b + sqrt(s2))/(2.0_r_2*a)
+    s2 = b**2 - 4.0_r2*a*c
+    A2 = (-b + sqrt(s2))/(2.0_r2*a)
 
   end subroutine fAn_c4
 
 
   elemental pure subroutine fdabc(Cs, g0, x, gamma, beta, Gammastar, Rd, da, db, dc)
 
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
-    real(r_2), intent(in)  :: Cs, g0, x, gamma, beta, Gammastar, Rd
-    real(r_2), intent(out) :: da, db, dc
+    real(r2), intent(in)  :: Cs, g0, x, gamma, beta, Gammastar, Rd
+    real(r2), intent(out) :: da, db, dc
 
-    da = 1.0_r_2-x
-    db = -2.0_r_2*g0*Cs + (1.0_r_2-x)*(Rd-gamma) - g0*beta
-    dc = -2.0_r_2*g0*(Rd-gamma)*Cs - g0*(gamma*Gammastar+Rd*beta)
+    da = 1.0_r2-x
+    db = -2.0_r2*g0*Cs + (1.0_r2-x)*(Rd-gamma) - g0*beta
+    dc = -2.0_r2*g0*(Rd-gamma)*Cs - g0*(gamma*Gammastar+Rd*beta)
 
   end subroutine fdabc
 
 
   elemental pure subroutine fdabc_c4(Cs, g0, x, gamma, beta, Gammastar, Rd, da, db, dc)
 
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
-    real(r_2), intent(in)  :: Cs, g0, x, gamma, beta, Gammastar, Rd
-    real(r_2), intent(out) :: da, db, dc
+    real(r2), intent(in)  :: Cs, g0, x, gamma, beta, Gammastar, Rd
+    real(r2), intent(out) :: da, db, dc
 
     da = 0.
-    db = g0 + gamma*(1.0_r_2-x)
-    dc = -2.0_r_2*gamma*g0*Cs - g0*(beta-Rd)
+    db = g0 + gamma*(1.0_r2-x)
+    dc = -2.0_r2*gamma*g0*Cs - g0*(beta-Rd)
 
   end subroutine fdabc_c4
 
 
   elemental pure subroutine fdAn_c3(a, b, c, da, db, dc, dA2)
 
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
-    real(r_2), intent(in) :: a, b, c, da, db, dc
-    real(r_2), intent(out) :: dA2
+    real(r2), intent(in) :: a, b, c, da, db, dc
+    real(r2), intent(out) :: dA2
 
-    real(r_2) :: s, p
+    real(r2) :: s, p
 
-    s = sqrt(b**2 - 4.0_r_2*a*c)
-    p = (2.0_r_2*b*db - 4.0_r_2*c*da - 4.0_r_2*a*dc)/(2.0_r_2*s)
-    dA2 = (-db - p)/(2.0_r_2*a) - (-b - s)/(2.0_r_2*a**2)*da
+    s = sqrt(b**2 - 4.0_r2*a*c)
+    p = (2.0_r2*b*db - 4.0_r2*c*da - 4.0_r2*a*dc)/(2.0_r2*s)
+    dA2 = (-db - p)/(2.0_r2*a) - (-b - s)/(2.0_r2*a**2)*da
 
   end subroutine fdAn_c3
 
 
   elemental pure subroutine fdAn_c4(a, b, c, da, db, dc, dA2)
 
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
-    real(r_2), intent(in)  :: a, b, c, da, db, dc
-    real(r_2), intent(out) :: dA2
+    real(r2), intent(in)  :: a, b, c, da, db, dc
+    real(r2), intent(out) :: dA2
 
-    real(r_2) :: s, p
+    real(r2) :: s, p
 
-    s = sqrt(b**2 - 4.0_r_2*a*c)
-    p = (2.0_r_2*b*db - 4.0_r_2*c*da - 4.0_r_2*a*dc)/(2.0_r_2*s)
-    dA2 = (-db + p)/(2.0_r_2*a) - (-b + s)/(2.0_r_2*a**2)*da
+    s = sqrt(b**2 - 4.0_r2*a*c)
+    p = (2.0_r2*b*db - 4.0_r2*c*da - 4.0_r2*a*dc)/(2.0_r2*s)
+    dA2 = (-db + p)/(2.0_r2*a) - (-b + s)/(2.0_r2*a**2)*da
 
   end subroutine fdAn_c4
 
 
   elemental pure subroutine fAndAn_c3(Cs, g0, x, gamma, beta, Gammastar, Rd, An, dAn)
 
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
-    real(r_2), intent(in)  :: Cs, g0, x, gamma, beta, Gammastar, Rd
-    real(r_2), intent(out) :: An, dAn
+    real(r2), intent(in)  :: Cs, g0, x, gamma, beta, Gammastar, Rd
+    real(r2), intent(out) :: An, dAn
 
-    real(r_2) :: a, b, c, da, db, dc
+    real(r2) :: a, b, c, da, db, dc
 
     call fabc(Cs, g0, x, gamma, beta, Gammastar, Rd,a,b,c)
     call fAn_c3(a, b, c, An)
@@ -3499,14 +3499,14 @@ CONTAINS
 
   elemental pure subroutine fAndAn_c4(Cs, g0, x, gamma, beta, Gammastar, Rd, An, dAn)
 
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
-    real(r_2), intent(in)  :: Cs, g0, x, gamma, beta, Gammastar, Rd
-    real(r_2), intent(out) :: An, dAn
+    real(r2), intent(in)  :: Cs, g0, x, gamma, beta, Gammastar, Rd
+    real(r2), intent(out) :: An, dAn
 
-    real(r_2) :: a, b, c, da, db, dc
+    real(r2) :: a, b, c, da, db, dc
 
     call fabc_c4(Cs, g0, x, gamma, beta, Gammastar, Rd,a,b,c)
     call fAn_c4(a, b, c, An)
@@ -3521,13 +3521,13 @@ CONTAINS
   !      flag_eps, &
   !      Anc, Ane, An, dAnc, dAne, dAn)
 
-  !   use cable_def_types_mod, only: r_2
+  !   use cable_def_types_mod, only: r2
 
   !   implicit none
 
-  !   real(r_2), intent(in)  :: Cs, g0, x, Gammastar, Rd, gammac, betac, gammae, betae
+  !   real(r2), intent(in)  :: Cs, g0, x, Gammastar, Rd, gammac, betac, gammae, betae
   !   logical,   intent(in)  :: flag_eps
-  !   real(r_2), intent(out) :: Anc, Ane, An, dAnc, dAne, dAn
+  !   real(r2), intent(out) :: Anc, Ane, An, dAnc, dAne, dAn
 
   !   call fAndAn1(Cs, g0, x, gammac, betac, Gammastar, Rd, Anc, dAnc)
   !   call fAndAn1(Cs, g0, x, gammae, betae, Gammastar, Rd, Ane, dAne)
@@ -3558,12 +3558,12 @@ CONTAINS
   ! elemental pure subroutines for finite mesophyll conductance
   elemental pure subroutine fabcd(Cs, g0, x, gamma, beta, Gammastar, Rd, gm, a, b, c1, d)
 
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
-    real(r_2), intent(in)  :: Cs, g0, x, gamma, beta, Gammastar, Rd, gm
-    real(r_2), intent(out) :: a, b, c1, d
+    real(r2), intent(in)  :: Cs, g0, x, gamma, beta, Gammastar, Rd, gm
+    real(r2), intent(out) :: a, b, c1, d
 
     a  = x
     b  = (gm+g0-gm*x)*Cs + x*(Rd-gamma) - gm*x*beta
@@ -3576,12 +3576,12 @@ CONTAINS
 
   elemental pure subroutine fabcm(Cs, g0, x, gamma, beta, Gammastar, Rd, gm, a, b, c1)
 
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
-    real(r_2), intent(in)  :: Cs, g0, x, gamma, beta, Gammastar, Rd, gm
-    real(r_2), intent(out) :: a,b,c1
+    real(r2), intent(in)  :: Cs, g0, x, gamma, beta, Gammastar, Rd, gm
+    real(r2), intent(out) :: a,b,c1
 
     a  = x*(gm+gamma)
     b  = ((gm+g0)*gamma + g0*gm - gm*gamma*x)*Cs - gm*x*(beta-Rd)
@@ -3592,147 +3592,147 @@ CONTAINS
 
   elemental pure subroutine fpq(a, b, c, d, p, q)
 
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
-    real(r_2), intent(in) :: a,b,c,d
-    real(r_2), intent(out) :: p, q
+    real(r2), intent(in) :: a,b,c,d
+    real(r2), intent(out) :: p, q
 
-    p = (3.0_r_2*a*c - b**2)/(3.0_r_2*a**2)
-    q = (2.0_r_2*b**3 - 9.0_r_2*a*b*c + 27.0_r_2*a**2*d)/(27.0_r_2*a**3)
+    p = (3.0_r2*a*c - b**2)/(3.0_r2*a**2)
+    q = (2.0_r2*b**3 - 9.0_r2*a*b*c + 27.0_r2*a**2*d)/(27.0_r2*a**3)
 
   end subroutine fpq
 
 
   elemental pure subroutine fdabcd(Cs, g0, x, gamma, beta, Gammastar, Rd, gm, da, db, dc, dd)
 
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
-    real(r_2), intent(in)  :: Cs, g0, x, gamma, beta, Gammastar, Rd, gm
-    real(r_2), intent(out) :: da, db, dc, dd
+    real(r2), intent(in)  :: Cs, g0, x, gamma, beta, Gammastar, Rd, gm
+    real(r2), intent(out) :: da, db, dc, dd
 
-    da = 0.0_r_2
+    da = 0.0_r2
     db = gm+g0-gm*x
-    dc = -2.0_r_2*gm*g0*Cs + (gm+g0-gm*x)*(Rd-gamma)-gm*g0*beta
-    dd = -2.0_r_2*gm*g0*(Rd-gamma)*Cs - gm*g0*(gamma*Gammastar+Rd*beta)
+    dc = -2.0_r2*gm*g0*Cs + (gm+g0-gm*x)*(Rd-gamma)-gm*g0*beta
+    dd = -2.0_r2*gm*g0*(Rd-gamma)*Cs - gm*g0*(gamma*Gammastar+Rd*beta)
 
   end subroutine fdabcd
 
 
   elemental pure subroutine fdabcm(Cs, g0, x, gamma, beta, Gammastar, Rd, gm, da, db, dc)
 
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
-    real(r_2), intent(in)  :: Cs, g0, x, gamma, beta, Gammastar, Rd, gm
-    real(r_2), intent(out) :: da, db, dc
+    real(r2), intent(in)  :: Cs, g0, x, gamma, beta, Gammastar, Rd, gm
+    real(r2), intent(out) :: da, db, dc
 
-    da = 0.0_r_2
+    da = 0.0_r2
     db = (gm+g0)*gamma + g0*gm - gm*gamma*x
-    dc = -2.0_r_2*gm*g0*gamma*Cs - gm*g0*(beta-Rd)
+    dc = -2.0_r2*gm*g0*gamma*Cs - gm*g0*(beta-Rd)
 
   end subroutine fdabcm
 
 
   elemental pure subroutine fdpq(a, b, c, d, da, db, dc, dd, dp, dq)
 
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
-    real(r_2), intent(in)  :: a, b, c, d, da, db, dc, dd
-    real(r_2), intent(out) :: dp, dq
+    real(r2), intent(in)  :: a, b, c, d, da, db, dc, dd
+    real(r2), intent(out) :: dp, dq
 
-    dp = (3.0_r_2*da*c + 3.0_r_2*a*dc - 2.0_r_2*b*db)/(3.0_r_2*a**2) - &
-         2.0_r_2*(3.0_r_2*a*c - b**2)/(3.0_r_2*a**3)*da
-    dq = (6.0_r_2*b**2*db - 9.0_r_2*da*b*c - 9.0_r_2*a*db*c - 9.0_r_2*a*b*dc + &
-         54.0_r_2*a*da*d + 27.0_r_2*a**2*dd) / (27.0_r_2*a**3) - &
-         3.0_r_2*(2.0_r_2*b**3 - 9.0_r_2*a*b*c + 27.0_r_2*a**2*d) / &
-         (27.0_r_2*a**4)*da
+    dp = (3.0_r2*da*c + 3.0_r2*a*dc - 2.0_r2*b*db)/(3.0_r2*a**2) - &
+         2.0_r2*(3.0_r2*a*c - b**2)/(3.0_r2*a**3)*da
+    dq = (6.0_r2*b**2*db - 9.0_r2*da*b*c - 9.0_r2*a*db*c - 9.0_r2*a*b*dc + &
+         54.0_r2*a*da*d + 27.0_r2*a**2*dd) / (27.0_r2*a**3) - &
+         3.0_r2*(2.0_r2*b**3 - 9.0_r2*a*b*c + 27.0_r2*a**2*d) / &
+         (27.0_r2*a**4)*da
 
   end subroutine fdpq
 
 
   elemental pure subroutine fAm_c3(a, b, c1, d, p, q, Am)
 
-    use cable_def_types_mod, only: r_2
-    use mo_constants, only: pi => pi_dp
+    use cable_def_types_mod, only: r2
+    use mo_constants, only: pi => pi_r2
 
     implicit none
 
-    real(r_2), intent(in)  :: a, b, c1, d, p, q
-    real(r_2), intent(out) :: Am
+    real(r2), intent(in)  :: a, b, c1, d, p, q
+    real(r2), intent(out) :: Am
 
-    real(r_2) :: p3, pq, k
+    real(r2) :: p3, pq, k
 
-    p3 = -p/3.0_r_2
-    pq = min(3.0_r_2*q/(2.0_r_2*p)*sqrt(1.0_r_2/p3),0.999999999999_r_2)
-    k  = 1.0_r_2
-    Am = 2.0_r_2*sqrt(p3)*cos(acos(pq)/3.0_r_2 - 2.0_r_2*pi*k/3.0_r_2) - b/(3.0_r_2*a)
+    p3 = -p/3.0_r2
+    pq = min(3.0_r2*q/(2.0_r2*p)*sqrt(1.0_r2/p3),0.999999999999_r2)
+    k  = 1.0_r2
+    Am = 2.0_r2*sqrt(p3)*cos(acos(pq)/3.0_r2 - 2.0_r2*pi*k/3.0_r2) - b/(3.0_r2*a)
 
   end subroutine fAm_c3
 
 
   elemental pure subroutine fAm_c4(a, b, c1, Am)
 
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
-    real(r_2), intent(in) :: a, b, c1
-    real(r_2), intent(out) :: Am
+    real(r2), intent(in) :: a, b, c1
+    real(r2), intent(out) :: Am
 
-    real(r_2) :: s2
+    real(r2) :: s2
 
-    s2 = b**2 - 4.0_r_2*a*c1
-    Am = (-b + sqrt(s2))/(2.0_r_2*a)
+    s2 = b**2 - 4.0_r2*a*c1
+    Am = (-b + sqrt(s2))/(2.0_r2*a)
 
   end subroutine fAm_c4
 
 
   elemental pure subroutine fdAm_c3(a, b, c1, d, p, q, da, db, dc, dd, dp, dq, dAm)
 
-    use cable_def_types_mod, only: r_2
-    use mo_constants, only: pi => pi_dp
+    use cable_def_types_mod, only: r2
+    use mo_constants, only: pi => pi_r2
 
     implicit none
 
-    real(r_2), intent(in)  :: a, b, c1, d, p, q, da, db, dc, dd, dp, dq
-    real(r_2), intent(out) :: dAm
+    real(r2), intent(in)  :: a, b, c1, d, p, q, da, db, dc, dd, dp, dq
+    real(r2), intent(out) :: dAm
 
-    real(r_2) :: k, p3, pq
+    real(r2) :: k, p3, pq
 
-    p3 = -p/3.0_r_2
-    pq = min(3.0_r_2*q/(2.0_r_2*p)*sqrt(1.0_r_2/p3),0.999999999999_r_2)
-    k  = 1.0_r_2
-    dAm = -1.0_r_2/(3.0_r_2*sqrt(p3))*cos(acos(pq)/3.0_r_2 - 2.0_r_2*pi*k/3.0_r_2)*dp + &
-         2.0_r_2*sqrt(p3) * (sin(acos(pq)/3.0_r_2 - 2.0_r_2*pi*k/3.0_r_2) / &
-         (3.0_r_2*sqrt(1.0_r_2-pq**2)) * &
-         3.0_r_2/2.0_r_2*(dq/p*sqrt(1.0_r_2/p3) - q/p**2*dp*sqrt(1.0_r_2/p3) + &
-         q/p*3.0_r_2/2.0_r_2*1.0_r_2/sqrt(1.0_r_2/p3)*1.0_r_2/p**2*dp)) - &
-         db/(3.0_r_2*a) + b/(3.0_r_2*a**2)*da
+    p3 = -p/3.0_r2
+    pq = min(3.0_r2*q/(2.0_r2*p)*sqrt(1.0_r2/p3),0.999999999999_r2)
+    k  = 1.0_r2
+    dAm = -1.0_r2/(3.0_r2*sqrt(p3))*cos(acos(pq)/3.0_r2 - 2.0_r2*pi*k/3.0_r2)*dp + &
+         2.0_r2*sqrt(p3) * (sin(acos(pq)/3.0_r2 - 2.0_r2*pi*k/3.0_r2) / &
+         (3.0_r2*sqrt(1.0_r2-pq**2)) * &
+         3.0_r2/2.0_r2*(dq/p*sqrt(1.0_r2/p3) - q/p**2*dp*sqrt(1.0_r2/p3) + &
+         q/p*3.0_r2/2.0_r2*1.0_r2/sqrt(1.0_r2/p3)*1.0_r2/p**2*dp)) - &
+         db/(3.0_r2*a) + b/(3.0_r2*a**2)*da
 
   end subroutine fdAm_c3
 
 
   elemental pure subroutine fdAm_c4(a, b, c1, da, db, dc, dAm)
 
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
-    real(r_2), intent(in) :: a, b, c1, da, db, dc
-    real(r_2), intent(out) :: dAm
+    real(r2), intent(in) :: a, b, c1, da, db, dc
+    real(r2), intent(out) :: dAm
 
-    real(r_2) :: s, p
+    real(r2) :: s, p
 
-    s = sqrt(b**2 - 4.0_r_2*a*c1)
-    p = (2.0_r_2*b*db - 4.0_r_2*c1*da - 4.0_r_2*a*dc)/(2.0_r_2*s)
-    dAm = (-db + p)/(2.0_r_2*a) - (-b + s)/(2.0_r_2*a**2)*da
+    s = sqrt(b**2 - 4.0_r2*a*c1)
+    p = (2.0_r2*b*db - 4.0_r2*c1*da - 4.0_r2*a*dc)/(2.0_r2*s)
+    dAm = (-db + p)/(2.0_r2*a) - (-b + s)/(2.0_r2*a**2)*da
 
   end subroutine fdAm_c4
 
@@ -3740,14 +3740,14 @@ CONTAINS
   elemental pure subroutine fAmdAm_c3(Cs, g0, x, gamma, beta, Gammastar, Rd, gm, &
        Am, dAm)
 
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
-    real(r_2), intent(in)  :: Cs, g0, x, gamma, beta, Gammastar, Rd, gm
-    real(r_2), intent(out) :: Am, dAm
+    real(r2), intent(in)  :: Cs, g0, x, gamma, beta, Gammastar, Rd, gm
+    real(r2), intent(out) :: Am, dAm
 
-    real(r_2) :: a, b, c, d, p, q, da, db, dc, dd, dp, dq
+    real(r2) :: a, b, c, d, p, q, da, db, dc, dd, dp, dq
 
     call fabcd(Cs, g0, x, gamma, beta, Gammastar, Rd, gm, a, b, c, d)
     call fpq(a, b, c, d, p, q)
@@ -3762,14 +3762,14 @@ CONTAINS
   elemental pure subroutine fAmdAm_c4(Cs, g0, x, gamma, beta, Gammastar, Rd, gm, &
        Am, dAm)
 
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
-    real(r_2), intent(in)  :: Cs, g0, x, gamma, beta, Gammastar, Rd, gm
-    real(r_2), intent(out) :: Am, dAm
+    real(r2), intent(in)  :: Cs, g0, x, gamma, beta, Gammastar, Rd, gm
+    real(r2), intent(out) :: Am, dAm
 
-    real(r_2) :: a, b, c1, da, db, dc
+    real(r2) :: a, b, c1, da, db, dc
 
     call fabcm(Cs, g0, x, gamma, beta, Gammastar, Rd, gm,a,b,c1)
     call fAm_c4(a, b, c1, Am)
@@ -3784,14 +3784,14 @@ CONTAINS
   !      flag_eps, &
   !      Amc, Ame, Am, dAmc, dAme, dAm)
 
-  !   use cable_def_types_mod, only: r_2
+  !   use cable_def_types_mod, only: r2
 
   !   implicit none
 
-  !   real(r_2), intent(in)  :: Cs, g0, x, Gammastar, &
+  !   real(r2), intent(in)  :: Cs, g0, x, Gammastar, &
   !        Rd, gm, gammac, betac,gammae, betae
   !   logical,   intent(in)  :: flag_eps
-  !   real(r_2), intent(out) :: Amc, Ame, Am, dAmc, dAme, dAm
+  !   real(r2), intent(out) :: Amc, Ame, Am, dAmc, dAme, dAm
 
   !   call fAmdAm1(Cs, g0, x, gammac, betac, Gammastar, Rd, gm, Amc, dAmc)
   !   call fAmdAm1(Cs, g0, x, gammae, betae, Gammastar, Rd, gm, Ame, dAme)

--- a/core/biogeophys/cable_cbm.F90
+++ b/core/biogeophys/cable_cbm.F90
@@ -162,11 +162,11 @@ CONTAINS
 
       canopy%fh = canopy%fhv + canopy%fhs
 
-      canopy%fes = canopy%fes + real(ssnow%tss-ssnow%otss, r_2) * &
-                real(ssnow%dfe_ddq * ssnow%ddq_dtg, r_2)
+      canopy%fes = canopy%fes + real(ssnow%tss-ssnow%otss, r2) * &
+                real(ssnow%dfe_ddq * ssnow%ddq_dtg, r2)
                 !( ssnow%cls * ssnow%dfe_ddq * ssnow%ddq_dtg )
-      canopy%fes_cor = canopy%fes_cor + real(ssnow%tss-ssnow%otss, r_2) * &
-                    real(ssnow%cls * ssnow%dfe_ddq * ssnow%ddq_dtg, r_2)
+      canopy%fes_cor = canopy%fes_cor + real(ssnow%tss-ssnow%otss, r2) * &
+                    real(ssnow%cls * ssnow%dfe_ddq * ssnow%ddq_dtg, r2)
 
    ENDIF
 

--- a/core/biogeophys/cable_climate.F90
+++ b/core/biogeophys/cable_climate.F90
@@ -20,8 +20,7 @@
 module cable_climate_mod
 
   use cable_def_types_mod,  only: met_type, climate_type, canopy_type,soil_snow_type, mp, &
-       r_2, radiation_type, veg_parameter_type
-  use TypeDef,              only: i4b, dp
+       radiation_type, veg_parameter_type
   use cable_IO_vars_module, only: patch
   use CABLE_COMMON_MODULE,  only: CurYear, filename, cable_user, HANDLE_ERR
 
@@ -492,7 +491,6 @@ contains
     ! MRR, 28-mar-05: Remove dependence of Rlat (latent heat vaporisation of water)
     !                 on temperature, use value at 20 C
     ! ------------------------------------------------------------------------------
-    ! USE TypeDef
     ! USE Constants
 
     implicit none

--- a/core/biogeophys/cable_constants.F90
+++ b/core/biogeophys/cable_constants.F90
@@ -16,14 +16,14 @@
 
 MODULE math_constants
 
-  USE cable_def_types_mod, ONLY : i_d, r_2
+  USE cable_def_types_mod, ONLY : i4, r2
 
   IMPLICIT NONE
 
   REAL, PARAMETER :: pi     = 3.141592653589793238462643383279502884197
   REAL, PARAMETER :: pi180  = pi / 180.0 ! radians / degree
   REAL, PARAMETER :: two_pi = 2.0 * pi
-  REAL(r_2), PARAMETER :: pi_r_2 = 3.141592653589793238462643383279502884197
+  REAL(r2), PARAMETER :: pi_r2 = 3.141592653589793238462643383279502884197
 
 END MODULE math_constants
 
@@ -31,7 +31,7 @@ END MODULE math_constants
 
 MODULE physical_constants
 
-  USE cable_def_types_mod, ONLY : i_d
+  USE cable_def_types_mod, ONLY : i4
 
   IMPLICIT NONE
 
@@ -66,7 +66,7 @@ MODULE physical_constants
   REAL,    PARAMETER :: ccw    = 2.0      ! ccw=(zw-d)/(h-d)
   REAL,    PARAMETER :: usuhm  = 0.3      ! (max of us/uh)
   ! Turbulence  parameters:
-  INTEGER(i_d), PARAMETER :: niter  = 10       ! number of iterations for za/L
+  INTEGER(i4), PARAMETER :: niter  = 10       ! number of iterations for za/L
   REAL,    PARAMETER :: zetmul = 0.4      ! if niter=2, final zeta=zetmul*zetar(2)
   REAL,    PARAMETER :: zeta0  = 0.0      ! initial value of za/L
   REAL,    PARAMETER :: zetneg = -10.0    ! negative limit on za/L when niter>=3
@@ -80,7 +80,7 @@ END MODULE physical_constants
 
 MODULE other_constants
 
-  USE cable_def_types_mod, ONLY : i_d, nrb
+  USE cable_def_types_mod, ONLY : i4, nrb
 
   IMPLICIT NONE
 
@@ -90,18 +90,18 @@ MODULE other_constants
   REAL,    PARAMETER, DIMENSION(nrb) :: refl    = (/ 0.1, 0.425, 0.02 /) ! mar08
   ! leaf transmittance
   REAL,    PARAMETER, DIMENSION(nrb) :: taul    = (/ 0.1, 0.425, 0.02 /) ! mar08
-  INTEGER(i_d), PARAMETER                 :: istemp  = 4                      ! soil temp:     1,2,3,4 = FR,kf,mrr,mrrkf
-  INTEGER(i_d), PARAMETER                 :: ismois  = 2                      ! soil moist:  1,2,3     = MP84,NP89,Richards
-  INTEGER(i_d), PARAMETER                 :: isinf   = 2                      ! soil infilt: 1,2       = MP84, FC96
-  INTEGER(i_d), PARAMETER                 :: isevap  = 2                      ! soil evap: 1,2,3 = alfa,beta,threshold
-  INTEGER(i_d), PARAMETER                 :: itherm  = 1                      ! VW or KGK algorithm for hconds,rkapps
-  INTEGER(i_d), PARAMETER                 :: irktem  = 5                      ! RK steps in soil temp schemes
-  INTEGER(i_d), PARAMETER                 :: irkmoi  = 5                      ! RK steps in soil moisture schemes
+  INTEGER(i4), PARAMETER                 :: istemp  = 4                      ! soil temp:     1,2,3,4 = FR,kf,mrr,mrrkf
+  INTEGER(i4), PARAMETER                 :: ismois  = 2                      ! soil moist:  1,2,3     = MP84,NP89,Richards
+  INTEGER(i4), PARAMETER                 :: isinf   = 2                      ! soil infilt: 1,2       = MP84, FC96
+  INTEGER(i4), PARAMETER                 :: isevap  = 2                      ! soil evap: 1,2,3 = alfa,beta,threshold
+  INTEGER(i4), PARAMETER                 :: itherm  = 1                      ! VW or KGK algorithm for hconds,rkapps
+  INTEGER(i4), PARAMETER                 :: irktem  = 5                      ! RK steps in soil temp schemes
+  INTEGER(i4), PARAMETER                 :: irkmoi  = 5                      ! RK steps in soil moisture schemes
   ! soil water  parameters:
   REAL,    PARAMETER                 :: etarct  = 0.7                    ! rel soil moisture for finding zst1,zst2
   REAL,    PARAMETER                 :: dbde    = 1.3333                 ! d(beta)/d(etar): 4/3, 8 for D78,KGK91
-  INTEGER(i_d), PARAMETER                 :: istsw   = 1                      !
-  INTEGER(i_d), PARAMETER                 :: iresp   = 0                      ! unscaled (iresp=0) or scaled (iresp=1) respiration
+  INTEGER(i4), PARAMETER                 :: istsw   = 1                      !
+  INTEGER(i4), PARAMETER                 :: iresp   = 0                      ! unscaled (iresp=0) or scaled (iresp=1) respiration
 
 END MODULE other_constants
 
@@ -109,11 +109,11 @@ END MODULE other_constants
 
 MODULE photosynthetic_constants
 
-  USE cable_def_types_mod, ONLY : i_d
+  USE cable_def_types_mod, ONLY : i4
 
   IMPLICIT NONE
 
-  INTEGER(i_d), PARAMETER :: maxiter         = 20       ! max # interations for leaf temperature
+  INTEGER(i4), PARAMETER :: maxiter         = 20       ! max # interations for leaf temperature
   ! a1c3 is defined inside cable_canopy.f90
   REAL,    PARAMETER :: a1c4_default    = 4.0
   REAL,    PARAMETER :: a1c3_default    = 9.0

--- a/core/biogeophys/cable_define_types.F90
+++ b/core/biogeophys/cable_define_types.F90
@@ -41,11 +41,9 @@ module cable_def_types_mod
        mland     ! # land grid cells
 
   integer, public, parameter :: &
-       ! i_d  = KIND(9), &             ! probably unintended
-       i_d  = SELECTED_INT_kind(9), &  ! as in pop.f90
-       ! r_2  = SELECTED_REAL_KIND(12, 50), & ! old
-       r_1 = c_float, &                ! for writing floats in netcdf files
-       r_2 = kind(1.0d0), &            ! as in pop.f90
+       i4  = SELECTED_INT_kind(9), &  ! as in pop.f90
+       r1 = c_float, &                ! for writing floats in netcdf files
+       r2 = kind(1.0d0), &            ! as in pop.f90
        n_tiles = 17,  & ! # possible no of different
        ncp = 3,       & ! # vegetation carbon stores
        ncs = 2,       & ! # soil carbon stores
@@ -154,7 +152,7 @@ module cable_def_types_mod
           soilcol => null(), & ! keep color for all patches/tiles
           albsoilf => null()   ! soil reflectance
 
-     real(r_2), dimension(:), pointer :: &
+     real(r2), dimension(:), pointer :: &
           cnsd => null(),    & ! thermal conductivity of dry soil [W/m/K]
           pwb_min => null()    ! working variable (swilt/ssat)**ibp2
 
@@ -164,12 +162,12 @@ module cable_def_types_mod
      ! Additional SLI parameters
      integer,   dimension(:),   pointer :: nhorizons => null() ! number of soil horizons
      integer,   dimension(:,:), pointer :: ishorizon => null() ! horizon number 1:nhorizons
-     real(r_2), dimension(:),   pointer :: clitt => null()     ! litter (tC/ha)
-     real(r_2), dimension(:),   pointer :: zeta => null()      ! macropore parameter
-     real(r_2), dimension(:),   pointer :: fsatmax => null()   ! variably saturated area parameter
-     real(r_2), dimension(:,:), pointer :: swilt_vec => null() ! vol H2O @ wilting
-     real(r_2), dimension(:,:), pointer :: ssat_vec => null()  ! vol H2O @ sat
-     real(r_2), dimension(:,:), pointer :: sfc_vec => null()   ! vol H2O @ fc
+     real(r2), dimension(:),   pointer :: clitt => null()     ! litter (tC/ha)
+     real(r2), dimension(:),   pointer :: zeta => null()      ! macropore parameter
+     real(r2), dimension(:),   pointer :: fsatmax => null()   ! variably saturated area parameter
+     real(r2), dimension(:,:), pointer :: swilt_vec => null() ! vol H2O @ wilting
+     real(r2), dimension(:,:), pointer :: ssat_vec => null()  ! vol H2O @ sat
+     real(r2), dimension(:,:), pointer :: sfc_vec => null()   ! vol H2O @ fc
 
   end type soil_parameter_type
 
@@ -243,10 +241,10 @@ module cable_def_types_mod
           evapfbl => null(),    & !
           tilefrac => null()      ! factor for latent heat
 
-     real(r_2), dimension(:), pointer :: &
+     real(r2), dimension(:), pointer :: &
           wbtot => null()   ! total soil water (mm)
 
-     real(r_2), dimension(:,:), pointer :: &
+     real(r2), dimension(:,:), pointer :: &
           gammzz => null(),  & ! heat capacity for each soil layer
           wb => null(),      & ! volumetric soil moisture (solid+liq)
           wbice => null(),   & ! soil ice
@@ -254,39 +252,39 @@ module cable_def_types_mod
           wbfice => null()     !
 
      ! Additional SLI variables:
-     real(r_2), dimension(:,:), pointer :: S => null()         ! moisture content relative to sat value    (edit vh 23/01/08)
-     real(r_2), dimension(:,:), pointer :: Tsoil => null()     ! Tsoil (deg C)
-     real(r_2), dimension(:),   pointer :: SL => null()        ! litter moisture content relative to sat value (edit vh 23/01/08)
-     real(r_2), dimension(:),   pointer :: TL => null()        ! litter temperature in K     (edit vh 23/01/08)
-     real(r_2), dimension(:),   pointer :: h0 => null()        ! pond height in m            (edit vh 23/01/08)
-     real(r_2), dimension(:,:), pointer :: rex => null()       ! root extraction from each layer (mm/dels)
-     real(r_2), dimension(:,:), pointer :: wflux => null()     ! water flux at layer boundaries (mm s-1)
-     real(r_2), dimension(:),   pointer :: delwcol => null()   ! change in water column (mm / dels)
-     real(r_2), dimension(:),   pointer :: zdelta => null()    ! water table depth           (edit vh 23/06/08)
-     real(r_2), dimension(:,:), pointer :: kth => null()       ! thermal conductivity           (edit vh 29/07/08)
-     real(r_2), dimension(:),   pointer :: Tsurface => null()  !  tepmerature at surface (soil, pond or litter) (edit vh 22/10/08)
-     real(r_2), dimension(:),   pointer :: lE => null()      ! soil latent heat flux
-     real(r_2), dimension(:),   pointer :: evap => null()    ! soil evaporation (mm / dels)
-     real(r_2), dimension(:,:), pointer :: ciso => null()    ! concentration of minor isotopologue in soil water (kg m-3 water)
-     real(r_2), dimension(:),   pointer :: cisoL => null()   ! concentration of minor isotopologue in litter water (kg m-3 water)
-     real(r_2), dimension(:),   pointer :: rlitt => null()   ! resistance to heat/moisture transfer through litter (m-1 s)
-     real(r_2), dimension(:,:), pointer :: thetai => null()  ! volumetric ice content (MC)
-     real(r_2), dimension(:,:), pointer :: snowliq => null() ! liquid snow content (mm H2O)
-     real(r_2), dimension(:),   pointer :: nsteps => null()  ! number of iterations at each timestep
-     real(r_2), dimension(:),   pointer :: TsurfaceFR => null() ! temperature at surface (soil, pond or litter) (edit vh 22/10/08)
-     real(r_2), dimension(:,:), pointer :: Ta_daily => null() ! air temp averaged over last 24h
+     real(r2), dimension(:,:), pointer :: S => null()         ! moisture content relative to sat value    (edit vh 23/01/08)
+     real(r2), dimension(:,:), pointer :: Tsoil => null()     ! Tsoil (deg C)
+     real(r2), dimension(:),   pointer :: SL => null()        ! litter moisture content relative to sat value (edit vh 23/01/08)
+     real(r2), dimension(:),   pointer :: TL => null()        ! litter temperature in K     (edit vh 23/01/08)
+     real(r2), dimension(:),   pointer :: h0 => null()        ! pond height in m            (edit vh 23/01/08)
+     real(r2), dimension(:,:), pointer :: rex => null()       ! root extraction from each layer (mm/dels)
+     real(r2), dimension(:,:), pointer :: wflux => null()     ! water flux at layer boundaries (mm s-1)
+     real(r2), dimension(:),   pointer :: delwcol => null()   ! change in water column (mm / dels)
+     real(r2), dimension(:),   pointer :: zdelta => null()    ! water table depth           (edit vh 23/06/08)
+     real(r2), dimension(:,:), pointer :: kth => null()       ! thermal conductivity           (edit vh 29/07/08)
+     real(r2), dimension(:),   pointer :: Tsurface => null()  !  tepmerature at surface (soil, pond or litter) (edit vh 22/10/08)
+     real(r2), dimension(:),   pointer :: lE => null()      ! soil latent heat flux
+     real(r2), dimension(:),   pointer :: evap => null()    ! soil evaporation (mm / dels)
+     real(r2), dimension(:,:), pointer :: ciso => null()    ! concentration of minor isotopologue in soil water (kg m-3 water)
+     real(r2), dimension(:),   pointer :: cisoL => null()   ! concentration of minor isotopologue in litter water (kg m-3 water)
+     real(r2), dimension(:),   pointer :: rlitt => null()   ! resistance to heat/moisture transfer through litter (m-1 s)
+     real(r2), dimension(:,:), pointer :: thetai => null()  ! volumetric ice content (MC)
+     real(r2), dimension(:,:), pointer :: snowliq => null() ! liquid snow content (mm H2O)
+     real(r2), dimension(:),   pointer :: nsteps => null()  ! number of iterations at each timestep
+     real(r2), dimension(:),   pointer :: TsurfaceFR => null() ! temperature at surface (soil, pond or litter) (edit vh 22/10/08)
+     real(r2), dimension(:,:), pointer :: Ta_daily => null() ! air temp averaged over last 24h
      integer, dimension(:),     pointer :: nsnow => null() ! number of layers in snow-pack (0-nsnow_max)
-     real(r_2), dimension(:),   pointer :: Qadv_daily => null() ! advective heat flux into surface , daily average (W m-2)
-     real(r_2), dimension(:),   pointer :: G0_daily => null()  ! conductive heat flux into surface , daily average (W m-2)
-     real(r_2), dimension(:),   pointer :: Qevap_daily => null() ! evaporative flux at surface, daily average (m s-1)
-     real(r_2), dimension(:),   pointer :: Qprec_daily => null() ! liquid precip, daily average (m s-1)
-     real(r_2), dimension(:),   pointer :: Qprec_snow_daily => null() ! solid precip, daily average (m s-1)
-     real(r_2), dimension(:),   pointer :: E_fusion_sn => null()
-     real(r_2), dimension(:),   pointer :: E_sublimation_sn => null()
-     real(r_2), dimension(:),   pointer :: latent_heat_sn => null()
-     real(r_2), dimension(:),   pointer :: evap_liq_sn => null()
-     real(r_2), dimension(:),   pointer :: surface_melt => null()
-     real(r_2), dimension(:),   pointer :: Qadv_rain_sn => null()
+     real(r2), dimension(:),   pointer :: Qadv_daily => null() ! advective heat flux into surface , daily average (W m-2)
+     real(r2), dimension(:),   pointer :: G0_daily => null()  ! conductive heat flux into surface , daily average (W m-2)
+     real(r2), dimension(:),   pointer :: Qevap_daily => null() ! evaporative flux at surface, daily average (m s-1)
+     real(r2), dimension(:),   pointer :: Qprec_daily => null() ! liquid precip, daily average (m s-1)
+     real(r2), dimension(:),   pointer :: Qprec_snow_daily => null() ! solid precip, daily average (m s-1)
+     real(r2), dimension(:),   pointer :: E_fusion_sn => null()
+     real(r2), dimension(:),   pointer :: E_sublimation_sn => null()
+     real(r2), dimension(:),   pointer :: latent_heat_sn => null()
+     real(r2), dimension(:),   pointer :: evap_liq_sn => null()
+     real(r2), dimension(:),   pointer :: surface_melt => null()
+     real(r2), dimension(:),   pointer :: Qadv_rain_sn => null()
 
   end type soil_snow_type
 
@@ -356,16 +354,16 @@ module cable_def_types_mod
           froot => null()      ! fraction of root in each soil layer
 
      ! Additional  veg parameters:
-     real(r_2), dimension(:), pointer :: rootbeta => null() ! parameter for estimating vertical root mass distribution (froot)
-     real(r_2), dimension(:), pointer :: gamma => null()    ! parameter in root efficiency function (Lai and Katul 2000)
-     real(r_2), dimension(:), pointer :: ZR => null()       ! maximum rooting depth (cm)
-     real(r_2), dimension(:), pointer :: F10 => null()      ! fraction of roots in top 10 cm
+     real(r2), dimension(:), pointer :: rootbeta => null() ! parameter for estimating vertical root mass distribution (froot)
+     real(r2), dimension(:), pointer :: gamma => null()    ! parameter in root efficiency function (Lai and Katul 2000)
+     real(r2), dimension(:), pointer :: ZR => null()       ! maximum rooting depth (cm)
+     real(r2), dimension(:), pointer :: F10 => null()      ! fraction of roots in top 10 cm
 
-     real(r_2), dimension(:), pointer :: clitt => null()     !
+     real(r2), dimension(:), pointer :: clitt => null()     !
 
      ! Additional POP veg param
      integer,   dimension(:,:), pointer :: disturbance_interval => null()
-     real(r_2), dimension(:,:), pointer :: disturbance_intensity => null()
+     real(r2), dimension(:,:), pointer :: disturbance_intensity => null()
 
   end type veg_parameter_type
 
@@ -429,7 +427,7 @@ module cable_def_types_mod
                                 !! vh_js !!
           zetash => null()     ! stability parameter (shear height)
 
-     real(r_2), dimension(:), pointer :: &
+     real(r2), dimension(:), pointer :: &
           fess => null(),    & ! latent heatfl from soil (W/m2)
           fesp => null(),    & ! latent heatfl from soil (W/m2)
           dgdtg => null(),   & ! derivative of gflux wrt soil temp
@@ -464,29 +462,29 @@ module cable_def_types_mod
           dlf => null()        ! dryleaf vp minus in-canopy vp (Pa)
 
      ! Additional variables:
-     real(r_2), dimension(:,:),   pointer :: gw => null()     ! dry canopy conductance (ms-1) edit vh 6/7/09
-     real(r_2), dimension(:,:,:), pointer :: ancj => null()   ! limiting photosynthetic rates (Rubisco,RuBP,sink) vh 6/7/09
-     real(r_2), dimension(:,:),   pointer :: tlfy => null()   ! sunlit and shaded leaf temperatures
-     real(r_2), dimension(:,:),   pointer :: ecy => null()    ! sunlit and shaded leaf transpiration (dry canopy)
-     real(r_2), dimension(:,:),   pointer :: ecx => null()    ! sunlit and shaded leaf latent heat flux
-     ! REAL(r_2), DIMENSION(:,:,:), POINTER :: ci => null()     ! intra-cellular CO2 vh 6/7/09
-     real(r_2), dimension(:),     pointer :: fwsoil => null() !
+     real(r2), dimension(:,:),   pointer :: gw => null()     ! dry canopy conductance (ms-1) edit vh 6/7/09
+     real(r2), dimension(:,:,:), pointer :: ancj => null()   ! limiting photosynthetic rates (Rubisco,RuBP,sink) vh 6/7/09
+     real(r2), dimension(:,:),   pointer :: tlfy => null()   ! sunlit and shaded leaf temperatures
+     real(r2), dimension(:,:),   pointer :: ecy => null()    ! sunlit and shaded leaf transpiration (dry canopy)
+     real(r2), dimension(:,:),   pointer :: ecx => null()    ! sunlit and shaded leaf latent heat flux
+     ! REAL(r2), DIMENSION(:,:,:), POINTER :: ci => null()     ! intra-cellular CO2 vh 6/7/09
+     real(r2), dimension(:),     pointer :: fwsoil => null() !
 
      ! vh_js - litter thermal conductivity (Wm-2K-1) and vapour diffusivity (m2s-1)
-     real(r_2), dimension(:), pointer :: kthLitt => null()
-     real(r_2), dimension(:), pointer :: DvLitt => null()
+     real(r2), dimension(:), pointer :: kthLitt => null()
+     real(r2), dimension(:), pointer :: DvLitt => null()
 
      ! 13C
-     real(r_2), dimension(:,:), pointer :: An => null()        ! sunlit and shaded net assimilation [mol(CO2)/m2/s]
-     real(r_2), dimension(:,:), pointer :: Rd => null()        ! sunlit and shaded leaf respiration [mol(CO2)/m2/s]
+     real(r2), dimension(:,:), pointer :: An => null()        ! sunlit and shaded net assimilation [mol(CO2)/m2/s]
+     real(r2), dimension(:,:), pointer :: Rd => null()        ! sunlit and shaded leaf respiration [mol(CO2)/m2/s]
      logical,   dimension(:),   pointer :: isc3 => null()      ! C3 / C4 mask
-     real(r_2), dimension(:,:), pointer :: vcmax => null()     ! max RuBP carboxylation rate [mol(CO2)/m2/s]
+     real(r2), dimension(:,:), pointer :: vcmax => null()     ! max RuBP carboxylation rate [mol(CO2)/m2/s]
      ! CO2 compensation point in absence of dark respiration [mol(CO2)/mol(air)]
-     real(r_2), dimension(:,:), pointer :: gammastar => null()
-     real(r_2), dimension(:,:), pointer :: gsc => null()       ! stomatal conductance for CO2 [mol(CO2)/m^2/s]
-     real(r_2), dimension(:,:), pointer :: gbc => null()       ! leaf boundary layer conductance for CO2 [mol(CO2)/m^2/s]
-     real(r_2), dimension(:,:), pointer :: gac => null()       ! aerodynamic conductance for CO2 [mol(CO2)/m^2/s]
-     real(r_2), dimension(:,:), pointer :: ci => null()        ! stomatal CO2 concentration [mol(CO2)/mol(air)]
+     real(r2), dimension(:,:), pointer :: gammastar => null()
+     real(r2), dimension(:,:), pointer :: gsc => null()       ! stomatal conductance for CO2 [mol(CO2)/m^2/s]
+     real(r2), dimension(:,:), pointer :: gbc => null()       ! leaf boundary layer conductance for CO2 [mol(CO2)/m^2/s]
+     real(r2), dimension(:,:), pointer :: gac => null()       ! aerodynamic conductance for CO2 [mol(CO2)/m^2/s]
+     real(r2), dimension(:,:), pointer :: ci => null()        ! stomatal CO2 concentration [mol(CO2)/mol(air)]
 
   end type canopy_type
 

--- a/core/biogeophys/cable_diag.F90
+++ b/core/biogeophys/cable_diag.F90
@@ -35,7 +35,7 @@
 
 !#define UM_BUILD YES
 MODULE cable_diag_module
-  use cable_def_types_mod, only : r_2
+  use cable_def_types_mod, only : r2
    IMPLICIT NONE
    INTEGER, PARAMETER :: gok=0
    INTEGER :: galloctest=1
@@ -499,10 +499,10 @@ END SUBROUTINE cable_diag_data1
 
   subroutine put_var_ncr2(ncid, var_name, var, n_call)
     use netcdf
-    use cable_def_types_mod, only : r_2, mp
+    use cable_def_types_mod, only : r2, mp
     implicit none
     character(len=*), intent(in) ::  var_name
-    real(r_2), dimension(:),intent(in) :: var
+    real(r2), dimension(:),intent(in) :: var
     integer, intent(in) :: ncid, n_call
     integer :: ncok, varID
 
@@ -519,12 +519,12 @@ END SUBROUTINE cable_diag_data1
   subroutine put_var_ncr3(ncid, var_name, var, n_call, nl)
     
     use netcdf
-    use cable_def_types_mod, only : r_2, mp
+    use cable_def_types_mod, only : r2, mp
     
     implicit none
     
     character(len=*), intent(in) :: var_name
-    real(r_2), dimension(:,:),intent(in) :: var
+    real(r2), dimension(:,:),intent(in) :: var
     integer, intent(in) :: ncid, n_call, nl
     integer :: ncok, varID
 
@@ -543,13 +543,13 @@ END SUBROUTINE cable_diag_data1
   subroutine get_var_ncr2(ncid, var_name, var, n_call)
     
     use netcdf,              only: nf90_inq_varid, nf90_noerr, nf90_get_var
-    use cable_def_types_mod, only: r_2,mp
+    use cable_def_types_mod, only: r2,mp
     
     implicit none
     
     integer,                 intent(in)  :: ncid
     character(len=*),        intent(in)  :: var_name
-    real(r_2), dimension(:), intent(out) :: var
+    real(r2), dimension(:), intent(out) :: var
     integer,                 intent(in)  :: n_call
     
     integer :: ncok, varID
@@ -567,13 +567,13 @@ END SUBROUTINE cable_diag_data1
   subroutine get_var_ncr3(ncid, var_name, var, n_call, nl)
 
     use netcdf,              only: nf90_inq_varid, nf90_noerr, nf90_get_var
-    use cable_def_types_mod, only : r_2, mp
+    use cable_def_types_mod, only : r2, mp
     
     implicit none
     
     integer,                   intent(in)  :: ncid
     character(len=*),          intent(in)  :: var_name
-    real(r_2), dimension(:,:), intent(out) :: var
+    real(r2), dimension(:,:), intent(out) :: var
     integer,                   intent(in)  :: n_call
     integer,                   intent(in)  :: nl
     

--- a/core/biogeophys/cable_sli_numbers.F90
+++ b/core/biogeophys/cable_sli_numbers.F90
@@ -1,96 +1,96 @@
 MODULE sli_numbers
 
-  USE cable_def_types_mod,  ONLY: r_2, i_d
+  USE cable_def_types_mod,  ONLY: r2, i4
 
   IMPLICIT NONE
 
   ! define some numbers
-  REAL(r_2), PARAMETER :: zero      = 0.0_r_2
-  REAL(r_2), PARAMETER :: half      = 0.5_r_2
-  REAL(r_2), PARAMETER :: one       = 1.0_r_2
-  REAL(r_2), PARAMETER :: two       = 2.0_r_2
-  REAL(r_2), PARAMETER :: four      = 4.0_r_2
-  REAL(r_2), PARAMETER :: thousand  = 1000._r_2
-  REAL(r_2), PARAMETER :: e1        = 1.e-1_r_2
-  REAL(r_2), PARAMETER :: e2        = 1.e-2_r_2
-  REAL(r_2), PARAMETER :: e3        = 1.e-3_r_2
-  REAL(r_2), PARAMETER :: e4        = 1.e-4_r_2
-  REAL(r_2), PARAMETER :: e5        = 1.e-5_r_2
-  REAL(r_2), PARAMETER :: e6        = 1.e-6_r_2
-  REAL(r_2), PARAMETER :: e7        = 1.e-7_r_2
+  REAL(r2), PARAMETER :: zero      = 0.0_r2
+  REAL(r2), PARAMETER :: half      = 0.5_r2
+  REAL(r2), PARAMETER :: one       = 1.0_r2
+  REAL(r2), PARAMETER :: two       = 2.0_r2
+  REAL(r2), PARAMETER :: four      = 4.0_r2
+  REAL(r2), PARAMETER :: thousand  = 1000._r2
+  REAL(r2), PARAMETER :: e1        = 1.e-1_r2
+  REAL(r2), PARAMETER :: e2        = 1.e-2_r2
+  REAL(r2), PARAMETER :: e3        = 1.e-3_r2
+  REAL(r2), PARAMETER :: e4        = 1.e-4_r2
+  REAL(r2), PARAMETER :: e5        = 1.e-5_r2
+  REAL(r2), PARAMETER :: e6        = 1.e-6_r2
+  REAL(r2), PARAMETER :: e7        = 1.e-7_r2
 
   ! define some constants
-  REAL(r_2), PARAMETER :: pi        = 3.1415927_r_2
-  REAL(r_2), PARAMETER :: Tzero     = 273.16_r_2          ! Celcius -> Kelvin
-  REAL(r_2), PARAMETER :: gravity   = 9.8086_r_2          ! gravitation constant [m/s2]
-  REAL(r_2), PARAMETER :: Mw        = 0.018016_r_2        ! weight of 1 mol of water [kg]
-  REAL(r_2), PARAMETER :: rmair     = 0.02897_r_2         ! molecular wt: dry air (kg/mol)
-  REAL(r_2), PARAMETER :: Mw18      = 0.018_r_2           ! weight of 1 mol of water [kg] (main isotopologue only)
-  REAL(r_2), PARAMETER :: cpa       = 1004.64_r_2         ! specific heat capacity of dry air at 0-40 degC [J/kgK]
-  REAL(r_2), PARAMETER :: esata     = 6.106_r_2*100.0_r_2 ! constants for saturated vapour pressure calculation
-  REAL(r_2), PARAMETER :: esatb     = 17.27_r_2           ! %
-  REAL(r_2), PARAMETER :: esatc     = 237.3_r_2           ! %
+  REAL(r2), PARAMETER :: pi        = 3.1415927_r2
+  REAL(r2), PARAMETER :: Tzero     = 273.16_r2          ! Celcius -> Kelvin
+  REAL(r2), PARAMETER :: gravity   = 9.8086_r2          ! gravitation constant [m/s2]
+  REAL(r2), PARAMETER :: Mw        = 0.018016_r2        ! weight of 1 mol of water [kg]
+  REAL(r2), PARAMETER :: rmair     = 0.02897_r2         ! molecular wt: dry air (kg/mol)
+  REAL(r2), PARAMETER :: Mw18      = 0.018_r2           ! weight of 1 mol of water [kg] (main isotopologue only)
+  REAL(r2), PARAMETER :: cpa       = 1004.64_r2         ! specific heat capacity of dry air at 0-40 degC [J/kgK]
+  REAL(r2), PARAMETER :: esata     = 6.106_r2*100.0_r2 ! constants for saturated vapour pressure calculation
+  REAL(r2), PARAMETER :: esatb     = 17.27_r2           ! %
+  REAL(r2), PARAMETER :: esatc     = 237.3_r2           ! %
 
-  REAL(r_2), PARAMETER :: rlambda   = 2.442e6_r_2  ! latent heat of condensation at 25 degC [J/kg]
-  REAL(r_2), PARAMETER :: lambdaf   = 335000._r_2  ! latent heat of fusion (J kg-1)
-  REAL(r_2), PARAMETER :: lambdas   = 2835000._r_2 ! latent heat of sublimation (J kg-1)
-  REAL(r_2), PARAMETER :: Dva       = 2.17e-5_r_2  ! vapour diffusivity of water in air at 0 degC [m2/s]
-  REAL(r_2), PARAMETER :: rhow      = 1000.0_r_2   ! denisty of water [kg/m3]
-  REAL(r_2), PARAMETER :: rhoi      = 920._r_2     ! density of ice (kg m-3)
+  REAL(r2), PARAMETER :: rlambda   = 2.442e6_r2  ! latent heat of condensation at 25 degC [J/kg]
+  REAL(r2), PARAMETER :: lambdaf   = 335000._r2  ! latent heat of fusion (J kg-1)
+  REAL(r2), PARAMETER :: lambdas   = 2835000._r2 ! latent heat of sublimation (J kg-1)
+  REAL(r2), PARAMETER :: Dva       = 2.17e-5_r2  ! vapour diffusivity of water in air at 0 degC [m2/s]
+  REAL(r2), PARAMETER :: rhow      = 1000.0_r2   ! denisty of water [kg/m3]
+  REAL(r2), PARAMETER :: rhoi      = 920._r2     ! density of ice (kg m-3)
 
-  REAL(r_2), PARAMETER :: rhoa      = 1.184_r_2    ! denisty of dry air at std (25 degC) [kg/m3]
-  REAL(r_2), PARAMETER :: rhocp     = 1189.8_r_2   ! cpa*rhoa at std (25 degC) [J/m3K]
+  REAL(r2), PARAMETER :: rhoa      = 1.184_r2    ! denisty of dry air at std (25 degC) [kg/m3]
+  REAL(r2), PARAMETER :: rhocp     = 1189.8_r2   ! cpa*rhoa at std (25 degC) [J/m3K]
 
-  REAL(r_2), PARAMETER :: esata_ice = 611.2_r_2   ! constants for saturated vapour pressure calculation over ice (WMO, 2008)
-  REAL(r_2), PARAMETER :: esatb_ice = 22.46_r_2   ! %
-  REAL(r_2), PARAMETER :: esatc_ice = 272.62_r_2  ! %
-  REAL(r_2), PARAMETER :: csice     = 2.100e3_r_2 ! specific heat capacity for ice
-  REAL(r_2), PARAMETER :: cswat     = 4.218e3_r_2 ! specific heat capacity for water
-  REAL(r_2), PARAMETER :: rgas      = 8.3143_r_2  ! universal gas const  (J/mol/K)
-  REAL(r_2), PARAMETER :: kw        = 0.58_r_2    ! dito
+  REAL(r2), PARAMETER :: esata_ice = 611.2_r2   ! constants for saturated vapour pressure calculation over ice (WMO, 2008)
+  REAL(r2), PARAMETER :: esatb_ice = 22.46_r2   ! %
+  REAL(r2), PARAMETER :: esatc_ice = 272.62_r2  ! %
+  REAL(r2), PARAMETER :: csice     = 2.100e3_r2 ! specific heat capacity for ice
+  REAL(r2), PARAMETER :: cswat     = 4.218e3_r2 ! specific heat capacity for water
+  REAL(r2), PARAMETER :: rgas      = 8.3143_r2  ! universal gas const  (J/mol/K)
+  REAL(r2), PARAMETER :: kw        = 0.58_r2    ! dito
 
   ! numerical limits
-  REAL(r_2), PARAMETER :: dSfac        = 5.25_r_2
-  !REAL(r_2), PARAMETER :: dSfac        = 1.25_r_2
-  REAL(r_2), PARAMETER :: dpmaxr       = 0.5_r_2
-  REAL(r_2), PARAMETER :: h0min        = -5.e-3_r_2
+  REAL(r2), PARAMETER :: dSfac        = 5.25_r2
+  !REAL(r2), PARAMETER :: dSfac        = 1.25_r2
+  REAL(r2), PARAMETER :: dpmaxr       = 0.5_r2
+  REAL(r2), PARAMETER :: h0min        = -5.e-3_r2
   ! Changed from 0.005 to 0.0005 because of results at Sodankyla in 2000-2003 for ESMSnowMIP
-  REAL(r_2), PARAMETER :: snmin        = 0.0005_r_2 ! depth of snowpack (m) without dedicated snow layer(s)
-  REAL(r_2), PARAMETER :: fsnowliq_max = 0.03_r_2  ! max fraction of snow water in liquid phase
-  INTEGER(i_d), PARAMETER :: nsnow_max = 1     ! maximum number of dedicated snow layers (1 or 2)
+  REAL(r2), PARAMETER :: snmin        = 0.0005_r2 ! depth of snowpack (m) without dedicated snow layer(s)
+  REAL(r2), PARAMETER :: fsnowliq_max = 0.03_r2  ! max fraction of snow water in liquid phase
+  INTEGER(i4), PARAMETER :: nsnow_max = 1     ! maximum number of dedicated snow layers (1 or 2)
 
-  REAL(r_2), PARAMETER :: dh0max    = 0.0001_r_2
-  REAL(r_2), PARAMETER :: SLmax     = 1.01_r_2
-  REAL(r_2), PARAMETER :: SLmin     = 0.001_r_2
-  REAL(r_2), PARAMETER :: Smax      = 1.05_r_2
-  REAL(r_2), PARAMETER :: h0max     = 0.005_r_2
-  REAL(r_2), PARAMETER :: qprecmax  = 1.0e10_r_2
-  !REAL(r_2), PARAMETER :: dSmax     = 0.5_r_2
-  !REAL(r_2), PARAMETER :: dSmaxr    = 0.5_r_2
-  REAL(r_2), PARAMETER :: dSmax     = 0.1_r_2
-  !REAL(r_2), PARAMETER :: dSmaxr    = 0.1_r_2
-  REAL(r_2), PARAMETER :: dSmaxr    = 0.4_r_2
-  REAL(r_2), PARAMETER :: dtmax     = 86400._r_2
-  REAL(r_2), PARAMETER :: dtmin     = 0.01_r_2
-  REAL(r_2), PARAMETER :: dsmmax    = 1.0_r_2
-  REAL(r_2), PARAMETER :: dTsoilmax = 30.0_r_2
-  REAL(r_2), PARAMETER :: dTLmax    = 30.0_r_2
-  !REAL(r_2), PARAMETER :: dTsoilmax = 1.0_r_2
-  !REAL(r_2), PARAMETER :: dTLmax    = 1.0_r_2
-  REAL(r_2), PARAMETER :: tol_dthetaldT = 1.e-12_r_2
-  INTEGER(i_d), PARAMETER :: nsteps_ice_max = 20
-  INTEGER(i_d), PARAMETER :: nsteps_max = 200
+  REAL(r2), PARAMETER :: dh0max    = 0.0001_r2
+  REAL(r2), PARAMETER :: SLmax     = 1.01_r2
+  REAL(r2), PARAMETER :: SLmin     = 0.001_r2
+  REAL(r2), PARAMETER :: Smax      = 1.05_r2
+  REAL(r2), PARAMETER :: h0max     = 0.005_r2
+  REAL(r2), PARAMETER :: qprecmax  = 1.0e10_r2
+  !REAL(r2), PARAMETER :: dSmax     = 0.5_r2
+  !REAL(r2), PARAMETER :: dSmaxr    = 0.5_r2
+  REAL(r2), PARAMETER :: dSmax     = 0.1_r2
+  !REAL(r2), PARAMETER :: dSmaxr    = 0.1_r2
+  REAL(r2), PARAMETER :: dSmaxr    = 0.4_r2
+  REAL(r2), PARAMETER :: dtmax     = 86400._r2
+  REAL(r2), PARAMETER :: dtmin     = 0.01_r2
+  REAL(r2), PARAMETER :: dsmmax    = 1.0_r2
+  REAL(r2), PARAMETER :: dTsoilmax = 30.0_r2
+  REAL(r2), PARAMETER :: dTLmax    = 30.0_r2
+  !REAL(r2), PARAMETER :: dTsoilmax = 1.0_r2
+  !REAL(r2), PARAMETER :: dTLmax    = 1.0_r2
+  REAL(r2), PARAMETER :: tol_dthetaldT = 1.e-12_r2
+  INTEGER(i4), PARAMETER :: nsteps_ice_max = 20
+  INTEGER(i4), PARAMETER :: nsteps_max = 200
   !MC - ToDo: Identify why smaller time-steps are needed for isotopes.
-  ! With isotopes  REAL(r_2), PARAMETER :: dSmax=0.1_r_2, dSmaxr=0.1_r_2, dtmax=0.05_r_2*3600.,
-  !                                        dtmin=0.0_r_2, dsmmax=1.0_r_2
-  ! With isotopes   REAL(r_2), PARAMETER ::  dTsoilmax=1.0_r_2, dTLmax=1.0_r_2
-  REAL(r_2), PARAMETER :: gf        = 1.0_r_2    ! gravity factor for flow direction (usually 1 for straight down).
-  REAL(r_2), PARAMETER :: hmin      = -1.0e6_r_2 ! minimum matric head h (used by MF).
-  REAL(r_2), PARAMETER :: csol      = 0.0_r_2    ! solute concentration (mol kg-1 soil water)
-  REAL(r_2), PARAMETER :: rhmin     = 0.05_r_2   ! minimum relative humidity in soil and litter
+  ! With isotopes  REAL(r2), PARAMETER :: dSmax=0.1_r2, dSmaxr=0.1_r2, dtmax=0.05_r2*3600.,
+  !                                        dtmin=0.0_r2, dsmmax=1.0_r2
+  ! With isotopes   REAL(r2), PARAMETER ::  dTsoilmax=1.0_r2, dTLmax=1.0_r2
+  REAL(r2), PARAMETER :: gf        = 1.0_r2    ! gravity factor for flow direction (usually 1 for straight down).
+  REAL(r2), PARAMETER :: hmin      = -1.0e6_r2 ! minimum matric head h (used by MF).
+  REAL(r2), PARAMETER :: csol      = 0.0_r2    ! solute concentration (mol kg-1 soil water)
+  REAL(r2), PARAMETER :: rhmin     = 0.05_r2   ! minimum relative humidity in soil and litter
 
   ! boundary conditions
-  REAL(r_2), PARAMETER :: hbot  = 0.0_r_2
+  REAL(r2), PARAMETER :: hbot  = 0.0_r2
   CHARACTER(LEN=20)    :: botbc = "free drainage"
   ! CHARACTER(LEN=20)    :: botbc = "zero flux"
   ! CHARACTER(LEN=20)    :: botbc = "aquifer"
@@ -101,77 +101,77 @@ MODULE sli_numbers
   !  0: normal run
   ! 11: Mizoguchi (1990) / Hansson et al. (2004) lab experiment of freezing unsaturated soil; etc.
   ! 16: Loetschental
-  INTEGER(i_d) :: experiment = 0
+  INTEGER(i4) :: experiment = 0
 
   ! Steeper freezing curve factor: 1=normal, >1=steeper (e.g. 1.5-2.0)
-  REAL(r_2), PARAMETER :: freezefac = 1.0_r_2
+  REAL(r2), PARAMETER :: freezefac = 1.0_r2
 
   ! Topmodel approach
   ! 0: normal ponding and free drainage
   ! 1: topmodel surface runoff
   ! 2: topmodel deep drainage
   ! 3: topmodel surface runoff and deep drainage
-  INTEGER(i_d), PARAMETER :: topmodel = 0
-  REAL(r_2),    PARAMETER :: alpha    = 0.1_r_2 ! anistropy param for lateral flow (topmodel)
-  REAL(r_2),    PARAMETER :: fsat_max = 2.0_r_2 ! exponent for vertical profile of Ksat (topmodel)
+  INTEGER(i4), PARAMETER :: topmodel = 0
+  REAL(r2),    PARAMETER :: alpha    = 0.1_r2 ! anistropy param for lateral flow (topmodel)
+  REAL(r2),    PARAMETER :: fsat_max = 2.0_r2 ! exponent for vertical profile of Ksat (topmodel)
 
   ! Thermal conductivity of soil
   ! 0: Campbell (1985)
   ! 1: Van de Griend and O'Neill (1986)
-  INTEGER(i_d) :: ithermalcond = 0
+  INTEGER(i4) :: ithermalcond = 0
 
   ! define types
   TYPE vars_met
-     REAL(r_2) :: Ta, rha, rbw, rbh, rrc, Rn, Da, cva, civa, phiva, Rnsw
+     REAL(r2) :: Ta, rha, rbw, rbh, rrc, Rn, Da, cva, civa, phiva, Rnsw
   END TYPE vars_met
 
   TYPE vars
-     INTEGER(i_d) :: isat
-     REAL(r_2)    :: h, phi, phiS, K, KS, Dv, cvsat, rh, phiv, phivS, kH
-     REAL(r_2)    :: kE, kth, csoil, eta_th, hS, rhS, sl, cv, cvsatT, cvS, kv
-     INTEGER(i_d) :: iice
-     REAL(r_2)    :: thetai, thetal, phiT, KT, lambdav, lambdaf, Sliq
-     REAL(r_2)    :: he, phie, Ksat ! air-entry potential values (different to core sp params for frozen soil)
-     REAL(r_2)    :: dthetaldT
-     REAL(r_2)    :: Tfrz ! freezing point (deg C) depends on csol and S
-     REAL(r_2)    :: csoileff
-     REAL(r_2)    :: zsat ! height of saturated/unsaturated boundary (relative to bottom of layer)
-     REAL(r_2)    :: macropore_factor
+     INTEGER(i4) :: isat
+     REAL(r2)    :: h, phi, phiS, K, KS, Dv, cvsat, rh, phiv, phivS, kH
+     REAL(r2)    :: kE, kth, csoil, eta_th, hS, rhS, sl, cv, cvsatT, cvS, kv
+     INTEGER(i4) :: iice
+     REAL(r2)    :: thetai, thetal, phiT, KT, lambdav, lambdaf, Sliq
+     REAL(r2)    :: he, phie, Ksat ! air-entry potential values (different to core sp params for frozen soil)
+     REAL(r2)    :: dthetaldT
+     REAL(r2)    :: Tfrz ! freezing point (deg C) depends on csol and S
+     REAL(r2)    :: csoileff
+     REAL(r2)    :: zsat ! height of saturated/unsaturated boundary (relative to bottom of layer)
+     REAL(r2)    :: macropore_factor
   END TYPE vars
 
   TYPE vars_snow
-     REAL(r_2), DIMENSION(nsnow_max):: depth, hsnow, hliq, dens, tsn, kH, kE, kth, &
+     REAL(r2), DIMENSION(nsnow_max):: depth, hsnow, hliq, dens, tsn, kH, kE, kth, &
           Dv, cv, sl, melt, &
           Jsensible, Jlatent,  deltaJlatent, deltaJsensible, fsnowliq_max
-     REAL(r_2) ::  wcol, Qadv_snow, Qadv_rain, totdepth, J, &
+     REAL(r2) ::  wcol, Qadv_snow, Qadv_rain, totdepth, J, &
           Qadv_melt, Qadv_vap, Qcond_net, &
           Qadv_transfer, Qmelt, Qtransfer, FluxDivergence, deltaJ, &
           Qvap, MoistureFluxDivergence, Qprec, Qevap, deltawcol
-     INTEGER(i_d) :: nsnow, nsnow_last
+     INTEGER(i4) :: nsnow, nsnow_last
   END TYPE vars_snow
 
   TYPE vars_aquifer
-     INTEGER(i_d) :: isat
-     REAL(r_2)    :: zdelta, zsoil, zzero, K, Wa, discharge, f, Rsmax, Sy
+     INTEGER(i4) :: isat
+     REAL(r2)    :: zdelta, zsoil, zzero, K, Wa, discharge, f, Rsmax, Sy
   END TYPE vars_aquifer
 
   TYPE params
-     REAL(r_2) :: the, thre, he, lam, Ke, eta, thr
-     REAL(r_2) :: KSe, phie, phiSe, rho, thw, thfc, kd, css, clay, tortuosity
-     INTEGER(i_d) :: ishorizon ! horizon number with different soil properties
-     REAL(r_2) :: zeta
-     REAL(r_2) :: fsatmax
-     REAL(r_2) :: lambc        ! original lam for storage
-     REAL(r_2) :: LambdaS      ! thermal inertia of saturation for van de Griend & O'Neill (1986) thermal conductivity
+     REAL(r2) :: the, thre, he, lam, Ke, eta, thr
+     REAL(r2) :: KSe, phie, phiSe, rho, thw, thfc, kd, css, clay, tortuosity
+     INTEGER(i4) :: ishorizon ! horizon number with different soil properties
+     REAL(r2) :: zeta
+     REAL(r2) :: fsatmax
+     REAL(r2) :: lambc        ! original lam for storage
+     REAL(r2) :: LambdaS      ! thermal inertia of saturation for van de Griend & O'Neill (1986) thermal conductivity
   END TYPE params
 
   TYPE rapointer
-     REAL(r_2), DIMENSION(:), POINTER :: p => null()
+     REAL(r2), DIMENSION(:), POINTER :: p => null()
   END TYPE rapointer
 
   TYPE solve_type ! for energy and moisture balance in rh0_sol, etc.
-     INTEGER(i_d) :: k
-     REAL(r_2)    :: T1, Ta, cva, Rnet, hr1, hra, Dv, gv, gh, Dh, dz, phie, he, K1, eta,lambda, Ks, lambdav
+     INTEGER(i4) :: k
+     REAL(r2)    :: T1, Ta, cva, Rnet, hr1, hra, Dv, gv, gh, Dh, dz, phie, he, K1, eta,lambda, Ks, lambdav
   END TYPE solve_type
 
 END MODULE sli_numbers

--- a/core/biogeophys/cable_sli_roots.F90
+++ b/core/biogeophys/cable_sli_roots.F90
@@ -1,6 +1,6 @@
 MODULE sli_roots
 
-  USE cable_def_types_mod, ONLY: r_2, i_d
+  USE cable_def_types_mod, ONLY: r2, i4
   USE sli_numbers,       ONLY: zero, half, one, two, e3
 
   IMPLICIT NONE
@@ -10,9 +10,9 @@ MODULE sli_roots
   PUBLIC :: setroots, getrex ! routines
 
   ! b1, b2 - params used to get root distribution param b (Li et al., J Hydrolo 2001).
-  REAL(r_2), PARAMETER :: b1     = 24.66_r_2
-  REAL(r_2), PARAMETER :: b2     = 1.59_r_2
-  REAL(r_2), PARAMETER :: lambda = 1.0_r_2
+  REAL(r2), PARAMETER :: b1     = 24.66_r2
+  REAL(r2), PARAMETER :: b2     = 1.59_r2
+  REAL(r2), PARAMETER :: lambda = 1.0_r2
 
   INTERFACE setroots
      MODULE PROCEDURE setroots_1d
@@ -39,20 +39,20 @@ CONTAINS
 
     IMPLICIT NONE
 
-    REAL(r_2), DIMENSION(:), INTENT(IN)  :: x
-    REAL(r_2),               INTENT(IN)  :: F10
-    REAL(r_2),               INTENT(IN)  :: Zr
-    REAL(r_2), DIMENSION(:), INTENT(OUT) :: Fs
+    REAL(r2), DIMENSION(:), INTENT(IN)  :: x
+    REAL(r2),               INTENT(IN)  :: F10
+    REAL(r2),               INTENT(IN)  :: Zr
+    REAL(r2), DIMENSION(:), INTENT(OUT) :: Fs
     ! Sets current weighted root length density distribn (Fs).
     !      Li et al. (J Hydrolo, 2001)
     ! Definitions of arguments:
     ! x(:) - depths to bottom of layers (cm).
     ! F10  - fraction of root length density in top 10% of the root zone
     ! Zr   - rooting depth (cm).
-    INTEGER(i_d)                    :: ms
-    REAL(r_2)                       :: b, extr
-    REAL(r_2), DIMENSION(1:size(x)) :: ext0, ext1, xend, Fi
-    REAL(r_2)                       :: tmp
+    INTEGER(i4)                    :: ms
+    REAL(r2)                       :: b, extr
+    REAL(r2), DIMENSION(1:size(x)) :: ext0, ext1, xend, Fi
+    REAL(r2)                       :: tmp
 
     ms = size(x) ! soil layers
 
@@ -83,13 +83,13 @@ CONTAINS
 
     IMPLICIT NONE
 
-    REAL(r_2), DIMENSION(:,:), INTENT(IN)  :: x
-    REAL(r_2), DIMENSION(:),   INTENT(IN)  :: F10
-    REAL(r_2), DIMENSION(:),   INTENT(IN)  :: Zr
-    REAL(r_2), DIMENSION(:,:), INTENT(OUT) :: Fs
+    REAL(r2), DIMENSION(:,:), INTENT(IN)  :: x
+    REAL(r2), DIMENSION(:),   INTENT(IN)  :: F10
+    REAL(r2), DIMENSION(:),   INTENT(IN)  :: Zr
+    REAL(r2), DIMENSION(:,:), INTENT(OUT) :: Fs
 
-    INTEGER(i_d)                      :: i
-    REAL(r_2), DIMENSION(1:size(x,2)) :: out
+    INTEGER(i4)                      :: i
+    REAL(r2), DIMENSION(1:size(x,2)) :: out
 
     do i=1, size(x,1) ! landpoints
        call setroots_1d(x(i,:), F10(i), Zr(i), out)
@@ -107,22 +107,22 @@ CONTAINS
 
     IMPLICIT NONE
 
-    REAL(r_2), DIMENSION(:), INTENT(IN)    :: S      ! relative saturation
-    REAL(r_2), DIMENSION(:), INTENT(OUT)   :: rex    ! water extraction per layer
-    REAL(r_2),               INTENT(INOUT) :: fws    ! stomatal limitation factor
-    REAL(r_2), DIMENSION(:), INTENT(IN)    :: Fs     ! root length density
-    REAL(r_2), DIMENSION(:), INTENT(IN)    :: thetaS ! saturation soil moisture
-    REAL(r_2), DIMENSION(:), INTENT(IN)    :: thetaw ! soil moisture at wiliting point
-    REAL(r_2),               INTENT(IN)    :: Etrans ! total transpiration
-    REAL(r_2),               INTENT(IN)    :: gamma  ! skew of Li & Katul alpha2 function
-    REAL(r_2), DIMENSION(:), INTENT(IN)    :: dx     ! layer thicknesses (m)
-    REAL(r_2),               INTENT(IN)    :: dt
+    REAL(r2), DIMENSION(:), INTENT(IN)    :: S      ! relative saturation
+    REAL(r2), DIMENSION(:), INTENT(OUT)   :: rex    ! water extraction per layer
+    REAL(r2),               INTENT(INOUT) :: fws    ! stomatal limitation factor
+    REAL(r2), DIMENSION(:), INTENT(IN)    :: Fs     ! root length density
+    REAL(r2), DIMENSION(:), INTENT(IN)    :: thetaS ! saturation soil moisture
+    REAL(r2), DIMENSION(:), INTENT(IN)    :: thetaw ! soil moisture at wiliting point
+    REAL(r2),               INTENT(IN)    :: Etrans ! total transpiration
+    REAL(r2),               INTENT(IN)    :: gamma  ! skew of Li & Katul alpha2 function
+    REAL(r2), DIMENSION(:), INTENT(IN)    :: dx     ! layer thicknesses (m)
+    REAL(r2),               INTENT(IN)    :: dt
 
     ! Gets rate of water extraction compatible with CABLE stomatal conductance model
     ! theta(:) - soil moisture(m3 m-3)
     ! rex(:)   - rate of water extraction by roots from layers (cm/h).
-    REAL(r_2), DIMENSION(1:size(S)) :: theta, lthetar, alpha_root, delta_root
-    REAL(r_2)                       :: trex
+    REAL(r2), DIMENSION(1:size(S)) :: theta, lthetar, alpha_root, delta_root
+    REAL(r2)                       :: trex
 
     theta(:)   = S(:)*thetaS(:)
     lthetar(:) = log(max(theta(:)-thetaw(:),e3)/thetaS(:))
@@ -150,7 +150,7 @@ CONTAINS
     rex(:) = Etrans*rex(:)
 
     ! reduce extraction efficiency where total extraction depletes soil moisture below wilting point
-    !where ((rex*dt) > (theta(:)-0.01_r_2)*dx(:))
+    !where ((rex*dt) > (theta(:)-0.01_r2)*dx(:))
     where (((rex*dt) > (theta(:)-thetaw(:))*dx(:)) .and. ((rex*dt) > zero))
        alpha_root = alpha_root*(theta(:)-thetaw(:))*dx(:)/(rex*dt)
     endwhere
@@ -165,11 +165,11 @@ CONTAINS
     rex(:) = Etrans*rex(:)
 
     ! check that the water available in each layer exceeds the extraction
-    !if (any((rex*dt) > (theta(:)-0.01_r_2)*dx(:))) then
+    !if (any((rex*dt) > (theta(:)-0.01_r2)*dx(:))) then
     if (any(((rex*dt) > (theta(:)-thetaw(:))*dx(:)) .and. ((rex*dt) > zero))) then
        fws = zero
        ! distribute extraction according to available water
-       !rex(:) = (theta(:)-0.01_r_2)*dx(:)
+       !rex(:) = (theta(:)-0.01_r2)*dx(:)
        rex(:) = max((theta(:)-thetaw(:))*dx(:),zero)
        trex = sum(rex(:))
        if (trex > zero) then
@@ -188,20 +188,20 @@ CONTAINS
 
     IMPLICIT NONE
 
-    REAL(r_2), DIMENSION(:,:), INTENT(IN)    :: S      ! relative saturation
-    REAL(r_2), DIMENSION(:,:), INTENT(OUT)   :: rex    ! water extraction per layer
-    REAL(r_2), DIMENSION(:),   INTENT(INOUT) :: fws    ! stomatal limitation factor
-    REAL(r_2), DIMENSION(:,:), INTENT(IN)    :: Fs     ! root length density
-    REAL(r_2), DIMENSION(:,:), INTENT(IN)    :: thetaS ! saturation soil moisture
-    REAL(r_2), DIMENSION(:,:), INTENT(IN)    :: thetaw ! soil moisture at wiliting point
-    REAL(r_2), DIMENSION(:),   INTENT(IN)    :: Etrans ! total transpiration
-    REAL(r_2), DIMENSION(:),   INTENT(IN)    :: gamma  ! skew of Li & Katul alpha2 function
-    REAL(r_2), DIMENSION(:,:), INTENT(IN)    :: dx     ! layer thicknesses (m)
-    REAL(r_2),                 INTENT(IN)    :: dt
+    REAL(r2), DIMENSION(:,:), INTENT(IN)    :: S      ! relative saturation
+    REAL(r2), DIMENSION(:,:), INTENT(OUT)   :: rex    ! water extraction per layer
+    REAL(r2), DIMENSION(:),   INTENT(INOUT) :: fws    ! stomatal limitation factor
+    REAL(r2), DIMENSION(:,:), INTENT(IN)    :: Fs     ! root length density
+    REAL(r2), DIMENSION(:,:), INTENT(IN)    :: thetaS ! saturation soil moisture
+    REAL(r2), DIMENSION(:,:), INTENT(IN)    :: thetaw ! soil moisture at wiliting point
+    REAL(r2), DIMENSION(:),   INTENT(IN)    :: Etrans ! total transpiration
+    REAL(r2), DIMENSION(:),   INTENT(IN)    :: gamma  ! skew of Li & Katul alpha2 function
+    REAL(r2), DIMENSION(:,:), INTENT(IN)    :: dx     ! layer thicknesses (m)
+    REAL(r2),                 INTENT(IN)    :: dt
 
-    INTEGER(i_d)                      :: i
-    REAL(r_2), DIMENSION(1:size(S,2)) :: rout
-    REAL(r_2)                         :: fout
+    INTEGER(i4)                      :: i
+    REAL(r2), DIMENSION(1:size(S,2)) :: rout
+    REAL(r2)                         :: fout
 
     do i=1, size(S,1) ! landpoints
        fout = fws(i)

--- a/core/biogeophys/cable_sli_solve.F90
+++ b/core/biogeophys/cable_sli_solve.F90
@@ -64,7 +64,7 @@
 
 MODULE sli_solve
 
-  USE cable_def_types_mod, ONLY: r_2, i_d
+  USE cable_def_types_mod, ONLY: r2, i4
   USE sli_numbers,         ONLY: &
        experiment, &
        zero, one, two, half, thousand, e5, &  ! numbers
@@ -96,7 +96,7 @@ MODULE sli_solve
 
   PUBLIC :: solve ! solution routine
 
-  INTEGER(i_d), DIMENSION(:), ALLOCATABLE :: nless, n_noconverge ! global counters
+  INTEGER(i4), DIMENSION(:), ALLOCATABLE :: nless, n_noconverge ! global counters
 #ifdef __MPI__
   integer :: ierr
 #endif
@@ -154,42 +154,42 @@ CONTAINS
 
     IMPLICIT NONE
 
-    INTEGER(i_d)                                           :: mp
-    REAL(r_2),      DIMENSION(1:mp)                        :: qprec
-    REAL(r_2),      DIMENSION(1:mp)                        :: qprec_snow
-    INTEGER(i_d)                                           :: n
-    REAL(r_2),      DIMENSION(1:n) :: dx
-    REAL(r_2),      DIMENSION(1:mp)                        :: h0
-    REAL(r_2),      DIMENSION(1:n) :: Tsoil
-    REAL(r_2),      DIMENSION(-nsnow_max:n) :: qh
+    INTEGER(i4)                                           :: mp
+    REAL(r2),      DIMENSION(1:mp)                        :: qprec
+    REAL(r2),      DIMENSION(1:mp)                        :: qprec_snow
+    INTEGER(i4)                                           :: n
+    REAL(r2),      DIMENSION(1:n) :: dx
+    REAL(r2),      DIMENSION(1:mp)                        :: h0
+    REAL(r2),      DIMENSION(1:n) :: Tsoil
+    REAL(r2),      DIMENSION(-nsnow_max:n) :: qh
     TYPE(vars_met), DIMENSION(1:mp)                        :: vmet
     TYPE(vars),     DIMENSION(1:mp)                        :: vlit
     TYPE(vars_snow), DIMENSION(1:mp)                       :: vsnow
     TYPE(vars),     DIMENSION(1:n) :: var
-    REAL(r_2),      DIMENSION(1:mp)                        :: T0, Tsurface
-    REAL(r_2),      DIMENSION(1:mp)                        :: SL, Tl
+    REAL(r2),      DIMENSION(1:mp)                        :: T0, Tsurface
+    REAL(r2),      DIMENSION(1:mp)                        :: SL, Tl
     TYPE(params),   DIMENSION(1:mp)                        :: plit
     TYPE(params),   DIMENSION(1:n) :: par
-    REAL(r_2),      DIMENSION(1:mp), OPTIONAL                        :: qali
-    REAL(r_2),      DIMENSION(-nsnow_max:n) :: qvh
-    REAL(r_2),    DIMENSION(1:mp)                          :: qevap
+    REAL(r2),      DIMENSION(1:mp), OPTIONAL                        :: qali
+    REAL(r2),      DIMENSION(-nsnow_max:n) :: qvh
+    REAL(r2),    DIMENSION(1:mp)                          :: qevap
     LOGICAL,      DIMENSION(1:mp)                          :: again, getq0,getqn,init
-    INTEGER(i_d), DIMENSION(1:mp)                          :: ns, nsat, nsatlast
-    REAL(r_2),    DIMENSION(1:mp)                          :: phip
-    REAL(r_2),    DIMENSION(1:mp)                          :: qpme
-    REAL(r_2),    DIMENSION(1:n) :: hint, phimin, qexd
-    REAL(r_2),    DIMENSION(-nsnow_max:n) :: q, qya, qyb, qTa, qTb,qhya, qhyb, qhTa, qhTb
-    REAL(r_2),    DIMENSION(-nsnow_max:n) :: qadv, qadvya, qadvyb, qadvTa, qadvTb
+    INTEGER(i4), DIMENSION(1:mp)                          :: ns, nsat, nsatlast
+    REAL(r2),    DIMENSION(1:mp)                          :: phip
+    REAL(r2),    DIMENSION(1:mp)                          :: qpme
+    REAL(r2),    DIMENSION(1:n) :: hint, phimin, qexd
+    REAL(r2),    DIMENSION(-nsnow_max:n) :: q, qya, qyb, qTa, qTb,qhya, qhyb, qhTa, qhTb
+    REAL(r2),    DIMENSION(-nsnow_max:n) :: qadv, qadvya, qadvyb, qadvTa, qadvTb
     TYPE(vars)                                             :: vtmp
-    REAL(r_2),    DIMENSION(-nsnow_max:n) :: qliq, qv, qvT, qlya, qlyb, qvya, qvyb, qlTb, qvTa, qvTb
+    REAL(r2),    DIMENSION(-nsnow_max:n) :: qliq, qv, qvT, qlya, qlyb, qvya, qvyb, qlTb, qvTa, qvTb
     TYPE(vars),         DIMENSION(1:mp)                    :: vtop, vbot
-    REAL(r_2),          DIMENSION(1:mp)                    :: lE0, G0, Epot
-    INTEGER(i_d),       DIMENSION(1:mp)                    :: surface_case
-    INTEGER(i_d),       DIMENSION(1:mp)                    :: iflux
-    INTEGER(i_d)                                           :: j, kk
-    INTEGER(i_d)                                           :: advection ! switches
-    REAL(r_2)                                              :: dTqwdTa, dTqwdTb, Tqw, keff
-    REAL(r_2),          DIMENSION(1:mp)                    :: hice
+    REAL(r2),          DIMENSION(1:mp)                    :: lE0, G0, Epot
+    INTEGER(i4),       DIMENSION(1:mp)                    :: surface_case
+    INTEGER(i4),       DIMENSION(1:mp)                    :: iflux
+    INTEGER(i4)                                           :: j, kk
+    INTEGER(i4)                                           :: advection ! switches
+    REAL(r2)                                              :: dTqwdTa, dTqwdTb, Tqw, keff
+    REAL(r2),          DIMENSION(1:mp)                    :: hice
 
 
     !----- get fluxes and derivs
@@ -321,7 +321,7 @@ CONTAINS
     if (vsnow(kk)%nsnow>1) then
        ! vapour flux at interfaces between snow layers
        do j=1, vsnow(kk)%nsnow-1
-          keff = 2_r_2*((vsnow(kk)%kE(j)/(thousand*lambdaf))*(vsnow(kk)%kE(j+1)/(thousand*lambdaf))/ &
+          keff = 2._r2*((vsnow(kk)%kE(j)/(thousand*lambdaf))*(vsnow(kk)%kE(j+1)/(thousand*lambdaf))/ &
                ((vsnow(kk)%kE(j)/(thousand*lambdaf))*vsnow(kk)%depth(j+1)+(vsnow(kk)%kE(j+1)/ &
                (thousand*lambdaf))*vsnow(kk)%depth(j)) )
           q(j-vsnow(kk)%nsnow) = keff*(vsnow(kk)%tsn(j)-vsnow(kk)%tsn(j+1))
@@ -330,7 +330,7 @@ CONTAINS
           qya(j-vsnow(kk)%nsnow) = zero
           qyb(j-vsnow(kk)%nsnow) = zero
           ! conductive heat flux at interface between snow layers
-          keff = 2_r_2*(vsnow(kk)%kth(j+1)*vsnow(kk)%kth(j))/ &
+          keff = 2._r2*(vsnow(kk)%kth(j+1)*vsnow(kk)%kth(j))/ &
                (vsnow(kk)%kth(j+1)*vsnow(kk)%depth(j)+vsnow(kk)%kth(j)*vsnow(kk)%depth(j+1))  ! check this!
           qh(j-vsnow(kk)%nsnow) = keff*(vsnow(kk)%tsn(j)-vsnow(kk)%tsn(j+1))
           qhTa(j-vsnow(kk)%nsnow) = merge(zero,keff,vsnow(kk)%hliq(j)>zero)
@@ -359,10 +359,10 @@ CONTAINS
     if (vsnow(kk)%nsnow.ge.1) then
        ! vapour flux at soil/snow interface
        if (var(1)%isat==1) then
-          keff = vsnow(kk)%kE(vsnow(kk)%nsnow)/(thousand*lambdaf)/vsnow(kk)%depth(vsnow(kk)%nsnow)/2_r_2
+          keff = vsnow(kk)%kE(vsnow(kk)%nsnow)/(thousand*lambdaf)/vsnow(kk)%depth(vsnow(kk)%nsnow)/2._r2
        endif
        if (var(1)%isat==0) then
-          keff = 2_r_2*((vsnow(kk)%kE(vsnow(kk)%nsnow)/(thousand*lambdaf))*(var(1)%kE/thousand/var(1)%lambdav))/ &
+          keff = 2._r2*((vsnow(kk)%kE(vsnow(kk)%nsnow)/(thousand*lambdaf))*(var(1)%kE/thousand/var(1)%lambdav))/ &
                ((vsnow(kk)%kE(vsnow(kk)%nsnow)/(thousand*lambdaf))*dx(1)+(var(1)%kE/thousand/var(1)%lambdav)* &
                vsnow(kk)%depth(vsnow(kk)%nsnow))
        endif
@@ -389,7 +389,7 @@ CONTAINS
        endif
 
        ! conductive heat flux at snow/soil interface  ! check this!
-       keff = 2._r_2*(vsnow(kk)%kth(vsnow(kk)%nsnow)*var(1)%kth)/ &
+       keff = 2._r2*(vsnow(kk)%kth(vsnow(kk)%nsnow)*var(1)%kth)/ &
             (vsnow(kk)%kth(vsnow(kk)%nsnow)*dx(1)+var(1)%kth*vsnow(kk)%depth(vsnow(kk)%nsnow))
        qh(0) = keff*(vsnow(kk)%tsn(vsnow(kk)%nsnow)-Tsoil(1))
        if (vsnow(kk)%hliq(1)>zero) then
@@ -516,34 +516,34 @@ CONTAINS
 
     IMPLICIT NONE
 
-    REAL(r_2)                                              :: tfin
-    INTEGER(i_d)                                           :: mp
-    INTEGER(i_d)                                           :: n
-    REAL(r_2),      DIMENSION(1:n) :: dx
-    REAL(r_2),      DIMENSION(1:mp)                        :: h0
-    REAL(r_2),      DIMENSION(-nsnow_max:n) :: qh
-    INTEGER(i_d),   DIMENSION(1:mp)                        :: nsteps
+    REAL(r2)                                              :: tfin
+    INTEGER(i4)                                           :: mp
+    INTEGER(i4)                                           :: n
+    REAL(r2),      DIMENSION(1:n) :: dx
+    REAL(r2),      DIMENSION(1:mp)                        :: h0
+    REAL(r2),      DIMENSION(-nsnow_max:n) :: qh
+    INTEGER(i4),   DIMENSION(1:mp)                        :: nsteps
     TYPE(vars),     DIMENSION(1:mp)                        :: vlit
     TYPE(vars_snow), DIMENSION(1:mp)                       :: vsnow
     TYPE(vars),     DIMENSION(1:n) :: var
-    REAL(r_2),      DIMENSION(1:mp)                        :: dxL
+    REAL(r2),      DIMENSION(1:mp)                        :: dxL
     TYPE(params),   DIMENSION(1:mp)                        :: plit
     TYPE(params),   DIMENSION(1:n) :: par
-    REAL(r_2),      DIMENSION(1:mp)                        :: deltaTa
-    REAL(r_2),    DIMENSION(1:mp)                          :: qL, qhL
+    REAL(r2),      DIMENSION(1:mp)                        :: deltaTa
+    REAL(r2),    DIMENSION(1:mp)                          :: qL, qhL
     LOGICAL,      DIMENSION(1:mp)                          :: again
-    INTEGER(i_d), DIMENSION(1:mp)                          :: ns, nsat, nsatlast, nsteps0
-    REAL(r_2),    DIMENSION(1:mp)                          :: dmax, dt
-    REAL(r_2),    DIMENSION(1:mp)                          :: qpme, t
-    REAL(r_2),    DIMENSION(-nsnow_max:n) :: q
-    REAL(r_2),    DIMENSION(-nsnow_max:n) :: qadv
-    REAL(r_2),    DIMENSION(0:n) :: tmp2d1, tmp2d2,  deltaTmax
-    REAL(r_2),          DIMENSION(1:mp)                    :: tmp1d1, tmp1d3
-    INTEGER(i_d),       DIMENSION(1:mp)                    :: iflux
+    INTEGER(i4), DIMENSION(1:mp)                          :: ns, nsat, nsatlast, nsteps0
+    REAL(r2),    DIMENSION(1:mp)                          :: dmax, dt
+    REAL(r2),    DIMENSION(1:mp)                          :: qpme, t
+    REAL(r2),    DIMENSION(-nsnow_max:n) :: q
+    REAL(r2),    DIMENSION(-nsnow_max:n) :: qadv
+    REAL(r2),    DIMENSION(0:n) :: tmp2d1, tmp2d2,  deltaTmax
+    REAL(r2),          DIMENSION(1:mp)                    :: tmp1d1, tmp1d3
+    INTEGER(i4),       DIMENSION(1:mp)                    :: iflux
     LOGICAL                                                :: litter
-    INTEGER(i_d)                                           :: kk
-    INTEGER(i_d)                                           :: advection ! switches
-    REAL(r_2),          DIMENSION(1:n) :: iqex
+    INTEGER(i4)                                           :: kk
+    INTEGER(i4)                                           :: advection ! switches
+    REAL(r2),          DIMENSION(1:n) :: iqex
 
     !----- first estimate of time step dt before the calculation
     !      gets revised after the calculation
@@ -553,7 +553,7 @@ CONTAINS
     ! estimate rate of change of moisture storage [m/s]
     where (var(1:n)%isat==0 .and. var(1:n)%iice==0) tmp2d1(1:n) = &
          abs(q(1:n)-q(0:n-1)-iqex(1:n))/(par(1:n)%thre*dx(1:n))
-    where (var(1:n)%iice==1)  tmp2d1(1:n) =  tmp2d1(1:n)/2._r_2
+    where (var(1:n)%iice==1)  tmp2d1(1:n) =  tmp2d1(1:n)/2._r2
     ! estimate rate of change of temperature [K/s]
     tmp2d2(1:n) = abs(qh(1:n)-qh(0:n-1))/(var(1:n)%csoileff*dx(1:n))
     if (advection==1) then
@@ -593,7 +593,7 @@ CONTAINS
        ! energy required to melt ice in snow-pack
        tmp1d1(kk) = -rhow*(vsnow(kk)%hsnow(1)-vsnow(kk)%hliq(1))*(csice*vsnow(kk)%tsn(1) - lambdaf)
        if (qh(-vsnow(kk)%nsnow)*dt(kk).gt.tmp1d1(kk)) then
-          dt(kk) = 0.9_r_2*tmp1d1(kk)/qh(-vsnow(kk)%nsnow)
+          dt(kk) = 0.9_r2*tmp1d1(kk)/qh(-vsnow(kk)%nsnow)
        endif
     endif
 
@@ -611,7 +611,7 @@ CONTAINS
        dt(kk)    = dtmin
     end if
     ! sprint to the end
-    if (t(kk)+1.1_r_2*dt(kk)>tfin) then ! step to finish
+    if (t(kk)+1.1_r2*dt(kk)>tfin) then ! step to finish
        dt(kk) = tfin-t(kk)
        t(kk)  = tfin
     else
@@ -659,98 +659,98 @@ CONTAINS
        nfac10, nfac11, nfac12, J0snow, wcol0snow, h_ex, wpi, err &
        )
     IMPLICIT NONE
-    REAL(r_2)                                              :: tfin
-    INTEGER(i_d)                                           :: irec, mp
-    REAL(r_2),      DIMENSION(1:mp)                        :: qprec
-    REAL(r_2),      DIMENSION(1:mp)                        :: qprec_snow
-    INTEGER(i_d)                                           :: n
-    REAL(r_2),      DIMENSION(1:n) :: dx
-    REAL(r_2),      DIMENSION(1:mp)                        :: h0
-    REAL(r_2),      DIMENSION(1:n) :: S
-    REAL(r_2),      DIMENSION(1:n) :: thetai
-    REAL(r_2),      DIMENSION(1:n) :: Jsensible
-    REAL(r_2),      DIMENSION(1:n) :: Tsoil
-    REAL(r_2),      DIMENSION(1:mp)                        :: evap
-    REAL(r_2),      DIMENSION(1:mp)                        :: infil
-    REAL(r_2),      DIMENSION(1:mp)                        :: drainage, discharge
-    REAL(r_2),      DIMENSION(1:mp,-nsnow_max:n)           :: qh
-    INTEGER(i_d),   DIMENSION(1:mp)                        :: nsteps
+    REAL(r2)                                              :: tfin
+    INTEGER(i4)                                           :: irec, mp
+    REAL(r2),      DIMENSION(1:mp)                        :: qprec
+    REAL(r2),      DIMENSION(1:mp)                        :: qprec_snow
+    INTEGER(i4)                                           :: n
+    REAL(r2),      DIMENSION(1:n) :: dx
+    REAL(r2),      DIMENSION(1:mp)                        :: h0
+    REAL(r2),      DIMENSION(1:n) :: S
+    REAL(r2),      DIMENSION(1:n) :: thetai
+    REAL(r2),      DIMENSION(1:n) :: Jsensible
+    REAL(r2),      DIMENSION(1:n) :: Tsoil
+    REAL(r2),      DIMENSION(1:mp)                        :: evap
+    REAL(r2),      DIMENSION(1:mp)                        :: infil
+    REAL(r2),      DIMENSION(1:mp)                        :: drainage, discharge
+    REAL(r2),      DIMENSION(1:mp,-nsnow_max:n)           :: qh
+    INTEGER(i4),   DIMENSION(1:mp)                        :: nsteps
     TYPE(vars_met), DIMENSION(1:mp)                        :: vmet
     TYPE(vars),     DIMENSION(1:mp)                        :: vlit
     TYPE(vars_snow), DIMENSION(1:mp)                       :: vsnow
     TYPE(vars),     DIMENSION(1:n) :: var
-    REAL(r_2),      DIMENSION(1:mp)                        :: T0, Tsurface
-    REAL(r_2),      DIMENSION(1:mp)                        :: Hcum, lEcum
-    REAL(r_2),      DIMENSION(1:mp)                        :: Gcum, Qadvcum
-    REAL(r_2),      DIMENSION(1:mp)                        :: Jcol_sensible, Jcol_latent_S, Jcol_latent_T
-    REAL(r_2),      DIMENSION(1:n) :: csoil, kth
-    REAL(r_2),      DIMENSION(1:n) :: phi
-    REAL(r_2),      DIMENSION(1:mp)                        :: dxL
-    REAL(r_2),      DIMENSION(1:mp)                        :: zdelta, SL, Tl
+    REAL(r2),      DIMENSION(1:mp)                        :: T0, Tsurface
+    REAL(r2),      DIMENSION(1:mp)                        :: Hcum, lEcum
+    REAL(r2),      DIMENSION(1:mp)                        :: Gcum, Qadvcum
+    REAL(r2),      DIMENSION(1:mp)                        :: Jcol_sensible, Jcol_latent_S, Jcol_latent_T
+    REAL(r2),      DIMENSION(1:n) :: csoil, kth
+    REAL(r2),      DIMENSION(1:n) :: phi
+    REAL(r2),      DIMENSION(1:mp)                        :: dxL
+    REAL(r2),      DIMENSION(1:mp)                        :: zdelta, SL, Tl
     TYPE(params),   DIMENSION(1:mp)                        :: plit
     TYPE(params),   DIMENSION(1:n) :: par
-    REAL(r_2),      DIMENSION(1:mp,1:n), OPTIONAL                    :: wex
-    REAL(r_2),      DIMENSION(1:mp,1:nsnow_max)            :: ciso_snow
-    REAL(r_2),      DIMENSION(1:mp,1:nsnow_max)            :: cisoice_snow
-    REAL(r_2),      DIMENSION(1:mp), OPTIONAL                        :: qali
-    REAL(r_2),      DIMENSION(1:mp,-nsnow_max:n)           :: qvsig, qlsig, qvTsig, qvh
-    REAL(r_2),      DIMENSION(1:mp)                        :: deltaTa
-    REAL(r_2),    DIMENSION(1:mp)                          :: precip, qevap
-    REAL(r_2),    DIMENSION(1:mp)                          :: qL, qhL, qybL, qTbL, qhTbL, qhybL, rexcol, wcol
+    REAL(r2),      DIMENSION(1:mp,1:n), OPTIONAL                    :: wex
+    REAL(r2),      DIMENSION(1:mp,1:nsnow_max)            :: ciso_snow
+    REAL(r2),      DIMENSION(1:mp,1:nsnow_max)            :: cisoice_snow
+    REAL(r2),      DIMENSION(1:mp), OPTIONAL                        :: qali
+    REAL(r2),      DIMENSION(1:mp,-nsnow_max:n)           :: qvsig, qlsig, qvTsig, qvh
+    REAL(r2),      DIMENSION(1:mp)                        :: deltaTa
+    REAL(r2),    DIMENSION(1:mp)                          :: precip, qevap
+    REAL(r2),    DIMENSION(1:mp)                          :: qL, qhL, qybL, qTbL, qhTbL, qhybL, rexcol, wcol
     LOGICAL,      DIMENSION(1:mp)                          :: again, getq0,getqn,init
     LOGICAL,      DIMENSION(1:mp,1:n)                      :: again_ice
-    INTEGER(i_d), DIMENSION(1:mp)                          :: ih0, iok, itmp, ns, nsat, nsatlast, nsteps0
-    REAL(r_2),    DIMENSION(1:mp)                          :: accel, dmax, dt, dwinfil, dwoff, fac, phip
-    REAL(r_2),    DIMENSION(1:mp)                          :: qpme, rsig, rsigdt, sig, t
-    REAL(r_2),    DIMENSION(1:n) :: hint, phimin, qexd
-    REAL(r_2),    DIMENSION(-nsnow_max+1:n) :: aa, bb, cc, dd, ee, ff, gg, dy
-    REAL(r_2),    DIMENSION(-nsnow_max+1:n) :: aah, bbh, cch, ddh, eeh, ffh, ggh, de
-    REAL(r_2),    DIMENSION(-nsnow_max:n) :: q, qya, qyb, qTa, qTb,qhya, qhyb, qhTa, qhTb
-    REAL(r_2),    DIMENSION(-nsnow_max:n) :: qadv, qadvya, qadvyb, qadvTa, qadvTb
+    INTEGER(i4), DIMENSION(1:mp)                          :: ih0, iok, itmp, ns, nsat, nsatlast, nsteps0
+    REAL(r2),    DIMENSION(1:mp)                          :: accel, dmax, dt, dwinfil, dwoff, fac, phip
+    REAL(r2),    DIMENSION(1:mp)                          :: qpme, rsig, rsigdt, sig, t
+    REAL(r2),    DIMENSION(1:n) :: hint, phimin, qexd
+    REAL(r2),    DIMENSION(-nsnow_max+1:n) :: aa, bb, cc, dd, ee, ff, gg, dy
+    REAL(r2),    DIMENSION(-nsnow_max+1:n) :: aah, bbh, cch, ddh, eeh, ffh, ggh, de
+    REAL(r2),    DIMENSION(-nsnow_max:n) :: q, qya, qyb, qTa, qTb,qhya, qhyb, qhTa, qhTb
+    REAL(r2),    DIMENSION(-nsnow_max:n) :: qadv, qadvya, qadvyb, qadvTa, qadvTb
     TYPE(vars)                                             :: vtmp
-    REAL(r_2),    DIMENSION(-nsnow_max:n) :: qsig, qhsig, qadvsig
-    REAL(r_2),    DIMENSION(-nsnow_max:n) :: qliq, qv, qvT, qlya, qlyb, qvya, qvyb, qlTb, qvTa, qvTb
-    REAL(r_2),    DIMENSION(1:n) :: deltaS, dTsoil
-    REAL(r_2),    DIMENSION(0:n) :: tmp2d1, tmp2d2
-    REAL(r_2),    DIMENSION(1:n) :: cv0
-    REAL(r_2),      DIMENSION(1:nsnow_max) :: cisoliqice_snow
-    REAL(r_2),    DIMENSION(1:n) :: dthetaldT, thetal
-    INTEGER(i_d), DIMENSION(1:n) :: isave, nsteps_ice, imelt
+    REAL(r2),    DIMENSION(-nsnow_max:n) :: qsig, qhsig, qadvsig
+    REAL(r2),    DIMENSION(-nsnow_max:n) :: qliq, qv, qvT, qlya, qlyb, qvya, qvyb, qlTb, qvTa, qvTb
+    REAL(r2),    DIMENSION(1:n) :: deltaS, dTsoil
+    REAL(r2),    DIMENSION(0:n) :: tmp2d1, tmp2d2
+    REAL(r2),    DIMENSION(1:n) :: cv0
+    REAL(r2),      DIMENSION(1:nsnow_max) :: cisoliqice_snow
+    REAL(r2),    DIMENSION(1:n) :: dthetaldT, thetal
+    INTEGER(i4), DIMENSION(1:n) :: isave, nsteps_ice, imelt
     TYPE(vars),         DIMENSION(1:mp)                    :: vtop, vbot
     TYPE(vars_aquifer), DIMENSION(1:mp)                    :: v_aquifer
-    REAL(r_2),          DIMENSION(1:mp)                    :: dwcol, dwdrainage, drn,inlit, dwinlit, drexcol, dwdischarge
-    REAL(r_2),          DIMENSION(1:mp)                    :: dJcol_latent_S, dJcol_latent_T, dJcol_sensible
-    REAL(r_2),          DIMENSION(1:n) :: deltaJ_latent_S, deltaJ_latent_T, deltaJ_sensible_S, deltaJ_sensible_T
-    REAL(r_2),          DIMENSION(1:mp)                    :: qevapsig
-    REAL(r_2),          DIMENSION(1:mp)                    :: qrunoff
-    REAL(r_2),          DIMENSION(1:mp)                    :: tmp1d1, tmp1d2, tmp1d3,  tmp1d4
-    REAL(r_2),          DIMENSION(1:mp)                    :: deltah0
-    REAL(r_2),          DIMENSION(1:mp)                    :: deltaSL
-    REAL(r_2),          DIMENSION(1:mp)                    :: lE0, G0, Epot
-    REAL(r_2),          DIMENSION(1:mp)                    :: Tfreezing
-    REAL(r_2),          DIMENSION(1:mp)                    :: dtdT
-    REAL(r_2),          DIMENSION(-nsnow_max+1:n) :: LHS, RHS, LHS_h, RHS_h
-    INTEGER(i_d),       DIMENSION(1:mp)                    :: surface_case
-    INTEGER(i_d),       DIMENSION(1:mp)                    :: nns, iflux
+    REAL(r2),          DIMENSION(1:mp)                    :: dwcol, dwdrainage, drn,inlit, dwinlit, drexcol, dwdischarge
+    REAL(r2),          DIMENSION(1:mp)                    :: dJcol_latent_S, dJcol_latent_T, dJcol_sensible
+    REAL(r2),          DIMENSION(1:n) :: deltaJ_latent_S, deltaJ_latent_T, deltaJ_sensible_S, deltaJ_sensible_T
+    REAL(r2),          DIMENSION(1:mp)                    :: qevapsig
+    REAL(r2),          DIMENSION(1:mp)                    :: qrunoff
+    REAL(r2),          DIMENSION(1:mp)                    :: tmp1d1, tmp1d2, tmp1d3,  tmp1d4
+    REAL(r2),          DIMENSION(1:mp)                    :: deltah0
+    REAL(r2),          DIMENSION(1:mp)                    :: deltaSL
+    REAL(r2),          DIMENSION(1:mp)                    :: lE0, G0, Epot
+    REAL(r2),          DIMENSION(1:mp)                    :: Tfreezing
+    REAL(r2),          DIMENSION(1:mp)                    :: dtdT
+    REAL(r2),          DIMENSION(-nsnow_max+1:n) :: LHS, RHS, LHS_h, RHS_h
+    INTEGER(i4),       DIMENSION(1:mp)                    :: surface_case
+    INTEGER(i4),       DIMENSION(1:mp)                    :: nns, iflux
     LOGICAL                                                :: litter
-    INTEGER(i_d)                                           :: i, j, k, kk, condition
-    INTEGER(i_d)                                           :: littercase, isotopologue, advection ! switches
-    REAL(r_2)                                              :: c2, theta
-    REAL(r_2)                                              :: dTqwdTa, dTqwdTb, Tqw, keff
-    REAL(r_2),          DIMENSION(1:mp)                    :: cp, cpeff, hice, h0_0, hice_0, h0_tmp, hice_tmp
-    REAL(r_2),          DIMENSION(nsnow_max)          :: qmelt, hsnow
-    REAL(r_2),  DIMENSION(1:mp)                            :: qtransfer
-    REAL(r_2),          DIMENSION(nsnow_max) :: delta_snowcol, delta_snowT, delta_snowliq
-    REAL(r_2),      DIMENSION(1:n) :: thetai_0, J0
-    REAL(r_2)                                              :: tmp1, tmp2
-    REAL(r_2),          DIMENSION(1:n) :: iqex
-    INTEGER(i_d),       DIMENSION(1:mp)                    :: nfac1, nfac2, nfac3, nfac4, nfac5, &
+    INTEGER(i4)                                           :: i, j, k, kk, condition
+    INTEGER(i4)                                           :: littercase, isotopologue, advection ! switches
+    REAL(r2)                                              :: c2, theta
+    REAL(r2)                                              :: dTqwdTa, dTqwdTb, Tqw, keff
+    REAL(r2),          DIMENSION(1:mp)                    :: cp, cpeff, hice, h0_0, hice_0, h0_tmp, hice_tmp
+    REAL(r2),          DIMENSION(nsnow_max)          :: qmelt, hsnow
+    REAL(r2),  DIMENSION(1:mp)                            :: qtransfer
+    REAL(r2),          DIMENSION(nsnow_max) :: delta_snowcol, delta_snowT, delta_snowliq
+    REAL(r2),      DIMENSION(1:n) :: thetai_0, J0
+    REAL(r2)                                              :: tmp1, tmp2
+    REAL(r2),          DIMENSION(1:n) :: iqex
+    INTEGER(i4),       DIMENSION(1:mp)                    :: nfac1, nfac2, nfac3, nfac4, nfac5, &
          nfac6, nfac7, nfac8, nfac9, nfac10, nfac11, nfac12
-    REAL(r_2),          DIMENSION(1:mp)                    :: J0snow, wcol0snow
-    REAL(r_2), DIMENSION(1:n)                              :: h_ex
-    REAL(r_2)                                              :: wpi
+    REAL(r2),          DIMENSION(1:mp)                    :: J0snow, wcol0snow
+    REAL(r2), DIMENSION(1:n)                              :: h_ex
+    REAL(r2)                                              :: wpi
     ! Error flag if nstep of SLI > nsteps_max: err=0 -> no error; err/=0 -> error
-    INTEGER(i_d),        INTENT(INOUT), OPTIONAL           :: err
+    INTEGER(i4),        INTENT(INOUT), OPTIONAL           :: err
 
     hsnow(:) = zero
 
@@ -774,8 +774,8 @@ CONTAINS
           !end do
 
           ! End debug hyofS
-          cp(kk) = real(1-var(1)%iice,r_2)*cswat*rhow & ! heat capacity of pond
-               + real(var(1)%iice,r_2)*rhow* &
+          cp(kk) = real(1-var(1)%iice,r2)*cswat*rhow & ! heat capacity of pond
+               + real(var(1)%iice,r2)*rhow* &
                ((one-var(1)%thetai/par(1)%thre)*cswat + (var(1)%thetai/par(1)%thre)*csice)
           cpeff(kk) = cp(kk) + rhow*lambdaf*var(1)%dthetaldT/par(1)%thre
           ! phip(kk) = max(var(1)%phie-var(1)%he*var(1)%Ksat, (one+e5)*var(1)%phie) !at onset of ponding
@@ -1000,41 +1000,41 @@ CONTAINS
        h_ex, wpi &
        )
     IMPLICIT NONE
-    INTEGER(i_d)                                           :: mp
-    INTEGER(i_d)                                           :: n
-    REAL(r_2),      DIMENSION(1:n) :: dx
-    REAL(r_2),      DIMENSION(1:mp)                        :: h0
-    REAL(r_2),      DIMENSION(1:n) :: S
-    REAL(r_2),      DIMENSION(1:n) :: thetai
-    REAL(r_2),      DIMENSION(1:n) :: Tsoil
-    REAL(r_2),      DIMENSION(1:mp)                        :: infil
-    INTEGER(i_d),   DIMENSION(1:mp)                        :: nsteps
+    INTEGER(i4)                                           :: mp
+    INTEGER(i4)                                           :: n
+    REAL(r2),      DIMENSION(1:n) :: dx
+    REAL(r2),      DIMENSION(1:mp)                        :: h0
+    REAL(r2),      DIMENSION(1:n) :: S
+    REAL(r2),      DIMENSION(1:n) :: thetai
+    REAL(r2),      DIMENSION(1:n) :: Tsoil
+    REAL(r2),      DIMENSION(1:mp)                        :: infil
+    INTEGER(i4),   DIMENSION(1:mp)                        :: nsteps
     TYPE(vars),     DIMENSION(1:n) :: var
     TYPE(params),   DIMENSION(1:n) :: par
-    REAL(r_2),      DIMENSION(-nsnow_max:n) :: qlsig
+    REAL(r2),      DIMENSION(-nsnow_max:n) :: qlsig
     LOGICAL,      DIMENSION(1:mp)                          :: again
-    INTEGER(i_d), DIMENSION(1:mp)                          :: ih0, ns
-    REAL(r_2),    DIMENSION(1:mp)                          :: dt
-    REAL(r_2),    DIMENSION(1:mp)                          :: sig
-    REAL(r_2),    DIMENSION(-nsnow_max+1:n) :: dy
-    REAL(r_2),    DIMENSION(-nsnow_max:n) :: qhsig
-    REAL(r_2),    DIMENSION(1:n) :: deltaS, dTsoil
-    REAL(r_2),          DIMENSION(1:mp)                    :: dJcol_latent_S, dJcol_latent_T, dJcol_sensible
-    REAL(r_2),          DIMENSION(1:n) :: deltaJ_latent_S, deltaJ_latent_T, deltaJ_sensible_S, deltaJ_sensible_T
-    REAL(r_2),          DIMENSION(1:mp)                    :: qrunoff
-    REAL(r_2),          DIMENSION(1:mp)                    :: tmp1d1, tmp1d2, tmp1d3,  tmp1d4
-    REAL(r_2),          DIMENSION(1:mp)                    :: deltah0
-    REAL(r_2),          DIMENSION(1:mp)                    :: Tfreezing
-    REAL(r_2),          DIMENSION(1:mp)                    :: dtdT
-    REAL(r_2),          DIMENSION(-nsnow_max+1:n) :: LHS_h
-    INTEGER(i_d)                                           :: i, j, k, kk
-    REAL(r_2)                                              :: theta
-    REAL(r_2),          DIMENSION(1:mp)                    :: cp, hice, hice_tmp
-    REAL(r_2),      DIMENSION(1:n) :: J0
-    REAL(r_2)                                              :: tmp1, tmp2
+    INTEGER(i4), DIMENSION(1:mp)                          :: ih0, ns
+    REAL(r2),    DIMENSION(1:mp)                          :: dt
+    REAL(r2),    DIMENSION(1:mp)                          :: sig
+    REAL(r2),    DIMENSION(-nsnow_max+1:n) :: dy
+    REAL(r2),    DIMENSION(-nsnow_max:n) :: qhsig
+    REAL(r2),    DIMENSION(1:n) :: deltaS, dTsoil
+    REAL(r2),          DIMENSION(1:mp)                    :: dJcol_latent_S, dJcol_latent_T, dJcol_sensible
+    REAL(r2),          DIMENSION(1:n) :: deltaJ_latent_S, deltaJ_latent_T, deltaJ_sensible_S, deltaJ_sensible_T
+    REAL(r2),          DIMENSION(1:mp)                    :: qrunoff
+    REAL(r2),          DIMENSION(1:mp)                    :: tmp1d1, tmp1d2, tmp1d3,  tmp1d4
+    REAL(r2),          DIMENSION(1:mp)                    :: deltah0
+    REAL(r2),          DIMENSION(1:mp)                    :: Tfreezing
+    REAL(r2),          DIMENSION(1:mp)                    :: dtdT
+    REAL(r2),          DIMENSION(-nsnow_max+1:n) :: LHS_h
+    INTEGER(i4)                                           :: i, j, k, kk
+    REAL(r2)                                              :: theta
+    REAL(r2),          DIMENSION(1:mp)                    :: cp, hice, hice_tmp
+    REAL(r2),      DIMENSION(1:n) :: J0
+    REAL(r2)                                              :: tmp1, tmp2
 
-    REAL(r_2), DIMENSION(1:n)                              :: h_ex
-    REAL(r_2)                                              :: wpi
+    REAL(r2), DIMENSION(1:n)                              :: h_ex
+    REAL(r2)                                              :: wpi
     ! update variables (S,T) to end of time step
     ! update variables to sig for use in isotope routine
     do i=1, n
@@ -1053,7 +1053,7 @@ CONTAINS
        else
           deltaS(i)  = zero    !required for isotope subroutine
           if (i==1) then
-             var(i)%phi = var(i)%phi + dy(i)*real(ns(kk),r_2) ! pond included in top soil layer
+             var(i)%phi = var(i)%phi + dy(i)*real(ns(kk),r2) ! pond included in top soil layer
           else
              var(i)%phi = var(i)%phi + dy(i)
           endif
@@ -1176,7 +1176,7 @@ CONTAINS
              if (Tsoil(i) < Tfreezing(kk) .and. var(i)%iice==0) then  ! start correction for onset of freezing
                 dtdT(kk)      = dthetalmaxdTh(Tfreezing(kk), S(i), par(i)%he, one/(par(i)%lambc*freezefac), &
                      par(i)%thre,par(i)%the)
-                tmp1d3(kk) = 1000._r_2
+                tmp1d3(kk) = 1000._r2
                 tmp1d2(kk) = Tsoil(i) - dTsoil(i)
                 k = 1
                 if ((i==1).and.(h0(kk)- deltah0(kk))>zero) then
@@ -1319,9 +1319,9 @@ CONTAINS
                par(i)%he, one/(par(i)%lambc*freezefac)))) then
 
              tmp1d2(kk) = J0(i) + LHS_h(i)*dt(kk) ! total energy in  soil layer
-             if (Tsoil(i) .lt. -40.0_r_2) then
+             if (Tsoil(i) .lt. -40.0_r2) then
                 ! assume no lquid below min temp threshhold
-                var(i)%thetal = 0.0_r_2
+                var(i)%thetal = 0.0_r2
                 var(i)%thetai = theta
                 if (i.eq.1) hice(kk) = h0(kk)
                 tmp1d3(kk) = (tmp1d2(kk) + rhow*lambdaf*(theta*dx(i) +  merge(h0(kk),zero,i==1)))/ &
@@ -1329,7 +1329,7 @@ CONTAINS
                      merge(h0(kk),zero,i==1)))
              else
                 !check there is a zero
-                tmp1 = GTfrozen(Tsoil(i)-dTsoil(i)-50._r_2, tmp1d2(kk), dx(i), theta,par(i)%css, par(i)%rho, &
+                tmp1 = GTfrozen(Tsoil(i)-dTsoil(i)-50._r2, tmp1d2(kk), dx(i), theta,par(i)%css, par(i)%rho, &
                      merge(h0(kk),zero,i==1), par(i)%thre, par(i)%the, par(i)%he, one/(par(i)%lambc*freezefac))
 
                 tmp2 = GTFrozen(Tfreezing(kk), tmp1d2(kk), dx(i), theta,par(i)%css, par(i)%rho, &
@@ -1339,13 +1339,13 @@ CONTAINS
                    tmp1d3(kk) = rtbis_Tfrozen(tmp1d2(kk), dx(i), theta,par(i)%css, par(i)%rho, &
                         merge(h0(kk),zero,i==1), par(i)%thre, par(i)%the, &
                         par(i)%he, one/(par(i)%lambc*freezefac), &
-                        Tsoil(i)-dTsoil(i)-50._r_2, Tfreezing(kk))
+                        Tsoil(i)-dTsoil(i)-50._r2, Tfreezing(kk))
                    tmp1d4(kk) = thetalmax(tmp1d3(kk), S(i), par(i)%he, one/(par(i)%lambc*freezefac), &
                         par(i)%thre, par(i)%the) ! liquid content at solution for Tsoil
                 else
                    write(wlogn,*) "Found no solution for Tfrozen 1. ", kk, i
                    write(wlogn,*) "Assume soil is totally frozen"
-                   var(i)%thetal = 0.0_r_2
+                   var(i)%thetal = 0.0_r2
                    var(i)%thetai = theta
                    if (i.eq.1) hice(kk) = h0(kk)
                    tmp1d3(kk) = (tmp1d2(kk) + rhow*lambdaf*(theta*dx(i) +  merge(h0(kk),zero,i==1)))/ &
@@ -1386,7 +1386,7 @@ CONTAINS
                   J0(i)- &
                   deltaJ_latent_S(i)
 
-             deltaJ_sensible_S(i) = 0._r_2
+             deltaJ_sensible_S(i) = 0._r2
 
              thetai(i) = var(i)%thetai
              Tsoil(i) = tmp1d3(kk)
@@ -1429,67 +1429,67 @@ CONTAINS
        J0snow, wcol0snow   &
        )
     IMPLICIT NONE
-    INTEGER(i_d)                                           :: irec, mp
-    REAL(r_2),      DIMENSION(1:mp)                        :: qprec
-    REAL(r_2),      DIMENSION(1:mp)                        :: qprec_snow
-    INTEGER(i_d)                                           :: n
-    REAL(r_2),      DIMENSION(1:n) :: dx
-    REAL(r_2),      DIMENSION(1:mp)                        :: h0
-    REAL(r_2),      DIMENSION(1:n) :: S
-    REAL(r_2),      DIMENSION(1:n) :: Tsoil
-    REAL(r_2),      DIMENSION(1:mp)                        :: evap
-    REAL(r_2),      DIMENSION(1:mp)                        :: infil
-    REAL(r_2),      DIMENSION(1:mp)                        :: drainage, discharge
-    REAL(r_2),      DIMENSION(-nsnow_max:n) :: qh
-    INTEGER(i_d),   DIMENSION(1:mp)                        :: nsteps
+    INTEGER(i4)                                           :: irec, mp
+    REAL(r2),      DIMENSION(1:mp)                        :: qprec
+    REAL(r2),      DIMENSION(1:mp)                        :: qprec_snow
+    INTEGER(i4)                                           :: n
+    REAL(r2),      DIMENSION(1:n) :: dx
+    REAL(r2),      DIMENSION(1:mp)                        :: h0
+    REAL(r2),      DIMENSION(1:n) :: S
+    REAL(r2),      DIMENSION(1:n) :: Tsoil
+    REAL(r2),      DIMENSION(1:mp)                        :: evap
+    REAL(r2),      DIMENSION(1:mp)                        :: infil
+    REAL(r2),      DIMENSION(1:mp)                        :: drainage, discharge
+    REAL(r2),      DIMENSION(-nsnow_max:n) :: qh
+    INTEGER(i4),   DIMENSION(1:mp)                        :: nsteps
     TYPE(vars_met), DIMENSION(1:mp)                        :: vmet
     TYPE(vars),     DIMENSION(1:mp)                        :: vlit
     TYPE(vars_snow), DIMENSION(1:mp)                       :: vsnow
     TYPE(vars),     DIMENSION(1:n) :: var
-    REAL(r_2),      DIMENSION(1:mp)                        :: Hcum, lEcum
-    REAL(r_2),      DIMENSION(1:mp)                        :: Gcum, Qadvcum
-    REAL(r_2),      DIMENSION(1:n) :: csoil, kth
-    REAL(r_2),      DIMENSION(1:n) :: phi
-    REAL(r_2),      DIMENSION(1:mp)                        :: zdelta, SL, Tl
+    REAL(r2),      DIMENSION(1:mp)                        :: Hcum, lEcum
+    REAL(r2),      DIMENSION(1:mp)                        :: Gcum, Qadvcum
+    REAL(r2),      DIMENSION(1:n) :: csoil, kth
+    REAL(r2),      DIMENSION(1:n) :: phi
+    REAL(r2),      DIMENSION(1:mp)                        :: zdelta, SL, Tl
     TYPE(params),   DIMENSION(1:n) :: par
-    REAL(r_2),      DIMENSION(1:mp,1:n), OPTIONAL                    :: wex
-    REAL(r_2),      DIMENSION(-nsnow_max:n) :: qvsig, qlsig, qvTsig
-    REAL(r_2),    DIMENSION(1:mp)                          :: precip, qevap
-    REAL(r_2),    DIMENSION(1:mp)                          :: rexcol, wcol
+    REAL(r2),      DIMENSION(1:mp,1:n), OPTIONAL                    :: wex
+    REAL(r2),      DIMENSION(-nsnow_max:n) :: qvsig, qlsig, qvTsig
+    REAL(r2),    DIMENSION(1:mp)                          :: precip, qevap
+    REAL(r2),    DIMENSION(1:mp)                          :: rexcol, wcol
     LOGICAL,      DIMENSION(1:mp)                          :: again
-    INTEGER(i_d), DIMENSION(1:mp)                          :: ih0, ns
-    REAL(r_2),    DIMENSION(1:mp)                          :: dt, dwinfil, dwoff
-    REAL(r_2),    DIMENSION(1:mp)                          :: sig
-    REAL(r_2),    DIMENSION(1:n) :: qexd
-    REAL(r_2),    DIMENSION(-nsnow_max+1:n) :: dy
-    REAL(r_2),    DIMENSION(-nsnow_max+1:n) :: de
-    REAL(r_2),    DIMENSION(-nsnow_max:n) :: q, qya, qyb, qTa, qTb,qhya, qhyb, qhTa, qhTb
-    REAL(r_2),    DIMENSION(-nsnow_max:n) :: qsig, qhsig, qadvsig
-    REAL(r_2),    DIMENSION(-nsnow_max:n) :: qliq, qv, qvT, qlyb, qvya, qvyb, qlTb, qvTa, qvTb
-    REAL(r_2),    DIMENSION(1:n) :: dTsoil
+    INTEGER(i4), DIMENSION(1:mp)                          :: ih0, ns
+    REAL(r2),    DIMENSION(1:mp)                          :: dt, dwinfil, dwoff
+    REAL(r2),    DIMENSION(1:mp)                          :: sig
+    REAL(r2),    DIMENSION(1:n) :: qexd
+    REAL(r2),    DIMENSION(-nsnow_max+1:n) :: dy
+    REAL(r2),    DIMENSION(-nsnow_max+1:n) :: de
+    REAL(r2),    DIMENSION(-nsnow_max:n) :: q, qya, qyb, qTa, qTb,qhya, qhyb, qhTa, qhTb
+    REAL(r2),    DIMENSION(-nsnow_max:n) :: qsig, qhsig, qadvsig
+    REAL(r2),    DIMENSION(-nsnow_max:n) :: qliq, qv, qvT, qlyb, qvya, qvyb, qlTb, qvTa, qvTb
+    REAL(r2),    DIMENSION(1:n) :: dTsoil
     TYPE(vars_aquifer), DIMENSION(1:mp)                    :: v_aquifer
-    REAL(r_2),          DIMENSION(1:mp)                    :: dwcol, dwdrainage, drn,inlit, dwinlit, drexcol, dwdischarge
-    REAL(r_2),          DIMENSION(1:mp)                    :: dJcol_latent_S, dJcol_latent_T, dJcol_sensible
-    REAL(r_2),          DIMENSION(1:n) :: deltaJ_latent_S, deltaJ_latent_T, deltaJ_sensible_S, deltaJ_sensible_T
-    REAL(r_2),          DIMENSION(1:mp)                    :: qevapsig
-    REAL(r_2),          DIMENSION(1:mp)                    :: qrunoff
-    REAL(r_2),          DIMENSION(1:mp)                    :: tmp1d1, tmp1d2, tmp1d3
-    REAL(r_2),          DIMENSION(1:mp)                    :: deltah0
-    REAL(r_2),          DIMENSION(1:mp)                    :: deltaSL
-    REAL(r_2),          DIMENSION(-nsnow_max+1:n) :: LHS_h
-    INTEGER(i_d),       DIMENSION(1:mp)                    :: surface_case
+    REAL(r2),          DIMENSION(1:mp)                    :: dwcol, dwdrainage, drn,inlit, dwinlit, drexcol, dwdischarge
+    REAL(r2),          DIMENSION(1:mp)                    :: dJcol_latent_S, dJcol_latent_T, dJcol_sensible
+    REAL(r2),          DIMENSION(1:n) :: deltaJ_latent_S, deltaJ_latent_T, deltaJ_sensible_S, deltaJ_sensible_T
+    REAL(r2),          DIMENSION(1:mp)                    :: qevapsig
+    REAL(r2),          DIMENSION(1:mp)                    :: qrunoff
+    REAL(r2),          DIMENSION(1:mp)                    :: tmp1d1, tmp1d2, tmp1d3
+    REAL(r2),          DIMENSION(1:mp)                    :: deltah0
+    REAL(r2),          DIMENSION(1:mp)                    :: deltaSL
+    REAL(r2),          DIMENSION(-nsnow_max+1:n) :: LHS_h
+    INTEGER(i4),       DIMENSION(1:mp)                    :: surface_case
     LOGICAL                                                :: litter
-    INTEGER(i_d)                                           :: i, j, kk
-    INTEGER(i_d)                                           :: advection ! switches
-    REAL(r_2)                                              :: theta
-    REAL(r_2)                                              :: Tqw
-    REAL(r_2),          DIMENSION(1:mp)                    :: cp
-    REAL(r_2),          DIMENSION(nsnow_max) :: hsnow
-    REAL(r_2),          DIMENSION(nsnow_max) :: delta_snowcol, delta_snowT, delta_snowliq
-    REAL(r_2),      DIMENSION(1:n) :: J0
-    REAL(r_2),          DIMENSION(1:n) :: iqex
+    INTEGER(i4)                                           :: i, j, kk
+    INTEGER(i4)                                           :: advection ! switches
+    REAL(r2)                                              :: theta
+    REAL(r2)                                              :: Tqw
+    REAL(r2),          DIMENSION(1:mp)                    :: cp
+    REAL(r2),          DIMENSION(nsnow_max) :: hsnow
+    REAL(r2),          DIMENSION(nsnow_max) :: delta_snowcol, delta_snowT, delta_snowliq
+    REAL(r2),      DIMENSION(1:n) :: J0
+    REAL(r2),          DIMENSION(1:n) :: iqex
 
-    REAL(r_2),          DIMENSION(1:mp)                    :: J0snow, wcol0snow
+    REAL(r2),          DIMENSION(1:mp)                    :: J0snow, wcol0snow
     !----- update unknowns
     ! i.e. update state variables to end of time step
     !      cumulate some surface fluxes
@@ -1500,7 +1500,7 @@ CONTAINS
        deltah0(kk) = zero
        precip(kk) = precip(kk) + (qprec(kk)+qprec_snow(kk))*dt(kk)
        dwcol(kk) = sum(par(1:n)%thre*dx(1:n)*dy(1:n)*(abs(var(1:n)%isat-1)),1) + &
-            real(1-ns(kk),r_2)*dy(1)
+            real(1-ns(kk),r2)*dy(1)
 
        if (vsnow(kk)%nsnow==1) dwcol(kk) = dwcol(kk) + dy(0)
 
@@ -1517,13 +1517,13 @@ CONTAINS
        do j=1, n
           if (j==1) then
              ! pond included in top soil layer
-             deltaJ_latent_S(j) = -dx(j)*dy(j)*par(j)%thre*real(var(j)%iice,r_2)* &
-                  real(1-var(j)%isat,r_2)*rhow*lambdaf - &
-                  real(1-ns(kk),r_2)*dy(1)*real(var(j)%iice,r_2)*rhow*lambdaf*(var(1)%thetai/par(1)%thre)
+             deltaJ_latent_S(j) = -dx(j)*dy(j)*par(j)%thre*real(var(j)%iice,r2)* &
+                  real(1-var(j)%isat,r2)*rhow*lambdaf - &
+                  real(1-ns(kk),r2)*dy(1)*real(var(j)%iice,r2)*rhow*lambdaf*(var(1)%thetai/par(1)%thre)
 
              deltaJ_latent_T(j) = var(j)%dthetaldT*dx(j)*dTsoil(j)*rhow*lambdaf* &
-                  real(var(j)%iice,r_2) + &
-                  h0(kk)/par(1)%thre*var(j)%dthetaldT*dTsoil(j)*rhow*lambdaf*real(var(j)%iice,r_2)
+                  real(var(j)%iice,r2) + &
+                  h0(kk)/par(1)%thre*var(j)%dthetaldT*dTsoil(j)*rhow*lambdaf*real(var(j)%iice,r2)
 
              deltaJ_sensible_T(j) = var(j)%csoil*dx(j)*dTsoil(j) + &
                   cp(kk)*h0(kk)*dTsoil(j) + &
@@ -1533,31 +1533,31 @@ CONTAINS
 
              if (advection==1) then
                 deltaJ_sensible_S(j) = rhow*cswat*(Tsoil(j))*dx(j)*par(j)%thre*dy(j)* &
-                     real(1-var(j)%isat,r_2)*real(1-var(j)%iice,r_2)  + &
+                     real(1-var(j)%isat,r2)*real(1-var(j)%iice,r2)  + &
                      rhow*csice*(Tsoil(j))*dx(j)*par(j)%thre*dy(j)* &
-                     real(1-var(j)%isat,r_2)*real(var(j)%iice,r_2) + &
-                     real(1-ns(kk),r_2)*real(1-var(1)%iice,r_2)* &
+                     real(1-var(j)%isat,r2)*real(var(j)%iice,r2) + &
+                     real(1-ns(kk),r2)*real(1-var(1)%iice,r2)* &
                      dy(1)*rhow*cswat*(Tsoil(1))  + &
-                     real(1-ns(kk),r_2)*real(var(1)%iice,r_2)* &
+                     real(1-ns(kk),r2)*real(var(1)%iice,r2)* &
                      dy(1)*rhow*csice*(Tsoil(1))*(var(1)%thetai/par(1)%thre) + &
-                     real(1-ns(kk),r_2)*real(var(1)%iice,r_2)* &
+                     real(1-ns(kk),r2)*real(var(1)%iice,r2)* &
                      dy(1)*rhow*cswat*(Tsoil(1))*(one-(var(1)%thetai/par(1)%thre))
              endif
           else ! (j>1)
-             deltaJ_latent_S(j) = -dx(j)*dy(j)*par(j)%thre*real(var(j)%iice,r_2)* &
-                  real(1-var(j)%isat,r_2)*rhow*lambdaf
+             deltaJ_latent_S(j) = -dx(j)*dy(j)*par(j)%thre*real(var(j)%iice,r2)* &
+                  real(1-var(j)%isat,r2)*rhow*lambdaf
              deltaJ_sensible_T(j) = var(j)%csoil*dx(j)*dTsoil(j) + &
                   var(j)%iice*var(j)%dthetaldT*(Tsoil(j))*rhow*(cswat-csice)*dx(j)*dTsoil(j)
 
 
              if (advection==1) then
                 deltaJ_sensible_S(j) = rhow*cswat*(Tsoil(j))*dx(j)*dy(j)*par(j)%thre* &
-                     real(1-var(j)%isat,r_2)*real(1-var(j)%iice,r_2) &
+                     real(1-var(j)%isat,r2)*real(1-var(j)%iice,r2) &
                      + rhow*csice*(Tsoil(j))*dx(j)*dy(j)*par(j)%thre &
-                     *real(1-var(j)%isat,r_2)*real(var(j)%iice,r_2)
+                     *real(1-var(j)%isat,r2)*real(var(j)%iice,r2)
              endif
 
-             deltaJ_latent_T(j) = var(j)%dthetaldT*dx(j)*dTsoil(j)*rhow*lambdaf*real(var(j)%iice,r_2)
+             deltaJ_latent_T(j) = var(j)%dthetaldT*dx(j)*dTsoil(j)*rhow*lambdaf*real(var(j)%iice,r2)
           endif
        end do
 
@@ -1869,15 +1869,15 @@ CONTAINS
           ! effect of new snowfall
 
           ! snowfall density (tmp1d1), LaChapelle 1969
-          if (vmet(kk)%Ta > 2.0_r_2) then
-             tmp1d1(kk) = 189.0_r_2
-          elseif ((vmet(kk)%Ta > -15.0_r_2) .and. (vmet(kk)%Ta <= 2.0_r_2)) then
-             tmp1d1(kk) = 50.0_r_2 + 1.7_r_2*(vmet(kk)%Ta+15.0_r_2)**1.5_r_2
+          if (vmet(kk)%Ta > 2.0_r2) then
+             tmp1d1(kk) = 189.0_r2
+          elseif ((vmet(kk)%Ta > -15.0_r2) .and. (vmet(kk)%Ta <= 2.0_r2)) then
+             tmp1d1(kk) = 50.0_r2 + 1.7_r2*(vmet(kk)%Ta+15.0_r2)**1.5_r2
           else
-             tmp1d1(kk) = 50.0_r_2
+             tmp1d1(kk) = 50.0_r2
           endif
 
-          if ((vsnow(kk)%hsnow(1)-qprec_snow(kk)*dt(kk)) > 1.e-3_r_2) then
+          if ((vsnow(kk)%hsnow(1)-qprec_snow(kk)*dt(kk)) > 1.e-3_r2) then
              vsnow(kk)%dens(1) = (vsnow(kk)%dens(1)*(vsnow(kk)%hsnow(1)-qprec_snow(kk)*dt(kk)) &
                   + tmp1d1(kk)*qprec_snow(kk)*dt(kk))/vsnow(kk)%hsnow(1)
           endif
@@ -1887,24 +1887,24 @@ CONTAINS
 
              ! adjust depth for compaction
              if (vsnow(kk)%hliq(i) .gt. zero) then
-                tmp1d1(kk) = merge(one, exp(-0.06_r_2*(vsnow(kk)%dens(i)-150._r_2)), vsnow(kk)%dens(i)<150._r_2)
+                tmp1d1(kk) = merge(one, exp(-0.06_r2*(vsnow(kk)%dens(i)-150._r2)), vsnow(kk)%dens(i)<150._r2)
                 tmp1d2(kk) = 2
              else
-                tmp1d1(kk) = merge(one, exp(-0.046_r_2*(vsnow(kk)%dens(i)-150._r_2)), vsnow(kk)%dens(i)<150._r_2)
+                tmp1d1(kk) = merge(one, exp(-0.046_r2*(vsnow(kk)%dens(i)-150._r2)), vsnow(kk)%dens(i)<150._r2)
                 tmp1d2(kk) = 1
              endif
-             tmp1d3(kk) =  vsnow(kk)%hsnow(i)*rhow/2._r_2    ! overburden kg/m2
+             tmp1d3(kk) =  vsnow(kk)%hsnow(i)*rhow/2._r2    ! overburden kg/m2
              if (i.gt.1) then
                 tmp1d3(kk) = tmp1d3(kk) + sum(vsnow(kk)%hsnow(1:i-1)*rhow)
              endif
 
              if (vsnow(kk)%depth(i)*dt(kk)* &
-                  (2.8e-6_r_2*tmp1d1(kk)*tmp1d2(kk)*exp(-vsnow(kk)%tsn(i)/25.0_r_2) + &
-                  tmp1d3(kk)/3.6e6_r_2*exp(-0.08_r_2*vsnow(kk)%tsn(i))*exp(-0.023_r_2*vsnow(kk)%dens(i))) &
-                  .lt.0.5_r_2*vsnow(kk)%depth(i)) then
+                  (2.8e-6_r2*tmp1d1(kk)*tmp1d2(kk)*exp(-vsnow(kk)%tsn(i)/25.0_r2) + &
+                  tmp1d3(kk)/3.6e6_r2*exp(-0.08_r2*vsnow(kk)%tsn(i))*exp(-0.023_r2*vsnow(kk)%dens(i))) &
+                  .lt.0.5_r2*vsnow(kk)%depth(i)) then
                 vsnow(kk)%depth(i) = vsnow(kk)%depth(i) - vsnow(kk)%depth(i)*dt(kk)* &
-                     (2.8e-6_r_2*tmp1d1(kk)*tmp1d2(kk)*exp(-vsnow(kk)%tsn(i)/25.0_r_2) + & ! metamorphism
-                     tmp1d3(kk)/3.6e6_r_2*exp(-0.08_r_2*vsnow(kk)%tsn(i))*exp(-0.023_r_2*vsnow(kk)%dens(i))) ! overburden
+                     (2.8e-6_r2*tmp1d1(kk)*tmp1d2(kk)*exp(-vsnow(kk)%tsn(i)/25.0_r2) + & ! metamorphism
+                     tmp1d3(kk)/3.6e6_r2*exp(-0.08_r2*vsnow(kk)%tsn(i))*exp(-0.023_r2*vsnow(kk)%dens(i))) ! overburden
              endif
              vsnow(kk)%dens(i) = vsnow(kk)%hsnow(i)*rhow/vsnow(kk)%depth(i)
           enddo
@@ -1948,59 +1948,59 @@ CONTAINS
        nfac10, nfac11, nfac12, err  &
        )
     IMPLICIT NONE
-    INTEGER(i_d)                                           :: irec, mp
-    REAL(r_2),      DIMENSION(1:mp)                        :: qprec
-    INTEGER(i_d)                                           :: n
-    REAL(r_2),      DIMENSION(1:n) :: dx
-    REAL(r_2),      DIMENSION(1:mp)                        :: h0
-    REAL(r_2),      DIMENSION(1:n) :: S
-    REAL(r_2),      DIMENSION(1:n) :: thetai
-    REAL(r_2),      DIMENSION(1:n) :: Tsoil
-    REAL(r_2),      DIMENSION(-nsnow_max:n) :: qh
-    INTEGER(i_d),   DIMENSION(1:mp)                        :: nsteps
+    INTEGER(i4)                                           :: irec, mp
+    REAL(r2),      DIMENSION(1:mp)                        :: qprec
+    INTEGER(i4)                                           :: n
+    REAL(r2),      DIMENSION(1:n) :: dx
+    REAL(r2),      DIMENSION(1:mp)                        :: h0
+    REAL(r2),      DIMENSION(1:n) :: S
+    REAL(r2),      DIMENSION(1:n) :: thetai
+    REAL(r2),      DIMENSION(1:n) :: Tsoil
+    REAL(r2),      DIMENSION(-nsnow_max:n) :: qh
+    INTEGER(i4),   DIMENSION(1:mp)                        :: nsteps
     TYPE(vars),     DIMENSION(1:mp)                        :: vlit
     TYPE(vars_snow), DIMENSION(1:mp)                       :: vsnow
     TYPE(vars),     DIMENSION(1:n) :: var
-    REAL(r_2),      DIMENSION(1:mp)                        :: dxL
+    REAL(r2),      DIMENSION(1:mp)                        :: dxL
     TYPE(params),   DIMENSION(1:mp)                        :: plit
     TYPE(params),   DIMENSION(1:n) :: par
-    REAL(r_2),      DIMENSION(1:mp)                        :: deltaTa
-    REAL(r_2),    DIMENSION(1:mp)                          :: qevap
-    REAL(r_2),    DIMENSION(1:mp)                          :: qL, qhL, qybL, qTbL, qhTbL, qhybL
+    REAL(r2),      DIMENSION(1:mp)                        :: deltaTa
+    REAL(r2),    DIMENSION(1:mp)                          :: qevap
+    REAL(r2),    DIMENSION(1:mp)                          :: qL, qhL, qybL, qTbL, qhTbL, qhybL
     LOGICAL,      DIMENSION(1:mp)                          :: again
     LOGICAL,      DIMENSION(1:mp,1:n)                      :: again_ice
-    INTEGER(i_d), DIMENSION(1:mp)                          :: iok, itmp, ns
-    REAL(r_2),    DIMENSION(1:mp)                          :: accel, dt, fac, phip
-    REAL(r_2),    DIMENSION(1:mp)                          :: rsig, rsigdt, sig, t
-    REAL(r_2),    DIMENSION(1:n) :: qexd
-    REAL(r_2),    DIMENSION(-nsnow_max+1:n) :: aa, bb, cc, dd, ee, ff, gg, dy
-    REAL(r_2),    DIMENSION(-nsnow_max+1:n) :: aah, bbh, cch, ddh, eeh, ffh, ggh, de
-    REAL(r_2),    DIMENSION(-nsnow_max:n) :: q, qya, qyb, qTa, qTb,qhya, qhyb, qhTa, qhTb
-    REAL(r_2),    DIMENSION(-nsnow_max:n) :: qadv, qadvya, qadvyb, qadvTa, qadvTb
-    REAL(r_2),    DIMENSION(-nsnow_max:n) :: qsig, qhsig, qadvsig
-    REAL(r_2),    DIMENSION(1:n) :: dTsoil
-    REAL(r_2),    DIMENSION(1:n) :: dthetaldT
-    INTEGER(i_d), DIMENSION(1:n) :: nsteps_ice, imelt
-    REAL(r_2),          DIMENSION(1:n) :: deltaJ_latent_T, deltaJ_sensible_S
-    REAL(r_2),          DIMENSION(1:mp)                    :: qrunoff
-    REAL(r_2),          DIMENSION(1:mp)                    :: tmp1d1, tmp1d2, tmp1d3,  tmp1d4
-    REAL(r_2),          DIMENSION(1:mp)                    :: G0
-    REAL(r_2),          DIMENSION(1:mp)                    :: Tfreezing
-    REAL(r_2),          DIMENSION(-nsnow_max+1:n) :: LHS, RHS, LHS_h, RHS_h
-    INTEGER(i_d),       DIMENSION(1:mp)                    :: nns, iflux
+    INTEGER(i4), DIMENSION(1:mp)                          :: iok, itmp, ns
+    REAL(r2),    DIMENSION(1:mp)                          :: accel, dt, fac, phip
+    REAL(r2),    DIMENSION(1:mp)                          :: rsig, rsigdt, sig, t
+    REAL(r2),    DIMENSION(1:n) :: qexd
+    REAL(r2),    DIMENSION(-nsnow_max+1:n) :: aa, bb, cc, dd, ee, ff, gg, dy
+    REAL(r2),    DIMENSION(-nsnow_max+1:n) :: aah, bbh, cch, ddh, eeh, ffh, ggh, de
+    REAL(r2),    DIMENSION(-nsnow_max:n) :: q, qya, qyb, qTa, qTb,qhya, qhyb, qhTa, qhTb
+    REAL(r2),    DIMENSION(-nsnow_max:n) :: qadv, qadvya, qadvyb, qadvTa, qadvTb
+    REAL(r2),    DIMENSION(-nsnow_max:n) :: qsig, qhsig, qadvsig
+    REAL(r2),    DIMENSION(1:n) :: dTsoil
+    REAL(r2),    DIMENSION(1:n) :: dthetaldT
+    INTEGER(i4), DIMENSION(1:n) :: nsteps_ice, imelt
+    REAL(r2),          DIMENSION(1:n) :: deltaJ_latent_T, deltaJ_sensible_S
+    REAL(r2),          DIMENSION(1:mp)                    :: qrunoff
+    REAL(r2),          DIMENSION(1:mp)                    :: tmp1d1, tmp1d2, tmp1d3,  tmp1d4
+    REAL(r2),          DIMENSION(1:mp)                    :: G0
+    REAL(r2),          DIMENSION(1:mp)                    :: Tfreezing
+    REAL(r2),          DIMENSION(-nsnow_max+1:n) :: LHS, RHS, LHS_h, RHS_h
+    INTEGER(i4),       DIMENSION(1:mp)                    :: nns, iflux
     LOGICAL                                                :: litter
-    INTEGER(i_d)                                           :: i, kk, condition
-    INTEGER(i_d)                                           :: advection ! switches
-    REAL(r_2)                                              :: c2, theta
-    REAL(r_2),          DIMENSION(1:mp)                    :: cp, cpeff, hice, h0_tmp
-    REAL(r_2),          DIMENSION(nsnow_max) :: hsnow
-    REAL(r_2),          DIMENSION(nsnow_max) :: delta_snowT, delta_snowliq
-    REAL(r_2),      DIMENSION(1:n) :: J0
-    REAL(r_2),          DIMENSION(1:n) :: iqex
-    INTEGER(i_d),       DIMENSION(1:mp)                    :: nfac1, nfac2, nfac3, nfac4, nfac5, &
+    INTEGER(i4)                                           :: i, kk, condition
+    INTEGER(i4)                                           :: advection ! switches
+    REAL(r2)                                              :: c2, theta
+    REAL(r2),          DIMENSION(1:mp)                    :: cp, cpeff, hice, h0_tmp
+    REAL(r2),          DIMENSION(nsnow_max) :: hsnow
+    REAL(r2),          DIMENSION(nsnow_max) :: delta_snowT, delta_snowliq
+    REAL(r2),      DIMENSION(1:n) :: J0
+    REAL(r2),          DIMENSION(1:n) :: iqex
+    INTEGER(i4),       DIMENSION(1:mp)                    :: nfac1, nfac2, nfac3, nfac4, nfac5, &
          nfac6, nfac7, nfac8, nfac9, nfac10, nfac11, nfac12
     ! Error flag if nstep of SLI > nsteps_max: err=0 -> no error; err/=0 -> error
-    INTEGER(i_d),       INTENT(INOUT), OPTIONAL            :: err
+    INTEGER(i4),       INTENT(INOUT), OPTIONAL            :: err
 
     iok(kk)         = 0 ! flag for time step test
     itmp(kk)        = 0 ! counter to abort if not getting solution
@@ -2009,7 +2009,7 @@ CONTAINS
     h0_tmp(kk) = h0(kk)
     do while (iok(kk)==0) ! keep reducing time step until all ok
        itmp(kk)  = itmp(kk) + 1
-       accel(kk) = one - 0.05_r_2*real(min(10,max(0,itmp(kk)-4)),r_2) ! acceleration [0.5,1], start with 1
+       accel(kk) = one - 0.05_r2*real(min(10,max(0,itmp(kk)-4)),r2) ! acceleration [0.5,1], start with 1
        if (itmp(kk) > 1000) then
           write(wlogn,*) "Solve: too many iterations of equation solution"
           write(wlogn,*) " irec, kk, S"
@@ -2073,30 +2073,30 @@ CONTAINS
        endif
 
        cch(1:n) = qhyb(0:n-1)-qhya(1:n) +   &
-            real(var(1:n)%iice,r_2)*real(1-var(1:n)%isat,r_2)*rhow*lambdaf*par(1:n)%thre*dx(1:n)*rsigdt(kk)
+            real(var(1:n)%iice,r2)*real(1-var(1:n)%isat,r2)*rhow*lambdaf*par(1:n)%thre*dx(1:n)*rsigdt(kk)
 
        if (ns(kk)==0) then ! change in pond height (top layer saturated)
           cch(1) = cch(1) +  &
-               real(var(1)%iice,r_2)*rhow*lambdaf*rsigdt(kk)*(var(1)%thetai/par(1)%thre)
+               real(var(1)%iice,r2)*rhow*lambdaf*rsigdt(kk)*(var(1)%thetai/par(1)%thre)
        endif
 
        ! modification to cch for advection
        if (advection==1) then
           if (ns(kk)==0) then  ! changing pond included in top soil layer
-             cch(1) = cch(1) -rhow*cswat*(Tsoil(1))*rsigdt(kk)*real(1-var(1)%iice,r_2) &
-                  -rhow*csice*(Tsoil(1))*rsigdt(kk)*real(var(1)%iice,r_2) &
+             cch(1) = cch(1) -rhow*cswat*(Tsoil(1))*rsigdt(kk)*real(1-var(1)%iice,r2) &
+                  -rhow*csice*(Tsoil(1))*rsigdt(kk)*real(var(1)%iice,r2) &
                   *(var(1)%thetai/par(1)%thre) &
-                  -rhow*cswat*(Tsoil(1))*rsigdt(kk)*real(var(1)%iice,r_2)* &
+                  -rhow*cswat*(Tsoil(1))*rsigdt(kk)*real(var(1)%iice,r2)* &
                   (one-(var(1)%thetai/par(1)%thre))
           else ! no pond
              cch(1) = cch(1) -rhow*(Tsoil(1))*par(1)%thre*dx(1)*rsigdt(kk)* &
-                  real(1-var(1)%isat,r_2)*(cswat*real(1-var(1)%iice,r_2) &
-                  +csice*real(var(1)%iice,r_2))
+                  real(1-var(1)%isat,r2)*(cswat*real(1-var(1)%iice,r2) &
+                  +csice*real(var(1)%iice,r2))
           endif
 
           cch(2:n) = cch(2:n) -rhow*(Tsoil(2:n))*par(2:n)%thre*dx(2:n)*rsigdt(kk)* &
-               real(1-var(2:n)%isat,r_2)*(cswat*real(1-var(2:n)%iice,r_2) &
-               +csice*real(var(2:n)%iice,r_2))
+               real(1-var(2:n)%isat,r2)*(cswat*real(1-var(2:n)%iice,r2) &
+               +csice*real(var(2:n)%iice,r2))
        endif
 
        dd(1:n)  = qTb(0:n-1)-qTa(1:n)
@@ -2105,11 +2105,11 @@ CONTAINS
             ! Only apply latent heat component of heat capacity to total deltaT if soil remains frozen
             var(1:n)%csoileff*dx(1:n)*rsigdt(kk)- &
             (cswat-csice)*dx(1:n)*var(1:n)%dthetaldt*rhow*(Tsoil(1:n))* &
-            rsigdt(kk)*real(var(1:n)%iice,r_2)
+            rsigdt(kk)*real(var(1:n)%iice,r2)
        ! modification to ddh(1) for pond
        ddh(1) = ddh(1) - cpeff(kk)*h0_tmp(kk)*rsigdt(kk) - &
             (cswat-csice)*h0(kk)/par(1)%thre*var(1)%dthetaldt*rhow*(Tsoil(1))* &
-            rsigdt(kk)*real(var(1)%iice,r_2)
+            rsigdt(kk)*real(var(1)%iice,r2)
 
        if (advection==1) then
           ddh(1:n) = ddh(1:n) - iqex(1:n)*cswat*rhow
@@ -2227,8 +2227,8 @@ CONTAINS
 
        LHS_h(1) = (dx(1)*var(1)%csoileff+h0_tmp(kk)*cpeff(kk))*dTsoil(1)/dt(kk) - &
             dy(1)*par(1)%thre*dx(1)*rhow*lambdaf/dt(kk)*var(1)%iice* &
-            real(1-var(1)%isat,r_2) - &
-            dy(1)*(var(1)%thetai/par(1)%thre)*rhow*lambdaf/dt(kk)*real(1-ns(kk),r_2)* &
+            real(1-var(1)%isat,r2) - &
+            dy(1)*(var(1)%thetai/par(1)%thre)*rhow*lambdaf/dt(kk)*real(1-ns(kk),r2)* &
             var(1)%iice  + &
             var(1)%dthetaldT*(Tsoil(1))*rhow*(cswat-csice)*dx(1)*dTsoil(1)/dt(kk)* &
             var(1)%iice + &
@@ -2237,7 +2237,7 @@ CONTAINS
 
        LHS_h(2:n) = (dx(2:n)*var(2:n)%csoileff)*dTsoil(2:n)/dt(kk)  - &
             dy(2:n)*par(2:n)%thre*dx(2:n)*rhow*lambdaf/dt(kk)*var(2:n)%iice* &
-            real(1-var(2:n)%isat,r_2) + &
+            real(1-var(2:n)%isat,r2) + &
             var(2:n)%dthetaldT*(Tsoil(2:n))*rhow*(cswat-csice)*dx(2:n)* &
             dTsoil(2:n)/dt(kk)*var(2:n)%iice
 
@@ -2245,17 +2245,17 @@ CONTAINS
 
        if (advection==1) then
           LHS_h(1:n) = LHS_h(1:n) &
-               + real(1-var(1:n)%iice,r_2) * real(1-var(1:n)%isat,r_2) * &
+               + real(1-var(1:n)%iice,r2) * real(1-var(1:n)%isat,r2) * &
                dx(1:n) * dy(1:n)/dt(kk) * par(1:n)%thre * (Tsoil(1:n)) * rhow * cswat &
-               + real(var(1:n)%iice,r_2) * real(1-var(1:n)%isat,r_2) * &
+               + real(var(1:n)%iice,r2) * real(1-var(1:n)%isat,r2) * &
                dx(1:n) * dy(1:n)/dt(kk) * par(1:n)%thre * rhow * csice * (Tsoil(1:n))
 
           LHS_h(1) = LHS_h(1) &
-               + real(1-ns(kk),r_2) * real(1-var(1)%iice,r_2) * &
+               + real(1-ns(kk),r2) * real(1-var(1)%iice,r2) * &
                dy(1)/dt(kk) * rhow * cswat * (Tsoil(1)) &
-               + real(1-ns(kk),r_2) * real(var(1)%iice,r_2)* &
+               + real(1-ns(kk),r2) * real(var(1)%iice,r2)* &
                dy(1)/dt(kk) * rhow * csice * (Tsoil(1)) * (var(1)%thetai/par(1)%thre) &
-               + real(1-ns(kk),r_2) * real(var(1)%iice,r_2)  * &
+               + real(1-ns(kk),r2) * real(var(1)%iice,r2)  * &
                dy(1)/dt(kk) * rhow * cswat * (Tsoil(1)) * (one-(var(1)%thetai/par(1)%thre))
 
           RHS_h(1:n) = RHS_h(1:n) - iqex(1:n)*cswat*rhow*(Tsoil(1:n)+ sig(kk)*dTsoil(1:n))
@@ -2324,7 +2324,7 @@ CONTAINS
           if (vsnow(kk)%nsnow>0) then
              do i=1, vsnow(kk)%nsnow
                 if ((vsnow(kk)%hsnow(i) + dy(i-vsnow(kk)%nsnow))<zero) then
-                   fac(kk) = 0.99_r_2*vsnow(kk)%hsnow(i)/abs(dy(i-vsnow(kk)%nsnow))
+                   fac(kk) = 0.99_r2*vsnow(kk)%hsnow(i)/abs(dy(i-vsnow(kk)%nsnow))
                    nfac6(kk) = nfac6(kk)+1
                    iok(kk) = 0
                    exit
@@ -2335,7 +2335,7 @@ CONTAINS
                         vsnow(kk)%hsnow(i))) then
 
                       ! adjust fac such that the residual snow layer will be removed at the next call to snow_adjust
-                      fac(kk) = 0.99_r_2*(vsnow(kk)%hsnow(i) - vsnow(kk)%hliq(i))/ &
+                      fac(kk) = 0.99_r2*(vsnow(kk)%hsnow(i) - vsnow(kk)%hliq(i))/ &
                            (de(i-vsnow(kk)%nsnow)-dy(i-vsnow(kk)%nsnow))
                       nfac7(kk) = nfac7(kk)+1
                       iok(kk) =0
@@ -2343,8 +2343,8 @@ CONTAINS
                       exit
                    endif
 
-                   if ((vsnow(kk)%hliq(i) + de(i-vsnow(kk)%nsnow)) < -0.01_r_2*vsnow(kk)%hsnow(i)) then
-                      fac(kk) = (-0.009_r_2*vsnow(kk)%hsnow(i)-vsnow(kk)%hliq(i))/de(i-vsnow(kk)%nsnow)
+                   if ((vsnow(kk)%hliq(i) + de(i-vsnow(kk)%nsnow)) < -0.01_r2*vsnow(kk)%hsnow(i)) then
+                      fac(kk) = (-0.009_r2*vsnow(kk)%hsnow(i)-vsnow(kk)%hliq(i))/de(i-vsnow(kk)%nsnow)
                       nfac8(kk) = nfac8(kk)+1
                       iok(kk) =0
                       exit
@@ -2356,7 +2356,7 @@ CONTAINS
                         dy(i-vsnow(kk)%nsnow)*rhow*(csice*(vsnow(kk)%tsn(i))-lambdaf))/ &
                         (rhow*(zero*(cswat-csice)+lambdaf))
                    if (delta_snowliq(i).gt.(vsnow(kk)%hsnow(i) + dy(i-vsnow(kk)%nsnow))) then
-                      fac(kk) = 0.9_r_2*vsnow(kk)%hsnow(i)/(delta_snowliq(i)- dy(i-vsnow(kk)%nsnow))
+                      fac(kk) = 0.9_r2*vsnow(kk)%hsnow(i)/(delta_snowliq(i)- dy(i-vsnow(kk)%nsnow))
                       nfac12(kk) = nfac12(kk)+1
                       iok(kk) = 0
                    endif
@@ -2388,7 +2388,7 @@ CONTAINS
                    exit
                 end if
                 if (S(i) >= one .and. dy(i) > half*(Smax-one)) then ! Check for limit at oversaturation
-                   fac(kk) = 0.25_r_2*(Smax-one)/dy(i)
+                   fac(kk) = 0.25_r2*(Smax-one)/dy(i)
                    nfac4(kk) = nfac4(kk)+1
                    iok(kk) = 0
                    exit
@@ -2487,7 +2487,7 @@ CONTAINS
                rhow*(tmp1d3(kk))*cswat*tmp1d4(kk)*(one-theta/par(1)%thre) + &
                dx(1)*(tmp1d3(kk))*par(1)%rho*par(1)%css
 !!$          if(((tmp1d2(kk))-c2)<zero) then
-!!$             fac(kk) = 0.5_r_2
+!!$             fac(kk) = 0.5_r2
 !!$             iok(kk) = 0
 !!$             nfac10(kk) = nfac10(kk)+1
 !!$          endif
@@ -2502,13 +2502,13 @@ CONTAINS
                 var(i)%csoil = par(i)%css*par(i)%rho + rhow*cswat*(theta-var(i)%thetai) + &
                      rhow*csice*var(i)%thetai
                 if ((i==1) .and. (ns(kk)==0)) then
-                   cp(kk) = real(1-var(1)%iice,r_2)*cswat*rhow & ! heat capacity of pond
-                        + real(var(1)%iice,r_2)*rhow* &
+                   cp(kk) = real(1-var(1)%iice,r2)*cswat*rhow & ! heat capacity of pond
+                        + real(var(1)%iice,r2)*rhow* &
                         ((one-var(1)%thetai/par(1)%thre)*cswat + (var(1)%thetai/par(1)%thre)*csice)
                 endif
              enddo
-             var(:)%csoileff = var(:)%csoil + rhow*lambdaf*var(:)%dthetaldT*real(var(:)%iice,r_2)
-             cpeff(kk)= cp(kk) + rhow*lambdaf*var(1)%dthetaldT/par(1)%thre*real(var(1)%iice,r_2)
+             var(:)%csoileff = var(:)%csoil + rhow*lambdaf*var(:)%dthetaldT*real(var(:)%iice,r2)
+             cpeff(kk)= cp(kk) + rhow*lambdaf*var(1)%dthetaldT/par(1)%thre*real(var(1)%iice,r2)
              h0_tmp(kk) = h0(kk)
 
           endif
@@ -2596,53 +2596,53 @@ CONTAINS
        nfac10, nfac11, nfac12, J0snow, wcol0snow, h_ex, wpi, err &
        )
     IMPLICIT NONE
-    REAL(r_2)              :: tfin
-    INTEGER(i_d)              :: irec, mp
-    REAL(r_2),      DIMENSION(1:mp)              :: qprec
-    REAL(r_2),      DIMENSION(1:mp)              :: qprec_snow
-    INTEGER(i_d)              :: n
-    REAL(r_2),      DIMENSION(1:n) :: dx
-    REAL(r_2),      DIMENSION(1:mp)           :: h0
-    REAL(r_2),      DIMENSION(1:n) :: S
-    REAL(r_2),      DIMENSION(1:n) :: thetai
-    REAL(r_2),      DIMENSION(1:n) :: Jsensible
-    REAL(r_2),      DIMENSION(1:n) :: Tsoil
-    REAL(r_2),      DIMENSION(1:mp)           :: evap
-    REAL(r_2),      DIMENSION(1:mp)             :: runoff, infil
-    REAL(r_2),      DIMENSION(1:mp)             :: drainage, discharge
-    REAL(r_2),      DIMENSION(1:mp,-nsnow_max:n)      :: qh
-    INTEGER(i_d),   DIMENSION(1:mp)             :: nsteps
+    REAL(r2)              :: tfin
+    INTEGER(i4)              :: irec, mp
+    REAL(r2),      DIMENSION(1:mp)              :: qprec
+    REAL(r2),      DIMENSION(1:mp)              :: qprec_snow
+    INTEGER(i4)              :: n
+    REAL(r2),      DIMENSION(1:n) :: dx
+    REAL(r2),      DIMENSION(1:mp)           :: h0
+    REAL(r2),      DIMENSION(1:n) :: S
+    REAL(r2),      DIMENSION(1:n) :: thetai
+    REAL(r2),      DIMENSION(1:n) :: Jsensible
+    REAL(r2),      DIMENSION(1:n) :: Tsoil
+    REAL(r2),      DIMENSION(1:mp)           :: evap
+    REAL(r2),      DIMENSION(1:mp)             :: runoff, infil
+    REAL(r2),      DIMENSION(1:mp)             :: drainage, discharge
+    REAL(r2),      DIMENSION(1:mp,-nsnow_max:n)      :: qh
+    INTEGER(i4),   DIMENSION(1:mp)             :: nsteps
     TYPE(vars_met), DIMENSION(1:mp)           :: vmet
     TYPE(vars),     DIMENSION(1:mp)           :: vlit
     TYPE(vars_snow), DIMENSION(1:mp)           :: vsnow
     TYPE(vars),     DIMENSION(1:n) :: var
-    REAL(r_2),      DIMENSION(1:mp)           :: T0, Tsurface
-    REAL(r_2),      DIMENSION(1:mp)             :: Hcum, lEcum,  deltaice_cum_T, deltaice_cum_S
-    REAL(r_2),      DIMENSION(1:mp)             :: Gcum, Qadvcum
-    REAL(r_2),      DIMENSION(1:mp)             :: Jcol_sensible, Jcol_latent_S, Jcol_latent_T
-    REAL(r_2),      DIMENSION(1:n) :: csoil, kth
-    REAL(r_2),      DIMENSION(1:n) :: phi
-    REAL(r_2),      DIMENSION(1:mp)              :: dxL
-    REAL(r_2),      DIMENSION(1:mp)           :: zdelta, SL, Tl
+    REAL(r2),      DIMENSION(1:mp)           :: T0, Tsurface
+    REAL(r2),      DIMENSION(1:mp)             :: Hcum, lEcum,  deltaice_cum_T, deltaice_cum_S
+    REAL(r2),      DIMENSION(1:mp)             :: Gcum, Qadvcum
+    REAL(r2),      DIMENSION(1:mp)             :: Jcol_sensible, Jcol_latent_S, Jcol_latent_T
+    REAL(r2),      DIMENSION(1:n) :: csoil, kth
+    REAL(r2),      DIMENSION(1:n) :: phi
+    REAL(r2),      DIMENSION(1:mp)              :: dxL
+    REAL(r2),      DIMENSION(1:mp)           :: zdelta, SL, Tl
     TYPE(params),   DIMENSION(1:mp)              :: plit
     TYPE(params),   DIMENSION(1:n) :: par
-    REAL(r_2),      DIMENSION(1:mp,1:n), OPTIONAL :: wex
-    REAL(r_2),      DIMENSION(1:mp,1:n), OPTIONAL :: ciso
-    REAL(r_2),      DIMENSION(1:mp,1:n), OPTIONAL :: cisoice
-    REAL(r_2),      DIMENSION(1:mp,1:nsnow_max), OPTIONAL :: ciso_snow
-    REAL(r_2),      DIMENSION(1:mp,1:nsnow_max), OPTIONAL :: cisoice_snow
-    REAL(r_2),      DIMENSION(1:mp), OPTIONAL :: cisos
-    REAL(r_2),      DIMENSION(1:mp),    OPTIONAL :: cprec
-    REAL(r_2),      DIMENSION(1:mp),    OPTIONAL :: cprec_snow
-    REAL(r_2),      DIMENSION(1:mp),    OPTIONAL :: qali
-    REAL(r_2),      DIMENSION(1:mp),   OPTIONAL :: qiso_in, qiso_out
-    REAL(r_2),      DIMENSION(1:mp),   OPTIONAL :: qiso_evap_cum, qiso_trans_cum
-    REAL(r_2),      DIMENSION(1:mp,-nsnow_max+1:n),   OPTIONAL :: qiso_liq_adv, qiso_vap_adv
-    REAL(r_2),      DIMENSION(1:mp,-nsnow_max+1:n-1),   OPTIONAL :: qiso_liq_diff, qiso_vap_diff
-    REAL(r_2),      DIMENSION(1:mp,-nsnow_max:n),   OPTIONAL :: qvsig, qlsig, qvTsig, qvh
-    REAL(r_2),      DIMENSION(1:mp), OPTIONAL :: deltaTa
+    REAL(r2),      DIMENSION(1:mp,1:n), OPTIONAL :: wex
+    REAL(r2),      DIMENSION(1:mp,1:n), OPTIONAL :: ciso
+    REAL(r2),      DIMENSION(1:mp,1:n), OPTIONAL :: cisoice
+    REAL(r2),      DIMENSION(1:mp,1:nsnow_max), OPTIONAL :: ciso_snow
+    REAL(r2),      DIMENSION(1:mp,1:nsnow_max), OPTIONAL :: cisoice_snow
+    REAL(r2),      DIMENSION(1:mp), OPTIONAL :: cisos
+    REAL(r2),      DIMENSION(1:mp),    OPTIONAL :: cprec
+    REAL(r2),      DIMENSION(1:mp),    OPTIONAL :: cprec_snow
+    REAL(r2),      DIMENSION(1:mp),    OPTIONAL :: qali
+    REAL(r2),      DIMENSION(1:mp),   OPTIONAL :: qiso_in, qiso_out
+    REAL(r2),      DIMENSION(1:mp),   OPTIONAL :: qiso_evap_cum, qiso_trans_cum
+    REAL(r2),      DIMENSION(1:mp,-nsnow_max+1:n),   OPTIONAL :: qiso_liq_adv, qiso_vap_adv
+    REAL(r2),      DIMENSION(1:mp,-nsnow_max+1:n-1),   OPTIONAL :: qiso_liq_diff, qiso_vap_diff
+    REAL(r2),      DIMENSION(1:mp,-nsnow_max:n),   OPTIONAL :: qvsig, qlsig, qvTsig, qvh
+    REAL(r2),      DIMENSION(1:mp), OPTIONAL :: deltaTa
     ! Error flag if nstep of SLI > nsteps_max: err=0 -> no error; err/=0 -> error
-    INTEGER(i_d),     INTENT(INOUT), OPTIONAL :: err
+    INTEGER(i4),     INTENT(INOUT), OPTIONAL :: err
 
     ! Solves the RE and, optionally, the ADE from time ts to tfin.
     ! Definitions of arguments:
@@ -2684,87 +2684,87 @@ CONTAINS
     !     linear adsorption does not require a sub, and other types
     !     are available in sub isosub.
 
-    REAL(r_2),    DIMENSION(1:mp)       :: precip, qevap
-    REAL(r_2),    DIMENSION(1:mp)       :: qL, qhL, qybL, qTbL, qhTbL, qhybL, rexcol, wcol, ql0, qv0
+    REAL(r2),    DIMENSION(1:mp)       :: precip, qevap
+    REAL(r2),    DIMENSION(1:mp)       :: qL, qhL, qybL, qTbL, qhTbL, qhybL, rexcol, wcol, ql0, qv0
     LOGICAL,      DIMENSION(1:mp)       :: again, getq0,getqn,init
     LOGICAL,      DIMENSION(1:mp,1:n)   :: again_ice
-    INTEGER(i_d), DIMENSION(1:mp)       :: ih0, iok, itmp, ns, nsat, nsatlast, nsteps0
-    REAL(r_2),    DIMENSION(1:mp)       :: accel, dmax, dt, dwinfil, dwoff, fac, phip
-    REAL(r_2),    DIMENSION(1:mp)       :: qpme, rsig, rsigdt, sig, t
-    REAL(r_2),    DIMENSION(1:n) :: hint, phimin, qexd
-    REAL(r_2),    DIMENSION(-nsnow_max+1:n) :: aa, bb, cc, dd, ee, ff, gg, dy
-    REAL(r_2),    DIMENSION(-nsnow_max+1:n) :: aah, bbh, cch, ddh, eeh, ffh, ggh, de
-    REAL(r_2),    DIMENSION(-nsnow_max:n) :: q, qya, qyb, qTa, qTb,qhya, qhyb, qhTa, qhTb
-    REAL(r_2),    DIMENSION(-nsnow_max:n) :: qadv, qadvya, qadvyb, qadvTa, qadvTb
+    INTEGER(i4), DIMENSION(1:mp)       :: ih0, iok, itmp, ns, nsat, nsatlast, nsteps0
+    REAL(r2),    DIMENSION(1:mp)       :: accel, dmax, dt, dwinfil, dwoff, fac, phip
+    REAL(r2),    DIMENSION(1:mp)       :: qpme, rsig, rsigdt, sig, t
+    REAL(r2),    DIMENSION(1:n) :: hint, phimin, qexd
+    REAL(r2),    DIMENSION(-nsnow_max+1:n) :: aa, bb, cc, dd, ee, ff, gg, dy
+    REAL(r2),    DIMENSION(-nsnow_max+1:n) :: aah, bbh, cch, ddh, eeh, ffh, ggh, de
+    REAL(r2),    DIMENSION(-nsnow_max:n) :: q, qya, qyb, qTa, qTb,qhya, qhyb, qhTa, qhTb
+    REAL(r2),    DIMENSION(-nsnow_max:n) :: qadv, qadvya, qadvyb, qadvTa, qadvTb
 
 
     TYPE(vars)                          :: vtmp
     !TYPE(vars),   DIMENSION(1:n) :: var
-    REAL(r_2),    DIMENSION(-nsnow_max:n) :: qsig, qhsig, qadvsig
-    REAL(r_2),    DIMENSION(-nsnow_max:n) :: qliq, qv, qvT, qlya, qlyb, qvya, qvyb, qlTb, qvTa, qvTb
-    REAL(r_2),    DIMENSION(1:n) :: deltaS, dTsoil
-    REAL(r_2),    DIMENSION(0:n) :: tmp2d1, tmp2d2
-    REAL(r_2),    DIMENSION(1:n) :: S0, Sliq0, Sliq, deltaSliq, cv0, deltacv
-    REAL(r_2),    DIMENSION(1:n) :: Sliqice0, Sliqice, deltaSliqice
-    REAL(r_2),    DIMENSION(1:n) :: Sice0, Sice, deltaSice
+    REAL(r2),    DIMENSION(-nsnow_max:n) :: qsig, qhsig, qadvsig
+    REAL(r2),    DIMENSION(-nsnow_max:n) :: qliq, qv, qvT, qlya, qlyb, qvya, qvyb, qlTb, qvTa, qvTb
+    REAL(r2),    DIMENSION(1:n) :: deltaS, dTsoil
+    REAL(r2),    DIMENSION(0:n) :: tmp2d1, tmp2d2
+    REAL(r2),    DIMENSION(1:n) :: S0, Sliq0, Sliq, deltaSliq, cv0, deltacv
+    REAL(r2),    DIMENSION(1:n) :: Sliqice0, Sliqice, deltaSliqice
+    REAL(r2),    DIMENSION(1:n) :: Sice0, Sice, deltaSice
 
-    REAL(r_2),    DIMENSION(-nsnow_max+1:n) :: Sliq0_ss, Sliq_ss, deltaSliq_ss
-    REAL(r_2),    DIMENSION(-nsnow_max+1:n) :: Sliqice0_ss, Sliqice_ss, deltaSliqice_ss
-    REAL(r_2),    DIMENSION(-nsnow_max+1:n) :: Sice0_ss, Sice_ss, deltaSice_ss
-    REAL(r_2),    DIMENSION(-nsnow_max+1:n) :: S0_ss, S_ss, Tsoil_ss, dTsoil_ss
-    REAL(r_2),    DIMENSION(-nsnow_max+1:n) :: cv0_ss, cv_ss, Dv_ss, deltacv_ss, dx_ss
-    REAL(r_2),    DIMENSION(-nsnow_max+1:n-1) :: dz_ss
-    REAL(r_2),      DIMENSION(1:nsnow_max) :: cisoliqice_snow
-    INTEGER(i_d) :: itop ! integer corresponding to top of soil-snow column
-    INTEGER(i_d) :: nsnow ! number of dedicated snow layers
-    REAL(r_2),    DIMENSION(1:n) :: tmp_thetasat, tmp_thetar
-    REAL(r_2),    DIMENSION(-nsnow_max+1:n) :: thetasat_ss, thetar_ss
-    REAL(r_2),    DIMENSION(-nsnow_max+1:n) :: tmp_tortuosity
-    REAL(r_2),    DIMENSION(-nsnow_max+1:n) :: ciso_ss, cisoice_ss
-    REAL(r_2),    DIMENSION(1:n)   :: delthetai, dthetaldT, thetal
-    INTEGER(i_d), DIMENSION(1:n) :: isave, nsteps_ice, imelt
+    REAL(r2),    DIMENSION(-nsnow_max+1:n) :: Sliq0_ss, Sliq_ss, deltaSliq_ss
+    REAL(r2),    DIMENSION(-nsnow_max+1:n) :: Sliqice0_ss, Sliqice_ss, deltaSliqice_ss
+    REAL(r2),    DIMENSION(-nsnow_max+1:n) :: Sice0_ss, Sice_ss, deltaSice_ss
+    REAL(r2),    DIMENSION(-nsnow_max+1:n) :: S0_ss, S_ss, Tsoil_ss, dTsoil_ss
+    REAL(r2),    DIMENSION(-nsnow_max+1:n) :: cv0_ss, cv_ss, Dv_ss, deltacv_ss, dx_ss
+    REAL(r2),    DIMENSION(-nsnow_max+1:n-1) :: dz_ss
+    REAL(r2),      DIMENSION(1:nsnow_max) :: cisoliqice_snow
+    INTEGER(i4) :: itop ! integer corresponding to top of soil-snow column
+    INTEGER(i4) :: nsnow ! number of dedicated snow layers
+    REAL(r2),    DIMENSION(1:n) :: tmp_thetasat, tmp_thetar
+    REAL(r2),    DIMENSION(-nsnow_max+1:n) :: thetasat_ss, thetar_ss
+    REAL(r2),    DIMENSION(-nsnow_max+1:n) :: tmp_tortuosity
+    REAL(r2),    DIMENSION(-nsnow_max+1:n) :: ciso_ss, cisoice_ss
+    REAL(r2),    DIMENSION(1:n)   :: delthetai, dthetaldT, thetal
+    INTEGER(i4), DIMENSION(1:n) :: isave, nsteps_ice, imelt
 
 
     TYPE(vars),         DIMENSION(1:mp) :: vtop, vbot
     TYPE(vars_aquifer), DIMENSION(1:mp) :: v_aquifer
-    REAL(r_2),          DIMENSION(1:mp) :: dwcol, dwdrainage, drn,inlit, dwinlit, drexcol, dwdischarge
-    REAL(r_2),          DIMENSION(1:mp) :: dJcol_latent_S, dJcol_latent_T, dJcol_sensible
-    REAL(r_2),          DIMENSION(1:n) :: deltaJ_latent_S, deltaJ_latent_T, deltaJ_sensible_S, deltaJ_sensible_T
-    REAL(r_2),          DIMENSION(1:mp) :: qevapsig
-    REAL(r_2),          DIMENSION(1:mp) :: qrunoff
-    REAL(r_2),          DIMENSION(1:mp) :: tmp1d1, tmp1d2, tmp1d3,  tmp1d4
-    REAL(r_2),          DIMENSION(1:mp) :: deltah0
-    REAL(r_2),          DIMENSION(1:mp) :: SL0, deltaSL, cvL0, SLliq0, deltacvL, SLliq, deltaSLliq
-    REAL(r_2),          DIMENSION(1:mp) :: qiso_evap, qiso_trans
-    REAL(r_2),          DIMENSION(1:mp) :: lE0, G0, Epot
-    REAL(r_2),          DIMENSION(1:mp) :: Tfreezing
-    REAL(r_2),          DIMENSION(1:mp) :: dtdT
-    REAL(r_2),          DIMENSION(-nsnow_max+1:n) :: LHS, RHS, LHS_h, RHS_h
-    INTEGER(i_d),       DIMENSION(1:mp) :: surface_case
+    REAL(r2),          DIMENSION(1:mp) :: dwcol, dwdrainage, drn,inlit, dwinlit, drexcol, dwdischarge
+    REAL(r2),          DIMENSION(1:mp) :: dJcol_latent_S, dJcol_latent_T, dJcol_sensible
+    REAL(r2),          DIMENSION(1:n) :: deltaJ_latent_S, deltaJ_latent_T, deltaJ_sensible_S, deltaJ_sensible_T
+    REAL(r2),          DIMENSION(1:mp) :: qevapsig
+    REAL(r2),          DIMENSION(1:mp) :: qrunoff
+    REAL(r2),          DIMENSION(1:mp) :: tmp1d1, tmp1d2, tmp1d3,  tmp1d4
+    REAL(r2),          DIMENSION(1:mp) :: deltah0
+    REAL(r2),          DIMENSION(1:mp) :: SL0, deltaSL, cvL0, SLliq0, deltacvL, SLliq, deltaSLliq
+    REAL(r2),          DIMENSION(1:mp) :: qiso_evap, qiso_trans
+    REAL(r2),          DIMENSION(1:mp) :: lE0, G0, Epot
+    REAL(r2),          DIMENSION(1:mp) :: Tfreezing
+    REAL(r2),          DIMENSION(1:mp) :: dtdT
+    REAL(r2),          DIMENSION(-nsnow_max+1:n) :: LHS, RHS, LHS_h, RHS_h
+    INTEGER(i4),       DIMENSION(1:mp) :: surface_case
 
-    INTEGER(i_d),       DIMENSION(1:mp) :: nns, iflux
+    INTEGER(i4),       DIMENSION(1:mp) :: nns, iflux
     LOGICAL      :: litter
-    INTEGER(i_d) :: i, j, k, kk, condition
-    INTEGER(i_d) :: littercase, isotopologue, advection ! switches
-    REAL(r_2)    :: c2, theta
-    REAL(r_2)    :: dTqwdTa, dTqwdTb, Tqw, keff
-    REAL(r_2),          DIMENSION(1:mp) :: cp, cpeff, hice, deltahice, h0_0, hice_0, h0_tmp, hice_tmp
-    REAL(r_2),          DIMENSION(nsnow_max) :: qmelt
+    INTEGER(i4) :: i, j, k, kk, condition
+    INTEGER(i4) :: littercase, isotopologue, advection ! switches
+    REAL(r2)    :: c2, theta
+    REAL(r2)    :: dTqwdTa, dTqwdTb, Tqw, keff
+    REAL(r2),          DIMENSION(1:mp) :: cp, cpeff, hice, deltahice, h0_0, hice_0, h0_tmp, hice_tmp
+    REAL(r2),          DIMENSION(nsnow_max) :: qmelt
     ! tranfer of water  from soil to   snow (+ve) or soil to snow (-ve) at init or termination of snowpack
-    REAL(r_2),  DIMENSION(1:mp) :: qtransfer
-    REAL(r_2),  DIMENSION(1:mp) :: qmelt_ss ! melt water from bottom snow layer to soil
-    REAL(r_2),  DIMENSION(1:mp) :: qprec_ss
-    REAL(r_2),  DIMENSION(1:mp) :: cprec_ss
-    REAL(r_2),          DIMENSION(nsnow_max) :: delta_snowcol, delta_snowT, delta_snowliq
-    REAL(r_2),      DIMENSION(1:n) :: thetai_0, J0
-    REAL(r_2) :: tmp1, tmp2
-    REAL(r_2),          DIMENSION(1:n) :: iqex
-    REAL(r_2),          DIMENSION(1:mp)     :: icali
-    INTEGER(i_d),       DIMENSION(1:mp) :: nfac1, nfac2, nfac3, nfac4, nfac5, &
+    REAL(r2),  DIMENSION(1:mp) :: qtransfer
+    REAL(r2),  DIMENSION(1:mp) :: qmelt_ss ! melt water from bottom snow layer to soil
+    REAL(r2),  DIMENSION(1:mp) :: qprec_ss
+    REAL(r2),  DIMENSION(1:mp) :: cprec_ss
+    REAL(r2),          DIMENSION(nsnow_max) :: delta_snowcol, delta_snowT, delta_snowliq
+    REAL(r2),      DIMENSION(1:n) :: thetai_0, J0
+    REAL(r2) :: tmp1, tmp2
+    REAL(r2),          DIMENSION(1:n) :: iqex
+    REAL(r2),          DIMENSION(1:mp)     :: icali
+    INTEGER(i4),       DIMENSION(1:mp) :: nfac1, nfac2, nfac3, nfac4, nfac5, &
          nfac6, nfac7, nfac8, nfac9, nfac10, nfac11, nfac12
-    REAL(r_2),          DIMENSION(1:mp)     :: J0snow, wcol0snow
-    REAL(r_2), DIMENSION(1:n) :: h_ex
-    REAL(r_2) :: wpi
+    REAL(r2),          DIMENSION(1:mp)     :: J0snow, wcol0snow
+    REAL(r2), DIMENSION(1:n) :: h_ex
+    REAL(r2) :: wpi
 
 
     aa(:)     = zero
@@ -3096,8 +3096,8 @@ CONTAINS
           nsnow = vsnow(kk)%nsnow
 
           dz_ss(itop:n-1) =   half*(dx_ss(itop:n-1)+dx_ss(itop+1:n)) ! flow paths
-          thetasat_ss(itop:0) = 1.0_r_2
-          thetar_ss(itop:0) = 1.0_r_2
+          thetasat_ss(itop:0) = 1.0_r2
+          thetar_ss(itop:0) = 1.0_r2
           thetasat_ss(1:n) = tmp_thetasat(1:n)
           thetar_ss(1:n) = tmp_thetar(1:n)
           qprec_ss(kk) = qprec(kk)
@@ -3105,9 +3105,9 @@ CONTAINS
           qmelt_ss(kk) = zero
           if (vsnow(kk)%nsnow.gt.0) then
              qmelt_ss(kk) = qmelt(vsnow(kk)%nsnow)/dt(kk)
-             tmp_tortuosity(itop:0) = 0.8_r_2
-             thetasat_ss(itop:0) = 1.0_r_2
-             thetar_ss(itop:0) = 0.0_r_2
+             tmp_tortuosity(itop:0) = 0.8_r2
+             thetasat_ss(itop:0) = 1.0_r2
+             thetar_ss(itop:0) = 0.0_r2
           elseif (vsnow(kk)%nsnow_last.gt.0.and.vsnow(kk)%nsnow.eq.0) then
              !qmelt_ss(kk) = -qtransfer(kk)/dt(kk)   ! transfer from terminated snowpack to soil column
              if (abs(qprec(kk)-qtransfer(kk)/dt(kk)).gt.zero) then
@@ -3163,61 +3163,61 @@ CONTAINS
 
     IMPLICIT NONE
 
-    REAL(r_2),                             INTENT(IN)              :: ts, tfin
-    INTEGER(i_d),                          INTENT(IN)              :: irec, mp
-    REAL(r_2),      DIMENSION(1:mp),       INTENT(IN)              :: qprec
-    REAL(r_2),      DIMENSION(1:mp),       INTENT(INOUT)           :: qprec_snow
-    INTEGER(i_d),                          INTENT(IN)              :: n
-    REAL(r_2),      DIMENSION(1:mp,1:n),   INTENT(IN)              :: dx
-    REAL(r_2),      DIMENSION(1:mp),       INTENT(INOUT)           :: h0
-    REAL(r_2),      DIMENSION(1:mp,1:n),   INTENT(INOUT)           :: S
-    REAL(r_2),      DIMENSION(1:mp,1:n),   INTENT(OUT)             :: thetai
-    REAL(r_2),      DIMENSION(1:mp,1:n),   INTENT(OUT)             :: Jsensible
-    REAL(r_2),      DIMENSION(1:mp,1:n),   INTENT(INOUT)           :: Tsoil
-    REAL(r_2),      DIMENSION(1:mp),       INTENT(INOUT)           :: evap
-    REAL(r_2),      DIMENSION(1:mp),       INTENT(OUT)             :: evap_pot, runoff, infil
-    REAL(r_2),      DIMENSION(1:mp),       INTENT(OUT)             :: drainage, discharge
-    REAL(r_2),      DIMENSION(1:mp,-nsnow_max:n), INTENT(OUT)      :: qh
-    INTEGER(i_d),   DIMENSION(1:mp),       INTENT(OUT)             :: nsteps
+    REAL(r2),                             INTENT(IN)              :: ts, tfin
+    INTEGER(i4),                          INTENT(IN)              :: irec, mp
+    REAL(r2),      DIMENSION(1:mp),       INTENT(IN)              :: qprec
+    REAL(r2),      DIMENSION(1:mp),       INTENT(INOUT)           :: qprec_snow
+    INTEGER(i4),                          INTENT(IN)              :: n
+    REAL(r2),      DIMENSION(1:mp,1:n),   INTENT(IN)              :: dx
+    REAL(r2),      DIMENSION(1:mp),       INTENT(INOUT)           :: h0
+    REAL(r2),      DIMENSION(1:mp,1:n),   INTENT(INOUT)           :: S
+    REAL(r2),      DIMENSION(1:mp,1:n),   INTENT(OUT)             :: thetai
+    REAL(r2),      DIMENSION(1:mp,1:n),   INTENT(OUT)             :: Jsensible
+    REAL(r2),      DIMENSION(1:mp,1:n),   INTENT(INOUT)           :: Tsoil
+    REAL(r2),      DIMENSION(1:mp),       INTENT(INOUT)           :: evap
+    REAL(r2),      DIMENSION(1:mp),       INTENT(OUT)             :: evap_pot, runoff, infil
+    REAL(r2),      DIMENSION(1:mp),       INTENT(OUT)             :: drainage, discharge
+    REAL(r2),      DIMENSION(1:mp,-nsnow_max:n), INTENT(OUT)      :: qh
+    INTEGER(i4),   DIMENSION(1:mp),       INTENT(OUT)             :: nsteps
     TYPE(vars_met), DIMENSION(1:mp),       INTENT(INOUT)           :: vmet
     TYPE(vars),     DIMENSION(1:mp),       INTENT(INOUT)           :: vlit
     TYPE(vars_snow), DIMENSION(1:mp),      INTENT(INOUT)           :: vsnow
     TYPE(vars),     DIMENSION(1:mp,1:n),   INTENT(INOUT)           :: var
-    REAL(r_2),      DIMENSION(1:mp),       INTENT(INOUT)           :: T0, Tsurface
-    REAL(r_2),      DIMENSION(1:mp),       INTENT(OUT)             :: Hcum, lEcum,  deltaice_cum_T, deltaice_cum_S
-    REAL(r_2),      DIMENSION(1:mp),       INTENT(OUT)             :: Gcum, Qadvcum
-    REAL(r_2),      DIMENSION(1:mp),       INTENT(OUT)             :: Jcol_sensible, Jcol_latent_S, Jcol_latent_T
-    REAL(r_2),      DIMENSION(1:mp,1:n),   INTENT(OUT)             :: csoil, kth
-    REAL(r_2),      DIMENSION(1:mp,1:n),   INTENT(INOUT)           :: phi
-    REAL(r_2),      DIMENSION(1:mp),       INTENT(IN)              :: dxL
-    REAL(r_2),      DIMENSION(1:mp),       INTENT(INOUT)           :: zdelta, SL, Tl
+    REAL(r2),      DIMENSION(1:mp),       INTENT(INOUT)           :: T0, Tsurface
+    REAL(r2),      DIMENSION(1:mp),       INTENT(OUT)             :: Hcum, lEcum,  deltaice_cum_T, deltaice_cum_S
+    REAL(r2),      DIMENSION(1:mp),       INTENT(OUT)             :: Gcum, Qadvcum
+    REAL(r2),      DIMENSION(1:mp),       INTENT(OUT)             :: Jcol_sensible, Jcol_latent_S, Jcol_latent_T
+    REAL(r2),      DIMENSION(1:mp,1:n),   INTENT(OUT)             :: csoil, kth
+    REAL(r2),      DIMENSION(1:mp,1:n),   INTENT(INOUT)           :: phi
+    REAL(r2),      DIMENSION(1:mp),       INTENT(IN)              :: dxL
+    REAL(r2),      DIMENSION(1:mp),       INTENT(INOUT)           :: zdelta, SL, Tl
     TYPE(params),   DIMENSION(1:mp),       INTENT(IN)              :: plit
     TYPE(params),   DIMENSION(1:mp,1:n),   INTENT(INOUT)           :: par
-    REAL(r_2),       DIMENSION(1:mp,1:n),  INTENT(IN), OPTIONAL    :: qex
-    REAL(r_2),      DIMENSION(1:mp,1:n),   INTENT(INOUT), OPTIONAL :: wex
-    REAL(r_2),      DIMENSION(1:mp,1:n),   INTENT(OUT),   OPTIONAL :: heads
-    REAL(r_2),      DIMENSION(1:mp,1:n),   INTENT(INOUT), OPTIONAL :: ciso
-    REAL(r_2),      DIMENSION(1:mp,1:n),   INTENT(INOUT), OPTIONAL :: cisoice
-    REAL(r_2),      DIMENSION(1:mp,1:nsnow_max),   INTENT(INOUT), OPTIONAL :: ciso_snow
-    REAL(r_2),      DIMENSION(1:mp,1:nsnow_max),   INTENT(INOUT), OPTIONAL :: cisoice_snow
-    REAL(r_2),      DIMENSION(1:mp),       INTENT(INOUT), OPTIONAL :: cisos
-    REAL(r_2),      DIMENSION(1:mp),       INTENT(IN),    OPTIONAL :: cprec
-    REAL(r_2),      DIMENSION(1:mp),       INTENT(IN),    OPTIONAL :: cprec_snow
-    REAL(r_2),      DIMENSION(1:mp),       INTENT(IN),    OPTIONAL :: cali
-    REAL(r_2),      DIMENSION(1:mp),       INTENT(IN),    OPTIONAL :: qali
-    REAL(r_2),      DIMENSION(1:mp),       INTENT(OUT),   OPTIONAL :: qiso_in, qiso_out
-    REAL(r_2),      DIMENSION(1:mp),       INTENT(OUT),   OPTIONAL :: qiso_evap_cum, qiso_trans_cum
-    REAL(r_2),      DIMENSION(1:mp,-nsnow_max+1:n),   INTENT(OUT),   OPTIONAL :: qiso_liq_adv, qiso_vap_adv
-    REAL(r_2),      DIMENSION(1:mp,-nsnow_max+1:n-1), INTENT(OUT),   OPTIONAL :: qiso_liq_diff, qiso_vap_diff
-    REAL(r_2),      DIMENSION(1:mp,-nsnow_max:n),   INTENT(OUT),   OPTIONAL :: qvsig, qlsig, qvTsig, qvh
-    REAL(r_2),      DIMENSION(1:mp),       INTENT(INOUT), OPTIONAL :: deltaTa
-    REAL(r_2),      DIMENSION(1:mp),       INTENT(IN),    OPTIONAL :: lE_old
-    INTEGER(i_d),                          INTENT(IN),    OPTIONAL :: dolitter       ! 0: no; 1: normal; 2: resistance
-    INTEGER(i_d),                          INTENT(IN),    OPTIONAL :: doisotopologue ! 0: no isotope; 1: HDO; 2: H218O
-    INTEGER(i_d),                          INTENT(IN),    OPTIONAL :: docondition    ! 0: no cond., 1: columns, 2: lines, 3: both
-    INTEGER(i_d),                          INTENT(IN),    OPTIONAL :: doadvection    ! 0: off; 1: onn
+    REAL(r2),       DIMENSION(1:mp,1:n),  INTENT(IN), OPTIONAL    :: qex
+    REAL(r2),      DIMENSION(1:mp,1:n),   INTENT(INOUT), OPTIONAL :: wex
+    REAL(r2),      DIMENSION(1:mp,1:n),   INTENT(OUT),   OPTIONAL :: heads
+    REAL(r2),      DIMENSION(1:mp,1:n),   INTENT(INOUT), OPTIONAL :: ciso
+    REAL(r2),      DIMENSION(1:mp,1:n),   INTENT(INOUT), OPTIONAL :: cisoice
+    REAL(r2),      DIMENSION(1:mp,1:nsnow_max),   INTENT(INOUT), OPTIONAL :: ciso_snow
+    REAL(r2),      DIMENSION(1:mp,1:nsnow_max),   INTENT(INOUT), OPTIONAL :: cisoice_snow
+    REAL(r2),      DIMENSION(1:mp),       INTENT(INOUT), OPTIONAL :: cisos
+    REAL(r2),      DIMENSION(1:mp),       INTENT(IN),    OPTIONAL :: cprec
+    REAL(r2),      DIMENSION(1:mp),       INTENT(IN),    OPTIONAL :: cprec_snow
+    REAL(r2),      DIMENSION(1:mp),       INTENT(IN),    OPTIONAL :: cali
+    REAL(r2),      DIMENSION(1:mp),       INTENT(IN),    OPTIONAL :: qali
+    REAL(r2),      DIMENSION(1:mp),       INTENT(OUT),   OPTIONAL :: qiso_in, qiso_out
+    REAL(r2),      DIMENSION(1:mp),       INTENT(OUT),   OPTIONAL :: qiso_evap_cum, qiso_trans_cum
+    REAL(r2),      DIMENSION(1:mp,-nsnow_max+1:n),   INTENT(OUT),   OPTIONAL :: qiso_liq_adv, qiso_vap_adv
+    REAL(r2),      DIMENSION(1:mp,-nsnow_max+1:n-1), INTENT(OUT),   OPTIONAL :: qiso_liq_diff, qiso_vap_diff
+    REAL(r2),      DIMENSION(1:mp,-nsnow_max:n),   INTENT(OUT),   OPTIONAL :: qvsig, qlsig, qvTsig, qvh
+    REAL(r2),      DIMENSION(1:mp),       INTENT(INOUT), OPTIONAL :: deltaTa
+    REAL(r2),      DIMENSION(1:mp),       INTENT(IN),    OPTIONAL :: lE_old
+    INTEGER(i4),                          INTENT(IN),    OPTIONAL :: dolitter       ! 0: no; 1: normal; 2: resistance
+    INTEGER(i4),                          INTENT(IN),    OPTIONAL :: doisotopologue ! 0: no isotope; 1: HDO; 2: H218O
+    INTEGER(i4),                          INTENT(IN),    OPTIONAL :: docondition    ! 0: no cond., 1: columns, 2: lines, 3: both
+    INTEGER(i4),                          INTENT(IN),    OPTIONAL :: doadvection    ! 0: off; 1: onn
     ! Error flag if nstep of SLI > nsteps_max: err=0 -> no error; err/=0 -> error
-    INTEGER(i_d),  DIMENSION(1:mp),        INTENT(INOUT), OPTIONAL :: err
+    INTEGER(i4),  DIMENSION(1:mp),        INTENT(INOUT), OPTIONAL :: err
 
     ! Solves the RE and, optionally, the ADE from time ts to tfin.
     ! Definitions of arguments:
@@ -3259,89 +3259,89 @@ CONTAINS
     !     linear adsorption does not require a sub, and other types
     !     are available in sub isosub.
 
-    REAL(r_2),    DIMENSION(1:mp)       :: precip, qevap
-    REAL(r_2),    DIMENSION(1:mp)       :: qL, qhL, qybL, qTbL, qhTbL, qhybL, rexcol, wcol, ql0, qv0
+    REAL(r2),    DIMENSION(1:mp)       :: precip, qevap
+    REAL(r2),    DIMENSION(1:mp)       :: qL, qhL, qybL, qTbL, qhTbL, qhybL, rexcol, wcol, ql0, qv0
     LOGICAL,      DIMENSION(1:mp)       :: again, getq0,getqn,init
     LOGICAL,      DIMENSION(1:mp,1:n)   :: again_ice
-    INTEGER(i_d), DIMENSION(1:mp)       :: ih0, iok, itmp, ns, nsat, nsatlast, nsteps0
-    REAL(r_2),    DIMENSION(1:mp)       :: accel, dmax, dt, dwinfil, dwoff, fac, Khmin1, Kmin1, phimin1, phip
-    REAL(r_2),    DIMENSION(1:mp)       :: qpme, rsig, rsigdt, sig, t
-    REAL(r_2),    DIMENSION(1:mp,1:n)   :: Sbot, Tbot
-    REAL(r_2),    DIMENSION(1:mp,1:n-1) :: dz
-    REAL(r_2),    DIMENSION(1:mp,1:n)   :: hint, phimin, qexd
-    !   REAL(r_2),    DIMENSION(1:mp,-nsnow_max+1:n)   :: aa, bb, cc, dd, ee, ff, gg, dy
-    !   REAL(r_2),    DIMENSION(1:mp,-nsnow_max+1:n)   :: aah, bbh, cch, ddh, eeh, ffh, ggh, de
-    !   REAL(r_2),    DIMENSION(1:mp,-nsnow_max:n)   :: q, qya, qyb, qTa, qTb,qhya, qhyb, qhTa, qhTb
-    !   REAL(r_2),    DIMENSION(1:mp,-nsnow_max:n)   :: qadv, qadvya, qadvyb, qadvTa, qadvTb
+    INTEGER(i4), DIMENSION(1:mp)       :: ih0, iok, itmp, ns, nsat, nsatlast, nsteps0
+    REAL(r2),    DIMENSION(1:mp)       :: accel, dmax, dt, dwinfil, dwoff, fac, Khmin1, Kmin1, phimin1, phip
+    REAL(r2),    DIMENSION(1:mp)       :: qpme, rsig, rsigdt, sig, t
+    REAL(r2),    DIMENSION(1:mp,1:n)   :: Sbot, Tbot
+    REAL(r2),    DIMENSION(1:mp,1:n-1) :: dz
+    REAL(r2),    DIMENSION(1:mp,1:n)   :: hint, phimin, qexd
+    !   REAL(r2),    DIMENSION(1:mp,-nsnow_max+1:n)   :: aa, bb, cc, dd, ee, ff, gg, dy
+    !   REAL(r2),    DIMENSION(1:mp,-nsnow_max+1:n)   :: aah, bbh, cch, ddh, eeh, ffh, ggh, de
+    !   REAL(r2),    DIMENSION(1:mp,-nsnow_max:n)   :: q, qya, qyb, qTa, qTb,qhya, qhyb, qhTa, qhTb
+    !   REAL(r2),    DIMENSION(1:mp,-nsnow_max:n)   :: qadv, qadvya, qadvyb, qadvTa, qadvTb
 
     TYPE(vars)                          :: vtmp
     !TYPE(vars),   DIMENSION(1:mp,1:n)   :: var
-    !    REAL(r_2),    DIMENSION(1:mp,-nsnow_max:n)   :: qsig, qhsig, qadvsig
-    !    REAL(r_2),    DIMENSION(1:mp,-nsnow_max:n)   :: qliq, qv, qvT, qlya, qlyb, qvya, qvyb, qlTb, qvTa, qvTb
+    !    REAL(r2),    DIMENSION(1:mp,-nsnow_max:n)   :: qsig, qhsig, qadvsig
+    !    REAL(r2),    DIMENSION(1:mp,-nsnow_max:n)   :: qliq, qv, qvT, qlya, qlyb, qvya, qvyb, qlTb, qvTa, qvTb
     TYPE(vars),   DIMENSION(1:mp,1:n)   :: vcall
-    REAL(r_2),    DIMENSION(1:mp,1:n)   :: deltaS, dTsoil
-    REAL(r_2),    DIMENSION(1:mp,0:n)   :: tmp2d1, tmp2d2
-    !    REAL(r_2),    DIMENSION(1:mp,1:n)   :: S0, Sliq0, Sliq, deltaSliq, cv0, deltacv
-    !    REAL(r_2),    DIMENSION(1:mp,1:n)   :: Sliqice0, Sliqice, deltaSliqice
-    !    REAL(r_2),    DIMENSION(1:mp,1:n)   :: Sice0, Sice, deltaSice
+    REAL(r2),    DIMENSION(1:mp,1:n)   :: deltaS, dTsoil
+    REAL(r2),    DIMENSION(1:mp,0:n)   :: tmp2d1, tmp2d2
+    !    REAL(r2),    DIMENSION(1:mp,1:n)   :: S0, Sliq0, Sliq, deltaSliq, cv0, deltacv
+    !    REAL(r2),    DIMENSION(1:mp,1:n)   :: Sliqice0, Sliqice, deltaSliqice
+    !    REAL(r2),    DIMENSION(1:mp,1:n)   :: Sice0, Sice, deltaSice
     !
-    !    REAL(r_2),    DIMENSION(1:mp,-nsnow_max+1:n)   :: Sliq0_ss, Sliq_ss, deltaSliq_ss
-    !    REAL(r_2),    DIMENSION(1:mp,-nsnow_max+1:n)   :: Sliqice0_ss, Sliqice_ss, deltaSliqice_ss
-    !    REAL(r_2),    DIMENSION(1:mp,-nsnow_max+1:n)   :: Sice0_ss, Sice_ss, deltaSice_ss
-    !    REAL(r_2),    DIMENSION(1:mp,-nsnow_max+1:n)   :: S0_ss, S_ss, deltaS_ss, Tsoil_ss, dTsoil_ss
-    !    REAL(r_2),    DIMENSION(1:mp,-nsnow_max+1:n)   :: cv0_ss, cv_ss, Dv_ss, deltacv_ss, dx_ss
-    !    REAL(r_2),    DIMENSION(1:mp,-nsnow_max+1:n-1)   :: dz_ss
-    !    REAL(r_2),      DIMENSION(1:mp,1:nsnow_max) :: cisoliqice_snow
-    !    INTEGER(i_d) :: itop ! integer corresponding to top of soil-snow column
-    !    INTEGER(i_d) :: nsnow ! number of dedicated snow layers
-    !    REAL(r_2),    DIMENSION(1:mp,1:n)   :: tmp_thetasat, tmp_thetar
-    !    REAL(r_2),    DIMENSION(1:mp,-nsnow_max+1:n)   :: thetasat_ss, thetar_ss
-    !    REAL(r_2),    DIMENSION(1:mp,-nsnow_max+1:n)   ::  tmp_tortuosity
-    !    REAL(r_2),    DIMENSION(1:mp,-nsnow_max+1:n)   ::  ciso_ss, cisoice_ss
-    !    REAL(r_2),    DIMENSION(1:mp,1:n)   :: delthetai, dthetaldT, thetal
-    INTEGER(i_d), DIMENSION(1:mp,1:n)   :: isave !, nsteps_ice, imelt
+    !    REAL(r2),    DIMENSION(1:mp,-nsnow_max+1:n)   :: Sliq0_ss, Sliq_ss, deltaSliq_ss
+    !    REAL(r2),    DIMENSION(1:mp,-nsnow_max+1:n)   :: Sliqice0_ss, Sliqice_ss, deltaSliqice_ss
+    !    REAL(r2),    DIMENSION(1:mp,-nsnow_max+1:n)   :: Sice0_ss, Sice_ss, deltaSice_ss
+    !    REAL(r2),    DIMENSION(1:mp,-nsnow_max+1:n)   :: S0_ss, S_ss, deltaS_ss, Tsoil_ss, dTsoil_ss
+    !    REAL(r2),    DIMENSION(1:mp,-nsnow_max+1:n)   :: cv0_ss, cv_ss, Dv_ss, deltacv_ss, dx_ss
+    !    REAL(r2),    DIMENSION(1:mp,-nsnow_max+1:n-1)   :: dz_ss
+    !    REAL(r2),      DIMENSION(1:mp,1:nsnow_max) :: cisoliqice_snow
+    !    INTEGER(i4) :: itop ! integer corresponding to top of soil-snow column
+    !    INTEGER(i4) :: nsnow ! number of dedicated snow layers
+    !    REAL(r2),    DIMENSION(1:mp,1:n)   :: tmp_thetasat, tmp_thetar
+    !    REAL(r2),    DIMENSION(1:mp,-nsnow_max+1:n)   :: thetasat_ss, thetar_ss
+    !    REAL(r2),    DIMENSION(1:mp,-nsnow_max+1:n)   ::  tmp_tortuosity
+    !    REAL(r2),    DIMENSION(1:mp,-nsnow_max+1:n)   ::  ciso_ss, cisoice_ss
+    !    REAL(r2),    DIMENSION(1:mp,1:n)   :: delthetai, dthetaldT, thetal
+    INTEGER(i4), DIMENSION(1:mp,1:n)   :: isave !, nsteps_ice, imelt
 
     TYPE(vars),         DIMENSION(1:mp) :: vtop, vbot
     TYPE(vars_aquifer), DIMENSION(1:mp) :: v_aquifer
-    REAL(r_2),          DIMENSION(1:mp) :: qd, dwcol, dwdrainage, drn,inlit, dwinlit, drexcol, dwdischarge
-    REAL(r_2),          DIMENSION(1:mp) :: dJcol_latent_S, dJcol_latent_T, dJcol_sensible
-    REAL(r_2),          DIMENSION(1:mp,1:n):: deltaJ_latent_S, deltaJ_latent_T, deltaJ_sensible_S, deltaJ_sensible_T
-    REAL(r_2),          DIMENSION(1:mp) :: qevapsig
-    REAL(r_2),          DIMENSION(1:mp) :: qrunoff
-    REAL(r_2),          DIMENSION(1:mp) :: tmp1d1, tmp1d2, tmp1d3,  tmp1d4
-    REAL(r_2),          DIMENSION(1:mp) :: deltah0
-    REAL(r_2),          DIMENSION(1:mp) :: SL0, deltaSL, cvL0, SLliq0, deltacvL, SLliq, deltaSLliq
-    REAL(r_2),          DIMENSION(1:mp) :: qiso_evap, qiso_trans
-    REAL(r_2),          DIMENSION(1:mp) :: lE0, G0, Epot
-    REAL(r_2),          DIMENSION(1:mp) :: Tfreezing, dT0
-    REAL(r_2),          DIMENSION(1:mp) :: dtdT
-    REAL(r_2),          DIMENSION(1:mp,-nsnow_max+1:n) :: LHS, RHS, LHS_h, RHS_h
-    INTEGER(i_d),       DIMENSION(1:mp) :: surface_case
+    REAL(r2),          DIMENSION(1:mp) :: qd, dwcol, dwdrainage, drn,inlit, dwinlit, drexcol, dwdischarge
+    REAL(r2),          DIMENSION(1:mp) :: dJcol_latent_S, dJcol_latent_T, dJcol_sensible
+    REAL(r2),          DIMENSION(1:mp,1:n):: deltaJ_latent_S, deltaJ_latent_T, deltaJ_sensible_S, deltaJ_sensible_T
+    REAL(r2),          DIMENSION(1:mp) :: qevapsig
+    REAL(r2),          DIMENSION(1:mp) :: qrunoff
+    REAL(r2),          DIMENSION(1:mp) :: tmp1d1, tmp1d2, tmp1d3,  tmp1d4
+    REAL(r2),          DIMENSION(1:mp) :: deltah0
+    REAL(r2),          DIMENSION(1:mp) :: SL0, deltaSL, cvL0, SLliq0, deltacvL, SLliq, deltaSLliq
+    REAL(r2),          DIMENSION(1:mp) :: qiso_evap, qiso_trans
+    REAL(r2),          DIMENSION(1:mp) :: lE0, G0, Epot
+    REAL(r2),          DIMENSION(1:mp) :: Tfreezing, dT0
+    REAL(r2),          DIMENSION(1:mp) :: dtdT
+    REAL(r2),          DIMENSION(1:mp,-nsnow_max+1:n) :: LHS, RHS, LHS_h, RHS_h
+    INTEGER(i4),       DIMENSION(1:mp) :: surface_case
 
-    INTEGER(i_d),       DIMENSION(1:mp) :: nns, iflux
+    INTEGER(i4),       DIMENSION(1:mp) :: nns, iflux
     LOGICAL      :: litter
-    INTEGER(i_d) :: i, j, k, kk, condition
-    INTEGER(i_d) :: littercase, isotopologue, advection ! switches
-    REAL(r_2)    :: ztmp, c2, theta
-    REAL(r_2)    :: dTqwdTa, dTqwdTb, Tqw, keff
-    REAL(r_2),          DIMENSION(1:mp) :: cp, cpeff, hice, deltahice, h0_0, hice_0, h0_tmp, hice_tmp
-    !REAL(r_2),          DIMENSION(1:mp,nsnow_max) :: qmelt, hsnow
+    INTEGER(i4) :: i, j, k, kk, condition
+    INTEGER(i4) :: littercase, isotopologue, advection ! switches
+    REAL(r2)    :: ztmp, c2, theta
+    REAL(r2)    :: dTqwdTa, dTqwdTb, Tqw, keff
+    REAL(r2),          DIMENSION(1:mp) :: cp, cpeff, hice, deltahice, h0_0, hice_0, h0_tmp, hice_tmp
+    !REAL(r2),          DIMENSION(1:mp,nsnow_max) :: qmelt, hsnow
     ! tranfer of water  from soil to   snow (+ve) or soil to snow (-ve) at init or termination of snowpack
-    REAL(r_2),  DIMENSION(1:mp) :: qtransfer
-    REAL(r_2),  DIMENSION(1:mp) :: qmelt_ss ! melt water from bottom snow layer to soil
-    REAL(r_2),  DIMENSION(1:mp) :: qprec_ss
-    REAL(r_2),  DIMENSION(1:mp) :: cprec_ss
-    REAL(r_2),          DIMENSION(1:mp,nsnow_max) :: delta_snowcol, delta_snowT, delta_snowliq, dTsnow
-    REAL(r_2),          DIMENSION(1:mp) :: melt ! cumulative loss of snow pack as melt water
-    REAL(r_2),      DIMENSION(1:mp,1:n)       :: thetai_0, J0
-    REAL(r_2) :: tmp1, tmp2
-    REAL(r_2),          DIMENSION(1:mp,1:n) :: iqex, thetal_max
-    REAL(r_2),          DIMENSION(1:mp)     :: icali
-    INTEGER(i_d),       DIMENSION(1:mp) :: nfac1, nfac2, nfac3, nfac4, nfac5, &
+    REAL(r2),  DIMENSION(1:mp) :: qtransfer
+    REAL(r2),  DIMENSION(1:mp) :: qmelt_ss ! melt water from bottom snow layer to soil
+    REAL(r2),  DIMENSION(1:mp) :: qprec_ss
+    REAL(r2),  DIMENSION(1:mp) :: cprec_ss
+    REAL(r2),          DIMENSION(1:mp,nsnow_max) :: delta_snowcol, delta_snowT, delta_snowliq, dTsnow
+    REAL(r2),          DIMENSION(1:mp) :: melt ! cumulative loss of snow pack as melt water
+    REAL(r2),      DIMENSION(1:mp,1:n)       :: thetai_0, J0
+    REAL(r2) :: tmp1, tmp2
+    REAL(r2),          DIMENSION(1:mp,1:n) :: iqex, thetal_max
+    REAL(r2),          DIMENSION(1:mp)     :: icali
+    INTEGER(i4),       DIMENSION(1:mp) :: nfac1, nfac2, nfac3, nfac4, nfac5, &
          nfac6, nfac7, nfac8, nfac9, nfac10, nfac11, nfac12
-    REAL(r_2),          DIMENSION(1:mp)     :: J0snow, wcol0snow
-    REAL(r_2), DIMENSION(1:n) :: h_ex
-    REAL(r_2) :: wpi
+    REAL(r2),          DIMENSION(1:mp)     :: J0snow, wcol0snow
+    REAL(r2), DIMENSION(1:n) :: h_ex
+    REAL(r2) :: wpi
 
     !open (unit=7, file="Test.out", status="replace", position="rewind")
     ! The derived types params and vars hold soil water parameters and variables.
@@ -3547,7 +3547,7 @@ CONTAINS
     if (littercase == 1) litter=.true. ! full litter model
 
     qexd(:,:) = zero
-    phip(:)   = zero !max(par(:,1)%phie-par(:,1)%he*par(:,1)%Ke, 1.00001_r_2*par(:,1)%phie) ! phi at h=0
+    phip(:)   = zero !max(par(:,1)%phie-par(:,1)%he*par(:,1)%Ke, 1.00001_r2*par(:,1)%phie) ! phi at h=0
 
     ! get K, Kh and phi at hmin (hmin is smallest h, stored in hy-props)
     do k=1, mp
@@ -3699,18 +3699,18 @@ CONTAINS
 
   !   IMPLICIT NONE
 
-  !   INTEGER(i_d),INTENT(IN)::n,ns,jt(n)
-  !   REAL(r_2),INTENT(IN)::ti,tf,thi(n),thf(n),win,cin(ns),dx(n),dsmmax
-  !   INTEGER(i_d),INTENT(INOUT)::nssteps(ns)
-  !   REAL(r_2),INTENT(INOUT)::sm(n,ns),sdrn(ns),c(n,ns)
+  !   INTEGER(i4),INTENT(IN)::n,ns,jt(n)
+  !   REAL(r2),INTENT(IN)::ti,tf,thi(n),thf(n),win,cin(ns),dx(n),dsmmax
+  !   INTEGER(i4),INTENT(INOUT)::nssteps(ns)
+  !   REAL(r2),INTENT(INOUT)::sm(n,ns),sdrn(ns),c(n,ns)
   !   OPTIONAL::isosub
   !   INTERFACE
   !      SUBROUTINE isosub(iso,c,p,f,fc)
-  !        USE sli_numbers, ONLY: r_2
+  !        USE sli_numbers, ONLY: r2
   !        CHARACTER(LEN=2),INTENT(IN)::iso
-  !        REAL(r_2),INTENT(IN)::c
-  !        REAL(r_2),DIMENSION(:),INTENT(INOUT)::p
-  !        REAL(r_2),INTENT(OUT)::f, fc
+  !        REAL(r2),INTENT(IN)::c
+  !        REAL(r2),DIMENSION(:),INTENT(INOUT)::p
+  !        REAL(r2),INTENT(OUT)::f, fc
   !      END SUBROUTINE isosub
   !   END INTERFACE
   !   ! Solves the ADE from time ti to tf. Diffusion of solute ignored - dispersion
@@ -3738,14 +3738,14 @@ CONTAINS
   !   !      Arguments: iso - 2 character code; c - concn in soil water;
   !   !      p(:) - isotherm parameters; f - adsorbed mass/g soil;
   !   !      fc - deriv of f wrt c (slope of isotherm curve).
-  !   INTEGER(i_d),PARAMETER::itmax=20 ! max iterations for finding c from sm
-  !   REAL(r_2),PARAMETER::eps=0.00001 ! for stopping
-  !   INTEGER(i_d)::i,it,j,k
-  !   REAL(r_2)::dc,dm,dmax,dt,dz(n-1),f,fc,r,rsig,rsigdt,sig,sigdt,t,tfin,th,v1,v2
-  !   REAL(r_2),DIMENSION(n-1)::coef1,coef2
-  !   REAL(r_2),DIMENSION(n)::csm,tht
-  !   REAL(r_2),DIMENSION(0:n)::aa,bb,cc,dd,dy,q,qw,qya,qyb
-  !   INTEGER(i_d) :: info
+  !   INTEGER(i4),PARAMETER::itmax=20 ! max iterations for finding c from sm
+  !   REAL(r2),PARAMETER::eps=0.00001 ! for stopping
+  !   INTEGER(i4)::i,it,j,k
+  !   REAL(r2)::dc,dm,dmax,dt,dz(n-1),f,fc,r,rsig,rsigdt,sig,sigdt,t,tfin,th,v1,v2
+  !   REAL(r2),DIMENSION(n-1)::coef1,coef2
+  !   REAL(r2),DIMENSION(n)::csm,tht
+  !   REAL(r2),DIMENSION(0:n)::aa,bb,cc,dd,dy,q,qw,qya,qyb
+  !   INTEGER(i4) :: info
 
   !   sig=half
   !   rsig=one/sig
@@ -3797,7 +3797,7 @@ CONTAINS
   !                  else
   !                     c(i,j)=c(i,j)+dc
   !                  end if
-  !                  if (abs(dm)<eps*(sm(i,j)+10.0_r_2*dsmmax)) exit
+  !                  if (abs(dm)<eps*(sm(i,j)+10.0_r2*dsmmax)) exit
   !                  if (it==itmax) then
   !                     write(*,*) "solute: too many iterations getting c"
   !                     stop
@@ -3820,7 +3820,7 @@ CONTAINS
   !         else
   !            dt=dsmmax/dmax
   !         end if
-  !         if (t+1.1_r_2*dt>tfin) then
+  !         if (t+1.1_r2*dt>tfin) then
   !            dt=tfin-t
   !            t=tfin
   !         else
@@ -3856,13 +3856,13 @@ CONTAINS
   ! SUBROUTINE snow_augment( mp, kk,  qprec_snow, Ta, tfin,     vsnow     &
   !      )
 
-  !   INTEGER(i_d),                               INTENT(IN)    :: mp    ! # of grid-cells
-  !   INTEGER(i_d),                               INTENT(IN)    :: kk    ! grid-cell reference
-  !   REAL(r_2),    DIMENSION(mp),             INTENT(INOUT) :: qprec_snow    ! snowfall ms-1
-  !   REAL(r_2),    DIMENSION(mp),             INTENT(IN) :: Ta    ! air temp
-  !   REAL(r_2),                 INTENT(IN) :: tfin    ! time
+  !   INTEGER(i4),                               INTENT(IN)    :: mp    ! # of grid-cells
+  !   INTEGER(i4),                               INTENT(IN)    :: kk    ! grid-cell reference
+  !   REAL(r2),    DIMENSION(mp),             INTENT(INOUT) :: qprec_snow    ! snowfall ms-1
+  !   REAL(r2),    DIMENSION(mp),             INTENT(IN) :: Ta    ! air temp
+  !   REAL(r2),                 INTENT(IN) :: tfin    ! time
   !   TYPE(vars_snow), DIMENSION(1:mp),           INTENT(INOUT) :: vsnow
-  !   REAL(r_2),       DIMENSION(1:mp) :: tmp1d1, tmp1d2
+  !   REAL(r2),       DIMENSION(1:mp) :: tmp1d1, tmp1d2
 
   !   if (qprec_snow(kk).gt.0) then
   !      ! total energy of augmented snow pack
@@ -3885,12 +3885,12 @@ CONTAINS
 
   !      ! density of augmented snow pack
   !      ! snowfall density (tmp1d1), LaChapelle 1969
-  !      if (Ta(kk) > 2.0_r_2) then
-  !         tmp1d2(kk) = 189.0_r_2
-  !      elseif ((Ta(kk) > -15.0_r_2) .and. (Ta(kk) <= 2.0_r_2)) then
-  !         tmp1d2(kk) = 50.0_r_2 + 1.7_r_2*(Ta(kk)+15.0_r_2)**1.5_r_2
+  !      if (Ta(kk) > 2.0_r2) then
+  !         tmp1d2(kk) = 189.0_r2
+  !      elseif ((Ta(kk) > -15.0_r2) .and. (Ta(kk) <= 2.0_r2)) then
+  !         tmp1d2(kk) = 50.0_r2 + 1.7_r2*(Ta(kk)+15.0_r2)**1.5_r2
   !      else
-  !         tmp1d2(kk) = 50.0_r_2
+  !         tmp1d2(kk) = 50.0_r2
   !      endif
 
   !      vsnow(kk)%dens(1) = (vsnow(kk)%dens(1)*(vsnow(kk)%hsnow(1)-qprec_snow(kk)*tfin) &
@@ -3914,27 +3914,27 @@ CONTAINS
   SUBROUTINE snow_adjust(irec, mp, n, kk, ns, h0, hice, thetai, dx, vsnow, var, par, S, Tsoil, &
        Jcol_latent_S, Jcol_latent_T, Jcol_sensible, deltaJ_sensible_S, qmelt, qtransfer, j0snow)
 
-    INTEGER(i_d),                               INTENT(IN)    :: irec  ! # of grid-cells
-    INTEGER(i_d),                               INTENT(IN)    :: mp    ! # of grid-cells
-    INTEGER(i_d),                               INTENT(IN)    :: n     ! # of soil layers
-    INTEGER(i_d),                               INTENT(IN)    :: kk    ! grid-cell reference
-    INTEGER(i_d),    DIMENSION(mp),             INTENT(INOUT) :: ns    ! pond (0), np ond (1)
-    REAL(r_2),       DIMENSION(1:n),         INTENT(IN)    :: dx    ! soil depths
-    REAL(r_2),       DIMENSION(1:n),         INTENT(INOUT) :: Tsoil ! soil temperatures soil
-    REAL(r_2),       DIMENSION(1:n),         INTENT(INOUT) :: S     ! soil temperatures soil
-    REAL(r_2),       DIMENSION(mp),             INTENT(INOUT) :: h0, hice, j0snow ! pond
-    REAL(r_2),       DIMENSION(1:n),       INTENT(INOUT) :: thetai
-    REAL(r_2),       DIMENSION(1:mp),           INTENT(INOUT) :: Jcol_latent_S, Jcol_latent_T, Jcol_sensible
-    REAL(r_2),       DIMENSION(1:n),       INTENT(INOUT) :: deltaJ_sensible_S
-    REAL(r_2),       DIMENSION(nsnow_max), INTENT(INOUT) :: qmelt
-    REAL(r_2),       DIMENSION(1:mp), INTENT(OUT) :: qtransfer
+    INTEGER(i4),                               INTENT(IN)    :: irec  ! # of grid-cells
+    INTEGER(i4),                               INTENT(IN)    :: mp    ! # of grid-cells
+    INTEGER(i4),                               INTENT(IN)    :: n     ! # of soil layers
+    INTEGER(i4),                               INTENT(IN)    :: kk    ! grid-cell reference
+    INTEGER(i4),    DIMENSION(mp),             INTENT(INOUT) :: ns    ! pond (0), np ond (1)
+    REAL(r2),       DIMENSION(1:n),         INTENT(IN)    :: dx    ! soil depths
+    REAL(r2),       DIMENSION(1:n),         INTENT(INOUT) :: Tsoil ! soil temperatures soil
+    REAL(r2),       DIMENSION(1:n),         INTENT(INOUT) :: S     ! soil temperatures soil
+    REAL(r2),       DIMENSION(mp),             INTENT(INOUT) :: h0, hice, j0snow ! pond
+    REAL(r2),       DIMENSION(1:n),       INTENT(INOUT) :: thetai
+    REAL(r2),       DIMENSION(1:mp),           INTENT(INOUT) :: Jcol_latent_S, Jcol_latent_T, Jcol_sensible
+    REAL(r2),       DIMENSION(1:n),       INTENT(INOUT) :: deltaJ_sensible_S
+    REAL(r2),       DIMENSION(nsnow_max), INTENT(INOUT) :: qmelt
+    REAL(r2),       DIMENSION(1:mp), INTENT(OUT) :: qtransfer
     TYPE(vars),      DIMENSION(1:n),       INTENT(INOUT) :: var
     TYPE(params),    DIMENSION(1:n),       INTENT(IN) :: par
     TYPE(vars_snow), DIMENSION(1:mp),           INTENT(INOUT) :: vsnow
-    REAL(r_2),       DIMENSION(1:mp) :: tmp1d1, tmp1d2, tmp1d3,  tmp1d4
-    REAL(r_2),       DIMENSION(1:mp) :: h0_tmp, hice_tmp
-    REAL(r_2) :: theta, tmp1, tmp2 ,Tfreezing(1:mp), Jsoil, theta_tmp
-    INTEGER(i_d) :: i,j ! counters
+    REAL(r2),       DIMENSION(1:mp) :: tmp1d1, tmp1d2, tmp1d3,  tmp1d4
+    REAL(r2),       DIMENSION(1:mp) :: h0_tmp, hice_tmp
+    REAL(r2) :: theta, tmp1, tmp2 ,Tfreezing(1:mp), Jsoil, theta_tmp
+    INTEGER(i4) :: i,j ! counters
     LOGICAL :: melt_transfer=.true.
 
     tmp1d1(kk) = h0(kk)+dx(1)*(var(1)%thetai+var(1)%thetal) ! total moisture content of top soil layer + pond
@@ -3945,7 +3945,7 @@ CONTAINS
     ! no dedicated snow pack if solid part of cumulated snow is less than min thresshold
     ! also, don't initialise dedicated snowpack if this would deplete water in top soil layer to less than 1 mm
     if (((vsnow(kk)%wcol-sum(vsnow(kk)%hliq(:)))<snmin*(vsnow(kk)%dens(1)/rhow)).or. &
-         ((vsnow(kk)%nsnow==0).and.(tmp1d1(kk)-vsnow(kk)%wcol)<0.001_r_2)) then
+         ((vsnow(kk)%nsnow==0).and.(tmp1d1(kk)-vsnow(kk)%wcol)<0.001_r2)) then
        vsnow(kk)%nsnow = 0
        theta         = S(1)*(par(1)%thre) + (par(1)%the - par(1)%thre)
        if (vsnow(kk)%hsnow(1)>zero)  then ! termination of dedicated snow layer
@@ -4012,7 +4012,7 @@ CONTAINS
 
              Jsoil = tmp1d1(kk)+tmp1d2(kk)! total energy in  soil layer
              !check there is a zero
-             tmp1 = GTfrozen(Tsoil(1)-50._r_2, Jsoil, dx(1), theta,par(1)%css, par(1)%rho, &
+             tmp1 = GTfrozen(Tsoil(1)-50._r2, Jsoil, dx(1), theta,par(1)%css, par(1)%rho, &
                   h0(kk), par(1)%thre, par(1)%the, par(1)%he, one/(par(1)%lambc*freezefac))
 
              tmp2 = GTFrozen(Tfreezing(kk), Jsoil, dx(1), theta,par(1)%css, par(1)%rho, &
@@ -4022,7 +4022,7 @@ CONTAINS
              if ((tmp1*tmp2) < zero) then
                 tmp1d3(kk) = rtbis_Tfrozen(tmp1d2(kk), dx(1), theta,par(1)%css, par(1)%rho, &
                      h0(kk), par(1)%thre, par(1)%the, par(1)%he, one/(par(1)%lambc*freezefac), &
-                     Tsoil(1)-50._r_2, Tfreezing(kk))
+                     Tsoil(1)-50._r2, Tfreezing(kk))
 
                 tmp1d4(kk) = thetalmax(tmp1d3(kk), S(1), par(1)%he, one/(par(1)%lambc*freezefac), &
                      par(1)%thre, par(1)%the) ! liquid content at new Tsoil
@@ -4031,7 +4031,7 @@ CONTAINS
                 write(wlogn,*) "Assume soil is totally frozen"
                 tmp1d3(kk) = (tmp1d2(kk) + rhow*lambdaf*(theta*dx(1) +  h0(kk))) / &
                      (dx(1)*par(1)%css*par(1)%rho + rhow*csice*(theta*dx(1) + h0(kk)))
-                tmp1d4(kk) = 0.0_r_2
+                tmp1d4(kk) = 0.0_r2
                 write(wlogn,*) "frozen soil temperature: ", tmp1d3(kk)
              endif
 
@@ -4184,7 +4184,7 @@ CONTAINS
 
                    Jsoil = tmp1d1(kk)+tmp1d2(kk)! total energy in  soil layer
                    !check there is a zero
-                   tmp1 = GTfrozen(Tsoil(1)-50._r_2, Jsoil, dx(1), theta,par(1)%css, par(1)%rho, &
+                   tmp1 = GTfrozen(Tsoil(1)-50._r2, Jsoil, dx(1), theta,par(1)%css, par(1)%rho, &
                         h0(kk), par(1)%thre, par(1)%the, par(1)%he, one/(par(1)%lambc*freezefac))
 
                    tmp2 = GTFrozen(Tfreezing(kk), Jsoil, dx(1), theta,par(1)%css, par(1)%rho, &
@@ -4194,7 +4194,7 @@ CONTAINS
                    if ((tmp1*tmp2) < zero) then
                       tmp1d3(kk) = rtbis_Tfrozen(tmp1d2(kk), dx(1), theta,par(1)%css, par(1)%rho, &
                            h0(kk), par(1)%thre, par(1)%the, par(1)%he, one/(par(1)%lambc*freezefac), &
-                           Tsoil(1)-50._r_2, Tfreezing(kk))
+                           Tsoil(1)-50._r2, Tfreezing(kk))
 
                       tmp1d4(kk) = thetalmax(tmp1d3(kk), S(1), par(1)%he, one/(par(1)%lambc*freezefac), &
                            par(1)%thre, par(1)%the) ! liquid content at new Tsoil
@@ -4203,7 +4203,7 @@ CONTAINS
                       write(wlogn,*) "Assume soil is totally frozen"
                       tmp1d3(kk) = (Jsoil + rhow*lambdaf*(theta*dx(1) +  h0(kk))) / &
                            (dx(1)*par(1)%css*par(1)%rho + rhow*csice*(theta*dx(1) + h0(kk)))
-                      tmp1d4(kk) = 0.0_r_2
+                      tmp1d4(kk) = 0.0_r2
                       write(wlogn,*) "frozen soil temperature: ", tmp1d3(kk)
                    endif
 
@@ -4265,7 +4265,7 @@ CONTAINS
        ! get snow melt from top layer
        if ((vsnow(kk)%hliq(1) - vsnow(kk)%hsnow(1)*vsnow(kk)%fsnowliq_max(1))>zero) then ! remove melt water
           qmelt(1) = max((vsnow(kk)%hliq(1) - vsnow(kk)%hsnow(1)*vsnow(kk)%fsnowliq_max(1)),zero)
-          qmelt(1) = min(qmelt(1), max(0.9_r_2*(vsnow(kk)%hsnow(1)-snmin*(vsnow(kk)%dens(1)/rhow)),zero))
+          qmelt(1) = min(qmelt(1), max(0.9_r2*(vsnow(kk)%hsnow(1)-snmin*(vsnow(kk)%dens(1)/rhow)),zero))
           vsnow(kk)%melt(1) = vsnow(kk)%melt(1) + qmelt(1)
           vsnow(kk)%hliq(1) = vsnow(kk)%hliq(1) - qmelt(1)
           vsnow(kk)%hsnow(1) = vsnow(kk)%hsnow(1) - qmelt(1)
@@ -4273,7 +4273,7 @@ CONTAINS
           !tmp1d3(kk) = vsnow(kk)%dens(1)*(one-vsnow(kk)%hliq(1)/vsnow(kk)%hsnow(1))
           !vsnow(kk)%depth(1) = vsnow(kk)%depth(1) - qmelt(1)*rhow/tmp1d3(kk)
           ! vsnow(kk)%dens(1) = vsnow(kk)%hsnow(1)*rhow/vsnow(kk)%depth(1)
-          !vsnow(kk)%dens(1) = max(vsnow(kk)%dens(1) - rhow*qmelt(1)/vsnow(kk)%depth(1), 50.0_r_2)
+          !vsnow(kk)%dens(1) = max(vsnow(kk)%dens(1) - rhow*qmelt(1)/vsnow(kk)%depth(1), 50.0_r2)
           do i=1, vsnow(kk)%nsnow
              vsnow(kk)%Jsensible(i) = (vsnow(kk)%hsnow(i)-vsnow(kk)%hliq(i))*rhow*csice*(vsnow(kk)%Tsn(i))
              vsnow(kk)%Jlatent(i) = (vsnow(kk)%hsnow(i)-vsnow(kk)%hliq(i))*rhow*(-lambdaf)
@@ -4302,10 +4302,10 @@ CONTAINS
 
              qmelt(vsnow(kk)%nsnow) =  tmp1d1(kk) + vsnow(kk)%melt(1) - &
                   vsnow(kk)%fsnowliq_max(vsnow(kk)%nsnow)*(tmp1d2(kk) - tmp1d1(kk))/ &
-                  (1._r_2-vsnow(kk)%fsnowliq_max(vsnow(kk)%nsnow))
+                  (1._r2-vsnow(kk)%fsnowliq_max(vsnow(kk)%nsnow))
 
              vsnow(kk)%hliq(vsnow(kk)%nsnow) = vsnow(kk)%fsnowliq_max(vsnow(kk)%nsnow)*(tmp1d2(kk)  - tmp1d1(kk) )/ &
-                  (1._r_2-vsnow(kk)%fsnowliq_max(vsnow(kk)%nsnow))
+                  (1._r2-vsnow(kk)%fsnowliq_max(vsnow(kk)%nsnow))
 
 
              vsnow(kk)%hsnow(vsnow(kk)%nsnow) = (tmp1d2(kk) - tmp1d1(kk)) + vsnow(kk)%hliq(vsnow(kk)%nsnow)
@@ -4338,11 +4338,11 @@ CONTAINS
 
                    qmelt(vsnow(kk)%nsnow) =  vsnow(kk)%hliq(vsnow(kk)%nsnow) - &
                         vsnow(kk)%fsnowliq_max(vsnow(kk)%nsnow)*(vsnow(kk)%hsnow(vsnow(kk)%nsnow) - &
-                        vsnow(kk)%hliq(vsnow(kk)%nsnow))/(1._r_2-vsnow(kk)%fsnowliq_max(vsnow(kk)%nsnow))
+                        vsnow(kk)%hliq(vsnow(kk)%nsnow))/(1._r2-vsnow(kk)%fsnowliq_max(vsnow(kk)%nsnow))
 
                    vsnow(kk)%hliq(vsnow(kk)%nsnow) = vsnow(kk)%fsnowliq_max(vsnow(kk)%nsnow)*(vsnow(kk)%hsnow(vsnow(kk)%nsnow) &
                         - vsnow(kk)%hliq(vsnow(kk)%nsnow))/ &
-                        (1._r_2-vsnow(kk)%fsnowliq_max(vsnow(kk)%nsnow))
+                        (1._r2-vsnow(kk)%fsnowliq_max(vsnow(kk)%nsnow))
 
                    vsnow(kk)%hsnow(vsnow(kk)%nsnow) = vsnow(kk)%hsnow(vsnow(kk)%nsnow) -  &
                         tmp1d1(kk) + vsnow(kk)%hliq(vsnow(kk)%nsnow)
@@ -4434,7 +4434,7 @@ CONTAINS
                    ! frozen remaining frozen
                    Jsoil = tmp1d2(kk) ! total energy in  soil layer
                    !check there is a zero
-                   tmp1 = GTfrozen(Tsoil(1)-50._r_2, Jsoil, dx(1), theta,par(1)%css, par(1)%rho, &
+                   tmp1 = GTfrozen(Tsoil(1)-50._r2, Jsoil, dx(1), theta,par(1)%css, par(1)%rho, &
                         h0(kk), par(1)%thre, par(1)%the, par(1)%he, one/(par(1)%lambc*freezefac))
 
                    tmp2 = GTFrozen(Tfreezing(kk), Jsoil, dx(1), theta,par(1)%css, par(1)%rho, &
@@ -4444,7 +4444,7 @@ CONTAINS
                    if ((tmp1*tmp2) < zero) then
                       tmp1d3(kk) = rtbis_Tfrozen(tmp1d2(kk), dx(1), theta,par(1)%css, par(1)%rho, &
                            h0(kk), par(1)%thre, par(1)%the, par(1)%he, one/(par(1)%lambc*freezefac), &
-                           Tsoil(1)-50._r_2, Tfreezing(kk))
+                           Tsoil(1)-50._r2, Tfreezing(kk))
 
                       tmp1d4(kk) = thetalmax(tmp1d3(kk), S(1), par(1)%he, one/(par(1)%lambc*freezefac), &
                            par(1)%thre, par(1)%the) ! liquid content at new Tsoil
@@ -4453,7 +4453,7 @@ CONTAINS
                       write(wlogn,*) "Assume soil is totally frozen"
                       tmp1d3(kk) = (Jsoil + rhow*lambdaf*(theta*dx(1) +  h0(kk))) / &
                            (dx(1)*par(1)%css*par(1)%rho + rhow*csice*(theta*dx(1) + h0(kk)))
-                      tmp1d4(kk) = 0.0_r_2
+                      tmp1d4(kk) = 0.0_r2
                       write(wlogn,*) "frozen soil temperature: ", tmp1d3(kk)
                    endif
 
@@ -4492,11 +4492,11 @@ CONTAINS
 
        do i=1, vsnow(kk)%nsnow
           vsnow(kk)%dens(i) = vsnow(kk)%hsnow(i)/vsnow(kk)%depth(i)*rhow
-          if (vsnow(kk)%dens(i).lt.50._r_2) then
-             vsnow(kk)%dens(i) = 50.0_r_2
+          if (vsnow(kk)%dens(i).lt.50._r2) then
+             vsnow(kk)%dens(i) = 50.0_r2
              vsnow(kk)%depth(i) = vsnow(kk)%hsnow(i)*rhow/vsnow(kk)%dens(i)
           endif
-          tmp1d3(kk) = (500._r_2*(vsnow(kk)%hsnow(i)-vsnow(kk)%hliq(i)) + rhow*vsnow(kk)%hliq(i))/vsnow(kk)%hsnow(i)
+          tmp1d3(kk) = (500._r2*(vsnow(kk)%hsnow(i)-vsnow(kk)%hliq(i)) + rhow*vsnow(kk)%hliq(i))/vsnow(kk)%hsnow(i)
           if (vsnow(kk)%dens(i).gt.tmp1d3(kk)) then
              vsnow(kk)%dens(i) = tmp1d3(kk)
              vsnow(kk)%depth(i) = vsnow(kk)%hsnow(i)*rhow/vsnow(kk)%dens(i)
@@ -4507,13 +4507,13 @@ CONTAINS
        vsnow(kk)%totdepth = sum(vsnow(kk)%depth(1:vsnow(kk)%nsnow))
 
        ! adjust number of snow layers if required
-       if (nsnow_max>1.and.vsnow(kk)%totdepth > 0.03_r_2) then
+       if (nsnow_max>1.and.vsnow(kk)%totdepth > 0.03_r2) then
           tmp1d3(kk) = vsnow(kk)%depth(1)
 
-          if (vsnow(kk)%totdepth.lt.0.06_r_2) then
-             vsnow(kk)%depth(1) = vsnow(kk)%totdepth/2._r_2
+          if (vsnow(kk)%totdepth.lt.0.06_r2) then
+             vsnow(kk)%depth(1) = vsnow(kk)%totdepth/2._r2
           else
-             vsnow(kk)%depth(1) = 0.03_r_2
+             vsnow(kk)%depth(1) = 0.03_r2
           endif
           vsnow(kk)%depth(nsnow_max) = vsnow(kk)%totdepth -  vsnow(kk)%depth(1)
 
@@ -4562,7 +4562,7 @@ CONTAINS
 
           endif
 
-       elseif (nsnow_max>1.and.vsnow(kk)%nsnow == 2.and.(vsnow(kk)%totdepth).le.0.03_r_2) then
+       elseif (nsnow_max>1.and.vsnow(kk)%nsnow == 2.and.(vsnow(kk)%totdepth).le.0.03_r2) then
           ! combine top two snow layers into 1
 
           ! total energy of combined snow layer
@@ -4593,10 +4593,10 @@ CONTAINS
        endif
 
        do i=1, vsnow(kk)%nsnow
-          vsnow(kk)%Dv(i) = Dva*((vsnow(kk)%tsn(i)+Tzero)/Tzero)**1.88_r_2 ! m2 s-1
+          vsnow(kk)%Dv(i) = Dva*((vsnow(kk)%tsn(i)+Tzero)/Tzero)**1.88_r2 ! m2 s-1
           vsnow(kk)%sl(i) = slope_esat_ice(vsnow(kk)%tsn(i)) * Mw/thousand/Rgas/(vsnow(kk)%tsn(i)+Tzero)
           vsnow(kk)%kE(i)     = vsnow(kk)%Dv(i)*vsnow(kk)%sl(i)*thousand*lambdaf
-          vsnow(kk)%kH(i) = 3.2217e-6_r_2 * vsnow(kk)%dens(i)**2
+          vsnow(kk)%kH(i) = 3.2217e-6_r2 * vsnow(kk)%dens(i)**2
           vsnow(kk)%kth(i) = vsnow(kk)%kE(i) + vsnow(kk)%kH(i)
           vsnow(kk)%cv(i) = esat_ice(vsnow(kk)%tsn(i))*Mw/thousand/Rgas/(vsnow(kk)%tsn(i)+Tzero) ! m3 m-3
           vsnow(kk)%depth(i) = vsnow(kk)%hsnow(i)/(vsnow(kk)%dens(i)/rhow)
@@ -4625,95 +4625,95 @@ CONTAINS
 
 
     IMPLICIT NONE
-    INTEGER(i_d),                    INTENT(IN)    :: irec
-    INTEGER(i_d),                    INTENT(IN)    :: isotopologue ! which isotope
-    INTEGER(i_d),                    INTENT(IN)    :: n            ! # of soil layers
-    INTEGER(i_d),                    INTENT(IN)    :: nsnow        ! # of snow layers
-    INTEGER(i_d),                    INTENT(IN)    :: nsnow_last   ! # of snow layers
-    INTEGER(i_d),                    INTENT(IN)    :: ns           ! index of top of soil/snow column (-nsnow_max+1)
-    REAL(r_2),    DIMENSION(ns:n),   INTENT(IN)    :: dx           ! soil/snow depths
-    REAL(r_2),    DIMENSION(ns:n-1), INTENT(IN)    :: deltaz       ! soil/snow layer thickness
-    REAL(r_2),                       INTENT(IN)    :: sig          ! implicit/explicit time steping constant
-    REAL(r_2),                       INTENT(IN)    :: dt           ! time step
-    REAL(r_2),    DIMENSION(ns:n),   INTENT(IN)    :: Tsoil0       ! soil/snow temperatures
-    REAL(r_2),    DIMENSION(ns:n),   INTENT(IN)    :: dTsoil       ! soil/snow temperatures change
-    REAL(r_2),    DIMENSION(ns:n),   INTENT(IN)    :: Sliqice      ! soil saturation
-    REAL(r_2),    DIMENSION(ns:n),   INTENT(IN)    :: deltaSliqice ! soil sturation change
-    REAL(r_2),    DIMENSION(ns:n),   INTENT(IN)    :: Sliq         ! soil saturation
-    REAL(r_2),    DIMENSION(ns:n),   INTENT(IN)    :: deltaSliq    ! soil sturation change
-    REAL(r_2),    DIMENSION(ns:n),   INTENT(IN)    :: Sice         ! soil saturation
-    REAL(r_2),    DIMENSION(ns:n),   INTENT(IN)    :: deltaSice    ! soil sturation change
-    REAL(r_2),                       INTENT(IN)    :: Ts           ! surface temperature
-    REAL(r_2),                       INTENT(IN)    :: Ta           ! air temperature [degC]
-    REAL(r_2),    DIMENSION(ns-1:n), INTENT(IN)    :: qsig         ! water flux
-    REAL(r_2),    DIMENSION(ns-1:n), INTENT(INOUT) :: qlsig        ! liquid water flux
-    REAL(r_2),    DIMENSION(ns-1:n), INTENT(INOUT) :: qvsig        ! vapour flux
-    REAL(r_2),                       INTENT(IN)    :: qprec        ! liquid  precip
-    REAL(r_2),                       INTENT(IN)    :: qprec_snow   ! solid precip
-    REAL(r_2),                       INTENT(IN)    :: qevap        ! evaporation
-    REAL(r_2),                       INTENT(IN)    :: qrunoff      ! runoff
-    REAL(r_2),    DIMENSION(1:n),    INTENT(IN)    :: qex          ! root extraction
-    REAL(r_2),                       INTENT(IN)    :: qmelt        !  melt water ! should eventually be dimensioned nsnow_max
-    REAL(r_2),                       INTENT(IN)    :: qtransfer    ! water transfer from soil to snow (+ve) or snow to soil (-ve)
+    INTEGER(i4),                    INTENT(IN)    :: irec
+    INTEGER(i4),                    INTENT(IN)    :: isotopologue ! which isotope
+    INTEGER(i4),                    INTENT(IN)    :: n            ! # of soil layers
+    INTEGER(i4),                    INTENT(IN)    :: nsnow        ! # of snow layers
+    INTEGER(i4),                    INTENT(IN)    :: nsnow_last   ! # of snow layers
+    INTEGER(i4),                    INTENT(IN)    :: ns           ! index of top of soil/snow column (-nsnow_max+1)
+    REAL(r2),    DIMENSION(ns:n),   INTENT(IN)    :: dx           ! soil/snow depths
+    REAL(r2),    DIMENSION(ns:n-1), INTENT(IN)    :: deltaz       ! soil/snow layer thickness
+    REAL(r2),                       INTENT(IN)    :: sig          ! implicit/explicit time steping constant
+    REAL(r2),                       INTENT(IN)    :: dt           ! time step
+    REAL(r2),    DIMENSION(ns:n),   INTENT(IN)    :: Tsoil0       ! soil/snow temperatures
+    REAL(r2),    DIMENSION(ns:n),   INTENT(IN)    :: dTsoil       ! soil/snow temperatures change
+    REAL(r2),    DIMENSION(ns:n),   INTENT(IN)    :: Sliqice      ! soil saturation
+    REAL(r2),    DIMENSION(ns:n),   INTENT(IN)    :: deltaSliqice ! soil sturation change
+    REAL(r2),    DIMENSION(ns:n),   INTENT(IN)    :: Sliq         ! soil saturation
+    REAL(r2),    DIMENSION(ns:n),   INTENT(IN)    :: deltaSliq    ! soil sturation change
+    REAL(r2),    DIMENSION(ns:n),   INTENT(IN)    :: Sice         ! soil saturation
+    REAL(r2),    DIMENSION(ns:n),   INTENT(IN)    :: deltaSice    ! soil sturation change
+    REAL(r2),                       INTENT(IN)    :: Ts           ! surface temperature
+    REAL(r2),                       INTENT(IN)    :: Ta           ! air temperature [degC]
+    REAL(r2),    DIMENSION(ns-1:n), INTENT(IN)    :: qsig         ! water flux
+    REAL(r2),    DIMENSION(ns-1:n), INTENT(INOUT) :: qlsig        ! liquid water flux
+    REAL(r2),    DIMENSION(ns-1:n), INTENT(INOUT) :: qvsig        ! vapour flux
+    REAL(r2),                       INTENT(IN)    :: qprec        ! liquid  precip
+    REAL(r2),                       INTENT(IN)    :: qprec_snow   ! solid precip
+    REAL(r2),                       INTENT(IN)    :: qevap        ! evaporation
+    REAL(r2),                       INTENT(IN)    :: qrunoff      ! runoff
+    REAL(r2),    DIMENSION(1:n),    INTENT(IN)    :: qex          ! root extraction
+    REAL(r2),                       INTENT(IN)    :: qmelt        !  melt water ! should eventually be dimensioned nsnow_max
+    REAL(r2),                       INTENT(IN)    :: qtransfer    ! water transfer from soil to snow (+ve) or snow to soil (-ve)
     ! TYPE(vars), DIMENSION(1:n),   INTENT(IN)    :: var           ! soil variables
-    REAL(r_2), DIMENSION(ns:n),   INTENT(IN)    :: var_cv        ! soil/snow variables cv
-    REAL(r_2), DIMENSION(ns:n),   INTENT(IN)    :: var_Dv        ! soil/snow variables Dv
-    REAL(r_2), DIMENSION(ns:n),   INTENT(IN)    :: thetasat      ! saturation moisture
-    REAL(r_2), DIMENSION(ns:n),   INTENT(IN)    :: thetar        ! residual moisture
-    REAL(r_2), DIMENSION(ns:n),   INTENT(IN)    :: tortuosity    ! soil tortuosity
-    REAL(r_2), DIMENSION(ns:n),   INTENT(INOUT) :: deltacv       !
-    REAL(r_2),                    INTENT(IN)    :: rbw           ! boundary layer resistance
-    REAL(r_2),                    INTENT(IN)    :: cva           !
-    REAL(r_2),                    INTENT(IN)    :: civa          ! iso conc in air
-    REAL(r_2),                    INTENT(IN)    :: cprec         ! iso conc in liquid precip
-    REAL(r_2),                    INTENT(IN)    :: cprec_snow    ! iso conc in snow
-    REAL(r_2),                    INTENT(IN)    :: cali          ! iso conc in alimenation water (from below)
-    REAL(r_2),                    INTENT(INOUT) :: ql0           ! liquid flux into soil or snow surface
-    REAL(r_2),                    INTENT(INOUT) :: qv0           ! vapour flux into soil or snow surface
-    REAL(r_2), DIMENSION(ns:n),   INTENT(INOUT) :: ciso          ! iso conc in soil
-    REAL(r_2), DIMENSION(ns:n),   INTENT(INOUT) :: cisoice       ! iso conc in soil
-    REAL(r_2),                    INTENT(INOUT) :: cisos         ! iso conc on surface
-    REAL(r_2),                    INTENT(OUT)   :: qiso_in       ! iso flux into soil
-    REAL(r_2),                    INTENT(OUT)   :: qiso_out      ! iso flux out of soil
-    REAL(r_2),                    INTENT(OUT)   :: qiso_evap     ! iso flux of evaporation
-    REAL(r_2),                    INTENT(OUT)   :: qiso_trans    ! iso flux of transpiration
-    REAL(r_2), DIMENSION(ns:n),   INTENT(OUT)   :: qiso_liq_adv  ! liquid iso flux in soil due to advection
-    REAL(r_2), DIMENSION(ns:n),   INTENT(OUT)   :: qiso_vap_adv  ! vapour iso flux in soil due to advection
-    REAL(r_2), DIMENSION(ns:n-1), INTENT(OUT)   :: qiso_liq_diff ! liquid iso flux in soil due to diffusion
-    REAL(r_2), DIMENSION(ns:n-1), INTENT(OUT)   :: qiso_vap_diff ! vapour iso flux in soil due to diffusion
+    REAL(r2), DIMENSION(ns:n),   INTENT(IN)    :: var_cv        ! soil/snow variables cv
+    REAL(r2), DIMENSION(ns:n),   INTENT(IN)    :: var_Dv        ! soil/snow variables Dv
+    REAL(r2), DIMENSION(ns:n),   INTENT(IN)    :: thetasat      ! saturation moisture
+    REAL(r2), DIMENSION(ns:n),   INTENT(IN)    :: thetar        ! residual moisture
+    REAL(r2), DIMENSION(ns:n),   INTENT(IN)    :: tortuosity    ! soil tortuosity
+    REAL(r2), DIMENSION(ns:n),   INTENT(INOUT) :: deltacv       !
+    REAL(r2),                    INTENT(IN)    :: rbw           ! boundary layer resistance
+    REAL(r2),                    INTENT(IN)    :: cva           !
+    REAL(r2),                    INTENT(IN)    :: civa          ! iso conc in air
+    REAL(r2),                    INTENT(IN)    :: cprec         ! iso conc in liquid precip
+    REAL(r2),                    INTENT(IN)    :: cprec_snow    ! iso conc in snow
+    REAL(r2),                    INTENT(IN)    :: cali          ! iso conc in alimenation water (from below)
+    REAL(r2),                    INTENT(INOUT) :: ql0           ! liquid flux into soil or snow surface
+    REAL(r2),                    INTENT(INOUT) :: qv0           ! vapour flux into soil or snow surface
+    REAL(r2), DIMENSION(ns:n),   INTENT(INOUT) :: ciso          ! iso conc in soil
+    REAL(r2), DIMENSION(ns:n),   INTENT(INOUT) :: cisoice       ! iso conc in soil
+    REAL(r2),                    INTENT(INOUT) :: cisos         ! iso conc on surface
+    REAL(r2),                    INTENT(OUT)   :: qiso_in       ! iso flux into soil
+    REAL(r2),                    INTENT(OUT)   :: qiso_out      ! iso flux out of soil
+    REAL(r2),                    INTENT(OUT)   :: qiso_evap     ! iso flux of evaporation
+    REAL(r2),                    INTENT(OUT)   :: qiso_trans    ! iso flux of transpiration
+    REAL(r2), DIMENSION(ns:n),   INTENT(OUT)   :: qiso_liq_adv  ! liquid iso flux in soil due to advection
+    REAL(r2), DIMENSION(ns:n),   INTENT(OUT)   :: qiso_vap_adv  ! vapour iso flux in soil due to advection
+    REAL(r2), DIMENSION(ns:n-1), INTENT(OUT)   :: qiso_liq_diff ! liquid iso flux in soil due to diffusion
+    REAL(r2), DIMENSION(ns:n-1), INTENT(OUT)   :: qiso_vap_diff ! vapour iso flux in soil due to diffusion
 
     ! Local variables
 
-    REAL(r_2), DIMENSION(ns:n)   :: aa, bb, cc, dd, dc,  LHS, RHS
-    REAL(r_2), DIMENSION(ns:n)   :: alphaplus, dalphaplusdT, deltaT, beta, deltabeta
-    REAL(r_2), DIMENSION(ns:n)   :: alphaplus_liqice, dalphaplusdT_liqice
+    REAL(r2), DIMENSION(ns:n)   :: aa, bb, cc, dd, dc,  LHS, RHS
+    REAL(r2), DIMENSION(ns:n)   :: alphaplus, dalphaplusdT, deltaT, beta, deltabeta
+    REAL(r2), DIMENSION(ns:n)   :: alphaplus_liqice, dalphaplusdT_liqice
     ! diffusivities (liquid, liq-vap, coefft for D, surface H2O vapour, surface minor isotopologue vapour)
-    REAL(r_2), DIMENSION(ns-1:n) :: Dl, Dv
-    ! REAL(r_2)                    :: Dvs, Divs
-    REAL(r_2)                    :: patm, nk, alphak, alphak_vdiff, alphak_ldiff
-    REAL(r_2)                    :: cevapin, cevapout, qevapin, qevapout, dcevapoutdciso
+    REAL(r2), DIMENSION(ns-1:n) :: Dl, Dv
+    ! REAL(r2)                    :: Dvs, Divs
+    REAL(r2)                    :: patm, nk, alphak, alphak_vdiff, alphak_ldiff
+    REAL(r2)                    :: cevapin, cevapout, qevapin, qevapout, dcevapoutdciso
     ! concentrations of advective fluxes and corresponding partial derivs wrt ciso
-    REAL(r_2), DIMENSION(ns-1:n) :: cql, dcqldca, dcqldcb, cqv, dcqvdca, dcqvdcb
-    REAL(r_2), DIMENSION(ns:n-1) :: wcql, wcqv
-    REAL(r_2), DIMENSION(ns-1:n) :: betaqv, dbetaqv
-    REAL(r_2), DIMENSION(ns-1:n) :: Dlmean, Dvmean, Dvbetamean, wl, wv
-    REAL(r_2)                    :: coefA, coefB, coefC
-    REAL(r_2)                    :: coefA_liqice, coefB_liqice, coefC_liqice
-    REAL(r_2), DIMENSION(ns:n)   :: Seff, deltaSeff, S, Tsoil, cvsig, Sliqsig, Sicesig,qex_ss
-    REAL(r_2), DIMENSION(ns:n)   :: thetaice, deltathetaice, dcice
-    INTEGER(i_d)                 :: ns_ciso
-    REAL(r_2)                    :: num, den, cv1
-    REAL(r_2)                    :: alphaplus_s, alphaplus_a
-    ! REAL(r_2)                    :: alphaplus_liqice
-    REAL(r_2)                    :: cvs !, qevapL, qevapoutL, qevapinL
-    ! REAL(r_2)                    :: cevapinL, cevapoutL, dcevapoutdcisoL, dcevapindcisoL
-    REAL(r_2)                    :: w1, w2
-    INTEGER(i_d), PARAMETER      :: formulation = 2  ! 1: betaql, betaqv of flux; 2: betaql, betaqv 0.5 of upper and lower
-    REAL(r_2), DIMENSION(ns:n)   :: kfreeze, kfreeze2         ! combination of freezing variables
-    REAL(r_2),   DIMENSION(ns:n) :: deltaS     !
-    INTEGER(i_d), DIMENSION(1)   :: ii
-    REAL(r_2)                    :: tmp
-    REAL(r_2), DIMENSION(ns:n)   :: tmp1d1
+    REAL(r2), DIMENSION(ns-1:n) :: cql, dcqldca, dcqldcb, cqv, dcqvdca, dcqvdcb
+    REAL(r2), DIMENSION(ns:n-1) :: wcql, wcqv
+    REAL(r2), DIMENSION(ns-1:n) :: betaqv, dbetaqv
+    REAL(r2), DIMENSION(ns-1:n) :: Dlmean, Dvmean, Dvbetamean, wl, wv
+    REAL(r2)                    :: coefA, coefB, coefC
+    REAL(r2)                    :: coefA_liqice, coefB_liqice, coefC_liqice
+    REAL(r2), DIMENSION(ns:n)   :: Seff, deltaSeff, S, Tsoil, cvsig, Sliqsig, Sicesig,qex_ss
+    REAL(r2), DIMENSION(ns:n)   :: thetaice, deltathetaice, dcice
+    INTEGER(i4)                 :: ns_ciso
+    REAL(r2)                    :: num, den, cv1
+    REAL(r2)                    :: alphaplus_s, alphaplus_a
+    ! REAL(r2)                    :: alphaplus_liqice
+    REAL(r2)                    :: cvs !, qevapL, qevapoutL, qevapinL
+    ! REAL(r2)                    :: cevapinL, cevapoutL, dcevapoutdcisoL, dcevapindcisoL
+    REAL(r2)                    :: w1, w2
+    INTEGER(i4), PARAMETER      :: formulation = 2  ! 1: betaql, betaqv of flux; 2: betaql, betaqv 0.5 of upper and lower
+    REAL(r2), DIMENSION(ns:n)   :: kfreeze, kfreeze2         ! combination of freezing variables
+    REAL(r2),   DIMENSION(ns:n) :: deltaS     !
+    INTEGER(i4), DIMENSION(1)   :: ii
+    REAL(r2)                    :: tmp
+    REAL(r2), DIMENSION(ns:n)   :: tmp1d1
 
     dcice = zero
     aa = zero
@@ -4788,22 +4788,22 @@ CONTAINS
     coefB = zero
     coefC = zero
     if (isotopologue==1) then
-       coefA = 24844.0_r_2
-       coefB = -76.248_r_2
-       coefC = 0.052612_r_2
-       ! alphaplus_liqice = 1.0212_r_2
-       coefA_liqice = 48888._r_2
-       coefB_liqice = -203.10_r_2
-       coefC_liqice = 0.2133_r_2
+       coefA = 24844.0_r2
+       coefB = -76.248_r2
+       coefC = 0.052612_r2
+       ! alphaplus_liqice = 1.0212_r2
+       coefA_liqice = 48888._r2
+       coefB_liqice = -203.10_r2
+       coefC_liqice = 0.2133_r2
     endif
     if (isotopologue==2) then
-       coefA = 1137.0_r_2
-       coefB = -0.4156_r_2
-       coefC = -0.0020667_r_2
-       ! alphaplus_liqice = 1.00291_r_2
-       coefA_liqice = 8312.5_r_2
-       coefB_liqice = -49.192_r_2
-       coefC_liqice = 0.0831_r_2
+       coefA = 1137.0_r2
+       coefB = -0.4156_r2
+       coefC = -0.0020667_r2
+       ! alphaplus_liqice = 1.00291_r2
+       coefA_liqice = 8312.5_r2
+       coefB_liqice = -49.192_r2
+       coefC_liqice = 0.0831_r2
     endif
     !MC - Test
     ! alphaplus_a                    = one/exp(coefA/((Ta+Tzero)**2)+coefB/(Ta+Tzero)+coefC) ! at soil or litter surface
@@ -4904,7 +4904,7 @@ CONTAINS
 
     where (var_cv(ns_ciso:n).gt.zero)
        deltacv(ns_ciso:n) = (deltaS(ns_ciso:n) - deltaSliqice(ns_ciso:n) + var_cv(ns_ciso:n)*deltaSliqice(ns_ciso:n))/ &
-            (1._r_2 - (S(ns_ciso:n) + deltaSliqice(ns_ciso:n)*(one-sig)))
+            (1._r2 - (S(ns_ciso:n) + deltaSliqice(ns_ciso:n)*(one-sig)))
     elsewhere
        deltacv(ns_ciso:n) = zero
     endwhere
@@ -4925,12 +4925,12 @@ CONTAINS
 
     ! diffusional fractionation factor
     ! air
-    if (isotopologue==1) alphak_vdiff = one / 1.0251_r_2   ! HDO diffusivity in air (Merlivat 1978)
-    if (isotopologue==2) alphak_vdiff = one / 1.0285_r_2   ! H218O diffusivity in air (Merlivat 1978)
+    if (isotopologue==1) alphak_vdiff = one / 1.0251_r2   ! HDO diffusivity in air (Merlivat 1978)
+    if (isotopologue==2) alphak_vdiff = one / 1.0285_r2   ! H218O diffusivity in air (Merlivat 1978)
     if ((experiment >= 1 .and. experiment <= 5) .or. (experiment == 9 .or. experiment == 10)) alphak_vdiff = one
     ! if (experiment == 9 .or. experiment == 10 .or. experiment == 16) alphak_vdiff = one
     ! kinetic fractionation factor at the surface
-    ! Dvs = Dva*1.e5_r_2/patm*((Ts+Tzero)/Tzero)**1.88_r_2 ! vapour diffusivity of water in air (m2s-1)
+    ! Dvs = Dva*1.e5_r2/patm*((Ts+Tzero)/Tzero)**1.88_r2 ! vapour diffusivity of water in air (m2s-1)
     ! if (isotopologue/=0) Divs = Dvs * alphak_vdiff  ! isotope diffusivity in air
     nk = min(S(1),one)*half + (one-min(S(1),one))*one
     if (experiment == 7 .or. experiment == 8) nk = one
@@ -4939,10 +4939,10 @@ CONTAINS
     ! if (experiment == 9 .or. experiment == 10 .or. experiment == 16) alphak = one
 
     ! liquid diffusivity in the pond and soil
-    if (isotopologue==1) alphak_ldiff = one / 1.013_r_2
-    if (isotopologue==2) alphak_ldiff = one / 1.026_r_2
+    if (isotopologue==1) alphak_ldiff = one / 1.013_r2
+    if (isotopologue==2) alphak_ldiff = one / 1.026_r2
     ! molecular diffusion of isotopes in normal liquid water (m2s-1)
-    Dl(ns_ciso:n) = tortuosity(ns_ciso:n) * alphak_ldiff * 1.0e-7_r_2*exp(-577.0_r_2/((Tsoil(ns_ciso:n)+Tzero)-145._r_2))
+    Dl(ns_ciso:n) = tortuosity(ns_ciso:n) * alphak_ldiff * 1.0e-7_r2*exp(-577.0_r2/((Tsoil(ns_ciso:n)+Tzero)-145._r2))
     Dl(ns_ciso:n) = Dl(ns_ciso:n) * (min(Sliqsig(ns_ciso:n),one) * (thetasat(ns_ciso:n)-thetar(ns_ciso:n)) + thetar(ns_ciso:n))
     if ((experiment >= 1 .and. experiment <= 4) .or. (experiment == 9 .or. experiment == 10)) Dl = zero
     ! if (experiment == 9 .or. experiment == 10 .or. experiment == 16) Dl = zero
@@ -5266,7 +5266,7 @@ CONTAINS
 
     ! if (any(abs(LHS(ns_ciso:n)-RHS(ns_ciso:n))>tiny(one))) then
     ! if (any(abs(LHS(ns_ciso:n)-RHS(ns_ciso:n))>epsilon(one))) then
-    if (any(abs(LHS(ns_ciso:n)-RHS(ns_ciso:n))>1.e-6_r_2)) then
+    if (any(abs(LHS(ns_ciso:n)-RHS(ns_ciso:n))>1.e-6_r2)) then
        write(*,*) 'abs(LHS-RHS) ', abs(LHS(ns_ciso:n)-RHS(ns_ciso:n))
        ii = maxloc(abs(LHS(ns_ciso:n)-RHS(ns_ciso:n)))
        write(*,*) 'Max of abs(LHS-RHS): ', maxval(abs(LHS(ns_ciso:n)-RHS(ns_ciso:n))), ii

--- a/core/biogeophys/cable_sli_utils.F90
+++ b/core/biogeophys/cable_sli_utils.F90
@@ -1,6 +1,6 @@
 MODULE sli_utils
 
-  USE cable_def_types_mod, ONLY: r_2, i_d
+  USE cable_def_types_mod, ONLY: r2, i4
   USE cable_def_types_mod, ONLY: soil_parameter_type, veg_parameter_type
   USE sli_numbers,         ONLY: &
        experiment, &
@@ -33,20 +33,20 @@ MODULE sli_utils
   PUBLIC :: rtbis_Tfrozen, GTfrozen, JSoilLayer, forcerestore, SEB
   PUBLIC :: spline_b, mean, nse
 
-  REAL(r_2),        DIMENSION(:,:),   ALLOCATABLE :: dx
-  REAL(r_2),        DIMENSION(:),     ALLOCATABLE :: dxL
+  REAL(r2),        DIMENSION(:,:),   ALLOCATABLE :: dx
+  REAL(r2),        DIMENSION(:),     ALLOCATABLE :: dxL
   TYPE(params),     DIMENSION(:,:),   ALLOCATABLE :: par
   TYPE(params),     DIMENSION(:),     ALLOCATABLE :: plit
   TYPE(solve_type), DIMENSION(:),     ALLOCATABLE :: sol
-  REAL(r_2),        DIMENSION(:,:),   ALLOCATABLE :: x
+  REAL(r2),        DIMENSION(:,:),   ALLOCATABLE :: x
 
   ! MC solute not done yet
-  !REAL(r_2),        DIMENSION(:,:),   ALLOCATABLE         :: bd
-  !REAL(r_2),        DIMENSION(:,:),   ALLOCATABLE         :: dis
+  !REAL(r2),        DIMENSION(:,:),   ALLOCATABLE         :: bd
+  !REAL(r2),        DIMENSION(:,:),   ALLOCATABLE         :: dis
   !TYPE(rapointer),  DIMENSION(:,:,:), ALLOCATABLE         :: isopar
   !CHARACTER(LEN=2), DIMENSION(:,:,:), ALLOCATABLE         :: isotype
-  REAL(r_2),        DIMENSION(:),   ALLOCATABLE         :: bd ! function solute not done yet
-  REAL(r_2),        DIMENSION(:),   ALLOCATABLE         :: dis
+  REAL(r2),        DIMENSION(:),   ALLOCATABLE         :: bd ! function solute not done yet
+  REAL(r2),        DIMENSION(:),   ALLOCATABLE         :: dis
   TYPE(rapointer),  DIMENSION(:,:), ALLOCATABLE         :: isopar
   CHARACTER(LEN=2), DIMENSION(:,:), ALLOCATABLE         :: isotype
 #ifdef __MPI__
@@ -133,14 +133,14 @@ CONTAINS
 
     TYPE(vars_aquifer), INTENT(INOUT) :: v_aquifer
 
-    v_aquifer%zzero     = 53.43_r_2  ! water table depth corresponding to Wa = zero
-    v_aquifer%Sy        = 0.2_r_2  ! specific yield of aquifer
+    v_aquifer%zzero     = 53.43_r2  ! water table depth corresponding to Wa = zero
+    v_aquifer%Sy        = 0.2_r2  ! specific yield of aquifer
     ! initialise water content of aquifer
     v_aquifer%Wa        = v_aquifer%Sy*(v_aquifer%zzero-max(v_aquifer%zdelta,v_aquifer%zsoil))
     v_aquifer%isat      = 0
     if (v_aquifer%zdelta <= v_aquifer%zsoil) v_aquifer%isat = 1
-    v_aquifer%f         = 1.25_r_2 ! multiplier in exponent of Rs (m-1)
-    v_aquifer%Rsmax     = 4.5e-7_r_2  ! maximum discharge rate from aquifer (ms-1)
+    v_aquifer%f         = 1.25_r2 ! multiplier in exponent of Rs (m-1)
+    v_aquifer%Rsmax     = 4.5e-7_r2  ! maximum discharge rate from aquifer (ms-1)
     v_aquifer%discharge = v_aquifer%Rsmax*exp(-v_aquifer%f*v_aquifer%zdelta)
 
   END SUBROUTINE aquifer_props
@@ -153,8 +153,8 @@ CONTAINS
     IMPLICIT NONE
 
     TYPE(params), INTENT(IN)  :: parin
-    REAL(r_2),    INTENT(IN)  :: dz
-    REAL(r_2),    INTENT(OUT) :: q, qya, qyb, qTa, qTb
+    REAL(r2),    INTENT(IN)  :: dz
+    REAL(r2),    INTENT(OUT) :: q, qya, qyb, qTa, qTb
     TYPE(vars),   INTENT(IN)  :: v1, v2
     ! Gets flux and partial derivs for specified flow path.
     ! Definitions of arguments:
@@ -165,7 +165,7 @@ CONTAINS
     ! q   - flux.
     ! qya - partial deriv of flux wrt S (if unsat) or phi (if sat) at upper end.
     ! qyb - ditto at lower end.
-    REAL(r_2) :: w, rdz
+    REAL(r2) :: w, rdz
 
     ! gf is gravity factor (0 to 1) assumed available in module
     if (gf < zero) then
@@ -213,26 +213,26 @@ CONTAINS
     ! method applicable to multilayer soil or soil/snow column
     ! derived using Eq's 3-12 in Hirota et al. JGR 2002
     IMPLICIT NONE
-    REAL(r_2), INTENT(IN)   :: Tg0 ! ground surface temp of previous time-step [deg C]
-    REAL(r_2), INTENT(IN)   :: Rnet0 ! Rnet at current time step, assuming Tg of previous time-step [W m-2]
-    REAL(r_2), INTENT(IN)   :: lE0 ! latent heat flux at current time step, assuming Tg of previous time-step  [W m-2]
-    REAL(r_2), INTENT(IN)   :: dlEdTg ! derivative of latent heat flux wrt Tg   [W m-2 K-1]
-    REAL(r_2), INTENT(IN)   :: Ta ! air temperature [deg C]
-    REAL(r_2), INTENT(IN)   :: Tbar ! temperature at diurnal damping depth
-    REAL(r_2), INTENT(IN)   :: d1 ! diurnal damping depth (m) = sqrt(2*lambda/c/omega) (Hirota et al. eq 40)
-    REAL(r_2), INTENT(IN)   :: rrc ! resistance to sensible heat and radiation transfer at ground/air interface [m-1 s]
-    REAL(r_2), INTENT(IN)   :: lambda ! thermal conductivity of soil or snow at surface [W m-1 K-1]
-    REAL(r_2), INTENT(IN)   :: dt ! time step [s]
+    REAL(r2), INTENT(IN)   :: Tg0 ! ground surface temp of previous time-step [deg C]
+    REAL(r2), INTENT(IN)   :: Rnet0 ! Rnet at current time step, assuming Tg of previous time-step [W m-2]
+    REAL(r2), INTENT(IN)   :: lE0 ! latent heat flux at current time step, assuming Tg of previous time-step  [W m-2]
+    REAL(r2), INTENT(IN)   :: dlEdTg ! derivative of latent heat flux wrt Tg   [W m-2 K-1]
+    REAL(r2), INTENT(IN)   :: Ta ! air temperature [deg C]
+    REAL(r2), INTENT(IN)   :: Tbar ! temperature at diurnal damping depth
+    REAL(r2), INTENT(IN)   :: d1 ! diurnal damping depth (m) = sqrt(2*lambda/c/omega) (Hirota et al. eq 40)
+    REAL(r2), INTENT(IN)   :: rrc ! resistance to sensible heat and radiation transfer at ground/air interface [m-1 s]
+    REAL(r2), INTENT(IN)   :: lambda ! thermal conductivity of soil or snow at surface [W m-1 K-1]
+    REAL(r2), INTENT(IN)   :: dt ! time step [s]
     INTEGER, INTENT(IN):: iice ! top layer frozen (1) or not (0)
-    REAL(r_2), INTENT(OUT) :: Tg, G, H, lE
+    REAL(r2), INTENT(OUT) :: Tg, G, H, lE
 
     ! local variables
-    REAL(r_2), PARAMETER :: tau1 = 86400._r_2 ! period of diurnal forcing (seconds)
-    REAL(r_2) :: c1, c2, omega, a, b
+    REAL(r2), PARAMETER :: tau1 = 86400._r2 ! period of diurnal forcing (seconds)
+    REAL(r2) :: c1, c2, omega, a, b
 
     a = Rnet0 - rhocp/rrc*(Tg0-Ta) -lE0 ! G0 at current time step, assuming surface T of previous time step
 
-    omega = 2._r_2*pi/tau1  ! diurnal forcing frequency (s-1)
+    omega = 2._r2*pi/tau1  ! diurnal forcing frequency (s-1)
     c1 = omega * d1 / lambda
     c2 = omega
     b = -rhocp/rrc  - dlEdTg
@@ -258,31 +258,31 @@ CONTAINS
   !      cs, dt, iice, Tg, G, H, lE)
 
   !   IMPLICIT NONE
-  !   REAL(r_2), INTENT(IN)   :: Tg0 ! ground surface temp of previous time-step [deg C]
-  !   REAL(r_2), INTENT(IN)   :: Rnet0 ! Rnet at current time step, assuming Tg of previous time-step [W m-2]
-  !   REAL(r_2), INTENT(IN)   :: lE0 ! latent heat flux at current time step, assuming Tg of previous time-step  [W m-2]
-  !   REAL(r_2), INTENT(IN)   :: dlEdTg ! derivative of latent heat flux wrt Tg   [W m-2 K-1]
-  !   REAL(r_2), INTENT(IN)   :: Ta ! air temperature [deg C]
-  !   REAL(r_2), INTENT(IN)   :: Tbar ! temperature at diurnal damping depth
-  !   REAL(r_2), INTENT(IN)   :: d1 ! diurnal damping depth (m)
-  !   REAL(r_2), INTENT(IN)   :: rrc ! resistance to sensible heat and radiation transfer at ground/air interface [m-1 s]
-  !   REAL(r_2), INTENT(IN)   :: rhos ! density of soil or snow at surface [kg m-3]
-  !   REAL(r_2), INTENT(IN)   :: cs ! heat capacity of soil or snow at surface [J kg-1 K-1]
-  !   REAL(r_2), INTENT(IN)   :: dt ! time step [s]
+  !   REAL(r2), INTENT(IN)   :: Tg0 ! ground surface temp of previous time-step [deg C]
+  !   REAL(r2), INTENT(IN)   :: Rnet0 ! Rnet at current time step, assuming Tg of previous time-step [W m-2]
+  !   REAL(r2), INTENT(IN)   :: lE0 ! latent heat flux at current time step, assuming Tg of previous time-step  [W m-2]
+  !   REAL(r2), INTENT(IN)   :: dlEdTg ! derivative of latent heat flux wrt Tg   [W m-2 K-1]
+  !   REAL(r2), INTENT(IN)   :: Ta ! air temperature [deg C]
+  !   REAL(r2), INTENT(IN)   :: Tbar ! temperature at diurnal damping depth
+  !   REAL(r2), INTENT(IN)   :: d1 ! diurnal damping depth (m)
+  !   REAL(r2), INTENT(IN)   :: rrc ! resistance to sensible heat and radiation transfer at ground/air interface [m-1 s]
+  !   REAL(r2), INTENT(IN)   :: rhos ! density of soil or snow at surface [kg m-3]
+  !   REAL(r2), INTENT(IN)   :: cs ! heat capacity of soil or snow at surface [J kg-1 K-1]
+  !   REAL(r2), INTENT(IN)   :: dt ! time step [s]
   !   INTEGER, INTENT(IN):: iice ! top layer frozen (1) or not (0)
-  !   REAL(r_2), INTENT(OUT) :: Tg, G, H, lE
+  !   REAL(r2), INTENT(OUT) :: Tg, G, H, lE
 
   !   ! local variables
-  !   REAL(r_2),    PARAMETER :: c1 = 3.72_r_2 ! Deardorff JGR (1978)
-  !   REAL(r_2),    PARAMETER :: c2 = 7.4_r_2 ! Deardorff JGR (1978)
-  !   REAL(r_2),    PARAMETER :: tau1 = 86400._r_2 ! period of diurnal forcing (seconds)
-  !   REAL(r_2) :: a, b
+  !   REAL(r2),    PARAMETER :: c1 = 3.72_r2 ! Deardorff JGR (1978)
+  !   REAL(r2),    PARAMETER :: c2 = 7.4_r2 ! Deardorff JGR (1978)
+  !   REAL(r2),    PARAMETER :: tau1 = 86400._r2 ! period of diurnal forcing (seconds)
+  !   REAL(r2) :: a, b
 
   !   a = Rnet0 - rhocp/rrc*(Tg0-Ta) -lE0
   !   b = -rhocp/rrc  - dlEdTg
 
   !   Tg = Tg0 + (c1*a/(rhos*cs*d1) - c2/tau1*(Tg0-Tbar))/ &
-  !        (1._r_2/dt - b*c1/(rhos*cs*d1) + c2/tau1)
+  !        (1._r2/dt - b*c1/(rhos*cs*d1) + c2/tau1)
 
   !   if (iice.eq.1) then
   !      Tg = min(zero, Tg)
@@ -303,35 +303,35 @@ CONTAINS
 
     IMPLICIT NONE
 
-    INTEGER(i_d),                    INTENT(IN) :: n
+    INTEGER(i4),                    INTENT(IN) :: n
     TYPE(params),    DIMENSION(1:n), INTENT(IN) :: par
     TYPE(vars_met),                  INTENT(IN) :: vmet
     TYPE(vars_snow),                 INTENT(IN) :: vsnow
     TYPE(vars),      DIMENSION(1:n), INTENT(IN) :: var
-    REAL(r_2),                       INTENT(IN) :: qprec
-    REAL(r_2),                       INTENT(IN) :: qprec_snow
-    REAL(r_2),       DIMENSION(1:n), INTENT(IN) :: dx
-    REAL(r_2),                       INTENT(IN) :: h0
-    REAL(r_2),       DIMENSION(1:n), INTENT(IN) :: Tsoil
+    REAL(r2),                       INTENT(IN) :: qprec
+    REAL(r2),                       INTENT(IN) :: qprec_snow
+    REAL(r2),       DIMENSION(1:n), INTENT(IN) :: dx
+    REAL(r2),                       INTENT(IN) :: h0
+    REAL(r2),       DIMENSION(1:n), INTENT(IN) :: Tsoil
 
-    REAL(r_2),                       INTENT(OUT)           :: Tsurface, G0, lE0, Epot ! SEB
-    REAL(r_2),                       INTENT(OUT)           :: qsurface          ! water flux into surface
-    REAL(r_2),                       INTENT(OUT)           :: qevap             ! evaporative water flux
+    REAL(r2),                       INTENT(OUT)           :: Tsurface, G0, lE0, Epot ! SEB
+    REAL(r2),                       INTENT(OUT)           :: qsurface          ! water flux into surface
+    REAL(r2),                       INTENT(OUT)           :: qevap             ! evaporative water flux
     ! liquid and vapour components of water flux from surface into soil
-    REAL(r_2),                       INTENT(OUT)           :: qliq, qv
+    REAL(r2),                       INTENT(OUT)           :: qliq, qv
     ! derivatives of water fluxes wrt moisture and T
-    REAL(r_2),                       INTENT(OUT)           :: qyb, qTb, qlyb, qvyb, qlTb, qvTb
+    REAL(r2),                       INTENT(OUT)           :: qyb, qTb, qlyb, qvyb, qlTb, qvTb
     ! total and advective components of heat flux into surface
-    REAL(r_2),                       INTENT(OUT)           :: qh, qadv
+    REAL(r2),                       INTENT(OUT)           :: qh, qadv
     ! derivatives of heat fluxes wrt moiture and T
-    REAL(r_2),                       INTENT(OUT)           :: qhyb, qhTb, qadvyb, qadvTb
+    REAL(r2),                       INTENT(OUT)           :: qhyb, qhTb, qadvyb, qadvTb
 
     ! local variables
-    INTEGER(i_d) :: surface_case
-    REAL(r_2) :: Tsurface_pot,  Hpot, Gpot, dEdrha, dEdTs, dEdTsoil, dGdTa, dGdTsoil
-    REAL(r_2) :: E_vap, dE_vapdT1, E_liq
-    REAL(r_2) :: Kmin, Khmin, phimin
-    REAL(r_2) :: Tqw, dtqwdtb, rhocp1, cs
+    INTEGER(i4) :: surface_case
+    REAL(r2) :: Tsurface_pot,  Hpot, Gpot, dEdrha, dEdTs, dEdTsoil, dGdTa, dGdTsoil
+    REAL(r2) :: E_vap, dE_vapdT1, E_liq
+    REAL(r2) :: Kmin, Khmin, phimin
+    REAL(r2) :: Tqw, dtqwdtb, rhocp1, cs
     LOGICAL   :: isEpot
 
     if (vsnow%nsnow.eq.0) surface_case = 1
@@ -343,10 +343,10 @@ CONTAINS
             Tsoil(1), var(1)%kth, half*dx(1)+h0, var(1)%lambdav, Tsurface_pot, Epot, Hpot, &
             Gpot, dEdrha, dEdTs, dEdTsoil, dGdTa, dGdTsoil)
        if (var(1)%iice.eq.1.and.Tsurface_pot> zero) then
-          Tsurface_pot = 0.0_r_2
-          Tsurface = 0.0_r_2
+          Tsurface_pot = 0.0_r2
+          Tsurface = 0.0_r2
 
-          Epot = (esat(Tsurface)*0.018_r_2/thousand/8.314_r_2/(vmet%Ta+Tzero)  - & ! m3 H2O (liq) m-3 (air)
+          Epot = (esat(Tsurface)*0.018_r2/thousand/8.314_r2/(vmet%Ta+Tzero)  - & ! m3 H2O (liq) m-3 (air)
                vmet%cva)*rhow*var(1)%lambdav/vmet%rbw
           dEdTsoil = zero
           dGdTsoil = zero
@@ -367,7 +367,7 @@ CONTAINS
           call hyofh(hmin, par(1)%lam, par(1)%eta, par(1)%Ke, par(1)%he, &
                Kmin, Khmin, phimin) ! get phi at hmin
           E_liq = ((var(1)%phi-phimin)/(half*dx(1))-var(1)%K)*thousand*var(1)%lambdav
-          if (var(1)%Dv > 1.e-12_r_2) then
+          if (var(1)%Dv > 1.e-12_r2) then
              ! E = (cs-ca)/rbw = E_liq + E_vap = E_liq + (c1-cs)/Dv/dx/2
              cs = ( E_liq/var(1)%lambdav + var(1)%rh*csat(Tsoil(1))*var(1)%Dv/(half*dx(1)) + &
                   vmet%cva*thousand/vmet%rbw ) &
@@ -403,10 +403,10 @@ CONTAINS
           dGdTsoil  =  -var(1)%kth/(half*dx(1))
 
           if ((var(1)%iice.eq.1) .and. (Tsurface>zero)) then
-             Tsurface = 0.0_r_2
-             rhocp1 = rmair*101325._r_2/rgas/(vmet%Ta+Tzero)*cpa
+             Tsurface = 0.0_r2
+             rhocp1 = rmair*101325._r2/rgas/(vmet%Ta+Tzero)*cpa
              G0 = vmet%Rn - rhocp1*(Tsurface - vmet%Ta)/vmet%rbh - lE0
-             dGdTsoil = 0.0_r_2
+             dGdTsoil = 0.0_r2
           endif
 
        endif
@@ -487,16 +487,16 @@ CONTAINS
 
        ! SEB at snow/air interface
        if (vsnow%hliq(1)>zero) then
-          Tsurface = 0.0_r_2
-          !Epot = (esat(Tsurface)*0.018_r_2/thousand/8.314_r_2/(vmet%Ta+Tzero)  - & ! m3 H2O (liq) m-3 (air)
+          Tsurface = 0.0_r2
+          !Epot = (esat(Tsurface)*0.018_r2/thousand/8.314_r2/(vmet%Ta+Tzero)  - & ! m3 H2O (liq) m-3 (air)
           !            vmet%cva)*rhow*rlambda/vmet%rbw !!vh check this !!
           Epot = (csat(Tsurface)/thousand - vmet%cva)/vmet%rbw *rlambda*rhow  ! m3 H2O (liq) m-3 (air) -> W/m2
           ! write(*,*) "Epot", vmet%rha, vmet%Ta,
-          !            esat(Tsurface)*0.018_r_2/thousand/8.314_r_2/(vmet%Ta+Tzero)*rhow*rlambda/vmet%rbw, &
+          !            esat(Tsurface)*0.018_r2/thousand/8.314_r2/(vmet%Ta+Tzero)*rhow*rlambda/vmet%rbw, &
           !vmet%cva*rhow*rlambda/vmet%rbw, Epot
           dEdTsoil = zero
           dGdTsoil = zero
-          rhocp1 = rmair*101325._r_2/rgas/(vmet%Ta+Tzero)*cpa
+          rhocp1 = rmair*101325._r2/rgas/(vmet%Ta+Tzero)*cpa
           Hpot = rhocp1*(Tsurface - vmet%Ta)/vmet%rbh
           Gpot = vmet%Rn-vmet%Rnsw - Hpot - Epot
           dEdTs = zero
@@ -508,12 +508,12 @@ CONTAINS
           !! leading to large negative surface temperatures when snow-pack is thick and
           !! Rn is large and negative (~-100 Wm-2)
           call potential_evap(vmet%Rn-vmet%Rnsw, vmet%rbh, vmet%rbw, vmet%Ta, vmet%rha, &
-               vsnow%tsn(1), max(vsnow%kth(1),0.1_r_2), half*min(vsnow%depth(1),0.05_r_2), &
+               vsnow%tsn(1), max(vsnow%kth(1),0.1_r2), half*min(vsnow%depth(1),0.05_r2), &
                lambdas, Tsurface, Epot, Hpot, &
                Gpot, dEdrha, dEdTs, dEdTsoil, dGdTa, dGdTsoil,iice=.TRUE.)
           if (Tsurface > zero) then ! temperature of frozen surface must be <= zero
-             Tsurface = 0.0_r_2
-             Epot = (esat(Tsurface)*0.018_r_2/thousand/8.314_r_2/(vmet%Ta+Tzero)  - & ! m3 H2O (liq) m-3 (air)
+             Tsurface = 0.0_r2
+             Epot = (esat(Tsurface)*0.018_r2/thousand/8.314_r2/(vmet%Ta+Tzero)  - & ! m3 H2O (liq) m-3 (air)
                   vmet%cva)*rhow*lambdas/vmet%rbw
              dEdTsoil = zero
              dGdTsoil = zero
@@ -524,7 +524,7 @@ CONTAINS
           endif
 !!$          elseif (abs(Tsurface - vmet%Ta).gt. 20) then
 !!$             Tsurface = min(vmet%Ta, 0.0)
-!!$             Epot = (esat(Tsurface)*0.018_r_2/thousand/8.314_r_2/(vmet%Ta+Tzero)  - & ! m3 H2O (liq) m-3 (air)
+!!$             Epot = (esat(Tsurface)*0.018_r2/thousand/8.314_r2/(vmet%Ta+Tzero)  - & ! m3 H2O (liq) m-3 (air)
 !!$                  vmet%cva)*rhow*lambdas/vmet%rbw
 !!$             dEdTsoil = zero
 !!$             dGdTsoil = zero
@@ -594,35 +594,35 @@ CONTAINS
 
   !   IMPLICIT NONE
 
-  !   INTEGER(i_d), INTENT(IN)              :: n
+  !   INTEGER(i4), INTENT(IN)              :: n
   !   TYPE(params),      DIMENSION(1:n), INTENT(IN)  :: par
   !   TYPE(vars_met),        INTENT(IN)           :: vmet
   !   TYPE(vars_snow),   INTENT(IN)           :: vsnow
   !   TYPE(vars),      DIMENSION(1:n),   INTENT(IN)           :: var
-  !   REAL(r_2),   INTENT(IN)              :: qprec
-  !   REAL(r_2),   INTENT(IN)              :: qprec_snow
-  !   INTEGER(i_d), INTENT(IN)              ::  nsteps, irec
-  !   REAL(r_2),      DIMENSION(1:n),   INTENT(IN)              :: dx
-  !   REAL(r_2),          INTENT(IN)           :: h0
-  !   REAL(r_2),      DIMENSION(1:n),   INTENT(IN)           :: Tsoil
-  !   REAL(r_2),   INTENT(IN)              :: dt
-  !   REAL(r_2),  INTENT(IN)           :: Tsurface0
+  !   REAL(r2),   INTENT(IN)              :: qprec
+  !   REAL(r2),   INTENT(IN)              :: qprec_snow
+  !   INTEGER(i4), INTENT(IN)              ::  nsteps, irec
+  !   REAL(r2),      DIMENSION(1:n),   INTENT(IN)              :: dx
+  !   REAL(r2),          INTENT(IN)           :: h0
+  !   REAL(r2),      DIMENSION(1:n),   INTENT(IN)           :: Tsoil
+  !   REAL(r2),   INTENT(IN)              :: dt
+  !   REAL(r2),  INTENT(IN)           :: Tsurface0
 
-  !   REAL(r_2),  INTENT(OUT)           :: Tsurface, G0, lE0  ! SEB (subdiurnal, uses T in top layer)
-  !   REAL(r_2),  INTENT(OUT)           :: TsurfaceFR, G0FR, lEFR, HFR  ! SEB (Force-Restore)
-  !   REAL(r_2),  INTENT(OUT)           :: qsurface ! water flux into surface
-  !   REAL(r_2),  INTENT(OUT)           :: qevap ! evaporative water flux
-  !   REAL(r_2),  INTENT(OUT)           :: qliq, qv ! liquid and vapour components of water flux from surface into soil
-  !   REAL(r_2),  INTENT(OUT)           :: qyb, qTb, qlyb, qvyb, qlTb, qvTb ! derivatives of water fluxes wrt moisture and T
-  !   REAL(r_2),  INTENT(OUT)           :: qh, qadv ! total and advective components of heat flux into surface
-  !   REAL(r_2),  INTENT(OUT)           :: qhyb, qhTb, qadvyb, qadvTb ! derivatives of heat fluxes wrt moiture and T
+  !   REAL(r2),  INTENT(OUT)           :: Tsurface, G0, lE0  ! SEB (subdiurnal, uses T in top layer)
+  !   REAL(r2),  INTENT(OUT)           :: TsurfaceFR, G0FR, lEFR, HFR  ! SEB (Force-Restore)
+  !   REAL(r2),  INTENT(OUT)           :: qsurface ! water flux into surface
+  !   REAL(r2),  INTENT(OUT)           :: qevap ! evaporative water flux
+  !   REAL(r2),  INTENT(OUT)           :: qliq, qv ! liquid and vapour components of water flux from surface into soil
+  !   REAL(r2),  INTENT(OUT)           :: qyb, qTb, qlyb, qvyb, qlTb, qvTb ! derivatives of water fluxes wrt moisture and T
+  !   REAL(r2),  INTENT(OUT)           :: qh, qadv ! total and advective components of heat flux into surface
+  !   REAL(r2),  INTENT(OUT)           :: qhyb, qhTb, qadvyb, qadvTb ! derivatives of heat fluxes wrt moiture and T
 
   !   ! local variables
-  !   INTEGER(i_d) :: surface_case, j
-  !   REAL(r_2) :: Tsurface_pot, Epot, Hpot, Gpot, dEdrha, dEdTs, dEdTsoil, dGdTa, dGdTsoil
-  !   REAL(r_2) :: E_vap, dE_vapdT1, E_liq
-  !   REAL(r_2) :: Kmin, Khmin, phimin
-  !   REAL(r_2) :: Tqw, dtqwdtb, d1, tmp1d2, Tbar, f, csnow
+  !   INTEGER(i4) :: surface_case, j
+  !   REAL(r2) :: Tsurface_pot, Epot, Hpot, Gpot, dEdrha, dEdTs, dEdTsoil, dGdTa, dGdTsoil
+  !   REAL(r2) :: E_vap, dE_vapdT1, E_liq
+  !   REAL(r2) :: Kmin, Khmin, phimin
+  !   REAL(r2) :: Tqw, dtqwdtb, d1, tmp1d2, Tbar, f, csnow
 
   !   if (vsnow%nsnow.eq.0) surface_case = 1
   !   if (vsnow%nsnow>0) surface_case = 2
@@ -633,8 +633,8 @@ CONTAINS
   !           Gpot, dEdrha, dEdTs, dEdTsoil, dGdTa, dGdTsoil)
 
   !      if (var(1)%iice.eq.1.and.Tsurface_pot> zero) then
-  !         Tsurface_pot = 0.0_r_2
-  !         Epot = (esat(Tsurface)*0.018_r_2/thousand/8.314_r_2/(vmet%Ta+Tzero)  - & ! m3 H2O (liq) m-3 (air)
+  !         Tsurface_pot = 0.0_r2
+  !         Epot = (esat(Tsurface)*0.018_r2/thousand/8.314_r2/(vmet%Ta+Tzero)  - & ! m3 H2O (liq) m-3 (air)
   !              vmet%cva)*rhow*var(1)%lambdav/vmet%rbw
   !         dEdTsoil = zero
   !         dGdTsoil = zero
@@ -651,7 +651,7 @@ CONTAINS
   !         dE_vapdT1 = zero
   !         E_liq = lE0
   !      else ! unsaturated surface: finite vapour transfer; surface flux may be supply limited
-  !         if (var(1)%Dv > 1.e-12_r_2) then
+  !         if (var(1)%Dv > 1.e-12_r2) then
   !            E_vap = (var(1)%rh*csat(Tsoil(1))-vmet%cva*thousand)/(vmet%rbw + half*dx(1)/var(1)%Dv)*var(1)%lambdav
   !            dE_vapdT1 = (var(1)%rh*slope_csat(Tsoil(1)))/(vmet%rbw + half*dx(1)/var(1)%Dv)*var(1)%lambdav
   !         else
@@ -666,7 +666,7 @@ CONTAINS
   !         Tsurface = (-half*dx(1)*lE0 + half*dx(1)*vmet%Rn + &
   !              var(1)%kth*Tsoil(1) + half*dx(1)*(one/vmet%rrc*rhocp)*vmet%Ta) &
   !              /(var(1)%kth + half*dx(1)*(one/vmet%rrc*rhocp))
-  !         if (var(1)%iice.eq.1.and.Tsurface> zero) Tsurface = 0.0_r_2
+  !         if (var(1)%iice.eq.1.and.Tsurface> zero) Tsurface = 0.0_r2
   !         G0       = var(1)%kth/(half*dx(1))*(Tsurface-Tsoil(1))
   !         dGdTsoil  =  -var(1)%kth/(half*dx(1))
   !      endif
@@ -761,8 +761,8 @@ CONTAINS
 
   !      ! SEB at snow/air interface
   !      if (vsnow%hliq(1)>zero) then
-  !         Tsurface = 0.0_r_2
-  !         Epot = (esat(Tsurface)*0.018_r_2/thousand/8.314_r_2/(vmet%Ta+Tzero)  - & ! m3 H2O (liq) m-3 (air)
+  !         Tsurface = 0.0_r2
+  !         Epot = (esat(Tsurface)*0.018_r2/thousand/8.314_r2/(vmet%Ta+Tzero)  - & ! m3 H2O (liq) m-3 (air)
   !              vmet%cva)*rhow*lambdaf/vmet%rbw
   !         dEdTsoil = zero
   !         dGdTsoil = zero
@@ -779,8 +779,8 @@ CONTAINS
   !              Gpot, dEdrha, dEdTs, dEdTsoil, dGdTa, dGdTsoil)
 
   !         if (Tsurface > zero) then ! temperature of frozen surface must be <= zero
-  !            Tsurface = 0.0_r_2
-  !            Epot = (esat(Tsurface)*0.018_r_2/thousand/8.314_r_2/(vmet%Ta+Tzero)  - & ! m3 H2O (liq) m-3 (air)
+  !            Tsurface = 0.0_r2
+  !            Epot = (esat(Tsurface)*0.018_r2/thousand/8.314_r2/(vmet%Ta+Tzero)  - & ! m3 H2O (liq) m-3 (air)
   !                 vmet%cva)*rhow*lambdas/vmet%rbw
   !            dEdTsoil = zero
   !            dGdTsoil = zero
@@ -829,12 +829,12 @@ CONTAINS
   !               csnow = (csice*(vsnow%hsnow(j+vsnow%nsnow)-vsnow%hliq(j+vsnow%nsnow))+cswat*vsnow%hliq(j+vsnow%nsnow))/ &
   !                    vsnow%depth(j+vsnow%nsnow)*rhow
   !               ! d1 = (vsnow%kth(j+vsnow%nsnow)/(csnow)*86400./pi)**0.5
-  !               d1 = sqrt(vsnow%kth(j+vsnow%nsnow)/(csnow)*86400._r_2/pi)
+  !               d1 = sqrt(vsnow%kth(j+vsnow%nsnow)/(csnow)*86400._r2/pi)
   !               tmp1d2 = tmp1d2 + vsnow%depth(j+vsnow%nsnow)/d1  ! check snow index here!
   !               Tbar = vsnow%tsn(j+vsnow%nsnow)
   !            else
   !               ! d1 = (var(j)%kth/(var(j)%csoileff)*86400./pi)**0.5
-  !               d1 = sqrt(var(j)%kth/(var(j)%csoileff)*86400._r_2/pi)
+  !               d1 = sqrt(var(j)%kth/(var(j)%csoileff)*86400._r2/pi)
   !               tmp1d2 = tmp1d2 + dx(j)/d1
   !               Tbar = Tsoil(j)
   !            endif
@@ -884,17 +884,17 @@ CONTAINS
     IMPLICIT NONE
 
     ! in/out
-    INTEGER(i_d),                      INTENT(IN)  :: n
-    REAL(r_2), DIMENSION(1:n,1:2,1:2), INTENT(IN)  :: A, B, C
-    REAL(r_2), DIMENSION(1:n,1:2),     INTENT(IN)  :: r
-    REAL(r_2), DIMENSION(1:n,1:2),     INTENT(OUT) :: u
-    INTEGER(i_d), OPTIONAL,            INTENT(OUT) :: err ! 0: no error; >0: error
+    INTEGER(i4),                      INTENT(IN)  :: n
+    REAL(r2), DIMENSION(1:n,1:2,1:2), INTENT(IN)  :: A, B, C
+    REAL(r2), DIMENSION(1:n,1:2),     INTENT(IN)  :: r
+    REAL(r2), DIMENSION(1:n,1:2),     INTENT(OUT) :: u
+    INTEGER(i4), OPTIONAL,            INTENT(OUT) :: err ! 0: no error; >0: error
     ! local
-    REAL(r_2), DIMENSION(1:n,1:2,1:2) :: G
-    REAL(r_2), DIMENSION(1:2,1:2)     :: bet
-    REAL(r_2), DIMENSION(1:2)         :: d
-    REAL(r_2)                         :: detbet, detbet1
-    INTEGER(i_d)                      :: j
+    REAL(r2), DIMENSION(1:n,1:2,1:2) :: G
+    REAL(r2), DIMENSION(1:2,1:2)     :: bet
+    REAL(r2), DIMENSION(1:2)         :: d
+    REAL(r2)                         :: detbet, detbet1
+    INTEGER(i4)                      :: j
 
     if (present(err)) err = 0
     ! j=1
@@ -959,20 +959,20 @@ CONTAINS
     IMPLICIT NONE
 
     ! in/out
-    INTEGER(i_d),                           INTENT(IN)  :: mp
-    INTEGER(i_d),                           INTENT(IN)  :: n
-    REAL(r_2), DIMENSION(1:mp,1:n,1:2,1:2), INTENT(IN)  :: A, B, C
-    REAL(r_2), DIMENSION(1:mp,1:n,1:2),     INTENT(IN)  :: r
-    REAL(r_2), DIMENSION(1:mp,1:n,1:2),     INTENT(OUT) :: u
-    INTEGER(i_d), OPTIONAL,                 INTENT(OUT) :: err ! 0: no error; >0: error
+    INTEGER(i4),                           INTENT(IN)  :: mp
+    INTEGER(i4),                           INTENT(IN)  :: n
+    REAL(r2), DIMENSION(1:mp,1:n,1:2,1:2), INTENT(IN)  :: A, B, C
+    REAL(r2), DIMENSION(1:mp,1:n,1:2),     INTENT(IN)  :: r
+    REAL(r2), DIMENSION(1:mp,1:n,1:2),     INTENT(OUT) :: u
+    INTEGER(i4), OPTIONAL,                 INTENT(OUT) :: err ! 0: no error; >0: error
     ! local
-    REAL(r_2), DIMENSION(1:mp,1:n,1:2,1:2) :: G
-    REAL(r_2), DIMENSION(1:mp,1:2,1:2)     :: bet
-    REAL(r_2), DIMENSION(1:mp,1:2)         :: d
-    REAL(r_2), DIMENSION(1:mp)             :: detbet, detbet1
-    INTEGER(i_d)                           :: j
-    REAL(r_2), DIMENSION(1:mp,1:2)         :: tmp1d
-    REAL(r_2), DIMENSION(1:mp,1:2,1:2)     :: tmp2d
+    REAL(r2), DIMENSION(1:mp,1:n,1:2,1:2) :: G
+    REAL(r2), DIMENSION(1:mp,1:2,1:2)     :: bet
+    REAL(r2), DIMENSION(1:mp,1:2)         :: d
+    REAL(r2), DIMENSION(1:mp)             :: detbet, detbet1
+    INTEGER(i4)                           :: j
+    REAL(r2), DIMENSION(1:mp,1:2)         :: tmp1d
+    REAL(r2), DIMENSION(1:mp,1:2,1:2)     :: tmp2d
 
     if (present(err)) err = 0
     ! j=1
@@ -1046,35 +1046,35 @@ CONTAINS
 
     IMPLICIT NONE
 
-    INTEGER(i_d),                 INTENT(IN)    :: n
-    REAL(r_2),    DIMENSION(1:n), INTENT(IN)    :: dx
+    INTEGER(i4),                 INTENT(IN)    :: n
+    REAL(r2),    DIMENSION(1:n), INTENT(IN)    :: dx
     TYPE(vars),                   INTENT(IN)    :: vtop
     TYPE(vars),                   INTENT(IN)    :: vbot
     TYPE(params), DIMENSION(1:n), INTENT(IN)    :: parin
     TYPE(vars),   DIMENSION(1:n), INTENT(INOUT)    :: var
-    REAL(r_2),    DIMENSION(1:n), INTENT(INOUT) :: hint
-    REAL(r_2),    DIMENSION(1:n), INTENT(INOUT) :: phimin
-    REAL(r_2),    DIMENSION(0:n), INTENT(INOUT) :: q
-    REAL(r_2),    DIMENSION(0:n), INTENT(INOUT) :: qya
-    REAL(r_2),    DIMENSION(0:n), INTENT(INOUT) :: qyb
-    REAL(r_2),    DIMENSION(0:n), INTENT(INOUT) :: qTa
-    REAL(r_2),    DIMENSION(0:n), INTENT(INOUT) :: qTb
-    REAL(r_2),    DIMENSION(0:n), INTENT(INOUT)   :: ql
-    REAL(r_2),    DIMENSION(0:n), INTENT(INOUT)   :: qlya
-    REAL(r_2),    DIMENSION(0:n), INTENT(INOUT)   :: qlyb
-    REAL(r_2),    DIMENSION(0:n), INTENT(INOUT)   :: qv
-    REAL(r_2),    DIMENSION(0:n), INTENT(INOUT)   :: qvT
-    REAL(r_2),    DIMENSION(0:n), INTENT(INOUT)   :: qvh
-    REAL(r_2),    DIMENSION(0:n), INTENT(INOUT)   :: qvya
-    REAL(r_2),    DIMENSION(0:n), INTENT(INOUT)   :: qvyb
-    INTEGER(i_d),                 INTENT(IN)    :: iflux
+    REAL(r2),    DIMENSION(1:n), INTENT(INOUT) :: hint
+    REAL(r2),    DIMENSION(1:n), INTENT(INOUT) :: phimin
+    REAL(r2),    DIMENSION(0:n), INTENT(INOUT) :: q
+    REAL(r2),    DIMENSION(0:n), INTENT(INOUT) :: qya
+    REAL(r2),    DIMENSION(0:n), INTENT(INOUT) :: qyb
+    REAL(r2),    DIMENSION(0:n), INTENT(INOUT) :: qTa
+    REAL(r2),    DIMENSION(0:n), INTENT(INOUT) :: qTb
+    REAL(r2),    DIMENSION(0:n), INTENT(INOUT)   :: ql
+    REAL(r2),    DIMENSION(0:n), INTENT(INOUT)   :: qlya
+    REAL(r2),    DIMENSION(0:n), INTENT(INOUT)   :: qlyb
+    REAL(r2),    DIMENSION(0:n), INTENT(INOUT)   :: qv
+    REAL(r2),    DIMENSION(0:n), INTENT(INOUT)   :: qvT
+    REAL(r2),    DIMENSION(0:n), INTENT(INOUT)   :: qvh
+    REAL(r2),    DIMENSION(0:n), INTENT(INOUT)   :: qvya
+    REAL(r2),    DIMENSION(0:n), INTENT(INOUT)   :: qvyb
+    INTEGER(i4),                 INTENT(IN)    :: iflux
     LOGICAL,                      INTENT(IN)    :: init
     LOGICAL,                      INTENT(IN)    :: getq0
     LOGICAL,                      INTENT(IN)    :: getqn
-    REAL(r_2),    DIMENSION(1:n), INTENT(IN)    :: Tsoil
-    REAL(r_2),                    INTENT(IN)    :: T0
-    INTEGER(i_d),                 INTENT(IN)    :: nsat
-    INTEGER(i_d),                 INTENT(IN)    :: nsatlast
+    REAL(r2),    DIMENSION(1:n), INTENT(IN)    :: Tsoil
+    REAL(r2),                    INTENT(IN)    :: T0
+    INTEGER(i4),                 INTENT(IN)    :: nsat
+    INTEGER(i4),                 INTENT(IN)    :: nsatlast
     ! Gets fluxes q and partial derivs qya, qyb wrt S (if unsat) or phi (if sat).
     ! Fluxes at top and bottom of profile, and fluxes due to plant extraction of
     ! water are included.
@@ -1099,11 +1099,11 @@ CONTAINS
     ! getq0    - true if q(0) required.
     ! getqn    - true if q(n) required.
     LOGICAL               :: flag, limit
-    INTEGER(i_d)          :: i, itmp, l
-    REAL(r_2)             :: dphii1, dhi, h1, h2, hi, Khi1, Khi2, phii1, q2, qya2, qyb2, y, y1, y2
-    REAL(r_2)             :: qTa2, qTb2
+    INTEGER(i4)          :: i, itmp, l
+    REAL(r2)             :: dphii1, dhi, h1, h2, hi, Khi1, Khi2, phii1, q2, qya2, qyb2, y, y1, y2
+    REAL(r2)             :: qTa2, qTb2
     TYPE(vars)            :: vi1, vi2
-    REAL(r_2), DIMENSION(1:n-1) :: dz
+    REAL(r2), DIMENSION(1:n-1) :: dz
 
     dz(:) = half*(dx(1:n-1)+dx(2:n))
     vi1 = zerovars()
@@ -1217,7 +1217,7 @@ CONTAINS
                 end if
                 phii1 = phii1+dphii1
                 dhi   = dphii1/(vi1%K+half*vi1%KS*dphii1) ! 2nd order Pade approx
-                if (-vi1%KS*dphii1 > 1.5_r_2*vi1%K) then ! use 1st order approx for dhi
+                if (-vi1%KS*dphii1 > 1.5_r2*vi1%K) then ! use 1st order approx for dhi
                    dhi = dphii1/vi1%K
                 end if
                 hi = hi+dhi
@@ -1248,29 +1248,29 @@ CONTAINS
        !MC Should be re-checked
        ! qvh(i) = ((((Tsoil(i)+Tzero)/Tzero)**1.88+((Tsoil(i+1)+Tzero)/Tzero)**1.88)/two) &
        !      * ((var(i)%cvsat+var(i+1)%cvsat)/two)*(var(i)%phiv-var(i+1)%phiv)/dz(i)
-       qvh(i) = (half*(exp(1.88_r_2*log((Tsoil(i)+Tzero)/Tzero))+exp(1.88_r_2*log((Tsoil(i+1)+Tzero)/Tzero)))) &
+       qvh(i) = (half*(exp(1.88_r2*log((Tsoil(i)+Tzero)/Tzero))+exp(1.88_r2*log((Tsoil(i+1)+Tzero)/Tzero)))) &
             * (half*(var(i)%cvsat+var(i+1)%cvsat)) * (var(i)%phiv-var(i+1)%phiv)/dz(i)
        ! qvh(i) = ((var(i)%Dv+var(i+1)%Dv)/two)* ((var(i)%cvsat+var(i+1)%cvsat)/two)*(var(i)%rh-var(i+1)%rh)/dz(i)
        qv(i)  = qvh(i) + qvT(i) ! whole vapour flux has one part from humidity (qvh) and one part from temp diff (qvT)
        q(i)   = qv(i) + ql(i)
 
        if (var(i)%isat==0) then
-          ! qvya(i) = var(i)%phivS/dz(i) *((((Tsoil(i)+Tzero)/Tzero)**1.88_r_2+ &
-          !      ((Tsoil(i+1)+Tzero)/Tzero)**1.88_r_2)/two) &
+          ! qvya(i) = var(i)%phivS/dz(i) *((((Tsoil(i)+Tzero)/Tzero)**1.88_r2+ &
+          !      ((Tsoil(i+1)+Tzero)/Tzero)**1.88_r2)/two) &
           !      * ((var(i)%cvsat+var(i+1)%cvsat)/two)
-          qvya(i) = var(i)%phivS/dz(i) *(half*(exp(1.88_r_2*log((Tsoil(i)+Tzero)/Tzero)) + &
-               exp(1.88_r_2*log((Tsoil(i+1)+Tzero)/Tzero)))) &
+          qvya(i) = var(i)%phivS/dz(i) *(half*(exp(1.88_r2*log((Tsoil(i)+Tzero)/Tzero)) + &
+               exp(1.88_r2*log((Tsoil(i+1)+Tzero)/Tzero)))) &
                * (half*(var(i)%cvsat+var(i+1)%cvsat))
        else
           qvya(i) = zero
        end if
 
        if (var(i)%isat==0) then
-          ! qvyb(i) = -var(i+1)%phivS/dz(i) *((((Tsoil(i)+Tzero)/Tzero)**1.88_r_2+ &
-          !      ((Tsoil(i+1)+Tzero)/Tzero)**1.88_r_2)/two) &
+          ! qvyb(i) = -var(i+1)%phivS/dz(i) *((((Tsoil(i)+Tzero)/Tzero)**1.88_r2+ &
+          !      ((Tsoil(i+1)+Tzero)/Tzero)**1.88_r2)/two) &
           !      * ((var(i)%cvsat+var(i+1)%cvsat)/two)
-          qvyb(i) = -var(i+1)%phivS/dz(i) *(half*(exp(1.88_r_2*log((Tsoil(i)+Tzero)/Tzero)) + &
-               exp(1.88_r_2*log((Tsoil(i+1)+Tzero)/Tzero)))) &
+          qvyb(i) = -var(i+1)%phivS/dz(i) *(half*(exp(1.88_r2*log((Tsoil(i)+Tzero)/Tzero)) + &
+               exp(1.88_r2*log((Tsoil(i+1)+Tzero)/Tzero)))) &
                * (half*(var(i)%cvsat+var(i+1)%cvsat))
        else
           qvyb(i) = zero
@@ -1327,34 +1327,34 @@ CONTAINS
 
     IMPLICIT NONE
 
-    REAL(r_2),    DIMENSION(:,:), INTENT(IN)    :: dx      ! 1:n
+    REAL(r2),    DIMENSION(:,:), INTENT(IN)    :: dx      ! 1:n
     TYPE(vars),   DIMENSION(:),   INTENT(IN)    :: vtop
     TYPE(vars),   DIMENSION(:),   INTENT(IN)    :: vbot
     TYPE(params), DIMENSION(:,:), INTENT(IN)    :: parin   ! 1:n
     TYPE(vars),   DIMENSION(:,:), INTENT(IN)    :: var     ! 1:n
-    REAL(r_2),    DIMENSION(:,:), INTENT(INOUT) :: hint    ! 1:n
-    REAL(r_2),    DIMENSION(:,:), INTENT(INOUT) :: phimin  ! 1:n
-    REAL(r_2),    DIMENSION(:,:), INTENT(INOUT) :: i_q       ! 0:n
-    REAL(r_2),    DIMENSION(:,:), INTENT(INOUT) :: i_qya     ! 0:n
-    REAL(r_2),    DIMENSION(:,:), INTENT(INOUT) :: i_qyb     ! 0:n
-    REAL(r_2),    DIMENSION(:,:), INTENT(INOUT) :: i_qTa     ! 0:n
-    REAL(r_2),    DIMENSION(:,:), INTENT(INOUT) :: i_qTb     ! 0:n
-    REAL(r_2),    DIMENSION(:,:), INTENT(OUT)   :: i_ql      ! 0:n
-    REAL(r_2),    DIMENSION(:,:), INTENT(OUT)   :: i_qlya    ! 0:n
-    REAL(r_2),    DIMENSION(:,:), INTENT(OUT)   :: i_qlyb    ! 0:n
-    REAL(r_2),    DIMENSION(:,:), INTENT(OUT)   :: i_qv      ! 0:n
-    REAL(r_2),    DIMENSION(:,:), INTENT(OUT)   :: i_qvT     ! 0:n
-    REAL(r_2),    DIMENSION(:,:), INTENT(OUT)   :: i_qvh     ! 0:n
-    REAL(r_2),    DIMENSION(:,:), INTENT(OUT)   :: i_qvya    ! 0:n
-    REAL(r_2),    DIMENSION(:,:), INTENT(OUT)   :: i_qvyb    ! 0:n
-    INTEGER(i_d), DIMENSION(:),   INTENT(IN)    :: iflux
+    REAL(r2),    DIMENSION(:,:), INTENT(INOUT) :: hint    ! 1:n
+    REAL(r2),    DIMENSION(:,:), INTENT(INOUT) :: phimin  ! 1:n
+    REAL(r2),    DIMENSION(:,:), INTENT(INOUT) :: i_q       ! 0:n
+    REAL(r2),    DIMENSION(:,:), INTENT(INOUT) :: i_qya     ! 0:n
+    REAL(r2),    DIMENSION(:,:), INTENT(INOUT) :: i_qyb     ! 0:n
+    REAL(r2),    DIMENSION(:,:), INTENT(INOUT) :: i_qTa     ! 0:n
+    REAL(r2),    DIMENSION(:,:), INTENT(INOUT) :: i_qTb     ! 0:n
+    REAL(r2),    DIMENSION(:,:), INTENT(OUT)   :: i_ql      ! 0:n
+    REAL(r2),    DIMENSION(:,:), INTENT(OUT)   :: i_qlya    ! 0:n
+    REAL(r2),    DIMENSION(:,:), INTENT(OUT)   :: i_qlyb    ! 0:n
+    REAL(r2),    DIMENSION(:,:), INTENT(OUT)   :: i_qv      ! 0:n
+    REAL(r2),    DIMENSION(:,:), INTENT(OUT)   :: i_qvT     ! 0:n
+    REAL(r2),    DIMENSION(:,:), INTENT(OUT)   :: i_qvh     ! 0:n
+    REAL(r2),    DIMENSION(:,:), INTENT(OUT)   :: i_qvya    ! 0:n
+    REAL(r2),    DIMENSION(:,:), INTENT(OUT)   :: i_qvyb    ! 0:n
+    INTEGER(i4), DIMENSION(:),   INTENT(IN)    :: iflux
     LOGICAL,      DIMENSION(:),   INTENT(IN)    :: init
     LOGICAL,      DIMENSION(:),   INTENT(IN)    :: getq0
     LOGICAL,      DIMENSION(:),   INTENT(IN)    :: getqn
-    REAL(r_2),    DIMENSION(:,:), INTENT(IN)    :: Tsoil   ! 1:n
-    REAL(r_2),    DIMENSION(:),   INTENT(IN)    :: T0
-    INTEGER(i_d), DIMENSION(:),   INTENT(IN)    :: nsat
-    INTEGER(i_d), DIMENSION(:),   INTENT(IN)    :: nsatlast
+    REAL(r2),    DIMENSION(:,:), INTENT(IN)    :: Tsoil   ! 1:n
+    REAL(r2),    DIMENSION(:),   INTENT(IN)    :: T0
+    INTEGER(i4), DIMENSION(:),   INTENT(IN)    :: nsat
+    INTEGER(i4), DIMENSION(:),   INTENT(IN)    :: nsatlast
     ! Gets fluxes q and partial derivs qya, qyb wrt S (if unsat) or phi (if sat).
     ! Fluxes at top and bottom of profile, and fluxes due to plant extraction of
     ! water are included.
@@ -1379,27 +1379,27 @@ CONTAINS
     ! getq0    - true if q(0) required.
     ! getqn    - true if q(n) required.
     LOGICAL,      DIMENSION(1:size(dx,1))                :: limit, l1, l2, l3
-    REAL(r_2),    DIMENSION(1:size(dx,1))                :: dphii1, dhi, h1, h2, hi, Khi1, Khi2, phii1
-    REAL(r_2),    DIMENSION(1:size(dx,1))                :: q2, qya2, qyb2, y, y1, y2
-    REAL(r_2),    DIMENSION(1:size(dx,1))                :: htmp
-    REAL(r_2),    DIMENSION(1:size(dx,1))                :: ztmp1, ztmp2, ztmp3, ztmp4, ztmp5
+    REAL(r2),    DIMENSION(1:size(dx,1))                :: dphii1, dhi, h1, h2, hi, Khi1, Khi2, phii1
+    REAL(r2),    DIMENSION(1:size(dx,1))                :: q2, qya2, qyb2, y, y1, y2
+    REAL(r2),    DIMENSION(1:size(dx,1))                :: htmp
+    REAL(r2),    DIMENSION(1:size(dx,1))                :: ztmp1, ztmp2, ztmp3, ztmp4, ztmp5
     TYPE(vars),   DIMENSION(1:size(dx,1))                :: vi1, vi2
-    REAL(r_2),    DIMENSION(1:size(dx,1),1:size(dx,2)-1) :: dz
-    REAL(r_2),    DIMENSION(1:size(dx,1),0:size(dx,2))   :: q
-    REAL(r_2),    DIMENSION(1:size(dx,1),0:size(dx,2))   :: qya
-    REAL(r_2),    DIMENSION(1:size(dx,1),0:size(dx,2))   :: qyb
-    REAL(r_2),    DIMENSION(1:size(dx,1),0:size(dx,2))   :: qTa
-    REAL(r_2),    DIMENSION(1:size(dx,1),0:size(dx,2))   :: qTb
-    REAL(r_2),    DIMENSION(1:size(dx,1),0:size(dx,2))   :: ql
-    REAL(r_2),    DIMENSION(1:size(dx,1),0:size(dx,2))   :: qlya
-    REAL(r_2),    DIMENSION(1:size(dx,1),0:size(dx,2))   :: qlyb
-    REAL(r_2),    DIMENSION(1:size(dx,1),0:size(dx,2))   :: qv
-    REAL(r_2),    DIMENSION(1:size(dx,1),0:size(dx,2))   :: qvT
-    REAL(r_2),    DIMENSION(1:size(dx,1),0:size(dx,2))   :: qvh
-    REAL(r_2),    DIMENSION(1:size(dx,1),0:size(dx,2))   :: qvya
-    REAL(r_2),    DIMENSION(1:size(dx,1),0:size(dx,2))   :: qvyb
+    REAL(r2),    DIMENSION(1:size(dx,1),1:size(dx,2)-1) :: dz
+    REAL(r2),    DIMENSION(1:size(dx,1),0:size(dx,2))   :: q
+    REAL(r2),    DIMENSION(1:size(dx,1),0:size(dx,2))   :: qya
+    REAL(r2),    DIMENSION(1:size(dx,1),0:size(dx,2))   :: qyb
+    REAL(r2),    DIMENSION(1:size(dx,1),0:size(dx,2))   :: qTa
+    REAL(r2),    DIMENSION(1:size(dx,1),0:size(dx,2))   :: qTb
+    REAL(r2),    DIMENSION(1:size(dx,1),0:size(dx,2))   :: ql
+    REAL(r2),    DIMENSION(1:size(dx,1),0:size(dx,2))   :: qlya
+    REAL(r2),    DIMENSION(1:size(dx,1),0:size(dx,2))   :: qlyb
+    REAL(r2),    DIMENSION(1:size(dx,1),0:size(dx,2))   :: qv
+    REAL(r2),    DIMENSION(1:size(dx,1),0:size(dx,2))   :: qvT
+    REAL(r2),    DIMENSION(1:size(dx,1),0:size(dx,2))   :: qvh
+    REAL(r2),    DIMENSION(1:size(dx,1),0:size(dx,2))   :: qvya
+    REAL(r2),    DIMENSION(1:size(dx,1),0:size(dx,2))   :: qvyb
     TYPE(vars)    :: vtmp
-    INTEGER(i_d)  :: i, n, mp, itmp
+    INTEGER(i4)  :: i, n, mp, itmp
 
     mp = size(dx,1)
     n  = size(dx,2)
@@ -1573,7 +1573,7 @@ CONTAINS
                 phii1(:) = phii1(:)+dphii1(:)
                 dhi(:)   = dphii1(:)/(vi1(:)%K+half*vi1(:)%KS*dphii1(:)) ! 2nd order Pade approx
              endwhere
-             where (l3(:) .and. (-vi1%KS*dphii1 > 1.5_r_2*vi1%K)) ! use 1st order approx for dhi
+             where (l3(:) .and. (-vi1%KS*dphii1 > 1.5_r2*vi1%K)) ! use 1st order approx for dhi
                 dhi(:) = dphii1(:)/vi1(:)%K
              endwhere
              where (l3(:))
@@ -1620,7 +1620,7 @@ CONTAINS
        !MC Should be re-checked
        ! qvh(:,i) = ((((Tsoil(:,i)+Tzero)/Tzero)**1.88+((Tsoil(:,i+1)+Tzero)/Tzero)**1.88)/two) &
        !      * ((var(:,i)%cvsat+var(:,i+1)%cvsat)/two)*(var(:,i)%phiv-var(:,i+1)%phiv)/dz(:,i)
-       qvh(:,i) = (half*(exp(1.88_r_2*log((Tsoil(:,i)+Tzero)/Tzero))+exp(1.88_r_2*log((Tsoil(:,i+1)+Tzero)/Tzero)))) &
+       qvh(:,i) = (half*(exp(1.88_r2*log((Tsoil(:,i)+Tzero)/Tzero))+exp(1.88_r2*log((Tsoil(:,i+1)+Tzero)/Tzero)))) &
             * (half*(var(:,i)%cvsat+var(:,i+1)%cvsat)) * (var(:,i)%phiv-var(:,i+1)%phiv)/dz(:,i)
        ! qvh(:,i) = ((var(:,i)%Dv+var(:,i+1)%Dv)/two) * &
        !             ((var(:,i)%cvsat+var(:,i+1)%cvsat)/two)*(var(:,i)%rh-var(:,i+1)%rh)/dz(:,i)
@@ -1628,22 +1628,22 @@ CONTAINS
        q(:,i)   = qv(:,i) + ql(:,i)
 
        where (var(:,i)%isat==0)
-          ! qvya(:,i) = var(:,i)%phivS/dz(:,i) *((((Tsoil(:,i)+Tzero)/Tzero)**1.88_r_2+ &
-          !      ((Tsoil(:,i+1)+Tzero)/Tzero)**1.88_r_2)/two) &
+          ! qvya(:,i) = var(:,i)%phivS/dz(:,i) *((((Tsoil(:,i)+Tzero)/Tzero)**1.88_r2+ &
+          !      ((Tsoil(:,i+1)+Tzero)/Tzero)**1.88_r2)/two) &
           !      * ((var(:,i)%cvsat+var(:,i+1)%cvsat)/two)
-          qvya(:,i) = var(:,i)%phivS/dz(:,i) *(half*(exp(1.88_r_2*log((Tsoil(:,i)+Tzero)/Tzero)) + &
-               exp(1.88_r_2*log((Tsoil(:,i+1)+Tzero)/Tzero)))) &
+          qvya(:,i) = var(:,i)%phivS/dz(:,i) *(half*(exp(1.88_r2*log((Tsoil(:,i)+Tzero)/Tzero)) + &
+               exp(1.88_r2*log((Tsoil(:,i+1)+Tzero)/Tzero)))) &
                * (half*(var(:,i)%cvsat+var(:,i+1)%cvsat))
        elsewhere
           qvya(:,i) = zero
        endwhere
 
        where (var(:,i)%isat==0)
-          ! qvyb(:,i) = -var(:,i+1)%phivS/dz(:,i) *((((Tsoil(:,i)+Tzero)/Tzero)**1.88_r_2+ &
-          !      ((Tsoil(:,i+1)+Tzero)/Tzero)**1.88_r_2)/two) &
+          ! qvyb(:,i) = -var(:,i+1)%phivS/dz(:,i) *((((Tsoil(:,i)+Tzero)/Tzero)**1.88_r2+ &
+          !      ((Tsoil(:,i+1)+Tzero)/Tzero)**1.88_r2)/two) &
           !      * ((var(:,i)%cvsat+var(:,i+1)%cvsat)/two)
-          qvyb(:,i) = -var(:,i+1)%phivS/dz(:,i) *(half*(exp(1.88_r_2*log((Tsoil(:,i)+Tzero)/Tzero)) + &
-               exp(1.88_r_2*log((Tsoil(:,i+1)+Tzero)/Tzero)))) &
+          qvyb(:,i) = -var(:,i+1)%phivS/dz(:,i) *(half*(exp(1.88_r2*log((Tsoil(:,i)+Tzero)/Tzero)) + &
+               exp(1.88_r2*log((Tsoil(:,i+1)+Tzero)/Tzero)))) &
                * (half*(var(:,i)%cvsat+var(:,i+1)%cvsat))
        elsewhere
           qvyb(:,i) = zero
@@ -1724,50 +1724,50 @@ CONTAINS
     ! modified 25/05/10 to include contribution to heat flux from liquid water flux in the presence of ice
     IMPLICIT NONE
 
-    INTEGER(i_d),               INTENT(IN)    :: n
-    REAL(r_2),  DIMENSION(1:n), INTENT(IN)    :: dx
-    REAL(r_2),  DIMENSION(0:n), INTENT(INOUT) :: qh, q, qadv
-    REAL(r_2),  DIMENSION(0:n), INTENT(INOUT) :: qhya, qya, qadvya
-    REAL(r_2),  DIMENSION(0:n), INTENT(INOUT) :: qhyb, qyb, qadvyb
-    REAL(r_2),  DIMENSION(0:n), INTENT(INOUT) :: qhTa, qTa, qadvTa
-    REAL(r_2),  DIMENSION(0:n), INTENT(INOUT) :: qhTb, qTb, qadvTb
+    INTEGER(i4),               INTENT(IN)    :: n
+    REAL(r2),  DIMENSION(1:n), INTENT(IN)    :: dx
+    REAL(r2),  DIMENSION(0:n), INTENT(INOUT) :: qh, q, qadv
+    REAL(r2),  DIMENSION(0:n), INTENT(INOUT) :: qhya, qya, qadvya
+    REAL(r2),  DIMENSION(0:n), INTENT(INOUT) :: qhyb, qyb, qadvyb
+    REAL(r2),  DIMENSION(0:n), INTENT(INOUT) :: qhTa, qTa, qadvTa
+    REAL(r2),  DIMENSION(0:n), INTENT(INOUT) :: qhTb, qTb, qadvTb
     TYPE(vars), DIMENSION(1:n), INTENT(IN)    :: var
-    REAL(r_2),  DIMENSION(1:n), INTENT(IN)    :: T
-    INTEGER(i_d),               INTENT(IN)    :: advection
+    REAL(r2),  DIMENSION(1:n), INTENT(IN)    :: T
+    INTEGER(i4),               INTENT(IN)    :: advection
     ! Gets heat fluxes qh and partial derivs qhya, qhyb wrt T and S (if unsat) or phi (if sat).
 
-    INTEGER(i_d)          :: i
-    REAL(r_2)             :: rdz, keff ! , w
-    REAL(r_2), DIMENSION(1:n-1) :: dz
-    REAL(r_2) :: dTqwdTa, dTqwdTb, Tqw
+    INTEGER(i4)          :: i
+    REAL(r2)             :: rdz, keff ! , w
+    REAL(r2), DIMENSION(1:n-1) :: dz
+    REAL(r2) :: dTqwdTa, dTqwdTb, Tqw
 
     dz(:) = half*(dx(1:n-1)+dx(2:n))
 
     do i=1, n-1
        rdz = one/dz(i)
-       keff = 2_r_2*(var(i)%kth*var(i+1)%kth)/(var(i)%kth*dx(i)+var(i+1)%kth*dx(i+1))
+       keff = 2._r2*(var(i)%kth*var(i+1)%kth)/(var(i)%kth*dx(i)+var(i+1)%kth*dx(i+1))
        ! qh(i) = keff*(T(i)-T(i+1)) +(var(i)%phiv-var(i+1)%phiv)*var(i)%lambdav*thousand*rdz &
-       !      * ((((T(i)+Tzero) /Tzero)**1.88_r_2+((T(i+1)+Tzero) /Tzero)**1.88_r_2)/two) &
+       !      * ((((T(i)+Tzero) /Tzero)**1.88_r2+((T(i+1)+Tzero) /Tzero)**1.88_r2)/two) &
        !      *((var(i)%cvsat+var(i+1)%cvsat)/two)
        qh(i) = keff*(T(i)-T(i+1)) +(var(i)%phiv-var(i+1)%phiv)*var(i)%lambdav*thousand*rdz &
-            * (half*(exp(1.88_r_2*log((T(i)+Tzero) /Tzero))+exp(1.88_r_2*log((T(i+1)+Tzero) /Tzero)))) &
+            * (half*(exp(1.88_r2*log((T(i)+Tzero) /Tzero))+exp(1.88_r2*log((T(i+1)+Tzero) /Tzero)))) &
             *(half*(var(i)%cvsat+var(i+1)%cvsat))
        if (var(i)%isat==0) then
-          ! qhya(i) = rdz*var(i)%lambdav*thousand*var(i)%phivS*((((T(i)+Tzero) /Tzero)**1.88_r_2+ &
-          !      ((T(i+1)+Tzero) /Tzero)**1.88_r_2)/two) &
+          ! qhya(i) = rdz*var(i)%lambdav*thousand*var(i)%phivS*((((T(i)+Tzero) /Tzero)**1.88_r2+ &
+          !      ((T(i+1)+Tzero) /Tzero)**1.88_r2)/two) &
           !      * ((var(i)%cvsat+var(i+1)%cvsat)/two)
-          qhya(i) = rdz*var(i)%lambdav*thousand*var(i)%phivS*(half*(exp(1.88_r_2*log((T(i)+Tzero) /Tzero)) + &
-               exp(1.88_r_2*log((T(i+1)+Tzero) /Tzero)))) &
+          qhya(i) = rdz*var(i)%lambdav*thousand*var(i)%phivS*(half*(exp(1.88_r2*log((T(i)+Tzero) /Tzero)) + &
+               exp(1.88_r2*log((T(i+1)+Tzero) /Tzero)))) &
                * (half*(var(i)%cvsat+var(i+1)%cvsat))
        else
           qhya(i) = zero
        end if
        if (var(i+1)%isat==0) then
-          ! qhyb(i) = -rdz*var(i)%lambdav*thousand*var(i+1)%phivS*((((T(i)+Tzero) /Tzero)**1.88_r_2+ &
-          !      ((T(i+1)+Tzero) /Tzero)**1.88_r_2)/two) &
+          ! qhyb(i) = -rdz*var(i)%lambdav*thousand*var(i+1)%phivS*((((T(i)+Tzero) /Tzero)**1.88_r2+ &
+          !      ((T(i+1)+Tzero) /Tzero)**1.88_r2)/two) &
           !      * ((var(i)%cvsat+var(i+1)%cvsat)/two)
-          qhyb(i) = -rdz*var(i)%lambdav*thousand*var(i+1)%phivS*(half*(exp(1.88_r_2*log((T(i)+Tzero) /Tzero)) + &
-               exp(1.88_r_2*log((T(i+1)+Tzero) /Tzero)))) &
+          qhyb(i) = -rdz*var(i)%lambdav*thousand*var(i+1)%phivS*(half*(exp(1.88_r2*log((T(i)+Tzero) /Tzero)) + &
+               exp(1.88_r2*log((T(i+1)+Tzero) /Tzero)))) &
                * (half*(var(i)%cvsat+var(i+1)%cvsat))
        else
           qhyb(i) = zero
@@ -1821,47 +1821,47 @@ CONTAINS
     ! modified 25/05/10 to include contribution to heat flux from liquid water flux in the presence of ice
     IMPLICIT NONE
 
-    REAL(r_2),    DIMENSION(:,:), INTENT(IN)    :: dx      ! :,1:n
-    REAL(r_2),    DIMENSION(:,:), INTENT(INOUT) :: i_qh    ! :,0:n => :,1:n+1
-    REAL(r_2),    DIMENSION(:,:), INTENT(INOUT) :: i_qhya  ! :,0:n => :,1:n+1
-    REAL(r_2),    DIMENSION(:,:), INTENT(INOUT) :: i_qhyb  ! :,0:n => :,1:n+1
-    REAL(r_2),    DIMENSION(:,:), INTENT(INOUT) :: i_qhTa  ! :,0:n => :,1:n+1
-    REAL(r_2),    DIMENSION(:,:), INTENT(INOUT) :: i_qhTb  ! :,0:n => :,1:n+1
-    REAL(r_2),    DIMENSION(:,:), INTENT(INOUT) :: i_q    ! :,0:n => :,1:n+1
-    REAL(r_2),    DIMENSION(:,:), INTENT(INOUT) :: i_qya  ! :,0:n => :,1:n+1
-    REAL(r_2),    DIMENSION(:,:), INTENT(INOUT) :: i_qyb  ! :,0:n => :,1:n+1
-    REAL(r_2),    DIMENSION(:,:), INTENT(INOUT) :: i_qTa  ! :,0:n => :,1:n+1
-    REAL(r_2),    DIMENSION(:,:), INTENT(INOUT) :: i_qTb  ! :,0:n => :,1:n+1
-    REAL(r_2),    DIMENSION(:,:), INTENT(INOUT) :: i_qadv    ! :,0:n => :,1:n+1
-    REAL(r_2),    DIMENSION(:,:), INTENT(INOUT) :: i_qadvya  ! :,0:n => :,1:n+1
-    REAL(r_2),    DIMENSION(:,:), INTENT(INOUT) :: i_qadvyb  ! :,0:n => :,1:n+1
-    REAL(r_2),    DIMENSION(:,:), INTENT(INOUT) :: i_qadvTa  ! :,0:n => :,1:n+1
-    REAL(r_2),    DIMENSION(:,:), INTENT(INOUT) :: i_qadvTb  ! :,0:n => :,1:n+1
+    REAL(r2),    DIMENSION(:,:), INTENT(IN)    :: dx      ! :,1:n
+    REAL(r2),    DIMENSION(:,:), INTENT(INOUT) :: i_qh    ! :,0:n => :,1:n+1
+    REAL(r2),    DIMENSION(:,:), INTENT(INOUT) :: i_qhya  ! :,0:n => :,1:n+1
+    REAL(r2),    DIMENSION(:,:), INTENT(INOUT) :: i_qhyb  ! :,0:n => :,1:n+1
+    REAL(r2),    DIMENSION(:,:), INTENT(INOUT) :: i_qhTa  ! :,0:n => :,1:n+1
+    REAL(r2),    DIMENSION(:,:), INTENT(INOUT) :: i_qhTb  ! :,0:n => :,1:n+1
+    REAL(r2),    DIMENSION(:,:), INTENT(INOUT) :: i_q    ! :,0:n => :,1:n+1
+    REAL(r2),    DIMENSION(:,:), INTENT(INOUT) :: i_qya  ! :,0:n => :,1:n+1
+    REAL(r2),    DIMENSION(:,:), INTENT(INOUT) :: i_qyb  ! :,0:n => :,1:n+1
+    REAL(r2),    DIMENSION(:,:), INTENT(INOUT) :: i_qTa  ! :,0:n => :,1:n+1
+    REAL(r2),    DIMENSION(:,:), INTENT(INOUT) :: i_qTb  ! :,0:n => :,1:n+1
+    REAL(r2),    DIMENSION(:,:), INTENT(INOUT) :: i_qadv    ! :,0:n => :,1:n+1
+    REAL(r2),    DIMENSION(:,:), INTENT(INOUT) :: i_qadvya  ! :,0:n => :,1:n+1
+    REAL(r2),    DIMENSION(:,:), INTENT(INOUT) :: i_qadvyb  ! :,0:n => :,1:n+1
+    REAL(r2),    DIMENSION(:,:), INTENT(INOUT) :: i_qadvTa  ! :,0:n => :,1:n+1
+    REAL(r2),    DIMENSION(:,:), INTENT(INOUT) :: i_qadvTb  ! :,0:n => :,1:n+1
     TYPE(vars),   DIMENSION(:,:), INTENT(IN)    :: var
-    REAL(r_2),    DIMENSION(:,:), INTENT(IN)    :: T       ! :,1:n
-    INTEGER(i_d),   INTENT(IN)    :: advection
+    REAL(r2),    DIMENSION(:,:), INTENT(IN)    :: T       ! :,1:n
+    INTEGER(i4),   INTENT(IN)    :: advection
     ! Gets heat fluxes qh and partial derivs qhya, qhyb wrt T and S (if unsat) or phi (if sat).
 
-    INTEGER(i_d)          :: i, n
-    REAL(r_2),  DIMENSION(1:size(dx,1))                :: rdz
-    REAL(r_2),  DIMENSION(1:size(dx,1))                :: keff
-    REAL(r_2),  DIMENSION(1:size(dx,1),1:size(dx,2)-1) :: dz
-    REAL(r_2),  DIMENSION(1:size(dx,1),0:size(dx,2))   :: qh   ! :,0:n
-    REAL(r_2),  DIMENSION(1:size(dx,1),0:size(dx,2))   :: qhya ! :,0:n
-    REAL(r_2),  DIMENSION(1:size(dx,1),0:size(dx,2))   :: qhyb ! :,0:n
-    REAL(r_2),  DIMENSION(1:size(dx,1),0:size(dx,2))   :: qhTa ! :,0:n
-    REAL(r_2),  DIMENSION(1:size(dx,1),0:size(dx,2))   :: qhTb ! :,0:n
-    REAL(r_2),  DIMENSION(1:size(dx,1),0:size(dx,2))   :: q   ! :,0:n
-    REAL(r_2),  DIMENSION(1:size(dx,1),0:size(dx,2))   :: qya ! :,0:n
-    REAL(r_2),  DIMENSION(1:size(dx,1),0:size(dx,2))   :: qyb ! :,0:n
-    REAL(r_2),  DIMENSION(1:size(dx,1),0:size(dx,2))   :: qTa ! :,0:n
-    REAL(r_2),  DIMENSION(1:size(dx,1),0:size(dx,2))   :: qTb ! :,0:n
-    REAL(r_2),  DIMENSION(1:size(dx,1),0:size(dx,2))   :: qadv   ! :,0:n
-    REAL(r_2),  DIMENSION(1:size(dx,1),0:size(dx,2))   :: qadvya ! :,0:n
-    REAL(r_2),  DIMENSION(1:size(dx,1),0:size(dx,2))   :: qadvyb ! :,0:n
-    REAL(r_2),  DIMENSION(1:size(dx,1),0:size(dx,2))   :: qadvTa ! :,0:n
-    REAL(r_2),  DIMENSION(1:size(dx,1),0:size(dx,2))   :: qadvTb ! :,0:n
-    REAL(r_2),  DIMENSION(1:size(dx,1)) :: dTqwdTa, dTqwdTb, Tqw
+    INTEGER(i4)          :: i, n
+    REAL(r2),  DIMENSION(1:size(dx,1))                :: rdz
+    REAL(r2),  DIMENSION(1:size(dx,1))                :: keff
+    REAL(r2),  DIMENSION(1:size(dx,1),1:size(dx,2)-1) :: dz
+    REAL(r2),  DIMENSION(1:size(dx,1),0:size(dx,2))   :: qh   ! :,0:n
+    REAL(r2),  DIMENSION(1:size(dx,1),0:size(dx,2))   :: qhya ! :,0:n
+    REAL(r2),  DIMENSION(1:size(dx,1),0:size(dx,2))   :: qhyb ! :,0:n
+    REAL(r2),  DIMENSION(1:size(dx,1),0:size(dx,2))   :: qhTa ! :,0:n
+    REAL(r2),  DIMENSION(1:size(dx,1),0:size(dx,2))   :: qhTb ! :,0:n
+    REAL(r2),  DIMENSION(1:size(dx,1),0:size(dx,2))   :: q   ! :,0:n
+    REAL(r2),  DIMENSION(1:size(dx,1),0:size(dx,2))   :: qya ! :,0:n
+    REAL(r2),  DIMENSION(1:size(dx,1),0:size(dx,2))   :: qyb ! :,0:n
+    REAL(r2),  DIMENSION(1:size(dx,1),0:size(dx,2))   :: qTa ! :,0:n
+    REAL(r2),  DIMENSION(1:size(dx,1),0:size(dx,2))   :: qTb ! :,0:n
+    REAL(r2),  DIMENSION(1:size(dx,1),0:size(dx,2))   :: qadv   ! :,0:n
+    REAL(r2),  DIMENSION(1:size(dx,1),0:size(dx,2))   :: qadvya ! :,0:n
+    REAL(r2),  DIMENSION(1:size(dx,1),0:size(dx,2))   :: qadvyb ! :,0:n
+    REAL(r2),  DIMENSION(1:size(dx,1),0:size(dx,2))   :: qadvTa ! :,0:n
+    REAL(r2),  DIMENSION(1:size(dx,1),0:size(dx,2))   :: qadvTb ! :,0:n
+    REAL(r2),  DIMENSION(1:size(dx,1)) :: dTqwdTa, dTqwdTb, Tqw
 
     n = size(dx,2)
     dz(:,1:n-1) = half*(dx(:,1:n-1)+dx(:,2:n))
@@ -1885,31 +1885,31 @@ CONTAINS
 
     do i=1, n-1
        rdz =  one/dz(:,i)
-       keff = 2_r_2*(var(:,i)%kth*var(:,i+1)%kth)/(var(:,i)%kth*dx(:,i)+var(:,i+1)%kth*dx(:,i+1))
+       keff = 2._r2*(var(:,i)%kth*var(:,i+1)%kth)/(var(:,i)%kth*dx(:,i)+var(:,i+1)%kth*dx(:,i+1))
        ! qh(:,i) = keff*(T(:,i)-T(:,i+1)) &
        !      + (var(:,i)%phiv-var(:,i+1)%phiv)*var(:,i)%lambdav*thousand*rdz(:) &
-       !      * ((((T(:,i)+Tzero) /Tzero)**1.88_r_2+((T(:,i+1)+Tzero) /Tzero)**1.88_r_2)/two) &
+       !      * ((((T(:,i)+Tzero) /Tzero)**1.88_r2+((T(:,i+1)+Tzero) /Tzero)**1.88_r2)/two) &
        !      *((var(:,i)%cvsat+var(:,i+1)%cvsat)/two)
        qh(:,i) = keff*(T(:,i)-T(:,i+1)) &
             + (var(:,i)%phiv-var(:,i+1)%phiv)*var(:,i)%lambdav*thousand*rdz(:) &
-            * (half*exp(1.88_r_2*log(((T(:,i)+Tzero) /Tzero)) + exp(1.88_r_2*log((T(:,i+1)+Tzero) /Tzero)))) &
+            * (half*exp(1.88_r2*log(((T(:,i)+Tzero) /Tzero)) + exp(1.88_r2*log((T(:,i+1)+Tzero) /Tzero)))) &
             *(half*(var(:,i)%cvsat+var(:,i+1)%cvsat))
        where (var(:,i)%isat == 0)
-          ! qhya(:,i) = rdz(:)*var(:,i)%lambdav*thousand*var(:,i)%phivS*((((T(:,i)+Tzero) /Tzero)**1.88_r_2+ &
-          !      ((T(:,i+1)+Tzero) /Tzero)**1.88_r_2)/two) &
+          ! qhya(:,i) = rdz(:)*var(:,i)%lambdav*thousand*var(:,i)%phivS*((((T(:,i)+Tzero) /Tzero)**1.88_r2+ &
+          !      ((T(:,i+1)+Tzero) /Tzero)**1.88_r2)/two) &
           !      * ((var(:,i)%cvsat+var(:,i+1)%cvsat)/two)
-          qhya(:,i) = rdz(:)*var(:,i)%lambdav*thousand*var(:,i)%phivS*(half*(exp(1.88_r_2*log((T(:,i)+Tzero) /Tzero)) + &
-               exp(1.88_r_2*log((T(:,i+1)+Tzero) /Tzero)))) &
+          qhya(:,i) = rdz(:)*var(:,i)%lambdav*thousand*var(:,i)%phivS*(half*(exp(1.88_r2*log((T(:,i)+Tzero) /Tzero)) + &
+               exp(1.88_r2*log((T(:,i+1)+Tzero) /Tzero)))) &
                * (half*(var(:,i)%cvsat+var(:,i+1)%cvsat))
        elsewhere
           qhya(:,i) = zero
        endwhere
        where (var(:,i+1)%isat == 0)
-          ! qhyb(:,i) = -rdz(:)*var(:,i)%lambdav*thousand*var(:,i+1)%phivS*((((T(:,i)+Tzero) /Tzero)**1.88_r_2+ &
-          !      ((T(:,i+1)+Tzero) /Tzero)**1.88_r_2)/two) &
+          ! qhyb(:,i) = -rdz(:)*var(:,i)%lambdav*thousand*var(:,i+1)%phivS*((((T(:,i)+Tzero) /Tzero)**1.88_r2+ &
+          !      ((T(:,i+1)+Tzero) /Tzero)**1.88_r2)/two) &
           !      * ((var(:,i)%cvsat+var(:,i+1)%cvsat)/two)
-          qhyb(:,i) = -rdz(:)*var(:,i)%lambdav*thousand*var(:,i+1)%phivS*(half*exp(1.88_r_2*log(((T(:,i)+Tzero) /Tzero)) + &
-               exp(1.88_r_2*log((T(:,i+1)+Tzero) /Tzero)))) &
+          qhyb(:,i) = -rdz(:)*var(:,i)%lambdav*thousand*var(:,i+1)%phivS*(half*exp(1.88_r2*log(((T(:,i)+Tzero) /Tzero)) + &
+               exp(1.88_r2*log((T(:,i+1)+Tzero) /Tzero)))) &
                * (half*(var(:,i)%cvsat+var(:,i+1)%cvsat))
        elsewhere
           qhyb(:,i) = zero
@@ -1967,21 +1967,21 @@ CONTAINS
 
     IMPLICIT NONE
 
-    REAL(r_2),    INTENT(IN)  :: h
-    REAL(r_2),    INTENT(IN)  :: lam
-    REAL(r_2),    INTENT(IN)  :: eta
-    REAL(r_2),    INTENT(IN)  :: Ke
-    REAL(r_2),    INTENT(IN)  :: he
-    REAL(r_2),    INTENT(OUT) :: K
-    REAL(r_2),    INTENT(OUT) :: Kh
-    REAL(r_2),    INTENT(OUT) :: phi
+    REAL(r2),    INTENT(IN)  :: h
+    REAL(r2),    INTENT(IN)  :: lam
+    REAL(r2),    INTENT(IN)  :: eta
+    REAL(r2),    INTENT(IN)  :: Ke
+    REAL(r2),    INTENT(IN)  :: he
+    REAL(r2),    INTENT(OUT) :: K
+    REAL(r2),    INTENT(OUT) :: Kh
+    REAL(r2),    INTENT(OUT) :: phi
     ! Get soil water variables from h.
     ! Definitions of arguments:
     ! h   - matric head.
     ! K   - hydraulic conductivity.
     ! Kh  - derivative dK/dh.
     ! phi - matric flux potential (MFP).
-    REAL(r_2) :: a
+    REAL(r2) :: a
 
     a   =  -lam * eta
     K   =  Ke * exp(a*log(h/he))
@@ -1998,8 +1998,8 @@ CONTAINS
 
     IMPLICIT NONE
 
-    REAL(r_2),    INTENT(IN)    :: S
-    REAL(r_2),    INTENT(IN)    :: Tsoil
+    REAL(r2),    INTENT(IN)    :: S
+    REAL(r2),    INTENT(IN)    :: Tsoil
     TYPE(params), INTENT(INOUT)    :: parin
     TYPE(vars),   INTENT(INOUT) :: var
     ! Get soil water variables from S.
@@ -2008,19 +2008,19 @@ CONTAINS
     ! ms        - no. of soil layers.
     ! jt(1:ms)  - layer soil type nos.
     ! var(1:ms) - other water vars of layers.
-    REAL(r_2) :: lnS, theta, c, v3, v4
-    REAL(r_2) :: dhdS, lambda, crh, int
-    REAL(r_2) :: thetal_max
-    REAL(r_2) :: Sliq
-    REAL(r_2) :: A, B, D, C1
-    INTEGER(i_d) :: E
-    REAL(r_2) :: F1, F2, F
-    ! REAL(r_2) :: macropore_modifier
-    REAL(r_2) :: cdry, tmp_thetai
-    REAL(r_2), parameter :: tol = 1.e-6_r_2
+    REAL(r2) :: lnS, theta, c, v3, v4
+    REAL(r2) :: dhdS, lambda, crh, int
+    REAL(r2) :: thetal_max
+    REAL(r2) :: Sliq
+    REAL(r2) :: A, B, D, C1
+    INTEGER(i4) :: E
+    REAL(r2) :: F1, F2, F
+    ! REAL(r2) :: macropore_modifier
+    REAL(r2) :: cdry, tmp_thetai
+    REAL(r2), parameter :: tol = 1.e-6_r2
     theta         = S*(parin%thre) + (parin%the - parin%thre)
     var%lambdav   = rlambda       ! latent heat of vaporisation
-    var%lambdav   = 1.91846e6_r_2*((Tsoil+Tzero)/((Tsoil+Tzero)-33.91_r_2))**2  ! Henderson-Sellers, QJRMS, 1984
+    var%lambdav   = 1.91846e6_r2*((Tsoil+Tzero)/((Tsoil+Tzero)-33.91_r2))**2  ! Henderson-Sellers, QJRMS, 1984
     var%lambdaf   = lambdaf        ! latent heat of fusion
     !var%Tfrz      = Tfrz(S,parin%he,one/parin%lam)
     var%Tfrz      = Tfrz(S, parin%he, one/(parin%lambc*freezefac)) ! freezefac for test of steep freezing curve
@@ -2036,8 +2036,8 @@ CONTAINS
        var%thetal = thetal_max
        ! liquid water content, relative to saturation
        ! Sliq      = (var%thetal - (parin%the-parin%thre))/parin%thre
-       if ((parin%thre-tmp_thetai) .le. max(parin%thr,1.e-5_r_2)) then
-          Sliq = max(parin%thr,1.e-5_r_2)
+       if ((parin%thre-tmp_thetai) .le. max(parin%thr,1.e-5_r2)) then
+          Sliq = max(parin%thr,1.e-5_r2)
        else
          ! Sliq = min((var%thetal-(parin%the-parin%thre))/(parin%thre-var%thetai), one)
           Sliq = min((var%thetal-(parin%the-parin%thre))/(parin%thre-tmp_thetai), one)
@@ -2057,7 +2057,7 @@ CONTAINS
        var%K  = var%Ksat
        var%KS = zero
        ! var%KT = var%dthetaldT * parin%Ke * parin%eta * exp(lnS*(parin%eta-one))/parin%thre
-       var%KT = var%dthetaldT * parin%Ke * parin%eta * exp(lnS*(parin%eta-one))/max(parin%thre-var%thetai,max(parin%thr,1e-5_r_2))
+       var%KT = var%dthetaldT * parin%Ke * parin%eta * exp(lnS*(parin%eta-one))/max(parin%thre-var%thetai,max(parin%thr,1e-5_r2))
        if (S < one) var%phi = var%phie
 
        ! var%phiT = parin%phie * exp(lnS*(parin%eta-one/parin%lam-one)) * var%dthetaldT * &
@@ -2086,7 +2086,7 @@ CONTAINS
           var%phiT = zero
        endif
 
-       !if ( ((parin%thre-var%thetai)<=max(parin%thr,1e-5_r_2)) .or. (Sliq==one) ) then
+       !if ( ((parin%thre-var%thetai)<=max(parin%thr,1e-5_r2)) .or. (Sliq==one) ) then
        !   var%phiS = zero
        !   var%phiT = zero
        !endif
@@ -2108,7 +2108,7 @@ CONTAINS
        v3      = exp(-lnS/parin%lam)
        v4      = exp(parin%eta*lnS)
     endif
-    if (var%thetal < 1.e-12_r_2) then ! completely frozen
+    if (var%thetal < 1.e-12_r2) then ! completely frozen
        var%dthetaldT = zero
        var%lambdav   = lambdas ! latent heat of sublimation
        var%KT        = zero
@@ -2143,7 +2143,7 @@ CONTAINS
     ! if (z.lt.3.and.theta>parin%thfc) then
     !    macropore_modifier = exp(-parin%zeta*(z-3))
     ! ! if (theta > parin%thfc) then
-    ! !    macropore_modifier = 1000._r_2*exp(-var%h/(-4._r_2))
+    ! !    macropore_modifier = 1000._r2*exp(-var%h/(-4._r2))
     !    var%macropore_factor = macropore_modifier
     ! else
     !    var%macropore_factor = one
@@ -2172,11 +2172,11 @@ CONTAINS
        var%cvsatT = zero
     endif
     ! Penman (1940): tortuosity*theta
-    ! var%Dv    = Dva*parin%tortuosity*(parin%the-theta)  * ((Tsoil+Tzero)/Tzero)**1.88_r_2 ! m2 s-1
-    var%Dv    = Dva*parin%tortuosity*(parin%the-theta)  * exp(1.88_r_2*log((Tsoil+Tzero)/Tzero)) ! m2 s-1
+    ! var%Dv    = Dva*parin%tortuosity*(parin%the-theta)  * ((Tsoil+Tzero)/Tzero)**1.88_r2 ! m2 s-1
+    var%Dv    = Dva*parin%tortuosity*(parin%the-theta)  * exp(1.88_r2*log((Tsoil+Tzero)/Tzero)) ! m2 s-1
     ! ! Moldrup et al. (2003), Table 2 repacked soil (from Moldrup et al. (2000)
     ! ! (thetas-theta)**1.5 * (thetas-theta)/thetas
-    ! var%Dv    = Dva* (parin%the-theta)**1.5_r_2 * (parin%the-theta)/parin%the * ((Tsoil+Tzero)/Tzero)**1.88_r_2 ! m2 s-1
+    ! var%Dv    = Dva* (parin%the-theta)**1.5_r2 * (parin%the-theta)/parin%the * ((Tsoil+Tzero)/Tzero)**1.88_r2 ! m2 s-1
     ! int       = (-c*parin%he)**lambda * igamma(one-lambda,-c*var%h)
     int       = exp(lambda*log(-c*parin%he)) * igamma(one-lambda,-c*var%h)
     var%phiv  = Dva*parin%tortuosity * (parin%thre*exp(c*var%h) -parin%thre*int)
@@ -2192,21 +2192,21 @@ CONTAINS
        case (11,17) ! Hansson et al. (2004) - special soil properties
           ! Hansson et al. (2004) - Eq. 13b
           ! A=C1, B=C2, C1=C3, D=C4, E=C5
-          A  = 0.55_r_2
-          B  = 0.8_r_2
-          C1 = 3.07_r_2
-          D  = 0.13_r_2
+          A  = 0.55_r2
+          B  = 0.8_r2
+          C1 = 3.07_r2
+          D  = 0.13_r2
           E  = 4
        case default
           ! calculate v%kH as in Campbell (1985) p.32 eq. 4.20
-          A  = 0.65_r_2 - 0.78_r_2*parin%rho/thousand + 0.60_r_2*(parin%rho/thousand)**2 ! (4.27)
-          B  = 2.8_r_2 * (one-parin%thre) !*theta   ! (4.24)
-          if (parin%clay > 0.001_r_2) then ! clay=0.001 -> C1=9.2
-             C1 = one + 2.6_r_2/sqrt(parin%clay*100._r_2) ! (4.28)
+          A  = 0.65_r2 - 0.78_r2*parin%rho/thousand + 0.60_r2*(parin%rho/thousand)**2 ! (4.27)
+          B  = 2.8_r2 * (one-parin%thre) !*theta   ! (4.24)
+          if (parin%clay > 0.001_r2) then ! clay=0.001 -> C1=9.2
+             C1 = one + 2.6_r2/sqrt(parin%clay*100._r2) ! (4.28)
           else
              C1 = one
           endif
-          D  = 0.03_r_2 + 0.7_r_2*(one-parin%thre)**2 ! (4.22)
+          D  = 0.03_r2 + 0.7_r2*(one-parin%thre)**2 ! (4.22)
           E  = 4
        end select
        select case (experiment)
@@ -2215,12 +2215,12 @@ CONTAINS
           var%kH = A + B*theta-(A-D)*exp(-(C1*theta)**E) ! (4.20)
        case default ! different thermal conductivity in ice and water
           ! Hansson et al. (2004) - Eq. 15
-          F1 = 13.05_r_2
-          F2 = 1.06_r_2
+          F1 = 13.05_r2
+          F2 = 1.06_r2
           if  (Tsoil < var%Tfrz-tol .and.  var%thetai.gt.zero ) then ! ice
              ! F  = one + F1*var%thetai**F2
              F  = one + F1*exp(F2*log(var%thetai))
-             if ((C1*(theta+F*var%thetai))**E > 100._r_2) then
+             if ((C1*(theta+F*var%thetai))**E > 100._r2) then
                 var%kH = A + B*(theta+F*var%thetai)
              else
                 var%kH = A + B*(theta+F*var%thetai)-(A-D)*exp(-(C1*(theta+F*var%thetai))**E)
@@ -2230,16 +2230,16 @@ CONTAINS
           endif
        end select
     case(1) ! van de Griend & O'Neill (1986)
-       cdry = 2.0e6_r_2 * (one-parin%thre) ! Sispat Manual (2000), Eq. 2.21
-       var%kH = one/(cdry + 4.18e6_r_2*theta) * ( (parin%LambdaS + 2300._r_2*theta - 1890._r_2)/0.654_r_2 )**2
+       cdry = 2.0e6_r2 * (one-parin%thre) ! Sispat Manual (2000), Eq. 2.21
+       var%kH = one/(cdry + 4.18e6_r2*theta) * ( (parin%LambdaS + 2300._r2*theta - 1890._r2)/0.654_r2 )**2
     end select
     var%eta_th = one
     var%kE     = var%Dv*var%rh*var%sl*thousand*var%lambdav*var%eta_th
     var%kth    = var%kE + var%kH ! thermal conductivity of soil (includes contribution from vapour phase)
 
-    var%csoil    = parin%css*parin%rho + rhow*cswat*var%thetal + merge(0._r_2, rhow*csice*var%thetai, experiment==183)
+    var%csoil    = parin%css*parin%rho + rhow*cswat*var%thetal + merge(0._r2, rhow*csice*var%thetai, experiment==183)
     if (Tsoil < var%Tfrz) then ! increase effective heat capacity due to presence of ice
-       var%csoileff = var%csoil + merge(0._r_2, rhow*lambdaf*var%dthetaldT, experiment==183)
+       var%csoileff = var%csoil + merge(0._r2, rhow*lambdaf*var%dthetaldT, experiment==183)
     else
        var%csoileff = var%csoil
     endif
@@ -2253,9 +2253,9 @@ CONTAINS
     IMPLICIT NONE
 
     CHARACTER(LEN=2),       INTENT(IN)    :: iso
-    REAL(r_2),               INTENT(IN)    :: c
-    REAL(r_2), DIMENSION(:), INTENT(INOUT) :: p
-    REAL(r_2),               INTENT(OUT)   :: f, fd
+    REAL(r2),               INTENT(IN)    :: c
+    REAL(r2), DIMENSION(:), INTENT(INOUT) :: p
+    REAL(r2),               INTENT(OUT)   :: f, fd
     ! Subroutine to get adsorbed solute (units/g soil) from concn in soil water
     ! according to chosen isotherm code ("Fr" for Freundlich, "La" for Langmuir
     ! and "Ll" for Langmuir-linear).
@@ -2265,12 +2265,12 @@ CONTAINS
     ! p(:) - isotherm parameters.
     ! f    - adsorbed mass/g soil.
     ! fc   - deriv of f wrt c (slope of isotherm curve).
-    REAL(r_2) :: x
+    REAL(r2) :: x
 
     select case (iso)
     case ("Fr")
        if (eq(p(3),zero)) then ! linearise near zero
-          p(3) = (0.01_r_2*dsmmax/p(1))**(one/p(2)) ! concn at 0.01*dsmmax
+          p(3) = (0.01_r2*dsmmax/p(1))**(one/p(2)) ! concn at 0.01*dsmmax
           p(4) = p(1)*p(3)**(p(2)-one) ! slope
        end if
        if (c < p(3)) then
@@ -2304,29 +2304,29 @@ CONTAINS
 
   SUBROUTINE massman_sparse_1d(aa, aah, bb, bbh, cc, cch, dd, ddh, ee, eeh, ff, ffh, gg, ggh, dy, dT, condition, err)
 
-    USE cable_def_types_mod, ONLY: r_2, i_d
+    USE cable_def_types_mod, ONLY: r2, i4
     USE sli_numbers,       ONLY: zero, one
 
     IMPLICIT NONE
 
     ! in/out
-    REAL(r_2), DIMENSION(:), INTENT(IN)  :: aa, aah, bb, bbh, ee, eeh, ff, ffh
-    REAL(r_2), DIMENSION(:), INTENT(IN)  :: cc, cch, dd, ddh, gg, ggh
-    REAL(r_2), DIMENSION(:), INTENT(OUT) :: dy, dT
-    INTEGER(i_d),  OPTIONAL, INTENT(IN)  :: condition
-    INTEGER(i_d),  OPTIONAL, INTENT(OUT) :: err ! 0: no error; >0: error
+    REAL(r2), DIMENSION(:), INTENT(IN)  :: aa, aah, bb, bbh, ee, eeh, ff, ffh
+    REAL(r2), DIMENSION(:), INTENT(IN)  :: cc, cch, dd, ddh, gg, ggh
+    REAL(r2), DIMENSION(:), INTENT(OUT) :: dy, dT
+    INTEGER(i4),  OPTIONAL, INTENT(IN)  :: condition
+    INTEGER(i4),  OPTIONAL, INTENT(OUT) :: err ! 0: no error; >0: error
     ! local
-    INTEGER(i_d)                         :: n, n2
-    REAL(r_2), DIMENSION(size(cc),2,2)   :: A, B, C
-    REAL(r_2), DIMENSION(size(cc),2)     :: d, x
+    INTEGER(i4)                         :: n, n2
+    REAL(r2), DIMENSION(size(cc),2,2)   :: A, B, C
+    REAL(r2), DIMENSION(size(cc),2)     :: d, x
     ! for conditioning
-    REAL(r_2), DIMENSION(2*size(cc))       :: lST, cST
-    REAL(r_2), DIMENSION(size(cc))         :: lS, lT, cS, cT
-    REAL(r_2), DIMENSION(2*size(cc)*2*size(cc)) :: allvec
-    REAL(r_2), DIMENSION(2*size(cc),2*size(cc)) :: allmat
-    REAL(r_2)    :: eps
-    INTEGER(i_d) :: docond ! 0: no conditioning, 1: columns, 2: lines, 3: both
-    INTEGER(i_d) :: iierr ! error code for generic_thomas
+    REAL(r2), DIMENSION(2*size(cc))       :: lST, cST
+    REAL(r2), DIMENSION(size(cc))         :: lS, lT, cS, cT
+    REAL(r2), DIMENSION(2*size(cc)*2*size(cc)) :: allvec
+    REAL(r2), DIMENSION(2*size(cc),2*size(cc)) :: allmat
+    REAL(r2)    :: eps
+    INTEGER(i4) :: docond ! 0: no conditioning, 1: columns, 2: lines, 3: both
+    INTEGER(i4) :: iierr ! error code for generic_thomas
     ! CHARACTER(LEN=20) :: form1
     ! integer :: i, nn
     !
@@ -2459,30 +2459,30 @@ CONTAINS
 
   SUBROUTINE massman_sparse_2d(aa, aah, bb, bbh, cc, cch, dd, ddh, ee, eeh, ff, ffh, gg, ggh, dy, dT, condition, err)
 
-    USE cable_def_types_mod, ONLY: r_2, i_d
+    USE cable_def_types_mod, ONLY: r2, i4
     USE sli_numbers,       ONLY: zero, one
 
     IMPLICIT NONE
 
     ! in/out
-    REAL(r_2), DIMENSION(:,:), INTENT(IN)  :: aa, aah, bb, bbh, ee, eeh, ff, ffh
-    REAL(r_2), DIMENSION(:,:), INTENT(IN)  :: cc, cch, dd, ddh, gg, ggh
-    REAL(r_2), DIMENSION(:,:), INTENT(OUT) :: dy, dT
-    INTEGER(i_d),    OPTIONAL, INTENT(IN)  :: condition
-    INTEGER(i_d),    OPTIONAL, INTENT(OUT) :: err ! 0: no error; >0: error
+    REAL(r2), DIMENSION(:,:), INTENT(IN)  :: aa, aah, bb, bbh, ee, eeh, ff, ffh
+    REAL(r2), DIMENSION(:,:), INTENT(IN)  :: cc, cch, dd, ddh, gg, ggh
+    REAL(r2), DIMENSION(:,:), INTENT(OUT) :: dy, dT
+    INTEGER(i4),    OPTIONAL, INTENT(IN)  :: condition
+    INTEGER(i4),    OPTIONAL, INTENT(OUT) :: err ! 0: no error; >0: error
     ! local
-    INTEGER(i_d)                                        :: n, mp
-    INTEGER(i_d)                                        :: n2
-    REAL(r_2), DIMENSION(1:size(cc,1),1:size(cc,2),2,2) :: A, B, C
-    REAL(r_2), DIMENSION(1:size(cc,1),1:size(cc,2),2)   :: d, x
+    INTEGER(i4)                                        :: n, mp
+    INTEGER(i4)                                        :: n2
+    REAL(r2), DIMENSION(1:size(cc,1),1:size(cc,2),2,2) :: A, B, C
+    REAL(r2), DIMENSION(1:size(cc,1),1:size(cc,2),2)   :: d, x
     ! for conditioning
-    REAL(r_2), DIMENSION(1:size(cc,1),2*size(cc,2))     :: lST, cST
-    REAL(r_2), DIMENSION(1:size(cc,1),size(cc,2))       :: lS, lT, cS, cT
-    REAL(r_2), DIMENSION(1:size(cc,1),2*size(cc,2)*2*size(cc,2)) :: allvec
-    REAL(r_2), DIMENSION(1:size(cc,1),2*size(cc,2),2*size(cc,2)) :: allmat
-    REAL(r_2)    :: eps
-    INTEGER(i_d) :: docond ! 0: no conditioning, 1: columns, 2: lines, 3: both
-    INTEGER(i_d) :: iierr ! error code for generic_thomas
+    REAL(r2), DIMENSION(1:size(cc,1),2*size(cc,2))     :: lST, cST
+    REAL(r2), DIMENSION(1:size(cc,1),size(cc,2))       :: lS, lT, cS, cT
+    REAL(r2), DIMENSION(1:size(cc,1),2*size(cc,2)*2*size(cc,2)) :: allvec
+    REAL(r2), DIMENSION(1:size(cc,1),2*size(cc,2),2*size(cc,2)) :: allmat
+    REAL(r2)    :: eps
+    INTEGER(i4) :: docond ! 0: no conditioning, 1: columns, 2: lines, 3: both
+    INTEGER(i4) :: iierr ! error code for generic_thomas
     ! CHARACTER(LEN=20) :: form1
     ! integer :: i, k, nn
     !
@@ -2645,22 +2645,22 @@ CONTAINS
 
     IMPLICIT NONE
 
-    REAL(r_2),    INTENT(IN)    :: S
-    REAL(r_2),    INTENT(IN)    :: Tsoil
+    REAL(r2),    INTENT(IN)    :: S
+    REAL(r2),    INTENT(IN)    :: Tsoil
     TYPE(vars),   INTENT(INOUT) :: vlit
     TYPE(params), INTENT(IN)    :: plit
-    REAL(r_2),    INTENT(IN)    :: h0
+    REAL(r2),    INTENT(IN)    :: h0
     ! Get soil water variables from S.
     ! Definitions of arguments:
     ! S(1:ms)    - degree of saturation ("effective satn") of layers.
     ! ms        - no. of soil layers.
     ! jt(1:ms)    - layer soil type nos.
     ! var(1:ms) - other water vars of layers.
-    REAL(r_2), PARAMETER :: u = 1.0 ! wind speed at litter surface
-    REAL(r_2) :: theta, c
-    REAL(r_2) :: dhdS, sl
-    REAL(r_2) :: rhoL, copo, c_w ! params for thermal vapour transfer enhancement factor (Campbell 1985)
-    REAL(r_2) :: chi, DT0
+    REAL(r2), PARAMETER :: u = 1.0 ! wind speed at litter surface
+    REAL(r2) :: theta, c
+    REAL(r2) :: dhdS, sl
+    REAL(r2) :: rhoL, copo, c_w ! params for thermal vapour transfer enhancement factor (Campbell 1985)
+    REAL(r2) :: chi, DT0
 
     sl      = slope_esat(Tsoil)*Mw/thousand/Rgas/(Tsoil+Tzero) ! m3 m-3 K-1
     vlit%sl = sl
@@ -2673,8 +2673,8 @@ CONTAINS
     !    vlit%hS = dhdS
     ! Mathews (2006), A process-based model of offine fuel moisture,
     !                 International Journal of Wildland Fire 15,155-168
-    chi     = 2.08_r_2+u*2.38_r_2 ! (Eq. 45, Tab. 1)
-    DT0     = Dva*exp(u*2.6_r_2) ! (Eq. 46, Tab. 1)
+    chi     = 2.08_r2+u*2.38_r2 ! (Eq. 45, Tab. 1)
+    DT0     = Dva*exp(u*2.6_r2) ! (Eq. 46, Tab. 1)
     vlit%Dv = DT0*exp(-half*chi) ! heat and vapour diffusivity half-way through layer (Eq. 11)
     !write(*,*) 'litter_props', vlit%Dv
     if (S < one) then
@@ -2696,9 +2696,9 @@ CONTAINS
     vlit%phiS   = vlit%phivS
     vlit%rhS    = dhdS*c*vlit%rh
     ! sensible heat conductivity of wet soil W m-1 K-1 (Matthews 2006)
-    vlit%kH     = 0.2_r_2 + 0.14_r_2*theta*thousand/rhoL
-    copo        = 1932._r_2
-    c_w         = 4.185e6_r_2
+    vlit%kH     = 0.2_r2 + 0.14_r2*theta*thousand/rhoL
+    copo        = 1932._r2
+    c_w         = 4.185e6_r2
     vlit%csoil  = copo*rhoL + c_w*theta + c_w*h0 !volumetric heat capacity of wet soil
     vlit%eta_th = one !enhancement factor for transport of water vapour due to a temperature gradient
     vlit%kE     = vlit%Dv*vlit%rh*sl*thousand*rlambda
@@ -2717,11 +2717,11 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
 
     IMPLICIT NONE
 
-    REAL(r_2), INTENT(IN)  :: Rn, rbh, rbw, Ta, rha, Tsoil, k, dz, lambdav
-    REAL(r_2), INTENT(OUT) :: Ts, E, H, G, dEdrha, dEdTs, dEdTsoil, dGdTa, dGdTsoil
+    REAL(r2), INTENT(IN)  :: Rn, rbh, rbw, Ta, rha, Tsoil, k, dz, lambdav
+    REAL(r2), INTENT(OUT) :: Ts, E, H, G, dEdrha, dEdTs, dEdTsoil, dGdTa, dGdTsoil
     LOGICAL, INTENT(IN), OPTIONAL :: iice
-    REAL(r_2) :: s, es, ea, dEdea, dEdesat, dTsdTa, dEdDa, Da
-    REAL(r_2):: rhocp, gamma != 67.0 ! psychrometric constant
+    REAL(r2) :: s, es, ea, dEdea, dEdesat, dTsdTa, dEdDa, Da
+    REAL(r2):: rhocp, gamma != 67.0 ! psychrometric constant
 
     if (present(iice)) then
        if(iice) then
@@ -2736,10 +2736,10 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
        s  = slope_esat(Ta)
     endif
 
-    rhocp = rmair*101325._r_2/rgas/(Ta+Tzero)*cpa
-    gamma = 101325._r_2*cpa/lambdav/(Mw/rmair)
-    ea = es * max(rha, 0.1_r_2)
-    Da = ea/max(rha, 0.1_r_2) - ea
+    rhocp = rmair*101325._r2/rgas/(Ta+Tzero)*cpa
+    gamma = 101325._r2*cpa/lambdav/(Mw/rmair)
+    ea = es * max(rha, 0.1_r2)
+    Da = ea/max(rha, 0.1_r2) - ea
 
     E  = (rhocp*(Da*(k*rbh + dz*rhocp) + rbh*s*(dz*Rn + k*(-Ta + Tsoil)))) / &
          (gamma*rbw*(k*rbh + dz*rhocp) + dz*rbh*rhocp*s)
@@ -2768,25 +2768,25 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
 
     IMPLICIT NONE
 
-    INTEGER(i_d),              INTENT(IN) :: mp
+    INTEGER(i4),              INTENT(IN) :: mp
     TYPE(veg_parameter_type), INTENT(IN) :: veg
-    integer(i_d), DIMENSION(:),  INTENT(IN) :: index
+    integer(i4), DIMENSION(:),  INTENT(IN) :: index
 
     allocate(plit(mp))
     allocate(dxL(mp))
 
-    plit%the   = 0.09_r_2
-    plit%thre  = 0.09_r_2
-    plit%he    = -35.0_r_2
-    plit%lam   = one/2.4_r_2
+    plit%the   = 0.09_r2
+    plit%thre  = 0.09_r2
+    plit%he    = -35.0_r2
+    plit%lam   = one/2.4_r2
     plit%Ke    = zero
     plit%eta   = zero
     plit%KSe   = zero
     plit%phie  = zero
     plit%phiSe = zero
-    plit%rho   = 63.5_r_2
+    plit%rho   = 63.5_r2
     ! dxL        = zero            ! litter params
-    dxL        = real(veg%clitt(index),r_2)*two/plit%rho*0.1_r_2
+    dxL        = real(veg%clitt(index),r2)*two/plit%rho*0.1_r2
 
     plit%ishorizon  = 0
     plit%thw        = zero
@@ -2814,86 +2814,86 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
 
     IMPLICIT NONE
 
-    INTEGER(i_d),                 INTENT(IN) :: mp
-    INTEGER(i_d),                 INTENT(IN) :: ms
+    INTEGER(i4),                 INTENT(IN) :: mp
+    INTEGER(i4),                 INTENT(IN) :: ms
     TYPE(soil_parameter_type),    INTENT(IN) :: soil
-    integer(i_d), DIMENSION(:),   INTENT(IN) :: index
+    integer(i4), DIMENSION(:),   INTENT(IN) :: index
 
-    INTEGER(i_d) :: i
+    INTEGER(i4) :: i
 
     allocate(par(mp,ms))
 
     do i=1, ms
        par(:,i)%ishorizon  = soil%ishorizon(index,i)
-       par(:,i)%thw        = real(soil%swilt(index),r_2)
-       par(:,i)%thfc       = real(soil%sfc(index),r_2)
-       par(:,i)%the        = real(soil%ssat(index),r_2)
+       par(:,i)%thw        = real(soil%swilt(index),r2)
+       par(:,i)%thfc       = real(soil%sfc(index),r2)
+       par(:,i)%the        = real(soil%ssat(index),r2)
        par(:,i)%thr        = zero
-       par(:,i)%thre       = real(soil%ssat(index),r_2) - par(:,i)%thr
-       par(:,i)%he         = real(soil%sucs(index),r_2)
-       par(:,i)%Ke         = real(soil%hyds(index),r_2)
-       par(:,i)%lam        = one/real(soil%bch(index),r_2)
+       par(:,i)%thre       = real(soil%ssat(index),r2) - par(:,i)%thr
+       par(:,i)%he         = real(soil%sucs(index),r2)
+       par(:,i)%Ke         = real(soil%hyds(index),r2)
+       par(:,i)%lam        = one/real(soil%bch(index),r2)
        par(:,i)%eta        = two/par(:,i)%lam + two + one
        par(:,i)%KSe        = par(:,i)%eta * par(:,i)%Ke    ! dK/dS at he
        par(:,i)%phie       = par(:,i)%Ke * par(:,i)%he / (one - par(:,i)%lam * par(:,i)%eta) ! MFP at he
        par(:,i)%phiSe      = (par(:,i)%eta - one/par(:,i)%lam) * par(:,i)%phie    ! dphi/dS at he
-       par(:,i)%kd         = real(soil%cnsd(index),r_2)
-       par(:,i)%css        = real(soil%css(index),r_2)
-       par(:,i)%rho        = real(soil%rhosoil(index),r_2)
-       par(:,i)%tortuosity = 0.67_r_2
-       par(:,i)%clay       = real(soil%clay(index),r_2)
-       par(:,i)%zeta       = real(soil%zeta(index),r_2)
-       par(:,i)%fsatmax    = real(soil%fsatmax(index),r_2)
+       par(:,i)%kd         = real(soil%cnsd(index),r2)
+       par(:,i)%css        = real(soil%css(index),r2)
+       par(:,i)%rho        = real(soil%rhosoil(index),r2)
+       par(:,i)%tortuosity = 0.67_r2
+       par(:,i)%clay       = real(soil%clay(index),r2)
+       par(:,i)%zeta       = real(soil%zeta(index),r2)
+       par(:,i)%fsatmax    = real(soil%fsatmax(index),r2)
        par(:,i)%lambc      = par(:,i)%lam
-       !par(:,i)%LambdaS    = real(soil%LambdaS(index),r_2)
-       par(:,i)%LambdaS    = 2830_r_2 ! Sispat Manual Table 2
+       !par(:,i)%LambdaS    = real(soil%LambdaS(index),r2)
+       par(:,i)%LambdaS    = 2830._r2 ! Sispat Manual Table 2
     enddo
 
 ! special for Cumberland: set soil params to clay:
     if (cable_user%Cumberland_soil) then
        do i=1,ms
-          par(:,i)%thw        = 0.286_r_2
-          par(:,i)%thfc       = 0.367_r_2
-          par(:,i)%the        = 0.482_r_2
-          par(:,i)%thre       = real(soil%ssat(index),r_2) - par(:,i)%thr
-          par(:,i)%he         = -0.405_r_2
-          par(:,i)%Ke         = 1.e-6_r_2
-          par(:,i)%lam        = 1._r_2/11.4_r_2
+          par(:,i)%thw        = 0.286_r2
+          par(:,i)%thfc       = 0.367_r2
+          par(:,i)%the        = 0.482_r2
+          par(:,i)%thre       = real(soil%ssat(index),r2) - par(:,i)%thr
+          par(:,i)%he         = -0.405_r2
+          par(:,i)%Ke         = 1.e-6_r2
+          par(:,i)%lam        = 1._r2/11.4_r2
           par(:,i)%eta        = two/par(:,i)%lam + two + one
           par(:,i)%KSe        = par(:,i)%eta * par(:,i)%Ke    ! dK/dS at he
           par(:,i)%phie       = par(:,i)%Ke * par(:,i)%he / (one - par(:,i)%lam * par(:,i)%eta) ! MFP at he
           par(:,i)%phiSe      = (par(:,i)%eta - one/par(:,i)%lam) * par(:,i)%phie    ! dphi/dS at he
-          par(:,i)%clay       = 0.67_r_2
+          par(:,i)%clay       = 0.67_r2
 
-!!$          par(:,i)%thw        = 0.178_r_2
-!!$          par(:,i)%thfc       = 0.367_r_2
-!!$          par(:,i)%the        = 0.45_r_2
-!!$          par(:,i)%thre       = real(soil%ssat(index),r_2) - par(:,i)%thr
-!!$          par(:,i)%he         = -0.572_r_2
-!!$          par(:,i)%Ke         = 2.8e-5_r_2
-!!$          par(:,i)%lam        = 1._r_2/8.7_r_2
+!!$          par(:,i)%thw        = 0.178_r2
+!!$          par(:,i)%thfc       = 0.367_r2
+!!$          par(:,i)%the        = 0.45_r2
+!!$          par(:,i)%thre       = real(soil%ssat(index),r2) - par(:,i)%thr
+!!$          par(:,i)%he         = -0.572_r2
+!!$          par(:,i)%Ke         = 2.8e-5_r2
+!!$          par(:,i)%lam        = 1._r2/8.7_r2
 !!$          par(:,i)%eta        = two/par(:,i)%lam + two + one
 !!$          par(:,i)%KSe        = par(:,i)%eta * par(:,i)%Ke    ! dK/dS at he
 !!$          par(:,i)%phie       = par(:,i)%Ke * par(:,i)%he / (one - par(:,i)%lam * par(:,i)%eta) ! MFP at he
 !!$          par(:,i)%phiSe      = (par(:,i)%eta - one/par(:,i)%lam) * par(:,i)%phie    ! dphi/dS at he
-!!$          par(:,i)%clay       = 0.2_r_2
+!!$          par(:,i)%clay       = 0.2_r2
        enddo
     endif
 
 !!$   ! special for Cumberland: set top 3 layers to sand
 !!$   do i=1,3
-!!$      par(:,i)%thw        = 0.175_r_2
-!!$      par(:,i)%thfc       = 0.255_r_2
-!!$      par(:,i)%the        = 0.420_r_2
-!!$      par(:,i)%thre       = real(soil%ssat(index),r_2) - par(:,i)%thr
-!!$      par(:,i)%he         = -0.299_r_2
-!!$      par(:,i)%Ke         = 6.e-6_r_2
-!!$      par(:,i)%lam        = 1._r_2/7.12_r_2
+!!$      par(:,i)%thw        = 0.175_r2
+!!$      par(:,i)%thfc       = 0.255_r2
+!!$      par(:,i)%the        = 0.420_r2
+!!$      par(:,i)%thre       = real(soil%ssat(index),r2) - par(:,i)%thr
+!!$      par(:,i)%he         = -0.299_r2
+!!$      par(:,i)%Ke         = 6.e-6_r2
+!!$      par(:,i)%lam        = 1._r2/7.12_r2
 !!$      par(:,i)%eta        = two/par(:,i)%lam + two + one
 !!$      par(:,i)%KSe        = par(:,i)%eta * par(:,i)%Ke    ! dK/dS at he
 !!$      par(:,i)%phie       = par(:,i)%Ke * par(:,i)%he / (one - par(:,i)%lam * par(:,i)%eta) ! MFP at he
 !!$      par(:,i)%phiSe      = (par(:,i)%eta - one/par(:,i)%lam) * par(:,i)%phie    ! dphi/dS at he
-!!$      par(:,i)%clay       = 0.27_r_2
+!!$      par(:,i)%clay       = 0.27_r2
 !!$
 !!$   enddo
 
@@ -2906,83 +2906,83 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
 
     IMPLICIT NONE
 
-    INTEGER(i_d),                 INTENT(IN)    :: mp
-    INTEGER(i_d),                 INTENT(IN)    :: ms
-    REAL(r_2),    DIMENSION(:,:), INTENT(IN)    :: x2dx
+    INTEGER(i4),                 INTENT(IN)    :: mp
+    INTEGER(i4),                 INTENT(IN)    :: ms
+    REAL(r2),    DIMENSION(:,:), INTENT(IN)    :: x2dx
 
-    INTEGER(i_d) :: i
+    INTEGER(i4) :: i
 
     allocate(par(mp,ms))
 
     do i=1, ms
-       where (x2dx(:,i) .lt. 0.15_r_2)
+       where (x2dx(:,i) .lt. 0.15_r2)
           par(:,i)%ishorizon  = 1
-          par(:,i)%thw        = 0.07_r_2
-          par(:,i)%thfc       = 0.45_r_2
-          par(:,i)%the        = 0.60_r_2
-          par(:,i)%thr        = 0.00_r_2
-          par(:,i)%he         = -6.76_r_2
-          par(:,i)%lam        = 0.70_r_2
-          par(:,i)%Ke         = 2.754e-5_r_2
-       elsewhere (x2dx(:,i) .gt. 2.0_r_2)
+          par(:,i)%thw        = 0.07_r2
+          par(:,i)%thfc       = 0.45_r2
+          par(:,i)%the        = 0.60_r2
+          par(:,i)%thr        = 0.00_r2
+          par(:,i)%he         = -6.76_r2
+          par(:,i)%lam        = 0.70_r2
+          par(:,i)%Ke         = 2.754e-5_r2
+       elsewhere (x2dx(:,i) .gt. 2.0_r2)
           par(:,i)%ishorizon  = 3
-          par(:,i)%thw        = 0.18_r_2
-          par(:,i)%thfc       = 0.35_r_2
-          par(:,i)%the        = 0.57_r_2
-          par(:,i)%thr        = 0.00_r_2
-          par(:,i)%he         = -1.23_r_2    ! optimised, was -1.46
-          par(:,i)%lam        = 0.67_r_2     ! optimised, was 0.25
-          par(:,i)%Ke         = 1.013e-5_r_2 ! optimised, was 2.481e-7
+          par(:,i)%thw        = 0.18_r2
+          par(:,i)%thfc       = 0.35_r2
+          par(:,i)%the        = 0.57_r2
+          par(:,i)%thr        = 0.0_r2
+          par(:,i)%he         = -1.23_r2    ! optimised, was -1.46
+          par(:,i)%lam        = 0.67_r2     ! optimised, was 0.25
+          par(:,i)%Ke         = 1.013e-5_r2 ! optimised, was 2.481e-7
        elsewhere
           par(:,i)%ishorizon  = 2
-          par(:,i)%thw        = 0.18_r_2
-          par(:,i)%thfc       = 0.35_r_2
-          par(:,i)%the        = 0.57_r_2
-          par(:,i)%thr        = 0.00_r_2
-          par(:,i)%he         = -1.46_r_2
-          par(:,i)%lam        = 0.25_r_2
-          par(:,i)%Ke         = 2.481e-5_r_2
+          par(:,i)%thw        = 0.18_r2
+          par(:,i)%thfc       = 0.35_r2
+          par(:,i)%the        = 0.57_r2
+          par(:,i)%thr        = 0.00_r2
+          par(:,i)%he         = -1.46_r2
+          par(:,i)%lam        = 0.25_r2
+          par(:,i)%Ke         = 2.481e-5_r2
        end where
     enddo
-    par%clay       = 0.06_r_2
-    par%tortuosity = 0.67_r_2
+    par%clay       = 0.06_r2
+    par%tortuosity = 0.67_r2
     par%thre       = par%the - par%thr
     par%eta        = two/par%lam + two + one
     par%KSe        = par%eta * par%Ke    ! dK/dS at he
     par%phie       = par%Ke * par%he / (one - par%lam * par%eta) ! MFP at he
     par%phiSe      = (par%eta - one/par%lam) * par%phie    ! dphi/dS at he
     par%kd         = zero ! not used
-    par%rho        = 2650._r_2 * par%the            ! porosity = soil/stone
-    par%css        = 2400._r_2/2650._r_2  * par%rho ! Campbell (1985)
-    par%zeta       = 2.0_r_2   ! topmodel exponent baseflow
-    par%fsatmax    = 0.30_r_2  ! topmodel maximum saturated fraction
+    par%rho        = 2650._r2 * par%the            ! porosity = soil/stone
+    par%css        = 2400._r2/2650._r2  * par%rho ! Campbell (1985)
+    par%zeta       = 2.0_r2   ! topmodel exponent baseflow
+    par%fsatmax    = 0.30_r2  ! topmodel maximum saturated fraction
     par%lambc      = par%lam
-    par%LambdaS    = 2539._r_2 ! optimised, was 2830 ! Sispat Manual Table 2
+    par%LambdaS    = 2539._r2 ! optimised, was 2830 ! Sispat Manual Table 2
 
     ! ! Cable coarse sand
     ! par%ishorizon  = 1
-    ! par%thw        = 0.072_r_2
-    ! par%thfc       = 0.143_r_2
-    ! par%the        = 0.398_r_2
+    ! par%thw        = 0.072_r2
+    ! par%thfc       = 0.143_r2
+    ! par%the        = 0.398_r2
     ! par%thr        = zero
-    ! par%he         = -0.106_r_2
-    ! par%Ke         = 166.e-6_r_2
-    ! par%lam        = 1.0_r_2/4.2_r_2
-    ! par%clay       = 0.09_r_2
-    ! par%rho        = 1600._r_2
-    ! par%css        = 850._r_2
+    ! par%he         = -0.106_r2
+    ! par%Ke         = 166.e-6_r2
+    ! par%lam        = 1.0_r2/4.2_r2
+    ! par%clay       = 0.09_r2
+    ! par%rho        = 1600._r2
+    ! par%css        = 850._r2
     ! !
-    ! par%tortuosity = 0.67_r_2
+    ! par%tortuosity = 0.67_r2
     ! par%thre       = par%the - par%thr
     ! par%eta        = two/par%lam + two + one
     ! par%KSe        = par%eta * par%Ke    ! dK/dS at he
     ! par%phie       = par%Ke * par%he / (one - par%lam * par%eta) ! MFP at he
     ! par%phiSe      = (par%eta - one/par%lam) * par%phie    ! dphi/dS at he
     ! par%kd         = zero ! not used
-    ! par%zeta       = 2.0_r_2
-    ! par%fsatmax    = 0.3_r_2
+    ! par%zeta       = 2.0_r2
+    ! par%fsatmax    = 0.3_r2
     ! par%lambc      = par%lam
-    ! par%LambdaS    = 2800._r_2 ! Sispat Manual Table 2
+    ! par%LambdaS    = 2800._r2 ! Sispat Manual Table 2
 
   END SUBROUTINE setpar_Loetsch
 
@@ -2992,7 +2992,7 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
 
     IMPLICIT NONE
 
-    INTEGER(i_d), INTENT(IN) :: mp
+    INTEGER(i4), INTENT(IN) :: mp
 
     allocate(sol(mp))
 
@@ -3023,24 +3023,24 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
 
     IMPLICIT NONE
 
-    INTEGER(i_d),              INTENT(IN) :: mp
-    INTEGER(i_d),              INTENT(IN) :: ms
+    INTEGER(i4),              INTENT(IN) :: mp
+    INTEGER(i4),              INTENT(IN) :: ms
     TYPE(soil_parameter_type), INTENT(IN) :: soil
 
-    REAL(r_2), DIMENSION(ms) :: tmp1d
+    REAL(r2), DIMENSION(ms) :: tmp1d
     INTEGER :: i
 
     allocate(x(mp,ms))
     allocate(dx(mp,ms))
 
     ! cumulative soil layer depths = bottom of soil layers
-    tmp1d(1) = real(soil%zse(1),r_2)
+    tmp1d(1) = real(soil%zse(1),r2)
     do i=2, ms
-       tmp1d(i) = tmp1d(i-1) + real(soil%zse(i),r_2)
+       tmp1d(i) = tmp1d(i-1) + real(soil%zse(i),r2)
     end do
 
     ! soil layer depth
-    dx(1:mp,1:ms) = spread(real(soil%zse(1:ms),r_2),1,mp)
+    dx(1:mp,1:ms) = spread(real(soil%zse(1:ms),r2),1,mp)
     ! bottom of each soil layer
     x(1:mp,1:ms)  = spread(tmp1d(1:ms),1,mp)
 
@@ -3052,13 +3052,13 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
 
     IMPLICIT NONE
 
-    INTEGER(i_d),                 INTENT(IN)    :: ns
-    INTEGER(i_d),                 INTENT(IN)    :: n
-    REAL(r_2),    DIMENSION(0:n), INTENT(IN)    :: aa
-    REAL(r_2),    DIMENSION(0:n), INTENT(IN)    :: cc
-    REAL(r_2),    DIMENSION(0:n), INTENT(IN)    :: dd
-    REAL(r_2),    DIMENSION(0:n), INTENT(INOUT) :: bb
-    REAL(r_2),    DIMENSION(0:n), INTENT(INOUT) :: dy
+    INTEGER(i4),                 INTENT(IN)    :: ns
+    INTEGER(i4),                 INTENT(IN)    :: n
+    REAL(r2),    DIMENSION(0:n), INTENT(IN)    :: aa
+    REAL(r2),    DIMENSION(0:n), INTENT(IN)    :: cc
+    REAL(r2),    DIMENSION(0:n), INTENT(IN)    :: dd
+    REAL(r2),    DIMENSION(0:n), INTENT(INOUT) :: bb
+    REAL(r2),    DIMENSION(0:n), INTENT(INOUT) :: dy
     ! Solves tridiag set of linear eqns. Coeff arrays aa and cc left intact.
     ! Definitions of arguments:
     ! ns      - start index for eqns.
@@ -3069,8 +3069,8 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
     ! dd(0:n) - rhs coeffs; ns:n used.
     ! ee(0:n) - work space.
     ! dy(0:n) - solution in ns:n.
-    REAL(r_2),   DIMENSION(0:n) :: ee
-    INTEGER(i_d)                :: i
+    REAL(r2),   DIMENSION(0:n) :: ee
+    INTEGER(i4)                :: i
 
     dy(ns) = dd(ns) ! decomposition and forward substitution
     do i=ns, n-1
@@ -3091,14 +3091,14 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
 
     IMPLICIT NONE
 
-    INTEGER(i_d),                      INTENT(IN)    :: mp
-    INTEGER(i_d),                      INTENT(IN)    :: ns
-    INTEGER(i_d),                      INTENT(IN)    :: n
-    REAL(r_2),    DIMENSION(1:mp,0:n), INTENT(IN)    :: aa
-    REAL(r_2),    DIMENSION(1:mp,0:n), INTENT(IN)    :: cc
-    REAL(r_2),    DIMENSION(1:mp,0:n), INTENT(IN)    :: dd
-    REAL(r_2),    DIMENSION(1:mp,0:n), INTENT(INOUT) :: bb
-    REAL(r_2),    DIMENSION(1:mp,0:n), INTENT(INOUT) :: dy
+    INTEGER(i4),                      INTENT(IN)    :: mp
+    INTEGER(i4),                      INTENT(IN)    :: ns
+    INTEGER(i4),                      INTENT(IN)    :: n
+    REAL(r2),    DIMENSION(1:mp,0:n), INTENT(IN)    :: aa
+    REAL(r2),    DIMENSION(1:mp,0:n), INTENT(IN)    :: cc
+    REAL(r2),    DIMENSION(1:mp,0:n), INTENT(IN)    :: dd
+    REAL(r2),    DIMENSION(1:mp,0:n), INTENT(INOUT) :: bb
+    REAL(r2),    DIMENSION(1:mp,0:n), INTENT(INOUT) :: dy
     ! Solves tridiag set of linear eqns. Coeff arrays aa and cc left intact.
     ! Definitions of arguments:
     ! mp      - number of land patches
@@ -3110,8 +3110,8 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
     ! dd(0:n) - rhs coeffs; ns:n used.
     ! ee(0:n) - work space.
     ! dy(0:n) - solution in ns:n.
-    REAL(r_2),   DIMENSION(1:mp,0:n) :: ee
-    INTEGER(i_d)                     :: i
+    REAL(r2),   DIMENSION(1:mp,0:n) :: ee
+    INTEGER(i4)                     :: i
 
     dy(:,ns) = dd(:,ns) ! decomposition and forward substitution
     do i=ns, n-1
@@ -3132,13 +3132,13 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
   ! FUNCTIONS - alphabetical
   !**********************************************************************************************************************
 
-  REAL(r_2) ELEMENTAL PURE FUNCTION csat(T)
+  REAL(r2) ELEMENTAL PURE FUNCTION csat(T)
     !returns  sat vapour pressure curve in kg m-3
     USE sli_numbers, ONLY: Tzero, Rgas, Mw, esata, esatb, esatc
 
     IMPLICIT NONE
 
-    real(r_2), intent(in) :: T
+    real(r2), intent(in) :: T
 
     csat = esata * exp(esatb*T/(T+esatc)) * Mw/Rgas/(T+Tzero)
 
@@ -3146,13 +3146,13 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
 
   !**********************************************************************************************************************
 
-  REAL(r_2) ELEMENTAL PURE FUNCTION csoil(thetal,thetai,css,rho)
+  REAL(r2) ELEMENTAL PURE FUNCTION csoil(thetal,thetai,css,rho)
     ! determines heat capacity of soil (Jkg-1K-1)
     USE sli_numbers, ONLY: rhow, cswat, csice
 
     IMPLICIT NONE
 
-    real(r_2), intent(in) ::  thetal, thetai, css, rho
+    real(r2), intent(in) ::  thetal, thetai, css, rho
 
     csoil = css*rho + rhow*cswat*thetal + rhow*csice*thetai
 
@@ -3160,14 +3160,14 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
 
   !**********************************************************************************************************************
 
-  REAL(r_2) ELEMENTAL PURE FUNCTION dthetalmaxdT(Tin,S,he,b,thre,the)
+  REAL(r2) ELEMENTAL PURE FUNCTION dthetalmaxdT(Tin,S,he,b,thre,the)
     ! determines derivative of thetalmax wrt T
     USE sli_numbers, ONLY: gravity, lambdaf, csol, Rgas, Tzero
 
     IMPLICIT NONE
 
-    real(r_2), intent(in) :: Tin,S,he,b,thre,the
-    real(r_2)             :: dthetaldh, h, psi, PI, T, thetalmax
+    real(r2), intent(in) :: Tin,S,he,b,thre,the
+    real(r2)             :: dthetaldh, h, psi, PI, T, thetalmax
 
     T = min(Tfrz(min(S,one),he,b),Tin)
     PI  = -csol*Rgas*(T+Tzero)/gravity ! osmotic potential (m)
@@ -3185,15 +3185,15 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
 
   !**********************************************************************************************************************
 
-  REAL(r_2) ELEMENTAL PURE FUNCTION dthetalmaxdTh(Tin,S,he,b,thre,the)
+  REAL(r2) ELEMENTAL PURE FUNCTION dthetalmaxdTh(Tin,S,he,b,thre,the)
     ! determines derivative of thetalmax wrt T
     ! (uses dthetaldh defined in terms of S ...required for crossing freezing point)
     USE sli_numbers, ONLY: gravity, lambdaf, csol, Rgas, Tzero
 
     IMPLICIT NONE
 
-    real(r_2), INTENT(in) :: Tin,S,he,b,thre,the
-    real(r_2)             :: dthetaldh, h, theta, T
+    real(r2), INTENT(in) :: Tin,S,he,b,thre,the
+    real(r2)             :: dthetaldh, h, theta, T
 
     T     = min(Tfrz(S,he,b),Tin)
     ! h     = he * S**(-b)
@@ -3208,13 +3208,13 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
 
   !*********************************************************************************************************************
 
-  REAL(r_2) ELEMENTAL PURE FUNCTION esat(T)
+  REAL(r2) ELEMENTAL PURE FUNCTION esat(T)
     !returns sat vapour pressure curve in Pa
     USE sli_numbers, ONLY: esata, esatb, esatc
 
     IMPLICIT NONE
 
-    real(r_2), intent(in) :: T
+    real(r2), intent(in) :: T
 
     esat = esata * exp(esatb*T/(T+esatc))
 
@@ -3222,7 +3222,7 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
 
   !**********************************************************************************************************************
 
-  REAL(r_2) ELEMENTAL PURE FUNCTION gammln(z)
+  REAL(r2) ELEMENTAL PURE FUNCTION gammln(z)
     !  Uses Lanczos-type approximation to ln(gamma) for z > 0.
     !  Reference:
     !       Lanczos, C. 'A precision approximation of the gamma
@@ -3235,20 +3235,20 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
     !  Latest revision - 14 October 1996
     IMPLICIT NONE
 
-    REAL(r_2), INTENT(IN) :: z
+    REAL(r2), INTENT(IN) :: z
     ! Local variables
-    REAL(r_2), PARAMETER :: a(9) = (/ &
-         0.9999999999995183_r_2, 676.5203681218835_r_2, -1259.139216722289_r_2, &
-         771.3234287757674_r_2, -176.6150291498386_r_2, 12.50734324009056_r_2, &
-         -0.1385710331296526_r_2, 0.9934937113930748E-05_r_2, 0.1659470187408462E-06_r_2 /)
-    REAL(r_2), PARAMETER :: zero = 0.0_r_2
-    REAL(r_2), PARAMETER :: one = 1.0_r_2
-    REAL(r_2), PARAMETER :: lnsqrt2pi =  0.9189385332046727_r_2
-    REAL(r_2), PARAMETER :: half = 0.5_r_2
-    REAL(r_2), PARAMETER :: sixpt5 = 6.5_r_2
-    REAL(r_2), PARAMETER :: seven = 7.0_r_2
-    REAL(r_2)    :: tmp, tmpgammln
-    INTEGER(i_d) :: j
+    REAL(r2), PARAMETER :: a(9) = (/ &
+         0.9999999999995183_r2, 676.5203681218835_r2, -1259.139216722289_r2, &
+         771.3234287757674_r2, -176.6150291498386_r2, 12.50734324009056_r2, &
+         -0.1385710331296526_r2, 0.9934937113930748E-05_r2, 0.1659470187408462E-06_r2 /)
+    REAL(r2), PARAMETER :: zero = 0.0_r2
+    REAL(r2), PARAMETER :: one = 1.0_r2
+    REAL(r2), PARAMETER :: lnsqrt2pi =  0.9189385332046727_r2
+    REAL(r2), PARAMETER :: half = 0.5_r2
+    REAL(r2), PARAMETER :: sixpt5 = 6.5_r2
+    REAL(r2), PARAMETER :: seven = 7.0_r2
+    REAL(r2)    :: tmp, tmpgammln
+    INTEGER(i4) :: j
 
     tmpgammln = zero
     tmp = z + seven
@@ -3264,36 +3264,36 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
 
   !**********************************************************************************************************************
 
-  REAL(r_2) ELEMENTAL PURE FUNCTION gcf(a,x)
+  REAL(r2) ELEMENTAL PURE FUNCTION gcf(a,x)
 
     IMPLICIT NONE
 
-    REAL(r_2), INTENT(IN) :: a,x
-    INTEGER(i_d), PARAMETER :: ITMAX=100
-    REAL(r_2),    PARAMETER :: EPS=epsilon(x)
-    REAL(r_2),    PARAMETER :: FPMIN=tiny(x)/EPS
-    INTEGER(i_d) :: i
-    REAL(r_2)     :: an, b, c, d, del, h
+    REAL(r2), INTENT(IN) :: a,x
+    INTEGER(i4), PARAMETER :: ITMAX=100
+    REAL(r2),    PARAMETER :: EPS=epsilon(x)
+    REAL(r2),    PARAMETER :: FPMIN=tiny(x)/EPS
+    INTEGER(i4) :: i
+    REAL(r2)     :: an, b, c, d, del, h
 
-    if (eq(x, 0.0_r_2)) then
-       gcf=1.0_r_2
+    if (eq(x, 0.0_r2)) then
+       gcf=1.0_r2
        RETURN
     end if
-    b = x + 1.0_r_2 - a
-    c = 1.0_r_2/FPMIN
-    d = 1.0_r_2/b
+    b = x + 1.0_r2 - a
+    c = 1.0_r2/FPMIN
+    d = 1.0_r2/b
     h = d
     do i=1, ITMAX
        an  = -i*(i-a)
-       b   = b + 2.0_r_2
+       b   = b + 2.0_r2
        d   = an*d + b
        if (abs(d)<FPMIN) d=FPMIN
        c   = b + an/c
        if (abs(c)<FPMIN) c=FPMIN
-       d   = 1.0_r_2/d
+       d   = 1.0_r2/d
        del = d*c
        h   = h*del
-       if (abs(del-1.0_r_2) <= EPS) exit
+       if (abs(del-1.0_r2) <= EPS) exit
     end do
     gcf = exp(-x + a*log(x) - gammln(a)) * h
 
@@ -3301,25 +3301,25 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
 
   !**********************************************************************************************************************
 
-  REAL(r_2) ELEMENTAL PURE FUNCTION gser(a,x)
+  REAL(r2) ELEMENTAL PURE FUNCTION gser(a,x)
 
     IMPLICIT NONE
 
-    REAL(r_2), INTENT(IN) :: a, x
-    INTEGER(i_d), PARAMETER :: ITMAX=100
-    REAL(r_2),     PARAMETER :: EPS=epsilon(x)
-    INTEGER(i_d) :: n
-    REAL(r_2)     :: ap, del, summ
+    REAL(r2), INTENT(IN) :: a, x
+    INTEGER(i4), PARAMETER :: ITMAX=100
+    REAL(r2),     PARAMETER :: EPS=epsilon(x)
+    INTEGER(i4) :: n
+    REAL(r2)     :: ap, del, summ
 
-    if (eq(x, 0.0_r_2)) then
-       gser = 0.0_r_2
+    if (eq(x, 0.0_r2)) then
+       gser = 0.0_r2
        RETURN
     end if
     ap   = a
-    summ = 1.0_r_2/a
+    summ = 1.0_r2/a
     del  = summ
     do n=1, ITMAX
-       ap   = ap + 1.0_r_2
+       ap   = ap + 1.0_r2
        del  = del*x/ap
        summ = summ + del
        if (abs(del) < abs(summ)*EPS) exit
@@ -3330,14 +3330,14 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
 
   !**********************************************************************************************************************
 
-  REAL(r_2) ELEMENTAL PURE FUNCTION igamma(a,x)
-    USE cable_def_types_mod, ONLY: r_2
+  REAL(r2) ELEMENTAL PURE FUNCTION igamma(a,x)
+    USE cable_def_types_mod, ONLY: r2
     IMPLICIT NONE
-    REAL(r_2), INTENT(IN) :: a, x
-    REAL(r_2) :: gln
+    REAL(r2), INTENT(IN) :: a, x
+    REAL(r2) :: gln
     gln = gammln(a)
-    if (x < a+1.0_r_2) then
-       igamma = 1.0_r_2 - gser(a,x)
+    if (x < a+1.0_r2) then
+       igamma = 1.0_r2 - gser(a,x)
     else
        igamma = gcf(a,x)
     end if
@@ -3348,16 +3348,16 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
   !**********************************************************************************************************************
 
   ! MC this routines has to be adjusted for csol in freezing, probably.
-  REAL(r_2) ELEMENTAL PURE FUNCTION phi(hr0, lambda, eta, phie, he, T, Ksat)
+  REAL(r2) ELEMENTAL PURE FUNCTION phi(hr0, lambda, eta, phie, he, T, Ksat)
 
     USE sli_numbers, ONLY: zero, one, gravity, lambdaf, Rgas, Tzero ! , csol
 
     IMPLICIT NONE
 
-    REAL(r_2), INTENT(IN)           :: hr0, lambda, eta, phie, he, T
-    REAL(r_2), INTENT(IN), OPTIONAL :: Ksat
+    REAL(r2), INTENT(IN)           :: hr0, lambda, eta, phie, he, T
+    REAL(r2), INTENT(IN), OPTIONAL :: Ksat
 
-    REAL(r_2) :: h, csol1
+    REAL(r2) :: h, csol1
 
     ! MC freezing point? csol?
     csol1 = zero ! use zero instead of csol for the moment
@@ -3382,11 +3382,11 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
 
   !**********************************************************************************************************************
 
-  REAL(r_2) ELEMENTAL PURE FUNCTION rh0_sol(hr0, solin)
+  REAL(r2) ELEMENTAL PURE FUNCTION rh0_sol(hr0, solin)
 
     IMPLICIT NONE
 
-    REAL(r_2),        INTENT(in) :: hr0
+    REAL(r2),        INTENT(in) :: hr0
     TYPE(solve_type), INTENT(in) :: solin
 
     !    Rnet = Rnet + rhow*lambdaf*var(1)%iice*((phi(hr1,lambda,eta,phie,he,T1) &
@@ -3410,16 +3410,16 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
   ! Write rh0_sol into rtbis -> rtbis_rh0
   ! It does not check that f(x1) and f(x2) have different signs and not if iteration > MAXIT
 
-  REAL(r_2) ELEMENTAL PURE FUNCTION rtbis_rh0(sol, x1, x2, xacc)
+  REAL(r2) ELEMENTAL PURE FUNCTION rtbis_rh0(sol, x1, x2, xacc)
 
     IMPLICIT NONE
 
     TYPE(solve_type), INTENT(IN) :: sol
-    REAL(r_2),        INTENT(IN) :: x1, x2, xacc
+    REAL(r2),        INTENT(IN) :: x1, x2, xacc
 
-    INTEGER(i_d), PARAMETER :: MAXIT=40
-    INTEGER(i_d) :: j
-    REAL(r_2)    :: dx, f, fmid, xmid
+    INTEGER(i4), PARAMETER :: MAXIT=40
+    INTEGER(i4) :: j
+    REAL(r2)    :: dx, f, fmid, xmid
 
     fmid = rh0_sol(x2,sol)
     f    = rh0_sol(x1,sol)
@@ -3442,14 +3442,14 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
 
   !**********************************************************************************************************************
 
-  REAL(r_2) ELEMENTAL PURE FUNCTION slope_csat(T)
+  REAL(r2) ELEMENTAL PURE FUNCTION slope_csat(T)
     !returns slope of sat vapour pressure curve in kg m-3 K-1
     USE sli_numbers, ONLY: Tzero, Rgas, Mw, esata, esatb, esatc
 
     IMPLICIT NONE
 
-    real(r_2), intent(in) :: T
-    real(r_2) :: csat
+    real(r2), intent(in) :: T
+    real(r2) :: csat
 
     csat       = esata * exp(esatb*T/(T+esatc)) * Mw/Rgas/(T+Tzero)
     slope_csat = csat * esatb*esatc/(T+esatc)**2
@@ -3458,14 +3458,14 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
 
   !**********************************************************************************************************************
 
-  REAL(r_2) ELEMENTAL PURE FUNCTION slope_esat(T)
+  REAL(r2) ELEMENTAL PURE FUNCTION slope_esat(T)
     !returns slope of sat vapour pressure curve in Pa K^-1
     USE sli_numbers, ONLY: esata, esatb, esatc
 
     IMPLICIT NONE
 
-    real(r_2), intent(in) :: T
-    real(r_2) :: esat
+    real(r2), intent(in) :: T
+    real(r2) :: esat
 
     esat       = esata * exp(esatb*T/(T+esatc))
     slope_esat = esat * esatb*esatc/(T+esatc)**2
@@ -3474,13 +3474,13 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
 
   !*********************************************************************************************************************
 
-  REAL(r_2) ELEMENTAL FUNCTION esat_ice(T)
+  REAL(r2) ELEMENTAL FUNCTION esat_ice(T)
     !returns sat vapour pressure curve in Pa
     USE sli_numbers, ONLY:  esata_ice, esatb_ice, esatc_ice
 
     IMPLICIT NONE
 
-    real(r_2), intent(in) :: T
+    real(r2), intent(in) :: T
 
     esat_ice = esata_ice * exp(esatb_ice*T/(T+esatc_ice))
 
@@ -3488,14 +3488,14 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
 
   !**********************************************************************************************************************
 
-  REAL(r_2) ELEMENTAL FUNCTION slope_esat_ice(T)
+  REAL(r2) ELEMENTAL FUNCTION slope_esat_ice(T)
     !returns slope of sat vapour pressure curve in Pa K^-1
     USE sli_numbers, ONLY:  esata_ice, esatb_ice, esatc_ice
 
     IMPLICIT NONE
 
-    real(r_2), intent(in) :: T
-    real(r_2) :: esat_ice
+    real(r2), intent(in) :: T
+    real(r2) :: esat_ice
 
     esat_ice       = esata_ice * exp(esatb_ice*T/(T+esatc_ice))
     slope_esat_ice = esat_ice * esatb_ice*esatc_ice/(T+esatc_ice)**2
@@ -3504,11 +3504,11 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
 
   !**********************************************************************************************************************
 
-  REAL(r_2) ELEMENTAL PURE FUNCTION Sofh(h,parin)
+  REAL(r2) ELEMENTAL PURE FUNCTION Sofh(h,parin)
 
     IMPLICIT NONE
 
-    REAL(r_2),    INTENT(IN) :: h
+    REAL(r2),    INTENT(IN) :: h
     TYPE(params), INTENT(IN) :: parin
 
     ! Get saturation S from matric head h.
@@ -3522,13 +3522,13 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
 
   !**********************************************************************************************************************
 
-  REAL(r_2) ELEMENTAL PURE FUNCTION Tfrz(S,he,b)
+  REAL(r2) ELEMENTAL PURE FUNCTION Tfrz(S,he,b)
     ! determines freezing point temperature for a given moisture content
     USE sli_numbers, ONLY: one, two, four, gravity, lambdaf, csol, Rgas, Tzero
 
     IMPLICIT NONE
 
-    real(r_2), intent(in) :: S, he, b
+    real(r2), intent(in) :: S, he, b
 
     if (csol > e3) then
        ! Tfrz = (gravity*he - (min(S,one))**b * (lambdaf + two*csol*Rgas*Tzero) + &
@@ -3541,20 +3541,20 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
             (two*csol*Rgas*exp(b*log(min(S,one))))
     else
        ! Tfrz = (gravity*he*Tzero) / (-(gravity*he) + lambdaf*(S)**b)
-       Tfrz = (gravity*he*Tzero) / (-gravity*he + lambdaf*exp(b*log(max(min(S,one),0.01_r_2))))
+       Tfrz = (gravity*he*Tzero) / (-gravity*he + lambdaf*exp(b*log(max(min(S,one),0.01_r2))))
     endif
 
   END FUNCTION Tfrz
 
   !**********************************************************************************************************************
 
-  REAL(r_2) ELEMENTAL PURE FUNCTION Tfrozen(J, dx, theta, thetal, csoil, rhosoil, h0, thetasat)
+  REAL(r2) ELEMENTAL PURE FUNCTION Tfrozen(J, dx, theta, thetal, csoil, rhosoil, h0, thetasat)
     ! determines temperature of frozen soil, given total energy content J and liquid water content thetal
     USE sli_numbers, ONLY: csice, cswat, rhow, lambdaf
 
     IMPLICIT NONE
 
-    real(r_2), intent(in) :: J, dx, theta, thetal, csoil, rhosoil, h0, thetasat
+    real(r2), intent(in) :: J, dx, theta, thetal, csoil, rhosoil, h0, thetasat
 
     if (h0 > zero) then
        Tfrozen = (cswat*h0*rhow*theta + h0*lambdaf*rhow*theta - &
@@ -3575,14 +3575,14 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
 
   !**********************************************************************************************************************
 
-  REAL(r_2) ELEMENTAL PURE FUNCTION GTfrozen(T, J, dx, theta, csoil, rhosoil, h0, thre, the, he, b)
+  REAL(r2) ELEMENTAL PURE FUNCTION GTfrozen(T, J, dx, theta, csoil, rhosoil, h0, thre, the, he, b)
     ! GTfrozen = sensible heat + latent heat - total energy (should be zero)
     USE sli_numbers, ONLY: csice, cswat, rhow, lambdaf
 
     IMPLICIT NONE
 
-    real(r_2), intent(in) :: T, J, dx, theta, csoil, rhosoil, h0, thre, the, he, b
-    real(r_2) :: thetal, S
+    real(r2), intent(in) :: T, J, dx, theta, csoil, rhosoil, h0, thre, the, he, b
+    real(r2) :: thetal, S
 
     S = (theta-(the-thre))/thre
 
@@ -3601,14 +3601,14 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
 
   !**********************************************************************************************************************
 
-  REAL(r_2) ELEMENTAL PURE FUNCTION JSoilLayer(T, dx, theta, csoil, rhosoil, h0, thre, the, he, b)
+  REAL(r2) ELEMENTAL PURE FUNCTION JSoilLayer(T, dx, theta, csoil, rhosoil, h0, thre, the, he, b)
     ! JSsoilLayer = sensible heat + latent heat (total energy in soil layer J/m2)
     USE sli_numbers, ONLY: one, csice, cswat, rhow, lambdaf
 
     IMPLICIT NONE
 
-    real(r_2), intent(in) :: T,  dx, theta, csoil, rhosoil, h0, thre, the, he, b
-    real(r_2) :: thetal, S
+    real(r2), intent(in) :: T,  dx, theta, csoil, rhosoil, h0, thre, the, he, b
+    real(r2) :: thetal, S
 
     S = (theta-(the-thre))/thre
 
@@ -3633,16 +3633,16 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
   ! Write rh0_sol into rtbis -> rtbis_rh0
   ! It does not check that f(x1) and f(x2) have different signs and not if iteration > MAXIT
 
-  REAL(r_2) ELEMENTAL PURE FUNCTION rtbis_Tfrozen(J, dxsoil, theta,csoil, rhosoil, h0, thre, the, he, b, x1, x2)
+  REAL(r2) ELEMENTAL PURE FUNCTION rtbis_Tfrozen(J, dxsoil, theta,csoil, rhosoil, h0, thre, the, he, b, x1, x2)
 
     IMPLICIT NONE
 
-    real(r_2), intent(in) :: J, dxsoil, theta, csoil, rhosoil, h0, thre, the, he, b
-    REAL(r_2), INTENT(IN) :: x1, x2
+    real(r2), intent(in) :: J, dxsoil, theta, csoil, rhosoil, h0, thre, the, he, b
+    REAL(r2), INTENT(IN) :: x1, x2
 
-    INTEGER(i_d), PARAMETER :: MAXIT=80
-    INTEGER(i_d) :: k
-    REAL(r_2)    :: dx, f, fmid, xmid
+    INTEGER(i4), PARAMETER :: MAXIT=80
+    INTEGER(i4) :: k
+    REAL(r2)    :: dx, f, fmid, xmid
 
     fmid = GTfrozen(x2, J, dxsoil, theta, csoil, rhosoil, h0, thre, the, he, b)
     f    = GTfrozen(x1, J, dxsoil, theta, csoil, rhosoil, h0, thre, the, he, b)
@@ -3669,14 +3669,14 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
 
   !*********************************************************************************************************************
 
-  REAL(r_2) ELEMENTAL PURE FUNCTION thetalmax(Tin,S,he,b,thre,the)
+  REAL(r2) ELEMENTAL PURE FUNCTION thetalmax(Tin,S,he,b,thre,the)
     ! determines maximum liquid water content, given T
     USE sli_numbers, ONLY: gravity, lambdaf, csol, Rgas, Tzero
 
     IMPLICIT NONE
 
-    real(r_2), intent(in) :: Tin, S, he, b, thre, the
-    real(r_2)             :: opsi, psi, h, T
+    real(r2), intent(in) :: Tin, S, he, b, thre, the
+    real(r2)             :: opsi, psi, h, T
 
     T    = min(Tfrz(min(S,one),he,b),Tin)
     opsi = -csol *Rgas *(T+Tzero)/gravity ! osmotic potential (m)
@@ -3691,24 +3691,24 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
 
   !**********************************************************************************************************************
 
-  REAL(r_2) ELEMENTAL PURE FUNCTION Tthetalmax(thetal,Tin,S,he,b,thre,the)
+  REAL(r2) ELEMENTAL PURE FUNCTION Tthetalmax(thetal,Tin,S,he,b,thre,the)
     ! determines T, given maximum liquid water content
     USE sli_numbers, ONLY: gravity, lambdaf, csol, Rgas, Tzero
 
     IMPLICIT NONE
 
-    real(r_2), intent(in) :: thetal,S,he,b,thre,the,Tin
-    real(r_2)             :: opsi, psi, h, T, Tfreezing
+    real(r2), intent(in) :: thetal,S,he,b,thre,the,Tin
+    real(r2)             :: opsi, psi, h, T, Tfreezing
 
-    !integer(i_d) :: k
+    !integer(i4) :: k
 
     T = Tin
     !do k=1,20
     Tfreezing  = Tfrz(S,he,b)
     T          = min(Tfreezing,T)
     opsi       = -csol *Rgas *(T+Tzero)/gravity                ! osmotic potential (m)
-    ! h          = he*(max((thetal-(the-thre)),0.01_r_2)/thre)**(-b) ! moisture potential in presence of ice
-    h          = he*exp(-b*log(max((thetal-(the-thre)),0.01_r_2)/thre)) ! moisture potential in presence of ice
+    ! h          = he*(max((thetal-(the-thre)),0.01_r2)/thre)**(-b) ! moisture potential in presence of ice
+    h          = he*exp(-b*log(max((thetal-(the-thre)),0.01_r2)/thre)) ! moisture potential in presence of ice
     psi        = h + opsi
     Tthetalmax = psi*(gravity*(T+Tzero)) / lambdaf
     !T = T + 0.1*(Tthetalmax-T)
@@ -3718,15 +3718,15 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
 
   !**********************************************************************************************************************
 
-  REAL(r_2) ELEMENTAL PURE FUNCTION weight(parin, h, K, phi, dz)
+  REAL(r2) ELEMENTAL PURE FUNCTION weight(parin, h, K, phi, dz)
 
     IMPLICIT NONE
 
     TYPE(params), INTENT(IN) :: parin
-    REAL(r_2),    INTENT(IN) :: h
-    REAL(r_2),    INTENT(IN) :: K
-    REAL(r_2),    INTENT(IN) :: phi
-    REAL(r_2),    INTENT(IN) :: dz
+    REAL(r2),    INTENT(IN) :: h
+    REAL(r2),    INTENT(IN) :: K
+    REAL(r2),    INTENT(IN) :: phi
+    REAL(r2),    INTENT(IN) :: dz
     ! Get conductivity weighting for gravity flux calculations.
     ! Definitions of arguments:
     ! l   - land point
@@ -3736,16 +3736,16 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
     ! phi - MFP.
     ! dz  - flow path length.
     LOGICAL   :: done
-    REAL(r_2) :: a, hz, Khz, Kz, phiz, w, x
+    REAL(r2) :: a, hz, Khz, Kz, phiz, w, x
 
     done = .false.
     hz   = h-gf*dz ! gf is gravity fac in direction of dz
     if (h<parin%he) then
        a = parin%lam*parin%eta
        x = -gf*dz/h
-       if (a <= 3.0_r_2 .or. x*(a-3.0_r_2) <= 4.0_r_2) then ! use predetermined approx.
-          w    = (60.0_r_2+x*(70.0_r_2+10.0_r_2*a+x*(16.0_r_2+a*(5.0_r_2+a))))/ &
-               (120.0_r_2+x*(120.0_r_2+x*(22.0_r_2+2.0_r_2*a**2)))
+       if (a <= 3.0_r2 .or. x*(a-3.0_r2) <= 4.0_r2) then ! use predetermined approx.
+          w    = (60.0_r2+x*(70.0_r2+10.0_r2*a+x*(16.0_r2+a*(5.0_r2+a))))/ &
+               (120.0_r2+x*(120.0_r2+x*(22.0_r2+2.0_r2*a**2)))
           done = .true.
        end if
     end if
@@ -4116,11 +4116,11 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
     !
     !  Parameters:
     !
-    !    Input, real(r_2) X(N), an array sorted into ascending order.
+    !    Input, real(r2) X(N), an array sorted into ascending order.
     !
-    !    Input, real(r_2) XVAL(M), values to be bracketed.
+    !    Input, real(r2) XVAL(M), values to be bracketed.
     !
-    !    Output, integer(i_d) LEFT(M), RIGHT(M), the results of the search.
+    !    Output, integer(i4) LEFT(M), RIGHT(M), the results of the search.
     !    Either:
     !      XVAL < X(1), when LEFT = 1, RIGHT = 2;
     !      X(N) < XVAL, when LEFT = N-1, RIGHT = N;
@@ -4129,13 +4129,13 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
     !
     implicit none
 
-    real(r_2), dimension(:), intent(in) :: x
-    real(r_2), dimension(:), intent(in) :: xval
-    integer(i_d), dimension(size(xval)), intent(out) :: left
-    integer(i_d), dimension(size(xval)), intent(out) :: right
+    real(r2), dimension(:), intent(in) :: x
+    real(r2), dimension(:), intent(in) :: xval
+    integer(i4), dimension(size(xval)), intent(out) :: left
+    integer(i4), dimension(size(xval)), intent(out) :: right
 
-    integer(i_d) :: n, m
-    integer(i_d) :: i, j
+    integer(i4) :: n, m
+    integer(i4) :: i, j
     logical :: istheend
 
     n = size(x)
@@ -4195,26 +4195,26 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
     !
     !  Parameters:
     !
-    !    Input, real(r_2) TVAL, the points at which the spline is to be evaluated.
+    !    Input, real(r2) TVAL, the points at which the spline is to be evaluated.
     !
-    !    Input, real(r_2) TDATA(NDATA), the abscissas of the data.
+    !    Input, real(r2) TDATA(NDATA), the abscissas of the data.
     !
-    !    Input, real(r_2) YDATA(NDATA), the data values.
+    !    Input, real(r2) YDATA(NDATA), the data values.
     !
-    !    Output, real(r_2) SPLINE_B, the values of the function at TVAL.
+    !    Output, real(r2) SPLINE_B, the values of the function at TVAL.
     !
     implicit none
 
-    real(r_2), dimension(:), intent(in) :: tval
-    real(r_2), dimension(:), intent(in) :: tdata
-    real(r_2), dimension(:), intent(in) :: ydata
-    real(r_2), dimension(size(tval))    :: spline_b
+    real(r2), dimension(:), intent(in) :: tval
+    real(r2), dimension(:), intent(in) :: tdata
+    real(r2), dimension(:), intent(in) :: ydata
+    real(r2), dimension(size(tval))    :: spline_b
 
-    integer(i_d) :: ndata
-    real(r_2),    dimension(size(tval)) :: bval
-    integer(i_d), dimension(size(tval)) :: left
-    integer(i_d), dimension(size(tval)) :: right
-    real(r_2),    dimension(size(tval)) :: u
+    integer(i4) :: ndata
+    real(r2),    dimension(size(tval)) :: bval
+    integer(i4), dimension(size(tval)) :: left
+    integer(i4), dimension(size(tval)) :: right
+    real(r2),    dimension(size(tval)) :: u
 
     ndata = size(tdata)
     !
@@ -4226,51 +4226,51 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
     !  weighted by their corresponding data values.
     !
     u = ( tval - tdata(left) ) / ( tdata(right) - tdata(left) )
-    spline_b = 0.0_r_2
+    spline_b = 0.0_r2
     !
     !  B function associated with node LEFT - 1, (or "phantom node"),
     !  evaluated in its 4th interval.
     !
-    bval = ( ( (     - 1.0_r_2   &
-         * u + 3.0_r_2 ) &
-         * u - 3.0_r_2 ) &
-         * u + 1.0_r_2 ) / 6.0_r_2
+    bval = ( ( (     - 1.0_r2   &
+         * u + 3.0_r2 ) &
+         * u - 3.0_r2 ) &
+         * u + 1.0_r2 ) / 6.0_r2
 
     where ( 0 < left-1 )
        spline_b = spline_b + ydata(left-1) * bval
     elsewhere
-       spline_b = spline_b + ( 2.0_r_2 * ydata(1) - ydata(2) ) * bval
+       spline_b = spline_b + ( 2.0_r2 * ydata(1) - ydata(2) ) * bval
     end where
     !
     !  B function associated with node LEFT,
     !  evaluated in its third interval.
     !
-    bval = ( ( (       3.0_r_2   &
-         * u - 6.0_r_2 ) &
-         * u + 0.0_r_2 ) &
-         * u + 4.0_r_2 ) / 6.0_r_2
+    bval = ( ( (       3.0_r2   &
+         * u - 6.0_r2 ) &
+         * u + 0.0_r2 ) &
+         * u + 4.0_r2 ) / 6.0_r2
 
     spline_b = spline_b + ydata(left) * bval
     !
     !  B function associated with node RIGHT,
     !  evaluated in its second interval.
     !
-    bval = ( ( (     - 3.0_r_2   &
-         * u + 3.0_r_2 ) &
-         * u + 3.0_r_2 ) &
-         * u + 1.0_r_2 ) / 6.0_r_2
+    bval = ( ( (     - 3.0_r2   &
+         * u + 3.0_r2 ) &
+         * u + 3.0_r2 ) &
+         * u + 1.0_r2 ) / 6.0_r2
 
     spline_b = spline_b + ydata(right) * bval
     !
     !  B function associated with node RIGHT+1, (or "phantom node"),
     !  evaluated in its first interval.
     !
-    bval = u**3 / 6.0_r_2
+    bval = u**3 / 6.0_r2
 
     where ( right+1 <= ndata )
        spline_b = spline_b + ydata(right+1) * bval
     elsewhere
-       spline_b = spline_b + ( 2.0_r_2 * ydata(ndata) - ydata(ndata-1) ) * bval
+       spline_b = spline_b + ( 2.0_r2 * ydata(ndata) - ydata(ndata-1) ) * bval
     end where
 
     return
@@ -4283,11 +4283,11 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
 
     IMPLICIT NONE
 
-    REAL(r_2), DIMENSION(:),           INTENT(IN)  :: dat
+    REAL(r2), DIMENSION(:),           INTENT(IN)  :: dat
     LOGICAL,   DIMENSION(:), OPTIONAL, INTENT(IN)  :: mask
-    REAL(r_2)                                      :: mean_1d
+    REAL(r2)                                      :: mean_1d
 
-    REAL(r_2) :: n
+    REAL(r2) :: n
 
     LOGICAL, DIMENSION(size(dat)) :: maske
 
@@ -4301,12 +4301,12 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
 #endif
        endif
        maske = mask
-       n = real(count(maske),r_2)
+       n = real(count(maske),r2)
     else
        maske(:) = .true.
-       n = real(size(dat),r_2)
+       n = real(size(dat),r2)
     endif
-    if (n <= (1.0_r_2+tiny(1.0_r_2))) then
+    if (n <= (1.0_r2+tiny(1.0_r2))) then
        write(*,*) 'mean_1d: n must be at least 2'
 #ifdef __MPI__
        call MPI_Abort(0, 161, ierr) ! Do not know comm nor rank here
@@ -4324,11 +4324,11 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
 
     IMPLICIT NONE
 
-    REAL(r_2), DIMENSION(:,:),           INTENT(IN)  :: dat
+    REAL(r2), DIMENSION(:,:),           INTENT(IN)  :: dat
     LOGICAL,   DIMENSION(:,:), OPTIONAL, INTENT(IN)  :: mask
-    REAL(r_2)                                        :: mean_2d
+    REAL(r2)                                        :: mean_2d
 
-    REAL(r_2) :: n
+    REAL(r2) :: n
 
     LOGICAL, DIMENSION(size(dat,1),size(dat,2)) :: maske
 
@@ -4342,12 +4342,12 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
 #endif
        endif
        maske = mask
-       n = real(count(maske),r_2)
+       n = real(count(maske),r2)
     else
        maske = .true.
-       n = real(size(dat),r_2)
+       n = real(size(dat),r2)
     endif
-    if (n <= (1.0_r_2+tiny(1.0_r_2))) then
+    if (n <= (1.0_r2+tiny(1.0_r2))) then
        write(*,*) 'mean_2d: n must be at least 2'
 #ifdef __MPI__
        call MPI_Abort(0, 163, ierr) ! Do not know comm nor rank here
@@ -4368,12 +4368,12 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
 
     IMPLICIT NONE
 
-    REAL(r_2), DIMENSION(:),           INTENT(IN) :: x, y
+    REAL(r2), DIMENSION(:),           INTENT(IN) :: x, y
     LOGICAL,   DIMENSION(:), OPTIONAL, INTENT(IN) :: mask
-    REAL(r_2)                                     :: nse_1d
+    REAL(r2)                                     :: nse_1d
 
-    REAL(r_2)                                     :: xmean
-    REAL(r_2), DIMENSION(size(x))                 :: v1, v2
+    REAL(r2)                                     :: xmean
+    REAL(r2), DIMENSION(size(x))                 :: v1, v2
     LOGICAL,   DIMENSION(size(x))                 :: maske
 
     if (present(mask)) then
@@ -4385,9 +4385,9 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
     ! mean of x
     xmean = mean(x, mask=maske)
     ! nse
-    v1 = merge(y - x    , 0.0_r_2, maske)
-    v2 = merge(x - xmean, 0.0_r_2, maske)
-    nse_1d = 1.0_r_2 - dot_product(v1,v1) / dot_product(v2,v2)
+    v1 = merge(y - x    , 0.0_r2, maske)
+    v2 = merge(x - xmean, 0.0_r2, maske)
+    nse_1d = 1.0_r2 - dot_product(v1,v1) / dot_product(v2,v2)
 
   END FUNCTION nse_1d
 
@@ -4396,15 +4396,15 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
 
     IMPLICIT NONE
 
-    REAL(r_2), DIMENSION(:,:),           INTENT(IN) :: x, y
+    REAL(r2), DIMENSION(:,:),           INTENT(IN) :: x, y
     LOGICAL,   DIMENSION(:,:), OPTIONAL, INTENT(IN) :: mask
-    REAL(r_2)                                       :: nse_2d
+    REAL(r2)                                       :: nse_2d
 
-    REAL(r_2)                                       :: xmean
-    REAL(r_2), DIMENSION(size(x,1),size(x,2))       :: v1, v2
+    REAL(r2)                                       :: xmean
+    REAL(r2), DIMENSION(size(x,1),size(x,2))       :: v1, v2
     LOGICAL,   DIMENSION(size(x,1),size(x,2))       :: maske
 
-    INTEGER(i_d) :: i
+    INTEGER(i4) :: i
 
     if (present(mask)) then
        maske = mask
@@ -4413,12 +4413,12 @@ SUBROUTINE potential_evap(Rn, rbh, rbw, Ta, rha, Tsoil, k, dz,lambdav, &
     endif
 
     ! nse
-    v1 = merge(y - x, 0.0_r_2, maske)
+    v1 = merge(y - x, 0.0_r2, maske)
     do i=1, size(x,1)
        xmean   = mean(x(i,:), mask=maske(i,:))
-       v2(i,:) = merge(x(i,:) - xmean, 0.0_r_2, maske(i,:))
+       v2(i,:) = merge(x(i,:) - xmean, 0.0_r2, maske(i,:))
     enddo
-    nse_2d = 1.0_r_2 - sum(v1*v1) / sum(v2*v2)
+    nse_2d = 1.0_r2 - sum(v1*v1) / sum(v2*v2)
 
   END FUNCTION nse_2d
 

--- a/core/biogeophys/cable_soilsnow.F90
+++ b/core/biogeophys/cable_soilsnow.F90
@@ -34,7 +34,7 @@ MODULE cable_soil_snow_module
 
    USE cable_def_types_mod, ONLY : soil_snow_type, soil_parameter_type,        &
                              veg_parameter_type, canopy_type, met_type,        &
-                             r_2, ms, mp
+                             r2, ms, mp
    USE cable_data_module, ONLY : issnow_type, point2constants
 
    IMPLICIT NONE
@@ -52,7 +52,7 @@ MODULE cable_soil_snow_module
       max_ssdn = 750.0,    & !
       max_sconds = 2.51
       
-   REAL(r_2), PARAMETER :: frozen_limit = 0.85_r_2  ! EAK Feb2011 (could be 0.95)
+   REAL(r2), PARAMETER :: frozen_limit = 0.85_r2  ! EAK Feb2011 (could be 0.95)
 
    REAL :: cp    ! specific heat capacity for air
 
@@ -82,14 +82,14 @@ SUBROUTINE trimb (a, b, c, rhs, kmax)
 
    INTEGER, INTENT(IN)                  :: kmax ! no. of discrete layers
 
-   REAL(r_2), DIMENSION(:,:), INTENT(IN) ::                                    &
+   REAL(r2), DIMENSION(:,:), INTENT(IN) ::                                    &
       a,    & ! coef "A" in finite diff eq
       b,    & ! coef "B" in finite diff eq
       c       ! coef "C" in finite diff eq
 
-   REAL(r_2), DIMENSION(:,:), INTENT(INOUT)  :: rhs ! right hand side of eq
+   REAL(r2), DIMENSION(:,:), INTENT(INOUT)  :: rhs ! right hand side of eq
 
-   REAL(r_2), DIMENSION(SIZE(a,1),SIZE(a,2)) ::                                &
+   REAL(r2), DIMENSION(SIZE(a,1),SIZE(a,2)) ::                                &
       e, temp, g
 
    INTEGER :: k   ! do lloop counter
@@ -146,7 +146,7 @@ SUBROUTINE smoisturev(dels, ssnow, soil)
    REAL, DIMENSION(mp) ::                                                      &
       wbficemx
 
-   REAL(r_2), DIMENSION(mp) ::                                                 &
+   REAL(r2), DIMENSION(mp) ::                                                 &
       fact,       & !
       fact2,      & !
       fluxhi,     & !
@@ -168,19 +168,19 @@ SUBROUTINE smoisturev(dels, ssnow, soil)
    REAL, DIMENSION(mp,ms+1) :: z1mult
 
    ! change dimension of at,bt,ct from 3*ms to ms (BP Jun2010)
-   REAL(r_2), DIMENSION(mp,ms) ::                                              &
+   REAL(r2), DIMENSION(mp,ms) ::                                              &
       at,      & ! coef "A" in finite diff eq
       bt,      & ! coef "B" in finite diff eq
       ct,      & ! coef "C" in finite diff eq
       ssatcurr   !
 
-   REAL(r_2), DIMENSION(mp,ms+1) ::                                            &
+   REAL(r2), DIMENSION(mp,ms+1) ::                                            &
       wbh,     & !
       z1,      & !
       z2,      & !
       z3         !
 
-   REAL(r_2), DIMENSION(mp,0:ms) ::                                            &
+   REAL(r2), DIMENSION(mp,0:ms) ::                                            &
       fluxh,      & !
       delt,       & !
       dtt           !
@@ -208,11 +208,11 @@ SUBROUTINE smoisturev(dels, ssnow, soil)
 
          ! Calculate amount of liquid soil water:
          IF (.not. cable_user%l_new_runoff_speed) THEN
-            wbl_k = MAX( 0.01_r_2, ssnow%wb(:,k) - ssnow%wbice(:,k) )
-            wbl_kp = MAX( 0.01_r_2, ssnow%wb(:,k+1) - ssnow%wbice(:,k+1) )
+            wbl_k = MAX( 0.01_r2, ssnow%wb(:,k) - ssnow%wbice(:,k) )
+            wbl_kp = MAX( 0.01_r2, ssnow%wb(:,k+1) - ssnow%wbice(:,k+1) )
          ELSE
-            wbl_k = MAX( 0.001_r_2, ssnow%wb(:,k) - ssnow%wbice(:,k) )
-            wbl_kp = MAX( 0.001_r_2, ssnow%wb(:,k+1) - ssnow%wbice(:,k+1) )
+            wbl_k = MAX( 0.001_r2, ssnow%wb(:,k) - ssnow%wbice(:,k) )
+            wbl_kp = MAX( 0.001_r2, ssnow%wb(:,k+1) - ssnow%wbice(:,k+1) )
          ENDIF
 
          ! Calculate difference in liq soil water b/w consecutive layers:
@@ -230,17 +230,17 @@ SUBROUTINE smoisturev(dels, ssnow, soil)
          speed_k = hydss * (wh / soil%ssat )**( soil%i2bp3 - 1 )
 
          ! update wb by TVD method
-         rat = delt(:,k - 1) / ( delt(:,k) + SIGN( REAL( 1.0e-20, r_2 ),       &
+         rat = delt(:,k - 1) / ( delt(:,k) + SIGN( REAL( 1.0e-20, r2 ),       &
                delt(:,k) ) )
 
-         phi = MAX( 0.0_r_2, MIN( 1.0_r_2, 2.0_r_2 * rat ),                    &
-               MIN( 2.0_r_2, rat ) ) ! 0 for -ve rat
+         phi = MAX( 0.0_r2, MIN( 1.0_r2, 2.0_r2 * rat ),                    &
+               MIN( 2.0_r2, rat ) ) ! 0 for -ve rat
          fluxhi = wh
          fluxlo = wbl_k
 
          ! scale speed to grid lengths per dels & limit speed for stability
          ! 1. OK too for stability
-         speed_k = MIN( speed_k, REAL( 0.5 * soil%zse(k) / dels , r_2 ) )
+         speed_k = MIN( speed_k, REAL( 0.5 * soil%zse(k) / dels , r2 ) )
          fluxh(:,k) = speed_k * ( fluxlo + phi * ( fluxhi - fluxlo ) )
 
       END DO
@@ -252,8 +252,8 @@ SUBROUTINE smoisturev(dels, ssnow, soil)
 
       WHERE( ssnow%wb(:,ms) > soil%sfc(:) )
 
-         wbl_k = MAX( 0.001_r_2, ssnow%wb(:,ms) - ssnow%wbice(:,ms) )
-         wbl_kp = MAX( 0.001_r_2, soil%ssat(:) - ssnow%wbice(:,ms) )
+         wbl_k = MAX( 0.001_r2, ssnow%wb(:,ms) - ssnow%wbice(:,ms) )
+         wbl_kp = MAX( 0.001_r2, soil%ssat(:) - ssnow%wbice(:,ms) )
 
          wh = MIN( wbl_k, wbl_kp )
 
@@ -263,12 +263,12 @@ SUBROUTINE smoisturev(dels, ssnow, soil)
          hydss = soil%hyds
 
          speed_k = hydss * ( wh / soil%ssat )**( soil%i2bp3 - 1 )
-         speed_k =  0.5 * speed_k / ( 1. - MIN( 0.5_r_2, 10. * ssnow%wbice(:,ms) ) )
+         speed_k =  0.5 * speed_k / ( 1. - MIN( 0.5_r2, 10. * ssnow%wbice(:,ms) ) )
          fluxlo = wbl_k
 
          ! scale speed to grid lengths per dt & limit speed for stability
-         speed_k = MIN( 0.5 * speed_k, 0.5_r_2 * soil%zse(ms) / dels )
-         fluxh(:,ms) = MAX( 0.0_r_2, speed_k * fluxlo )
+         speed_k = MIN( 0.5 * speed_k, 0.5_r2 * soil%zse(ms) / dels )
+         fluxh(:,ms) = MAX( 0.0_r2, speed_k * fluxlo )
 
       END WHERE
 
@@ -276,8 +276,8 @@ SUBROUTINE smoisturev(dels, ssnow, soil)
 
       WHERE( ssnow%wb(:,ms) > soil%sfc(:) )
 
-         wbl_k = MAX( 0.001_r_2, ssnow%wb(:,ms) - ssnow%wbice(:,ms) )
-         wbl_kp = MAX( 0.001_r_2, soil%ssat(:) - ssnow%wbice(:,ms) )
+         wbl_k = MAX( 0.001_r2, ssnow%wb(:,ms) - ssnow%wbice(:,ms) )
+         wbl_kp = MAX( 0.001_r2, soil%ssat(:) - ssnow%wbice(:,ms) )
 
          wh = MIN( wbl_k, wbl_kp )
 
@@ -287,12 +287,12 @@ SUBROUTINE smoisturev(dels, ssnow, soil)
          hydss = soil%hyds
 
          speed_k = hydss * ( wh / soil%ssat )**( soil%i2bp3 - 1 )
-         speed_k =  speed_k / ( 1. - MIN( 0.5_r_2, 10. * ssnow%wbice(:,ms) ) )
+         speed_k =  speed_k / ( 1. - MIN( 0.5_r2, 10. * ssnow%wbice(:,ms) ) )
          fluxlo = wbl_k
 
          ! scale speed to grid lengths per dt & limit speed for stability
-         speed_k = MIN( speed_k, real(0.5 * soil%zse(ms) / dels, r_2) )
-         fluxh(:,ms) = MAX( 0.0_r_2, speed_k * fluxlo )
+         speed_k = MIN( speed_k, real(0.5 * soil%zse(ms) / dels, r2) )
+         fluxh(:,ms) = MAX( 0.0_r2, speed_k * fluxlo )
 
       END WHERE
 
@@ -325,17 +325,17 @@ SUBROUTINE smoisturev(dels, ssnow, soil)
       ! wbh_k represents wblf(k-.5)
       DO k = 2, ms
 
-         ssatcurr_k = REAL( soil%ssat, r_2 ) - ssnow%wbice(:,k)
+         ssatcurr_k = REAL( soil%ssat, r2 ) - ssnow%wbice(:,k)
          wbh_k = ( soil%zse(k) * ssnow%wblf(:,k-1) + soil%zse(k-1)             &
                  * ssnow%wblf(:,k) ) / ( soil%zse(k) + soil%zse(k-1) )
          ! i.e. wbh**(bch+1)
          fact = wbh_k**( soil%ibp2 - 1 )
 
          ! with 50% wbice, reduce hbsh by 1.e-5
-         pwb_wbh = ( soil%hsbh * ( 1. - MIN( 2. * MIN (0.1_r_2, MAX(           &
-                  ssnow%wbice(:,k-1) / MAX( 0.01_r_2, ssnow%wb(:,k-1) ),       &
-                  ssnow%wbice(:,k)   / MAX( 0.01_r_2, ssnow%wb(:,k) ) ) )      &
-                  , 0.1_r_2 ) ) )                                              &
+         pwb_wbh = ( soil%hsbh * ( 1. - MIN( 2. * MIN (0.1_r2, MAX(           &
+                  ssnow%wbice(:,k-1) / MAX( 0.01_r2, ssnow%wb(:,k-1) ),       &
+                  ssnow%wbice(:,k)   / MAX( 0.01_r2, ssnow%wb(:,k) ) ) )      &
+                  , 0.1_r2 ) ) )                                              &
                   * MAX( soil%pwb_min, wbh_k * fact )
 
          ! moisture diffusivity (D) is  wbh*pwb; hsbh includes b
@@ -362,7 +362,7 @@ SUBROUTINE smoisturev(dels, ssnow, soil)
 
       DO k = 1, ms
 
-         ssatcurr(:,k) = REAL(soil%ssat,r_2) - ssnow%wbice(:,k)
+         ssatcurr(:,k) = REAL(soil%ssat,r2) - ssnow%wbice(:,k)
 
          ! this defn of wblf has different meaning from previous one in surfbv
          ! N.B. are imposing wbice<wb, so wblf <1
@@ -507,7 +507,7 @@ SUBROUTINE smoisturev(dels, ssnow, soil)
            IF (nmeth == 3) THEN
          ! artificial fix applied here for safety (explicit nmeth only)
          DO k = 1, ms
-            ssnow%wblf(:,k) = MAX( 0.0_r_2, MIN( ssnow%wblf(:,k), 1.0_r_2 ) )
+            ssnow%wblf(:,k) = MAX( 0.0_r2, MIN( ssnow%wblf(:,k), 1.0_r2 ) )
          END DO
       END IF
 
@@ -886,10 +886,10 @@ USE cable_common_module
       ssnow%evapsn = dels * real(canopy%fess + canopy%fes_cor) / ( C%HL + C%HLF )
       xxx = ssnow%evapsn
 
-      WHERE ((ssnow%isflag == 0) .AND. ((canopy%fess+canopy%fes_cor).GT. 0.0_r_2) ) &
+      WHERE ((ssnow%isflag == 0) .AND. ((canopy%fess+canopy%fes_cor).GT. 0.0_r2) ) &
          ssnow%evapsn = MIN( ssnow%snowd, xxx )
 
-      WHERE ((ssnow%isflag  > 0) .AND. ((canopy%fess+canopy%fes_cor) .GT. 0.0_r_2) ) &
+      WHERE ((ssnow%isflag  > 0) .AND. ((canopy%fess+canopy%fes_cor) .GT. 0.0_r2) ) &
          ssnow%evapsn = MIN( 0.9 * ssnow%smass(:,1), xxx )
 
       ssnow%snowd = ssnow%snowd - ssnow%evapsn
@@ -923,7 +923,7 @@ SUBROUTINE surfbv(dels, ssnow, soil, veg)
       rnof5,      & !
       sgamm,      & !
       smasstot
-   REAL(r_2), DIMENSION(mp) :: xxx
+   REAL(r2), DIMENSION(mp) :: xxx
 
    REAL, DIMENSION(mp,0:3) :: smelt1
 
@@ -932,10 +932,10 @@ SUBROUTINE surfbv(dels, ssnow, soil, veg)
    CALL smoisturev(dels, ssnow, soil)
 
    DO k = 1, ms
-      xxx = REAL( soil%ssat,r_2 )
-      ssnow%rnof1 = ssnow%rnof1 + REAL( MAX( ssnow%wb(:,k) - xxx, 0.0_r_2 )  &
+      xxx = REAL( soil%ssat,r2 )
+      ssnow%rnof1 = ssnow%rnof1 + REAL( MAX( ssnow%wb(:,k) - xxx, 0.0_r2 )  &
                     * 1000.0 )  * soil%zse(k)
-      ssnow%wb(:,k) = MAX( 0.01_r_2, MIN( ssnow%wb(:,k), xxx ) )
+      ssnow%wb(:,k) = MAX( 0.01_r2, MIN( ssnow%wb(:,k), xxx ) )
    END DO
    ! for deep runoff use wb-sfc, but this value not to exceed .99*wb-wbice
    ! account for soil/ice cracking
@@ -994,11 +994,11 @@ SUBROUTINE surfbv(dels, ssnow, soil, veg)
       ssnow%sinfil  = MIN( ssnow%rnof2, ssnow%wb_lake ) ! water that can be extracted from the rnof2
       ssnow%rnof2   = MAX( 0.0, ssnow%rnof2 - ssnow%sinfil )
       ssnow%wb_lake = MAX( 0.0, ssnow%wb_lake - ssnow%sinfil)
-      xxx = MAX(0.0_r_2, (ssnow%wb(:,ms) - real(soil%sfc(:),r_2))*soil%zse(ms)*1000.0)
+      xxx = MAX(0.0_r2, (ssnow%wb(:,ms) - real(soil%sfc(:),r2))*soil%zse(ms)*1000.0)
       ssnow%sinfil  = MIN( real(xxx), ssnow%wb_lake )
-      ssnow%wb(:,ms) = ssnow%wb(:,ms) - real(ssnow%sinfil / (soil%zse(ms)*1000.0), r_2)
+      ssnow%wb(:,ms) = ssnow%wb(:,ms) - real(ssnow%sinfil / (soil%zse(ms)*1000.0), r2)
       ssnow%wb_lake = MAX( 0.0, ssnow%wb_lake - ssnow%sinfil)
-      xxx = MAX(0.0_r_2, (ssnow%wb(:,ms) - 0.5*(soil%sfc + soil%swilt))*soil%zse(ms)*1000.0)
+      xxx = MAX(0.0_r2, (ssnow%wb(:,ms) - 0.5*(soil%sfc + soil%swilt))*soil%zse(ms)*1000.0)
       ssnow%sinfil  = MIN( real(xxx), ssnow%wb_lake )
       ssnow%wb(:,ms) = ssnow%wb(:,ms) - ssnow%sinfil / (soil%zse(ms)*1000.0)
       ssnow%wb_lake = MAX( 0.0, ssnow%wb_lake - ssnow%sinfil)
@@ -1045,32 +1045,32 @@ SUBROUTINE stempv(dels, canopy, ssnow, soil)
       coefa, coefb,  & !
       sgamm            !
 
-   REAL(r_2), DIMENSION(mp) ::                                                 &
+   REAL(r2), DIMENSION(mp) ::                                                 &
       dtg,     & !
       ew,      & !
       xx,      & !
       wblfsp     !
 
-   REAL(r_2), DIMENSION(mp,ms) ::                                              &
+   REAL(r2), DIMENSION(mp,ms) ::                                              &
       ccnsw  ! soil thermal conductivity (incl water/ice)
 
-   REAL(r_2), DIMENSION(mp, -2:ms) ::                                          &
+   REAL(r2), DIMENSION(mp, -2:ms) ::                                          &
       at, bt, ct, rhs !
 
-   REAL(r_2), DIMENSION(mp,-2:ms+1) :: coeff
+   REAL(r2), DIMENSION(mp,-2:ms+1) :: coeff
 
-   REAL(r_2), DIMENSION(mp,ms+3)    :: tmp_mat ! temp. matrix for tggsn & tgg
+   REAL(r2), DIMENSION(mp,ms+3)    :: tmp_mat ! temp. matrix for tggsn & tgg
 
    INTEGER   :: j,k
    REAL      :: snow_ccnsw
-   REAL(r_2) :: exp_arg
+   REAL(r2) :: exp_arg
    LOGICAL   :: direct2min = .FALSE.
 
 
-   at         = 0.0_r_2
-   bt         = 1.0_r_2
-   ct         = 0.0_r_2
-   coeff      = 0.0_r_2
+   at         = 0.0_r2
+   bt         = 1.0_r2
+   ct         = 0.0_r2
+   coeff      = 0.0_r2
    snow_ccnsw = 2.0
 
    DO k = 1, ms
@@ -1081,24 +1081,24 @@ SUBROUTINE stempv(dels, canopy, ssnow, soil)
             ! permanent ice: fix hard-wired number in next version
             ccnsw(j,k) = snow_ccnsw
          ELSE
-            ew(j) = ssnow%wblf(j,k) * real(soil%ssat(j),r_2)
-            exp_arg = (ew(j) * LOG(60.0_r_2)) + (ssnow%wbfice(j,k) &
-                      * real(soil%ssat(j),r_2) * LOG(250.0_r_2))
+            ew(j) = ssnow%wblf(j,k) * real(soil%ssat(j),r2)
+            exp_arg = (ew(j) * LOG(60.0_r2)) + (ssnow%wbfice(j,k) &
+                      * real(soil%ssat(j),r2) * LOG(250.0_r2))
 
-            IF ( exp_arg > 30.0_r_2 ) direct2min = .TRUE.
+            IF ( exp_arg > 30.0_r2 ) direct2min = .TRUE.
 
             IF ( direct2min) THEN
 
-               ccnsw(j,k) = 1.5_r_2 * MAX( 1.0_r_2, SQRT( MIN( 2.0_r_2, 0.5_r_2 * &
-                            real(soil%ssat(j),r_2) / &
-                            MIN( ew(j), 0.5_r_2 * real(soil%ssat(j),r_2) ) ) ) )
+               ccnsw(j,k) = 1.5_r2 * MAX( 1.0_r2, SQRT( MIN( 2.0_r2, 0.5_r2 * &
+                            real(soil%ssat(j),r2) / &
+                            MIN( ew(j), 0.5_r2 * real(soil%ssat(j),r2) ) ) ) )
 
             ELSE
 
-               ccnsw(j,k) = MIN( soil%cnsd(j) * EXP(exp_arg), 1.5_r_2 ) &
-                            * MAX( 1.0_r_2, SQRT( MIN( 2.0_r_2, 0.5_r_2 * &
-                            real(soil%ssat(j),r_2) / &
-                            MIN( ew(j), 0.5_r_2 * real(soil%ssat(j),r_2) ) ) ) )
+               ccnsw(j,k) = MIN( soil%cnsd(j) * EXP(exp_arg), 1.5_r2 ) &
+                            * MAX( 1.0_r2, SQRT( MIN( 2.0_r2, 0.5_r2 * &
+                            real(soil%ssat(j),r2) / &
+                            MIN( ew(j), 0.5_r2 * real(soil%ssat(j),r2) ) ) ) )
 
             ENDIF
 
@@ -1255,8 +1255,8 @@ SUBROUTINE stempv(dels, canopy, ssnow, soil)
 
 
    !     note in the following that tgg and tggsn are processed together
-   tmp_mat(:,1:3)      = REAL(ssnow%tggsn,r_2)
-   tmp_mat(:,4:(ms+3)) = REAL(ssnow%tgg,r_2)
+   tmp_mat(:,1:3)      = REAL(ssnow%tggsn,r2)
+   tmp_mat(:,4:(ms+3)) = REAL(ssnow%tgg,r2)
 
    CALL trimb( at, bt, ct, tmp_mat, ms + 3 )
 
@@ -1376,7 +1376,7 @@ SUBROUTINE snowl_adjust(ssnow)
 
    TYPE(soil_snow_type), INTENT(INOUT) :: ssnow
 
-   REAL(r_2), DIMENSION(mp) ::                                                 &
+   REAL(r2), DIMENSION(mp) ::                                                 &
       excd,    & !
       excm,    & !
       frac,    & !
@@ -1402,7 +1402,7 @@ SUBROUTINE snowl_adjust(ssnow)
          osm = ssnow%smass(:,2)
          ssnow%smass(:,2) = MAX( 0.01, ssnow%smass(:,2) + REAL(excm) )
 
-         ssnow%ssdn(:,2) = REAL( MAX( 120.0_r_2, MIN( REAL( max_ssdn, r_2 ),   &
+         ssnow%ssdn(:,2) = REAL( MAX( 120.0_r2, MIN( REAL( max_ssdn, r2 ),   &
                            ssnow%ssdn(:,2) * osm / ssnow%smass(:,2) +          &
                            ssnow%ssdn(:,1) * excm / ssnow%smass(:,2) ) ) )
 
@@ -1423,7 +1423,7 @@ SUBROUTINE snowl_adjust(ssnow)
          osm = ssnow%smass(:,1)
          ssnow%smass(:,1) = ssnow%smass(:,1) + REAL(excm)
          ssnow%sdepth(:,1) = ssnow%t_snwlr
-         ssnow%ssdn(:,1) = REAL( MAX( 120.0_r_2, MIN( REAL( max_ssdn,r_2 ),    &
+         ssnow%ssdn(:,1) = REAL( MAX( 120.0_r2, MIN( REAL( max_ssdn,r2 ),    &
                            ssnow%ssdn(:,1) * osm / ssnow%smass(:,1)            &
                            + ssnow%ssdn(:,2) * excm / ssnow%smass(:,1) ) ) )
 
@@ -1523,8 +1523,8 @@ END SUBROUTINE snowl_adjust
 !    REAL, INTENT(IN)                    :: dels ! integration time step (s)
 !    TYPE(soil_snow_type), INTENT(INOUT)      :: ssnow
 !    TYPE(soil_parameter_type), INTENT(INOUT) :: soil
-!    REAL(r_2), DIMENSION(mp)           :: sicefreeze
-!    REAL(r_2), DIMENSION(mp)           :: sicemelt
+!    REAL(r2), DIMENSION(mp)           :: sicefreeze
+!    REAL(r2), DIMENSION(mp)           :: sicemelt
 !    REAL, DIMENSION(mp)           :: xx
 !    INTEGER k
 
@@ -1534,17 +1534,17 @@ END SUBROUTINE snowl_adjust
 !       WHERE (ssnow%tgg(:,k) < C%TFRZ &
 !           & .AND. frozen_limit * ssnow%wb(:,k) - ssnow%wbice(:,k) > .001)
 
-!          sicefreeze = MIN( MAX( 0.0_r_2, ( frozen_limit * ssnow%wb(:,k) -      &
+!          sicefreeze = MIN( MAX( 0.0_r2, ( frozen_limit * ssnow%wb(:,k) -      &
 !                       ssnow%wbice(:,k) ) ) * soil%zse(k) * 1000.0,             &
 !                       ( C%TFRZ - ssnow%tgg(:,k) ) * ssnow%gammzz(:,k) / C%HLF )
 !          ssnow%wbice(:,k) = MIN( ssnow%wbice(:,k) + sicefreeze / (soil%zse(k)  &
 !                             * 1000.0), frozen_limit * ssnow%wb(:,k) )
 !          xx = soil%css * soil%rhosoil
 !          ssnow%gammzz(:,k) = MAX(                                              &
-!              REAL((1.0 - soil%ssat) * soil%css * soil%rhosoil ,r_2)            &
-!              + (ssnow%wb(:,k) - ssnow%wbice(:,k)) * REAL(cswat * rhowat,r_2)   &
-!              + ssnow%wbice(:,k) * REAL(csice * rhowat * 0.9,r_2),              &
-!              REAL(xx,r_2)) * REAL( soil%zse(k),r_2 )
+!              REAL((1.0 - soil%ssat) * soil%css * soil%rhosoil ,r2)            &
+!              + (ssnow%wb(:,k) - ssnow%wbice(:,k)) * REAL(cswat * rhowat,r2)   &
+!              + ssnow%wbice(:,k) * REAL(csice * rhowat * 0.9,r2),              &
+!              REAL(xx,r2)) * REAL( soil%zse(k),r2 )
 
 !          WHERE (k == 1 .AND. ssnow%isflag == 0)
 !             ssnow%gammzz(:,k) = ssnow%gammzz(:,k) + cgsnow * ssnow%snowd
@@ -1557,14 +1557,14 @@ END SUBROUTINE snowl_adjust
 !          sicemelt = MIN( ssnow%wbice(:,k) * soil%zse(k) * 1000.0,              &
 !                     ( ssnow%tgg(:,k) - C%TFRZ ) * ssnow%gammzz(:,k) / C%HLF )
 
-!          ssnow%wbice(:,k) = MAX( 0.0_r_2, ssnow%wbice(:,k) - sicemelt          &
+!          ssnow%wbice(:,k) = MAX( 0.0_r2, ssnow%wbice(:,k) - sicemelt          &
 !                             / (soil%zse(k) * 1000.0) )
 !          xx = soil%css * soil%rhosoil
 !          ssnow%gammzz(:,k) = MAX(                                              &
-!               REAL((1.0-soil%ssat) * soil%css * soil%rhosoil,r_2)             &
-!               + (ssnow%wb(:,k) - ssnow%wbice(:,k)) * REAL(cswat*rhowat,r_2)   &
-!               + ssnow%wbice(:,k) * REAL(csice * rhowat * 0.9,r_2),            &
-!               REAL(xx,r_2) ) * REAL(soil%zse(k),r_2)
+!               REAL((1.0-soil%ssat) * soil%css * soil%rhosoil,r2)             &
+!               + (ssnow%wb(:,k) - ssnow%wbice(:,k)) * REAL(cswat*rhowat,r2)   &
+!               + ssnow%wbice(:,k) * REAL(csice * rhowat * 0.9,r2),            &
+!               REAL(xx,r2) ) * REAL(soil%zse(k),r2)
 !          WHERE (k == 1 .AND. ssnow%isflag == 0)
 !             ssnow%gammzz(:,k) = ssnow%gammzz(:,k) + cgsnow * ssnow%snowd
 !          END WHERE
@@ -1585,46 +1585,46 @@ SUBROUTINE soilfreeze_serial(soil, ssnow)
    TYPE(soil_snow_type),      INTENT(INOUT) :: ssnow
    TYPE(soil_parameter_type), INTENT(INOUT) :: soil
 
-   REAL(r_2), DIMENSION(mp) :: sicefreeze
-   REAL(r_2), DIMENSION(mp) :: sicemelt
+   REAL(r2), DIMENSION(mp) :: sicefreeze
+   REAL(r2), DIMENSION(mp) :: sicemelt
    REAL,      DIMENSION(mp) :: xx
-   real(r_2), dimension(ms) :: zse
+   real(r2), dimension(ms) :: zse
    INTEGER :: k, i
 
-   zse = real(soil%zse,r_2)
+   zse = real(soil%zse,r2)
    
    xx = 0.
    DO k = 1, ms
       do i=1, mp
          if (ssnow%tgg(i,k) < C%TFRZ &
-              .AND. frozen_limit * ssnow%wb(i,k) - ssnow%wbice(i,k) > 0.001_r_2) then
-            sicefreeze(i) = MIN( MAX( 0.0_r_2, ( frozen_limit * ssnow%wb(i,k) - &
-                 ssnow%wbice(i,k) ) ) * zse(k) * 1000.0_r_2, &
+              .AND. frozen_limit * ssnow%wb(i,k) - ssnow%wbice(i,k) > 0.001_r2) then
+            sicefreeze(i) = MIN( MAX( 0.0_r2, ( frozen_limit * ssnow%wb(i,k) - &
+                 ssnow%wbice(i,k) ) ) * zse(k) * 1000.0_r2, &
                  ( C%TFRZ - ssnow%tgg(i,k) ) * ssnow%gammzz(i,k) / C%HLF )
             ssnow%wbice(i,k) = MIN( ssnow%wbice(i,k) + sicefreeze(i) / (zse(k) &
-                 * 1000.0_r_2), frozen_limit * ssnow%wb(i,k) )
+                 * 1000.0_r2), frozen_limit * ssnow%wb(i,k) )
             xx(i) = soil%css(i) * soil%rhosoil(i)
             ssnow%gammzz(i,k) = MAX( &
-                 REAL((1.0 - soil%ssat(i)) * soil%css(i) * soil%rhosoil(i), r_2) &
-                 + (ssnow%wb(i,k) - ssnow%wbice(i,k)) * REAL(cswat * rhowat, r_2) &
-                 + ssnow%wbice(i,k) * REAL(csice * rhowat * 0.9, r_2), &
-                 REAL(xx(i),r_2)) * zse(k)
-            if (k == 1 .AND. ssnow%isflag(i) == 0) ssnow%gammzz(i,k) = ssnow%gammzz(i,k) + real(cgsnow * ssnow%snowd(i),r_2)
-            if (sicefreeze(i)/ssnow%gammzz(i,k) > real(tiny(1.0),r_2)) &
+                 REAL((1.0 - soil%ssat(i)) * soil%css(i) * soil%rhosoil(i), r2) &
+                 + (ssnow%wb(i,k) - ssnow%wbice(i,k)) * REAL(cswat * rhowat, r2) &
+                 + ssnow%wbice(i,k) * REAL(csice * rhowat * 0.9, r2), &
+                 REAL(xx(i),r2)) * zse(k)
+            if (k == 1 .AND. ssnow%isflag(i) == 0) ssnow%gammzz(i,k) = ssnow%gammzz(i,k) + real(cgsnow * ssnow%snowd(i),r2)
+            if (sicefreeze(i)/ssnow%gammzz(i,k) > real(tiny(1.0),r2)) &
                  ssnow%tgg(i,k) = ssnow%tgg(i,k) + REAL(sicefreeze(i)/ssnow%gammzz(i,k)) * C%HLF
-         elseif (ssnow%tgg(i,k) > C%TFRZ .AND. ssnow%wbice(i,k) > 0._r_2 ) then
-            sicemelt(i) = MIN( ssnow%wbice(i,k) * zse(k) * 1000.0_r_2, &
-                 real(ssnow%tgg(i,k) - C%TFRZ,r_2) * ssnow%gammzz(i,k) / real(C%HLF,r_2) )
-            ssnow%wbice(i,k) = MAX( 0.0_r_2, ssnow%wbice(i,k) - sicemelt(i) &
-                 / (zse(k) * 1000.0_r_2) )
+         elseif (ssnow%tgg(i,k) > C%TFRZ .AND. ssnow%wbice(i,k) > 0._r2 ) then
+            sicemelt(i) = MIN( ssnow%wbice(i,k) * zse(k) * 1000.0_r2, &
+                 real(ssnow%tgg(i,k) - C%TFRZ,r2) * ssnow%gammzz(i,k) / real(C%HLF,r2) )
+            ssnow%wbice(i,k) = MAX( 0.0_r2, ssnow%wbice(i,k) - sicemelt(i) &
+                 / (zse(k) * 1000.0_r2) )
             xx(i) = soil%css(i) * soil%rhosoil(i)
             ssnow%gammzz(i,k) = MAX( &
-                 REAL((1.0-soil%ssat(i)) * soil%css(i) * soil%rhosoil(i),r_2) &
-                 + (ssnow%wb(i,k) - ssnow%wbice(i,k)) * REAL(cswat*rhowat,r_2)   &
-                 + ssnow%wbice(i,k) * REAL(csice * rhowat * 0.9,r_2), &
-                 REAL(xx(i),r_2) ) * zse(k)
+                 REAL((1.0-soil%ssat(i)) * soil%css(i) * soil%rhosoil(i),r2) &
+                 + (ssnow%wb(i,k) - ssnow%wbice(i,k)) * REAL(cswat*rhowat,r2)   &
+                 + ssnow%wbice(i,k) * REAL(csice * rhowat * 0.9,r2), &
+                 REAL(xx(i),r2) ) * zse(k)
             if (k == 1 .AND. ssnow%isflag(i) == 0) ssnow%gammzz(i,k) = ssnow%gammzz(i,k) + cgsnow * ssnow%snowd(i)
-            if (sicemelt(i)/ssnow%gammzz(i,k) > real(tiny(1.0),r_2)) &
+            if (sicemelt(i)/ssnow%gammzz(i,k) > real(tiny(1.0),r2)) &
                  ssnow%tgg(i,k) = ssnow%tgg(i,k) - REAL(sicemelt(i) / ssnow%gammzz(i,k)) * C%HLF
          endif
       enddo
@@ -1644,30 +1644,30 @@ SUBROUTINE remove_trans(dels, soil, ssnow, canopy, veg)
    TYPE(soil_snow_type), INTENT(INOUT)      :: ssnow
    TYPE(soil_parameter_type), INTENT(INOUT) :: soil
    TYPE(veg_parameter_type), INTENT(INOUT)  :: veg
-   REAL(r_2), DIMENSION(mp,0:ms) :: diff
-   REAL(r_2), DIMENSION(mp)      :: xx, xxd
+   REAL(r2), DIMENSION(mp,0:ms) :: diff
+   REAL(r2), DIMENSION(mp)      :: xx, xxd
    INTEGER :: k
 
   IF (cable_user%FWSOIL_switch.ne.'Haverd2013') THEN
-     xx  = 0.0_r_2
-     xxd = 0.0_r_2
-     diff(:,:) = 0.0_r_2
+     xx  = 0.0_r2
+     xxd = 0.0_r2
+     diff(:,:) = 0.0_r2
      DO k = 1, ms
 
         ! Removing transpiration from soil:
-        WHERE (canopy%fevc > 0.0_r_2)     ! convert to mm/dels
+        WHERE (canopy%fevc > 0.0_r2)     ! convert to mm/dels
            ! Calculate the amount (perhaps moisture/ice limited)
            ! which can be removed:
-           xx = canopy%fevc * real(dels / C%HL * veg%froot(:,k),r_2) + diff(:,k-1)   ! kg/m2
-           diff(:,k) = MAX( 0.0_r_2, ssnow%wb(:,k) - real(soil%swilt,r_2)) &      ! m3/m3
-                * real(soil%zse(k),r_2)*1000.0_r_2
+           xx = canopy%fevc * real(dels / C%HL * veg%froot(:,k),r2) + diff(:,k-1)   ! kg/m2
+           diff(:,k) = MAX( 0.0_r2, ssnow%wb(:,k) - real(soil%swilt,r2)) &      ! m3/m3
+                * real(soil%zse(k),r2)*1000.0_r2
            xxd = xx - diff(:,k)
-           WHERE ( xxd .GT. 0.0_r_2 )
-              ssnow%wb(:,k) = ssnow%wb(:,k) - diff(:,k) / real(soil%zse(k)*1000.0,r_2)
+           WHERE ( xxd .GT. 0.0_r2 )
+              ssnow%wb(:,k) = ssnow%wb(:,k) - diff(:,k) / real(soil%zse(k)*1000.0,r2)
               diff(:,k) = xxd
            ELSEWHERE
-              ssnow%wb(:,k) = ssnow%wb(:,k) - xx / real(soil%zse(k)*1000.0,r_2)
-              diff(:,k) = 0.0_r_2
+              ssnow%wb(:,k) = ssnow%wb(:,k) - xx / real(soil%zse(k)*1000.0,r2)
+              diff(:,k) = 0.0_r2
            ENDWHERE
 
         END WHERE
@@ -1675,12 +1675,12 @@ SUBROUTINE remove_trans(dels, soil, ssnow, canopy, veg)
      END DO
 
   ELSE
-     WHERE (canopy%fevc .lt. 0.0_r_2)
+     WHERE (canopy%fevc .lt. 0.0_r2)
         canopy%fevw = canopy%fevw + real(canopy%fevc)
-        canopy%fevc = 0.0_r_2
+        canopy%fevc = 0.0_r2
      END WHERE
      DO k = 1,ms
-        ssnow%wb(:,k) = ssnow%wb(:,k) - real(ssnow%evapfbl(:,k)/(soil%zse(k)*1000.0),r_2)
+        ssnow%wb(:,k) = ssnow%wb(:,k) - real(ssnow%evapfbl(:,k)/(soil%zse(k)*1000.0),r2)
       !  write(59,*) k,  ssnow%wb(:,k),  ssnow%evapfbl(:,k)/(soil%zse(k)*1000.0)
       !  write(59,*)
      ENDDO
@@ -1717,7 +1717,7 @@ SUBROUTINE soil_snow(dels, soil, ssnow, canopy, met, veg)
    REAL, DIMENSION(mp) :: totwet
    REAL, DIMENSION(mp) :: weting
    REAL, DIMENSION(mp) :: xxx
-   REAL(r_2), DIMENSION(mp) :: xx
+   REAL(r2), DIMENSION(mp) :: xx
    REAL, DIMENSION(mp) :: sinfil1, sinfil2, sinfil3
    REAL                :: zsetot
    INTEGER, SAVE :: ktau =0
@@ -1819,11 +1819,11 @@ SUBROUTINE soil_snow(dels, soil, ssnow, canopy, met, veg)
    DO k = 1, ms ! for stempv
 
       ! Set liquid soil water fraction (fraction of saturation value):
-      ssnow%wblf(:,k) = MAX( 0.01_r_2, (ssnow%wb(:,k) - ssnow%wbice(:,k)) )    &
-           & / REAL(soil%ssat,r_2)
+      ssnow%wblf(:,k) = MAX( 0.01_r2, (ssnow%wb(:,k) - ssnow%wbice(:,k)) )    &
+           & / REAL(soil%ssat,r2)
 
       ! Set ice soil water fraction (fraction of saturation value):
-      ssnow%wbfice(:,k) = ssnow%wbice(:,k) / real(soil%ssat, r_2)
+      ssnow%wbfice(:,k) = ssnow%wbice(:,k) / real(soil%ssat, r2)
    END DO
 
    CALL snowcheck(ssnow, soil)
@@ -1897,7 +1897,7 @@ SUBROUTINE soil_snow(dels, soil, ssnow, canopy, met, veg)
 
    ssnow%wbtot = 0.0
    DO k = 1, ms
-      ssnow%wbtot = ssnow%wbtot + REAL(ssnow%wb(:,k)*1000.0*soil%zse(k),r_2)
+      ssnow%wbtot = ssnow%wbtot + REAL(ssnow%wb(:,k)*1000.0*soil%zse(k),r2)
    END DO
 
 END SUBROUTINE soil_snow
@@ -2032,8 +2032,8 @@ SUBROUTINE hydraulic_redistribution(dels, soil, ssnow, canopy, veg, met)
 
          ENDWHERE
 
-         ssnow%wb(:,k) = ssnow%wb(:,k) + real(hr_perTime(:,k,j),r_2)
-         ssnow%wb(:,j) = ssnow%wb(:,j) + real(hr_perTime(:,j,k),r_2)
+         ssnow%wb(:,k) = ssnow%wb(:,k) + real(hr_perTime(:,k,j),r2)
+         ssnow%wb(:,j) = ssnow%wb(:,j) + real(hr_perTime(:,j,k),r2)
 
       ENDDO
 

--- a/core/biogeophys/mo_c13o2_photosynthesis.f90
+++ b/core/biogeophys/mo_c13o2_photosynthesis.f90
@@ -37,7 +37,8 @@
 
 MODULE mo_c13o2_photosynthesis
 
-  use mo_kind, only: dp, i4
+  use cable_def_types_mod, only: r2
+  use mo_kind, only: i4
 
   implicit none
 
@@ -51,13 +52,13 @@ MODULE mo_c13o2_photosynthesis
   public :: init_sugar_pools            ! Initialise isotope ratios of leaf carbohydrate pools
 
   ! Transitory starch concentration in leaf [mol(C)/m2]
-  real(dp), dimension(:), allocatable, public :: Vstarch
+  real(r2), dimension(:), allocatable, public :: Vstarch
   ! Isotopic composition if transitory starch
-  real(dp), dimension(:), allocatable, public :: Rstarch
+  real(r2), dimension(:), allocatable, public :: Rstarch
   ! Isotopic composition if leaf sucrose
-  real(dp), dimension(:), allocatable, public :: Rsucrose
+  real(r2), dimension(:), allocatable, public :: Rsucrose
   ! Isotopic composition if pool used for photorespiration
-  real(dp), dimension(:), allocatable, public :: Rphoto
+  real(r2), dimension(:), allocatable, public :: Rphoto
 
 
   ! Private parameters
@@ -69,42 +70,42 @@ MODULE mo_c13o2_photosynthesis
   ! and suggests: if any temp depence, take the one of Vcmax.
   ! -> C3: gm(CO2) =   meso_cond_fac*Vcmax [mol(CO2) m-2 s-1]
   !    C4: gm(CO2) = 2*meso_cond_fac*Vcmax
-  real(dp), parameter :: meso_cond_fac = 4000.0_dp
+  real(r2), parameter :: meso_cond_fac = 4000.0_r2
 
   ! fraction of leaf respiration in mesophyll in C4, rest in bundle sheats: Rdm = frdm*Rd
-  real(dp), parameter :: frdm = 0.5_dp    ! von Caemmerer (2000), Table 4.1
+  real(r2), parameter :: frdm = 0.5_r2    ! von Caemmerer (2000), Table 4.1
 
   ! mesophyll to bundle sheat conductance for CO2 in C4, von Caemmerer (2000) Section 4.3.2.2
-  real(dp), parameter :: gbsc = 2.e-3_dp
+  real(r2), parameter :: gbsc = 2.e-3_r2
 
   ! Leakage of bundle sheat to mesophyll in C4 plants during the day, von Caemmerer (2000) Section 4.3.3.2
   ! LPJ used 0.4
-  real(dp), parameter :: Phi  = 0.2_dp ! von Caemmerer (2000), Fig. 4.11
+  real(r2), parameter :: Phi  = 0.2_r2 ! von Caemmerer (2000), Fig. 4.11
 
   ! Fractionation of leaf respiration
   ! Ghashghaie et al. (2003) reviews around -6.
   ! Tcherkez et al. (2004) calculates -5.5
   ! Gessler et al. (2008) determines -2. for Ricinus
-  real(dp), parameter :: eps_e = -6.0e-03_dp
+  real(r2), parameter :: eps_e = -6.0e-03_r2
 
   ! Fractionation of photo respiration
   ! Ghashghaie et al. (2003) reviews around +10.
   ! Tcherkez et al. (2004) calculates -9.2
-  real(dp), parameter :: eps_f = 10.0e-03_dp
+  real(r2), parameter :: eps_f = 10.0e-03_r2
 
   ! Parameters for photosynthesis discrimination: Lloyd and Farquhar (1994)
-  real(dp), parameter :: &
-       eps_a    =  4.4e-03_dp, & ! diffusion frac.
-       eps_al   =  0.7e-03_dp, & ! diffusion in liquid
-       eps_b3   = 30.0e-03_dp, & ! fractionation during RUBISCO carboxylation
-       eps_b_ci = 27.0e-03_dp, & ! effective carboxylation fractionation in 'simple' model
-       beta     =  0.05_dp       ! fraction of PEP carboxylation in C3
+  real(r2), parameter :: &
+       eps_a    =  4.4e-03_r2, & ! diffusion frac.
+       eps_al   =  0.7e-03_r2, & ! diffusion in liquid
+       eps_b3   = 30.0e-03_r2, & ! fractionation during RUBISCO carboxylation
+       eps_b_ci = 27.0e-03_r2, & ! effective carboxylation fractionation in 'simple' model
+       beta     =  0.05_r2       ! fraction of PEP carboxylation in C3
 
   ! Sucrose content of leaf
   ! 100-500 mol(C6)/gDW guess from figures in Grimmer & Komor (1999) and Komor (2000) for Ricinus
   ! Conversion to mol(CO2)/m2(leaf) based on values from Ricinus experiment with Claudia Keitel
   ! -> mol(C6)/gDW * C/C6 * gDW/leaf * leaf/cm2(leaf) * cm2(leaf)/m2(leaf)
-  real(dp), parameter :: Vsucrose = 300.e-6_dp * 6._dp * 2.2_dp * 1.0_dp/500._dp * 1.e4_dp
+  real(r2), parameter :: Vsucrose = 300.e-6_r2 * 6._r2 * 2.2_r2 * 1.0_r2/500._r2 * 1.e4_r2
 
   ! Photorespiration pool
   ! This is some mixed sugar/enzyme pool.
@@ -112,12 +113,12 @@ MODULE mo_c13o2_photosynthesis
   ! This is definitely too large. It is little, though, compared to the oxygenation flux and hence mixes rapidly.
   ! Mathematically, we only need that the isotope ratio is not equal the assimilation.
   ! Hence, take 10% of sucrose pool.
-  real(dp), parameter :: Vphoto = Vsucrose/10._dp
+  real(r2), parameter :: Vphoto = Vsucrose/10._r2
 
   ! Fractionation of starch synthesis
   ! Tcherkez et al. (2004) models about Rchloroplast/Rinput=1.006, i.e. eps_starch = -6.
   ! The measured equilibrium fractionation is -4.4 (according to Gerd Gleixner)
-  real(dp), parameter :: eps_starch = -4.4e-03_dp
+  real(r2), parameter :: eps_starch = -4.4e-03_r2
 
   ! Fractionation of sucrose
   ! Tcherkez et al. (2004) models about Rcytoplasm/Rinput=1.0019, i.e. eps_sucrose ~ -2.
@@ -126,7 +127,7 @@ MODULE mo_c13o2_photosynthesis
   ! so if F_starch = A/3 and F_sucrose=2A/3 then eps_sucrose = -eps_starch/2.
   ! This is the 'wrong' direction, according to Tcherkez et al. (2004).
   ! But the effect on sucrose is rather small so that we rather 'close the mass balance' and take -eps_starch/2.
-  real(dp), parameter :: eps_sucrose = -eps_starch * 0.5_dp
+  real(r2), parameter :: eps_sucrose = -eps_starch * 0.5_r2
 
 contains
 
@@ -177,25 +178,25 @@ contains
   !>        This is an elemental subroutine and can be called with scalars and arrays. <- ToDo
 
   !     PARAMETER
-  !>        \param[in]    "real(dp) :: dt"         Time step [s]
+  !>        \param[in]    "real(r2) :: dt"         Time step [s]
   !>        \param[in]    "logical  :: isc3"       C3 mask with .true. for C3 and .false. for C4 plants
-  !>        \param[in]    "real(dp) :: Vcmax"      Maximal carboxylation rate at leaf temperature Vcmax(Tl) [mol(CO2)/m^2/s]
-  !>        \param[in]    "real(dp) :: GPP"        Gross assimilation [mol(CO2)/m^2/s]
-  !>        \param[in]    "real(dp) :: Rd"         Leaf respiration [mol(CO2)/m^2/s]
-  !>        \param[in]    "real(dp) :: Gammstar"   CO2 compensation point in absence of dark respiration [mol(CO2)/mol(air)]
-  !>        \param[in]    "real(dp) :: ca"         Ambient CO2 mixing ratio [mol(CO2)/mol(air)]
-  !>        \param[in]    "real(dp) :: ci"         Stomatal CO2 mixing ratio [mol(CO2)/mol(air)]
-  !>        \param[in]    "real(dp) :: gsc"        Stomatal conductance for CO2 [mol(CO2)/m^2/s]
-  !>        \param[in]    "real(dp) :: gac"        Aerodynamic conductance for CO2 [mol(CO2)/m^2/s]
-  !>        \param[in]    "real(dp) :: gbc"        Boundary layer conductance for CO2 [mol(CO2)/m^2/s]
-  !>        \param[in]    "real(dp) :: Tl"         Leaf temperature [K]
-  !>        \param[in]    "real(dp) :: Rair"       Isotope ratio of ambient CO2 ([13C]/[12C])
-  !>        \param[inout] "real(dp) :: Vstarch"    Transitory starch pool [mol(C)/m2]
-  !>        \param[inout] "real(dp) :: Rstarch"    Isotope ratio of transitory starch ([13C]/[12C])
-  !>        \param[inout] "real(dp) :: Rsucrose"   Isotope ratio of sucrose pool ([13C]/[12C])
-  !>        \param[inout] "real(dp) :: Rphoto"     Isotope ratio of pool for photorespiration ([13C]/[12C])
-  !>        \param[out]   "real(dp) :: Disc"       Leaf discrimination
-  !>        \param[out]   "real(dp) :: Ass13"      13C net assimilation [mol(13CO2)/m^2/s]
+  !>        \param[in]    "real(r2) :: Vcmax"      Maximal carboxylation rate at leaf temperature Vcmax(Tl) [mol(CO2)/m^2/s]
+  !>        \param[in]    "real(r2) :: GPP"        Gross assimilation [mol(CO2)/m^2/s]
+  !>        \param[in]    "real(r2) :: Rd"         Leaf respiration [mol(CO2)/m^2/s]
+  !>        \param[in]    "real(r2) :: Gammstar"   CO2 compensation point in absence of dark respiration [mol(CO2)/mol(air)]
+  !>        \param[in]    "real(r2) :: ca"         Ambient CO2 mixing ratio [mol(CO2)/mol(air)]
+  !>        \param[in]    "real(r2) :: ci"         Stomatal CO2 mixing ratio [mol(CO2)/mol(air)]
+  !>        \param[in]    "real(r2) :: gsc"        Stomatal conductance for CO2 [mol(CO2)/m^2/s]
+  !>        \param[in]    "real(r2) :: gac"        Aerodynamic conductance for CO2 [mol(CO2)/m^2/s]
+  !>        \param[in]    "real(r2) :: gbc"        Boundary layer conductance for CO2 [mol(CO2)/m^2/s]
+  !>        \param[in]    "real(r2) :: Tl"         Leaf temperature [K]
+  !>        \param[in]    "real(r2) :: Rair"       Isotope ratio of ambient CO2 ([13C]/[12C])
+  !>        \param[inout] "real(r2) :: Vstarch"    Transitory starch pool [mol(C)/m2]
+  !>        \param[inout] "real(r2) :: Rstarch"    Isotope ratio of transitory starch ([13C]/[12C])
+  !>        \param[inout] "real(r2) :: Rsucrose"   Isotope ratio of sucrose pool ([13C]/[12C])
+  !>        \param[inout] "real(r2) :: Rphoto"     Isotope ratio of pool for photorespiration ([13C]/[12C])
+  !>        \param[out]   "real(r2) :: Disc"       Leaf discrimination
+  !>        \param[out]   "real(r2) :: Ass13"      13C net assimilation [mol(13CO2)/m^2/s]
 
   !     HISTORY
   !>        \author Written Matthias Cuntz
@@ -223,51 +224,51 @@ contains
        Ass13)
 
     use mo_utils,     only: ne
-    use mo_constants, only: onethird_dp, twothird_dp, T0_dp
+    use mo_constants, only: onethird_r2, twothird_r2, T0_r2
 
     implicit none
 
-    real(dp),               intent(in)    :: dt                   ! time step
+    real(r2),               intent(in)    :: dt                   ! time step
     logical,  dimension(:), intent(in)    :: isc3                 ! C3 mask
-    real(dp), dimension(:), intent(in)    :: Vcmax                ! Vcmax(Tl) [mol(air)/m2s]
-    real(dp), dimension(:), intent(in)    :: GPP                  ! A+Rd [mol(co2)/m2s]
-    real(dp), dimension(:), intent(in)    :: Rd                   ! Leaf respiration Rd [mol(co2)/m2s]
-    real(dp), dimension(:), intent(in)    :: Gammastar            ! CO2 compensation point Gamma* [ppm]
-    real(dp), dimension(:), intent(in)    :: ca                   ! Ambient CO2 concentration [ppm]
-    real(dp), dimension(:), intent(in)    :: ci                   ! Stomatal CO2 concentration [ppm]
-    real(dp), dimension(:), intent(in)    :: gsc                  ! Stomatal conductance for CO2 [mol(CO2)/m2s]
-    real(dp), dimension(:), intent(in)    :: gac                  ! Aerodynamic conductance for CO2 [mol(CO2)/m2s]
-    real(dp), dimension(:), intent(in)    :: gbc                  ! Boundary layer conductance for CO2 [mol(CO2)/m2s]
-    real(dp), dimension(:), intent(in)    :: Tl                   ! Leaf temperature [K]
-    real(dp), dimension(:), intent(in)    :: Rair                 ! Isotopic composition of ambient CO2
-    real(dp), dimension(:), intent(inout) :: Vstarch              ! Transitory starch pool [mol(C)/m2]
-    real(dp), dimension(:), intent(inout) :: Rstarch              ! Isotopic composition of transitory starch
-    real(dp), dimension(:), intent(inout) :: Rsucrose             ! Isotopic composition of sucrose pool
-    real(dp), dimension(:), intent(inout) :: Rphoto               ! Isotopic composition of pool for photorespiration
-    real(dp), dimension(:), intent(out)   :: Disc                 ! Discrimination
-    real(dp), dimension(:), intent(out)   :: Ass13                ! 13CO2 flux [mol(13CO2)/m2s]
+    real(r2), dimension(:), intent(in)    :: Vcmax                ! Vcmax(Tl) [mol(air)/m2s]
+    real(r2), dimension(:), intent(in)    :: GPP                  ! A+Rd [mol(co2)/m2s]
+    real(r2), dimension(:), intent(in)    :: Rd                   ! Leaf respiration Rd [mol(co2)/m2s]
+    real(r2), dimension(:), intent(in)    :: Gammastar            ! CO2 compensation point Gamma* [ppm]
+    real(r2), dimension(:), intent(in)    :: ca                   ! Ambient CO2 concentration [ppm]
+    real(r2), dimension(:), intent(in)    :: ci                   ! Stomatal CO2 concentration [ppm]
+    real(r2), dimension(:), intent(in)    :: gsc                  ! Stomatal conductance for CO2 [mol(CO2)/m2s]
+    real(r2), dimension(:), intent(in)    :: gac                  ! Aerodynamic conductance for CO2 [mol(CO2)/m2s]
+    real(r2), dimension(:), intent(in)    :: gbc                  ! Boundary layer conductance for CO2 [mol(CO2)/m2s]
+    real(r2), dimension(:), intent(in)    :: Tl                   ! Leaf temperature [K]
+    real(r2), dimension(:), intent(in)    :: Rair                 ! Isotopic composition of ambient CO2
+    real(r2), dimension(:), intent(inout) :: Vstarch              ! Transitory starch pool [mol(C)/m2]
+    real(r2), dimension(:), intent(inout) :: Rstarch              ! Isotopic composition of transitory starch
+    real(r2), dimension(:), intent(inout) :: Rsucrose             ! Isotopic composition of sucrose pool
+    real(r2), dimension(:), intent(inout) :: Rphoto               ! Isotopic composition of pool for photorespiration
+    real(r2), dimension(:), intent(out)   :: Disc                 ! Discrimination
+    real(r2), dimension(:), intent(out)   :: Ass13                ! 13CO2 flux [mol(13CO2)/m2s]
 
     ! Local variables
     integer(i4) :: nn  ! number of grid points
     integer(i4) :: jl  ! counter
-    real(dp)    :: tmp ! temporary real
-    real(dp), dimension(size(isc3)) :: Rdm, Rds, leakage, Vp, Phi1 ! for C4
-    real(dp), dimension(size(isc3)) :: Ass                         ! net assimilation
-    real(dp), dimension(size(isc3)) :: k                           ! carboxylation efficiency
-    real(dp), dimension(size(isc3)) :: Vc                          ! carboxylation rate
-    real(dp), dimension(size(isc3)) :: Photo                       ! Photorespiration
+    real(r2)    :: tmp ! temporary real
+    real(r2), dimension(size(isc3)) :: Rdm, Rds, leakage, Vp, Phi1 ! for C4
+    real(r2), dimension(size(isc3)) :: Ass                         ! net assimilation
+    real(r2), dimension(size(isc3)) :: k                           ! carboxylation efficiency
+    real(r2), dimension(size(isc3)) :: Vc                          ! carboxylation rate
+    real(r2), dimension(size(isc3)) :: Photo                       ! Photorespiration
     ! resistances and conductances
-    real(dp), dimension(size(isc3)) :: rac, rbc, rsc, rmc, rwc, rmlc, rabsmc ! resistances for CO2
-    real(dp), dimension(size(isc3)) :: gmc, gabsc, gabsmc                    ! conductances for CO2
+    real(r2), dimension(size(isc3)) :: rac, rbc, rsc, rmc, rwc, rmlc, rabsmc ! resistances for CO2
+    real(r2), dimension(size(isc3)) :: gmc, gabsc, gabsmc                    ! conductances for CO2
     ! CO2 concentrations
-    real(dp), dimension(size(isc3)) :: cc, cbs, ctmp ! , cs, cw
+    real(r2), dimension(size(isc3)) :: cc, cbs, ctmp ! , cs, cw
     ! fractionations
-    real(dp), dimension(size(isc3)) :: eps_es, eps_b4, eps_b, eps_s, eps_a_eff
-    real(dp) :: eps_ab
-    real(dp) :: eps_night ! fractionation during night
+    real(r2), dimension(size(isc3)) :: eps_es, eps_b4, eps_b, eps_s, eps_a_eff
+    real(r2) :: eps_ab
+    real(r2) :: eps_night ! fractionation during night
     ! for pools update
-    real(dp) :: add_flux  ! new flux to pool
-    real(dp) :: add_r     ! isotope ratio of new flux
+    real(r2) :: add_flux  ! new flux to pool
+    real(r2) :: add_r     ! isotope ratio of new flux
 
     nn = size(isc3,1)
 
@@ -285,7 +286,7 @@ contains
     ! PhiL(GPP=0)=0; PhiL(GPP=Rds)=1 -> PhiL = 1/Rds*GPP < 5.
     ! Rds is changing with time but this effect of a changing slope is rather small.
     ! This comes to vp=gpp and leakage=rds if gpp<5*rds otherwise phiL=1/phi.
-    tmp = 1.0_dp / (1.0_dp-Phi)
+    tmp = 1.0_r2 / (1.0_r2-Phi)
     where (GPP > (Rds/Phi))
        leakage = (GPP-Rds)*(Phi*tmp)
        Vp      = (GPP-Rds)*tmp
@@ -294,10 +295,10 @@ contains
        Vp      = GPP
     end where
     ! New continuous Phi
-    where (Vp > 0.0_dp)
+    where (Vp > 0.0_r2)
        Phi1    = leakage/Vp
     elsewhere
-       Phi1    = 0.0_dp ! dummy
+       Phi1    = 0.0_r2 ! dummy
     end where
 
     ! net assimilation
@@ -308,22 +309,22 @@ contains
     !
 
     ! Aerodynamic resistance
-    where (gac < huge(1.0_dp)*0.1_dp)
-       rac = 1.0_dp / gac ! [mol(CO2) m-2 s-1]^-1
+    where (gac < huge(1.0_r2)*0.1_r2)
+       rac = 1.0_r2 / gac ! [mol(CO2) m-2 s-1]^-1
     elsewhere
-       rac = tiny(1.0_dp)
+       rac = tiny(1.0_r2)
     endwhere
     ! Leaf boundary layer resistance
-    where (gbc < huge(1.0_dp)*0.1_dp)
-       rbc = 1.0_dp / gbc ! [mol(CO2) m-2 s-1]^-1
+    where (gbc < huge(1.0_r2)*0.1_r2)
+       rbc = 1.0_r2 / gbc ! [mol(CO2) m-2 s-1]^-1
     elsewhere
-       rbc = tiny(1.0_dp)
+       rbc = tiny(1.0_r2)
     endwhere
     ! Stomatal resistance
-    where (gsc < huge(1.0_dp)*0.1_dp)
-       rsc = 1.0_dp / gsc ! [mol(CO2) m-2 s-1]^-1
+    where (gsc < huge(1.0_r2)*0.1_r2)
+       rsc = 1.0_r2 / gsc ! [mol(CO2) m-2 s-1]^-1
     elsewhere
-       rsc = tiny(1.0_dp)
+       rsc = tiny(1.0_r2)
     endwhere
     ! Mesophyll conductance [mol(CO2) m-2 s-1]
     ! ISOLSM takes 8000 for C4. John Evans suggests that it should be ca. 3000 for C3.
@@ -333,31 +334,31 @@ contains
     where (isc3) ! c3
        gmc =        meso_cond_fac*Vcmax
     elsewhere    ! c4
-       gmc = 2.0_dp*meso_cond_fac*Vcmax
+       gmc = 2.0_r2*meso_cond_fac*Vcmax
     end where
-    where (gmc > 0.0_dp)
-       rmc = 1.0_dp / gmc ! [mol(co2) m-2 s-1]^-1
+    where (gmc > 0.0_r2)
+       rmc = 1.0_r2 / gmc ! [mol(co2) m-2 s-1]^-1
     elsewhere
-       rmc = 0.0_dp       ! dummy
+       rmc = 0.0_r2       ! dummy
     end where
     ! Resistance from stoma middle to the chloroplast surface [mol(CO2) m-2 s-1]^-1
     ! 0.25 of mesophyll resistance: Lloyd & Farquhar (1994)
-    rwc  = 0.25_dp * rmc
+    rwc  = 0.25_r2 * rmc
     ! Resistance from the chloroplast surface to inside the chloroplast [mol(CO2) m-2 s-1]^-1
-    rmlc = (1.0_dp-0.25_dp) * rmc
+    rmlc = (1.0_r2-0.25_r2) * rmc
 
     ! Total conductance from canopy to stomatal air space for CO2
-    gabsc = 1.0_dp / (rac+rbc+rsc)
+    gabsc = 1.0_r2 / (rac+rbc+rsc)
     ! Total conductance from canopy to sites of carboxylation for CO2
     rabsmc = rac + rbc + rsc + rwc + rmlc
-    gabsmc = 1.0_dp / rabsmc
+    gabsmc = 1.0_r2 / rabsmc
 
     !
     !-- CO2 concentrations
     !
 
     ! CO2 at the site of carboxylation, i.e. in the chloroplasts
-    where ((gmc > 0.0_dp) .and. (ass > 0.0_dp))
+    where ((gmc > 0.0_r2) .and. (ass > 0.0_r2))
        cc = ci - ass*rmc
        cc = max(cc, 1.1*Gammastar) ! from isolsm
     elsewhere
@@ -369,7 +370,7 @@ contains
     ! cs   = ca - ass*(rac+rbc) ! same: cs = ci + ass*rsc
     ! ! CO2 at the chloroplast surface = 1/4 down from Ci->Cc
     ! ! cf. rwc, rmlc above (0.25 from Lloyd & Farquhar 1994)
-    ! cw = ci - 0.25_dp*(ci-cc)
+    ! cw = ci - 0.25_r2*(ci-cc)
 
 
     !
@@ -393,7 +394,7 @@ contains
     where (ctmp > Gammastar)
        k = GPP/(ctmp-Gammastar)
     elsewhere
-       k = 0.0_dp
+       k = 0.0_r2
     end where
     ! Carboxylation rate
     Vc = k*ctmp
@@ -405,59 +406,59 @@ contains
     !
 
     ! diffusion fractionation through lamina
-    eps_ab = 1.0_dp - (1.0_dp-eps_a)**twothird_dp
+    eps_ab = 1.0_r2 - (1.0_r2-eps_a)**twothird_r2
     ! frac. during CO2 dissolution
-    eps_es = (1.18_dp - 0.0041_dp*(Tl-T0_dp))*1.e-3_dp ! Vogel et al. (Z Physik, 1970), Szaran (Chemical Geology, 1998)
+    eps_es = (1.18_r2 - 0.0041_r2*(Tl-T0_r2))*1.e-3_r2 ! Vogel et al. (Z Physik, 1970), Szaran (Chemical Geology, 1998)
     ! discrimination by PEP-c (<0)
-    eps_b4 = (26.19_dp - 9483._dp/Tl)*1.e-3_dp         ! Henderson et al. (Aust J Plant Physiol, 1992)
+    eps_b4 = (26.19_r2 - 9483._r2/Tl)*1.e-3_r2         ! Henderson et al. (Aust J Plant Physiol, 1992)
     ! effective discrimination of carboxylation in C3 plants
-    eps_b = eps_b3*(1.0_dp-beta) + eps_b4*beta         ! Brugnoli & Farquhar (2000)
+    eps_b = eps_b3*(1.0_r2-beta) + eps_b4*beta         ! Brugnoli & Farquhar (2000)
     ! frac. during leakage of bundle sheets in C4
     eps_s = eps_es + eps_al
     ! effective fractionation from canopy canopy to sites of carboxylation (chloroplast interior)
-    eps_a_eff = (rac*0.0_dp + rbc*eps_ab + rsc*eps_a + rwc*eps_a + rmlc*eps_s) / (rabsmc)
+    eps_a_eff = (rac*0.0_r2 + rbc*eps_ab + rsc*eps_a + rwc*eps_a + rmlc*eps_s) / (rabsmc)
 
     !
     !-- 13CO2 fluxes
     !
 
-    eps_night = 0.0_dp
+    eps_night = 0.0_r2
     do jl=1, nn
-       if (k(jl) > 0.0_dp) then
+       if (k(jl) > 0.0_r2) then
           ! Day
           ! Same for photorespiration as Wingate et al. (2007) for leaf respiration
           if (isc3(jl)) then ! C3
-             Ass13(jl) = (1.0_dp-eps_a_eff(jl)) * gabsmc(jl) / &
-                  ( (1.0_dp-eps_a_eff(jl)) * gabsmc(jl) + (1.0_dp-eps_b(jl)) * k(jl) ) * &
-                  ( (1.0_dp-eps_b(jl)) * Rair(jl) * k(jl) * ca(jl) - &
-                  (1.0_dp-eps_f) * Rphoto(jl) * k(jl) * Gammastar(jl) - &
-                  (1.0_dp-eps_e) * Rsucrose(jl) * Rd(jl) )
-             if (ne(Ass(jl),0.0_dp)) then
-                Disc(jl) = 1.0_dp - Ass13(jl) / (Ass(jl)*Rair(jl))
+             Ass13(jl) = (1.0_r2-eps_a_eff(jl)) * gabsmc(jl) / &
+                  ( (1.0_r2-eps_a_eff(jl)) * gabsmc(jl) + (1.0_r2-eps_b(jl)) * k(jl) ) * &
+                  ( (1.0_r2-eps_b(jl)) * Rair(jl) * k(jl) * ca(jl) - &
+                  (1.0_r2-eps_f) * Rphoto(jl) * k(jl) * Gammastar(jl) - &
+                  (1.0_r2-eps_e) * Rsucrose(jl) * Rd(jl) )
+             if (ne(Ass(jl),0.0_r2)) then
+                Disc(jl) = 1.0_r2 - Ass13(jl) / (Ass(jl)*Rair(jl))
              else
-                Disc(jl) = 0.0_dp
+                Disc(jl) = 0.0_r2
              end if
           else               ! C4
-             tmp = cc(jl) * ( 1.0_dp - (1.0_dp-eps_a_eff(jl)) / (1.0_dp-eps_b4(jl)) * Ass(jl)/Vp(jl) - &
-                  (1.0_dp-eps_s(jl)) / (1.0_dp-eps_b3) * (1.0_dp-eps_a_eff(jl)) / (1.0_dp-eps_b4(jl)) * &
+             tmp = cc(jl) * ( 1.0_r2 - (1.0_r2-eps_a_eff(jl)) / (1.0_r2-eps_b4(jl)) * Ass(jl)/Vp(jl) - &
+                  (1.0_r2-eps_s(jl)) / (1.0_r2-eps_b3) * (1.0_r2-eps_a_eff(jl)) / (1.0_r2-eps_b4(jl)) * &
                   Phi1(jl) * Ass(jl) / vc(jl) )
-             if (abs(1.0_dp-tmp/ca(jl)) > 0.01_dp) then
-                Ass13(jl) = (1.0_dp-eps_a_eff(jl)) * ( Rair(jl)*ca(jl) - & ! no *ass
-                     (1.0_dp-eps_e) / (1.0_dp-eps_b4(jl)) * Rdm(jl) / Vp(jl) * Rsucrose(jl) * cc(jl) - &
-                     (1.0_dp-eps_s(jl)) / (1.0_dp-eps_b3) / (1.0_dp-eps_b4(jl)) * Phi1(jl) * cc(jl) * &
-                     ( (1.0_dp-eps_e) * Rsucrose(jl) * Rd(jl) + &
-                     (1.0_dp-eps_f) * Photo(jl) * Rphoto(jl) ) / vc(jl) ) / &
+             if (abs(1.0_r2-tmp/ca(jl)) > 0.01_r2) then
+                Ass13(jl) = (1.0_r2-eps_a_eff(jl)) * ( Rair(jl)*ca(jl) - & ! no *ass
+                     (1.0_r2-eps_e) / (1.0_r2-eps_b4(jl)) * Rdm(jl) / Vp(jl) * Rsucrose(jl) * cc(jl) - &
+                     (1.0_r2-eps_s(jl)) / (1.0_r2-eps_b3) / (1.0_r2-eps_b4(jl)) * Phi1(jl) * cc(jl) * &
+                     ( (1.0_r2-eps_e) * Rsucrose(jl) * Rd(jl) + &
+                     (1.0_r2-eps_f) * Photo(jl) * Rphoto(jl) ) / vc(jl) ) / &
                      (ca(jl)-tmp)
              else
-                Ass13(jl) = 0.0_dp
+                Ass13(jl) = 0.0_r2
              end if
-             Disc(jl)  = 1.0_dp - Ass13(jl)/Rair(jl)
+             Disc(jl)  = 1.0_r2 - Ass13(jl)/Rair(jl)
              Ass13(jl) = Ass13(jl) * Ass(jl)                               ! *ass
           endif              ! end C3/C4
        else
           ! Night
-          Ass13(jl) = (1.0_dp-eps_night) * Rstarch(jl) ! no *ass
-          Disc(jl)  = 1.0_dp - Ass13(jl)/Rair(jl)
+          Ass13(jl) = (1.0_r2-eps_night) * Rstarch(jl) ! no *ass
+          Disc(jl)  = 1.0_r2 - Ass13(jl)/Rair(jl)
           Ass13(jl) = Ass13(jl) * Ass(jl)              ! *ass
        end if ! end day/night
 
@@ -467,25 +468,25 @@ contains
 
        ! Update substrate pools
        ! 2/3 of assimilation is sugar, 1/3 goes into starch pool
-       if (Ass(jl) > 0.0_dp) then
+       if (Ass(jl) > 0.0_r2) then
           ! average sucrose pool (continuous)
-          add_flux     = dt * twothird_dp * Ass(jl)
-          add_r        = (1.0_dp-eps_sucrose) * Ass13(jl)/Ass(jl)
+          add_flux     = dt * twothird_r2 * Ass(jl)
+          add_r        = (1.0_r2-eps_sucrose) * Ass13(jl)/Ass(jl)
           Rsucrose(jl) = (Vsucrose*Rsucrose(jl) + add_flux*add_r) / (Vsucrose + add_flux)
           ! average photorespiration pool (continuous)
-          add_flux    = dt * 2.0_dp * Photo(jl) ! vo=2*photo
-          add_r       = (1.0_dp-eps_sucrose) * Ass13(jl)/Ass(jl)
+          add_flux    = dt * 2.0_r2 * Photo(jl) ! vo=2*photo
+          add_r       = (1.0_r2-eps_sucrose) * Ass13(jl)/Ass(jl)
           Rphoto(jl)  = (Vphoto*Rphoto(jl) + add_flux*add_r) / (Vphoto + add_flux)
           ! integrated starch pool (new at every day)
-          add_flux    = dt * onethird_dp * Ass(jl)
-          add_r       = (1.0_dp-eps_starch) * Ass13(jl)/Ass(jl)
+          add_flux    = dt * onethird_r2 * Ass(jl)
+          add_r       = (1.0_r2-eps_starch) * Ass13(jl)/Ass(jl)
           Rstarch(jl) = (Vstarch(jl)*Rstarch(jl) + add_flux*add_r) / (Vstarch(jl) + add_flux)
           Vstarch(jl) = Vstarch(jl) + add_flux
        else
           ! Rsucrose(jl) = Rsucrose(jl)
           ! Rphoto(jl)   = Rphoto(jl)
           ! Rstarch(jl)  = Rstarch(jl)
-          Vstarch(jl) = 0.0_dp ! start new starch integration each day
+          Vstarch(jl) = 0.0_r2 ! start new starch integration each day
        end if
 
     end do
@@ -525,18 +526,18 @@ contains
   !>        This is an elemental subroutine and can be called with scalars and arrays.
 
   !     PARAMETER
-  !>        \param[in]    "real(dp) :: dt"        Time step [s]
+  !>        \param[in]    "real(r2) :: dt"        Time step [s]
   !>        \param[in]    "logical  :: isc3"      C3 mask with .true. for C3 and .false. for C4 plants
-  !>        \param[in]    "real(dp) :: GPP"       Gross assimilation [mol(CO2)/m^2/s]
-  !>        \param[in]    "real(dp) :: Rd"        Leaf respiration [mol(CO2)/m^2/s]
-  !>        \param[in]    "real(dp) :: ca"        Ambient CO2 mixing ratio [mol(CO2)/mol(air)]
-  !>        \param[in]    "real(dp) :: ci"        Stomatal CO2 mixing ratio [mol(CO2)/mol(air)]
-  !>        \param[in]    "real(dp) :: Tl"        Leaf temperature [K]
-  !>        \param[in]    "real(dp) :: Rair"      Isotope ratio of ambient CO2 ([13C]/[12C])
-  !>        \param[inout] "real(dp) :: Vstarch"   Transitory starch pool [mol(C)/m2]
-  !>        \param[inout] "real(dp) :: Rstarch"   Isotope ratio of transitory starch ([13C]/[12C])
-  !>        \param[out]   "real(dp) :: Disc"      Leaf discrimination
-  !>        \param[out]   "real(dp) :: Ass13"     13C net assimilation [mol(13CO2)/m^2/s]
+  !>        \param[in]    "real(r2) :: GPP"       Gross assimilation [mol(CO2)/m^2/s]
+  !>        \param[in]    "real(r2) :: Rd"        Leaf respiration [mol(CO2)/m^2/s]
+  !>        \param[in]    "real(r2) :: ca"        Ambient CO2 mixing ratio [mol(CO2)/mol(air)]
+  !>        \param[in]    "real(r2) :: ci"        Stomatal CO2 mixing ratio [mol(CO2)/mol(air)]
+  !>        \param[in]    "real(r2) :: Tl"        Leaf temperature [K]
+  !>        \param[in]    "real(r2) :: Rair"      Isotope ratio of ambient CO2 ([13C]/[12C])
+  !>        \param[inout] "real(r2) :: Vstarch"   Transitory starch pool [mol(C)/m2]
+  !>        \param[inout] "real(r2) :: Rstarch"   Isotope ratio of transitory starch ([13C]/[12C])
+  !>        \param[out]   "real(r2) :: Disc"      Leaf discrimination
+  !>        \param[out]   "real(r2) :: Ass13"     13C net assimilation [mol(13CO2)/m^2/s]
 
   !     HISTORY
   !>        \author Written Matthias Cuntz
@@ -561,40 +562,40 @@ contains
        ! 13CO2 flux
        Ass13)
 
-    use mo_constants, only: onethird_dp, T0_dp
+    use mo_constants, only: onethird_r2, T0_r2
 
     implicit none
 
-    real(dp), intent(in)    :: dt      ! time step
+    real(r2), intent(in)    :: dt      ! time step
     logical,  intent(in)    :: isc3    ! C3 mask
-    real(dp), intent(in)    :: GPP     ! A+Rd [mol(CO2)/m2s]
-    real(dp), intent(in)    :: Rd      ! Leaf respiration Rd [mol(CO2)/m2s]
-    real(dp), intent(in)    :: ci      ! Stomatal CO2 concentration [mol(CO2)/mol(air)]
-    real(dp), intent(in)    :: ca      ! Ambient CO2 concentration [mol(CO2)/mol(air)]
-    real(dp), intent(in)    :: Tl      ! Leaf temperature [K]
-    real(dp), intent(in)    :: Rair    ! Isotopic composition of ambient CO2
-    real(dp), intent(inout) :: Vstarch ! Transitory starch pool [mol(C)/m2]
-    real(dp), intent(inout) :: Rstarch ! Isotopic composition of transitory starch
-    real(dp), intent(out)   :: Disc    ! Discrimination
-    real(dp), intent(out)   :: Ass13   ! 13CO2 flux [mol(13CO2)/m2s]
+    real(r2), intent(in)    :: GPP     ! A+Rd [mol(CO2)/m2s]
+    real(r2), intent(in)    :: Rd      ! Leaf respiration Rd [mol(CO2)/m2s]
+    real(r2), intent(in)    :: ci      ! Stomatal CO2 concentration [mol(CO2)/mol(air)]
+    real(r2), intent(in)    :: ca      ! Ambient CO2 concentration [mol(CO2)/mol(air)]
+    real(r2), intent(in)    :: Tl      ! Leaf temperature [K]
+    real(r2), intent(in)    :: Rair    ! Isotopic composition of ambient CO2
+    real(r2), intent(inout) :: Vstarch ! Transitory starch pool [mol(C)/m2]
+    real(r2), intent(inout) :: Rstarch ! Isotopic composition of transitory starch
+    real(r2), intent(out)   :: Disc    ! Discrimination
+    real(r2), intent(out)   :: Ass13   ! 13CO2 flux [mol(13CO2)/m2s]
 
     ! Local variables
-    real(dp) :: tmp
-    real(dp) :: Ass                   ! net assimilation
+    real(r2) :: tmp
+    real(r2) :: Ass                   ! net assimilation
     ! fractionations
-    real(dp) :: eps_es, eps_b4, eps_s ! for C4
+    real(r2) :: eps_es, eps_b4, eps_s ! for C4
     ! for pool update
-    real(dp) :: add_flux  ! new flux to pool
-    real(dp) :: add_r     ! isotope ratio of new flux
+    real(r2) :: add_flux  ! new flux to pool
+    real(r2) :: add_r     ! isotope ratio of new flux
 
     ! net assimilation
     Ass = GPP - Rd
 
     ! For C4
     ! frac. during CO2 dissolution
-    eps_es = (1.18_dp - 0.0041_dp*(Tl-T0_dp))*1.e-3_dp ! Vogel et al. (Z Physik, 1970), Szaran (Chemical Geology, 1998)
+    eps_es = (1.18_r2 - 0.0041_r2*(Tl-T0_r2))*1.e-3_r2 ! Vogel et al. (Z Physik, 1970), Szaran (Chemical Geology, 1998)
     ! discrimination by PEP-c (<0)
-    eps_b4 = (26.19_dp - 9483._dp/Tl)*1.e-3_dp         ! Henderson et al. (Aust J Plant Physiol, 1992)
+    eps_b4 = (26.19_r2 - 9483._r2/Tl)*1.e-3_r2         ! Henderson et al. (Aust J Plant Physiol, 1992)
     ! frac. during leakage of bundle sheets in C4
     eps_s = eps_es + eps_al
 
@@ -606,15 +607,15 @@ contains
        if (isc3) then ! C3
           Disc = eps_a + (eps_b_ci-eps_a) * ci/ca
        else           ! C4
-          tmp = ci * ( 1.0_dp - (1.0_dp-eps_a) / (1.0_dp-eps_b4) * (1.0_dp-Phi) - &
-               (1.0_dp-eps_s) / (1.0_dp-eps_b3) * (1.0_dp-eps_a) / (1.0_dp-eps_b4) * Phi )
-          Ass13 = (1.0_dp-eps_a) * ca / (ca-tmp) ! no *A*Ra
-          Disc  = 1.0_dp - Ass13                 ! D = 1 - A'/A/Ra
+          tmp = ci * ( 1.0_r2 - (1.0_r2-eps_a) / (1.0_r2-eps_b4) * (1.0_r2-Phi) - &
+               (1.0_r2-eps_s) / (1.0_r2-eps_b3) * (1.0_r2-eps_a) / (1.0_r2-eps_b4) * Phi )
+          Ass13 = (1.0_r2-eps_a) * ca / (ca-tmp) ! no *A*Ra
+          Disc  = 1.0_r2 - Ass13                 ! D = 1 - A'/A/Ra
        end if ! end C3/C4
-       Ass13 = (1.0_dp-Disc) * Ass * Rair        ! D = 1 - A'/A/Ra
+       Ass13 = (1.0_r2-Disc) * Ass * Rair        ! D = 1 - A'/A/Ra
     else              ! night
        Ass13 = Rstarch     ! no *ass
-       Disc  = 1.0_dp - Ass13/Rair
+       Disc  = 1.0_r2 - Ass13/Rair
        Ass13 = Ass13 * Ass ! *ass
     endif ! end day/night
 
@@ -626,13 +627,13 @@ contains
     ! 2/3 of assimilation is sugar, 1/3 goes into starch pool
     if (ca > ci) then ! day
        ! integrated starch pool (new at every day)
-       add_flux = dt * onethird_dp * Ass
+       add_flux = dt * onethird_r2 * Ass
        add_r    = Ass13/Ass
        Rstarch  = (Vstarch*Rstarch + add_flux*add_r) / (Vstarch + add_flux)
        Vstarch  = Vstarch + add_flux
     else
        ! Rstarch  = Rstarch
-       Vstarch = 0.0_dp ! start new starch integration each day
+       Vstarch = 0.0_r2 ! start new starch integration each day
     end if
 
     return
@@ -658,10 +659,10 @@ contains
 
   !     PARAMETER
   !>        \param[in]    "logical  :: isc3"       C3 mask with .true. for C3 and .false. for C4 plants
-  !>        \param[inout] "real(dp) :: Vstarch"    Transitory starch pool
-  !>        \param[inout] "real(dp) :: Rstarch"    Isotope ratio of transitory starch
-  !>        \param[in]    "real(dp) :: Rinitc3"    Initial isotope ratio if isc3=.true., i.e. of C3 plants
-  !>        \param[in]    "real(dp) :: Rinitc4"    Initial isotope ratio if isc3=.false., i.e. of C4 plants
+  !>        \param[inout] "real(r2) :: Vstarch"    Transitory starch pool
+  !>        \param[inout] "real(r2) :: Rstarch"    Isotope ratio of transitory starch
+  !>        \param[in]    "real(r2) :: Rinitc3"    Initial isotope ratio if isc3=.true., i.e. of C3 plants
+  !>        \param[in]    "real(r2) :: Rinitc4"    Initial isotope ratio if isc3=.false., i.e. of C4 plants
 
   !     HISTORY
   !>        \author Written Matthias Cuntz
@@ -671,13 +672,13 @@ contains
     implicit none
 
     logical,  intent(in)    :: isc3
-    real(dp), intent(inout) :: Vstarch
-    real(dp), intent(inout) :: Rstarch
-    real(dp), intent(in)    :: Rinitc3
-    real(dp), intent(in)    :: Rinitc4
+    real(r2), intent(inout) :: Vstarch
+    real(r2), intent(inout) :: Rstarch
+    real(r2), intent(in)    :: Rinitc3
+    real(r2), intent(in)    :: Rinitc4
 
     ! initialise
-    Vstarch  = 0.0_dp
+    Vstarch  = 0.0_r2
     if (isc3) then
        Rstarch  = Rinitc3
     else
@@ -707,10 +708,10 @@ contains
 
   !     PARAMETER
   !>        \param[in]    "logical  :: isc3"       C3 mask with .true. for C3 and .false. for C4 plants
-  !>        \param[inout] "real(dp) :: Rsucrose"   Isotope ratio of leaf sucrose
-  !>        \param[inout] "real(dp) :: Rphoto"     Isotope ratio of substrate for photorespiration
-  !>        \param[in]    "real(dp) :: Rinitc3"    Initial isotope ratio if isc3=.true., i.e. of C3 plants
-  !>        \param[in]    "real(dp) :: Rinitc4"    Initial isotope ratio if isc3=.false., i.e. of C4 plants
+  !>        \param[inout] "real(r2) :: Rsucrose"   Isotope ratio of leaf sucrose
+  !>        \param[inout] "real(r2) :: Rphoto"     Isotope ratio of substrate for photorespiration
+  !>        \param[in]    "real(r2) :: Rinitc3"    Initial isotope ratio if isc3=.true., i.e. of C3 plants
+  !>        \param[in]    "real(r2) :: Rinitc4"    Initial isotope ratio if isc3=.false., i.e. of C4 plants
 
   !     HISTORY
   !>        \author Written Matthias Cuntz
@@ -720,10 +721,10 @@ contains
     implicit none
 
     logical,  intent(in)    :: isc3
-    real(dp), intent(inout) :: Rsucrose
-    real(dp), intent(inout) :: Rphoto
-    real(dp), intent(in)    :: Rinitc3
-    real(dp), intent(in)    :: Rinitc4
+    real(r2), intent(inout) :: Rsucrose
+    real(r2), intent(inout) :: Rphoto
+    real(r2), intent(in)    :: Rinitc3
+    real(r2), intent(in)    :: Rinitc4
 
     ! initialise
     if (isc3) then

--- a/core/biogeophys/mo_constants.f90
+++ b/core/biogeophys/mo_constants.f90
@@ -41,167 +41,168 @@ module mo_constants
   ! OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
   ! SOFTWARE.
 
-  use mo_kind, only: sp, dp
   use, intrinsic :: iso_fortran_env, only: input_unit, output_unit, error_unit
+
+  use cable_def_types_mod, only: r1, r2
 
   implicit none
 
   ! Computational
   !> epsilon(1.0) in double precision
-  real(dp), parameter :: eps_dp = epsilon(1.0_dp)
+  real(r2), parameter :: eps_r2 = epsilon(1.0_r2)
   !> epsilon(1.0) in single precision
-  real(sp), parameter :: eps_sp = epsilon(1.0_sp)
+  real(r1), parameter :: eps_r1 = epsilon(1.0_r1)
 
   
   ! Mathematical
   !> pi in double precision
-  real(dp), parameter :: pi_dp        = 3.141592653589793238462643383279502884197_dp    ! pi
+  real(r2), parameter :: pi_r2        = 3.141592653589793238462643383279502884197_r2    ! pi
   !> pi in single precision
-  real(sp), parameter :: pi_sp        = 3.141592653589793238462643383279502884197_sp
+  real(r1), parameter :: pi_r1        = 3.141592653589793238462643383279502884197_r1
   !> pi/2 in double precision
-  real(dp), parameter :: pio2_dp      = 1.57079632679489661923132169163975144209858_dp  ! pi/2
+  real(r2), parameter :: pio2_r2      = 1.57079632679489661923132169163975144209858_r2  ! pi/2
   !> pi/2 in single precision
-  real(sp), parameter :: pio2_sp      = 1.57079632679489661923132169163975144209858_sp
+  real(r1), parameter :: pio2_r1      = 1.57079632679489661923132169163975144209858_r1
   !> 2*pi in double precision
-  real(dp), parameter :: twopi_dp     = 6.283185307179586476925286766559005768394_dp    ! 2*pi
+  real(r2), parameter :: twopi_r2     = 6.283185307179586476925286766559005768394_r2    ! 2*pi
   !> 2*pi in single precision
-  real(sp), parameter :: twopi_sp     = 6.283185307179586476925286766559005768394_sp
+  real(r1), parameter :: twopi_r1     = 6.283185307179586476925286766559005768394_r1
   !> square root of 2 in double precision
-  real(dp), parameter :: sqrt2_dp     = 1.41421356237309504880168872420969807856967_dp  ! sqrt(2)
+  real(r2), parameter :: sqrt2_r2     = 1.41421356237309504880168872420969807856967_r2  ! sqrt(2)
   !> square root of 2 in single precision
-  real(sp), parameter :: sqrt2_sp     = 1.41421356237309504880168872420969807856967_sp
+  real(r1), parameter :: sqrt2_r1     = 1.41421356237309504880168872420969807856967_r1
   !> 1/3 in double precision
-  real(dp), parameter :: onethird_dp  = 0.3333333333333333333333333333333333333_dp      ! 1/3
+  real(r2), parameter :: onethird_r2  = 0.3333333333333333333333333333333333333_r2      ! 1/3
   !> 1/3 in single precision
-  real(sp), parameter :: onethird_sp  = 0.3333333333333333333333333333333333333_sp
+  real(r1), parameter :: onethird_r1  = 0.3333333333333333333333333333333333333_r1
   !> 2/3 in double precision
-  real(dp), parameter :: twothird_dp  = 1.0_dp - onethird_dp                            ! 2/3
+  real(r2), parameter :: twothird_r2  = 1.0_r2 - onethird_r2                            ! 2/3
   !> 2/3 in single precision
-  real(sp), parameter :: twothird_sp  = 1.0_sp - onethird_sp
+  real(r1), parameter :: twothird_r1  = 1.0_r1 - onethird_r1
   !> degree to radian conversion (pi/180) in double precision
-  real(dp), parameter :: deg2rad_dp   = pi_dp/180._dp            ! deg2rad
+  real(r2), parameter :: deg2rad_r2   = pi_r2/180._r2            ! deg2rad
   !> degree to radian conversion (pi/180) in single precision
-  real(sp), parameter :: deg2rad_sp   = pi_sp/180._sp
+  real(r1), parameter :: deg2rad_r1   = pi_r1/180._r1
   !> radian to degree conversion (180/pi) in double precision
-  real(dp), parameter :: rad2deg_dp   = 180._dp/pi_dp            ! rad2deg
+  real(r2), parameter :: rad2deg_r2   = 180._r2/pi_r2            ! rad2deg
   !> radian to degree conversion (180/pi) in single precision
-  real(sp), parameter :: rad2deg_sp   = 180._sp/pi_sp
+  real(r1), parameter :: rad2deg_r1   = 180._r1/pi_r1
   !> arc to radian conversion (180/pi) in double precision
-  real(dp), parameter :: arc2rad_dp   = pi_dp/12._dp             ! arc2rad
+  real(r2), parameter :: arc2rad_r2   = pi_r2/12._r2             ! arc2rad
   !> arc to radian conversion (180/pi) in single precision
-  real(sp), parameter :: arc2rad_sp   = pi_sp/12._sp
+  real(r1), parameter :: arc2rad_r1   = pi_r1/12._r1
   ! seconds per radian of hour angle in single precision
-  real(dp), parameter :: secperrad_dp = 13750.9871_dp            ! secperrad
+  real(r2), parameter :: secperrad_r2 = 13750.9871_r2            ! secperrad
   ! seconds per radian of hour angle in single precision
-  real(sp), parameter :: secperrad_sp = 13750.9871_sp
+  real(r1), parameter :: secperrad_r1 = 13750.9871_r1
   
 
   ! Physical
   !> seconds per day [s] in double precision
-  real(dp), parameter :: secday_dp      = 86400._dp               ! secday [s]
+  real(r2), parameter :: secday_r2      = 86400._r2               ! secday [s]
   !> seconds per day [s] in single precision
-  real(sp), parameter :: secday_sp      = 86400._sp
+  real(r1), parameter :: secday_r1      = 86400._r1
   !> psychrometric constant [kPa K^-1] in double precision
-  real(dp), parameter :: psychro_dp     = 0.0646_dp               ! psychrometric constant [kPa c-1]
+  real(r2), parameter :: psychro_r2     = 0.0646_r2               ! psychrometric constant [kPa c-1]
   !> psychrometric constant [kPa K^-1] in sibgle precision
-  real(sp), parameter :: psychro_sp     = 0.0646_sp
+  real(r1), parameter :: psychro_r1     = 0.0646_r1
   !> gravity accelaration [m^2 s^-1] in double precision
-  real(dp), parameter :: gravity_dp     = 9.81_dp                 ! gravity acceleration [m^2/s]
+  real(r2), parameter :: gravity_r2     = 9.81_r2                 ! gravity acceleration [m^2/s]
   !> gravity accelaration [m^2 s^-1] in single precision
-  real(sp), parameter :: gravity_sp     = 9.81_sp
+  real(r1), parameter :: gravity_r1     = 9.81_r1
   !>  solar constant in [J m^-2 s^-1] in double precision
-  real(dp), parameter :: solarconst_dp  = 1367._dp                ! solar constant in [W m-2 = kg s-3]
+  real(r2), parameter :: solarconst_r2  = 1367._r2                ! solar constant in [W m-2 = kg s-3]
   !>  solar constant in [J m^-2 s^-1] in single precision
-  real(sp), parameter :: solarconst_sp  = 1367._sp
+  real(r1), parameter :: solarconst_r1  = 1367._r1
   !> specific heat for vaporization of water in [J m-2 mm-1] in double precision
-  real(dp), parameter :: specheatet_dp  = 2.45e06_dp              ! specific heat in [W s m-2 mm-1 = kg s-2 mm-1]
+  real(r2), parameter :: specheatet_r2  = 2.45e06_r2              ! specific heat in [W s m-2 mm-1 = kg s-2 mm-1]
   !> specific heat for vaporization of water in [J m-2 mm-1] in single precision
-  real(sp), parameter :: specheatet_sp  = 2.45e06_sp
+  real(r1), parameter :: specheatet_r1  = 2.45e06_r1
   !> standard temperature [k] in double precision
-  real(dp), parameter :: T0_dp          = 273.15_dp               ! celcius <-> kelvin [K]
+  real(r2), parameter :: T0_r2          = 273.15_r2               ! celcius <-> kelvin [K]
   !> standard temperature [k] in single precision
-  real(sp), parameter :: T0_sp          = 273.15_sp
+  real(r1), parameter :: T0_r1          = 273.15_r1
   !> stefan-boltzmann constant [W m^-2 K^-4] in double precision
-  real(dp), parameter :: sigma_dp       = 5.67e-08_dp             ! stefan-boltzmann constant [w/m^2/k^4]
+  real(r2), parameter :: sigma_r2       = 5.67e-08_r2             ! stefan-boltzmann constant [w/m^2/k^4]
   !> stefan-boltzmann constant [W m^-2 K^-4] in single precision
-  real(sp), parameter :: sigma_sp       = 5.67e-08_sp
+  real(r1), parameter :: sigma_r1       = 5.67e-08_r1
   ! earth radius [m] in double precision
-  real(dp), parameter :: radiusearth_dp = 6371228._dp
+  real(r2), parameter :: radiusearth_r2 = 6371228._r2
   ! earth radius [m] in single precision
-  real(sp), parameter :: radiusearth_sp = 6371228._sp
+  real(r1), parameter :: radiusearth_r1 = 6371228._r1
   ! radians of earth orbit per julian day
-  real(dp), parameter :: radperday_dp   = 0.017214_dp
+  real(r2), parameter :: rar2erday_r2   = 0.017214_r2
   ! radians of earth orbit per julian day
-  real(sp), parameter :: radperday_sp   = 0.017214_sp
+  real(r1), parameter :: rar2erday_r1   = 0.017214_r1
   ! minimum declination (radians)
-  real(dp), parameter :: mindecl_dp     = -0.4092797_dp
+  real(r2), parameter :: mindecl_r2     = -0.4092797_r2
   ! minimum declination (radians)
-  real(sp), parameter :: mindecl_sp     = -0.4092797_sp
+  real(r1), parameter :: mindecl_r1     = -0.4092797_r1
   ! julian day offset of winter solstice
-  real(dp), parameter :: daysoff_dp     = 11.25_dp
+  real(r2), parameter :: daysoff_r2     = 11.25_r2
   ! julian day offset of winter solstice
-  real(sp), parameter :: daysoff_sp     = 11.25_sp
+  real(r1), parameter :: daysoff_r1     = 11.25_r1
   ! molecular weight of air (kg mol-1)
-  real(dp), parameter :: Ma_dp          = 28.9644e-3_dp
+  real(r2), parameter :: Ma_r2          = 28.9644e-3_r2
   ! molecular weight of air (kg mol-1)
-  real(sp), parameter :: Ma_sp          = 28.9644e-3_sp
+  real(r1), parameter :: Ma_r1          = 28.9644e-3_r1
   ! molecular weight of water (kg mol-1)
-  real(dp), parameter :: Mw_dp          = 18.0148e-3_dp
+  real(r2), parameter :: Mw_r2          = 18.0148e-3_r2
   ! molecular weight of water (kg mol-1)
-  real(sp), parameter :: Mw_sp          = 18.0148e-3_sp
+  real(r1), parameter :: Mw_r1          = 18.0148e-3_r1
   ! unitless ratio of molec weights (mw/ma)
-  real(dp), parameter :: epsair_dp      = Mw_dp/Ma_dp
+  real(r2), parameter :: epsair_r2      = Mw_r2/Ma_r2
   ! unitless ratio of molec weights (mw/ma)
-  real(sp), parameter :: epsair_sp      = Mw_sp/Ma_sp
+  real(r1), parameter :: epsair_r1      = Mw_r1/Ma_r1
   ! gas law constant (m3 pa mol-1 K-1)
-  real(dp), parameter :: R_dp           = 8.3143_dp
+  real(r2), parameter :: R_r2           = 8.3143_r2
   ! gas law constant (m3 pa mol-1 K-1)
-  real(sp), parameter :: R_sp           = 8.3143_sp
+  real(r1), parameter :: R_r1           = 8.3143_r1
   ! standard temperature lapse rate (-K m-1)
-  real(dp), parameter :: lr_std_dp      = 0.0065_dp
+  real(r2), parameter :: lr_std_r2      = 0.0065_r2
   ! standard temperature lapse rate (-K m-1)
-  real(sp), parameter :: lr_std_sp      = 0.0065_sp
+  real(r1), parameter :: lr_std_r1      = 0.0065_r1
 
   !> Standard atmosphere
   !> standard pressure [Pa] in double precision
-  real(dp), parameter :: p0_dp    = 101325._dp      ! standard pressure [Pa]
+  real(r2), parameter :: p0_r2    = 101325._r2      ! standard pressure [Pa]
   !> standard pressure [Pa] in single precision
-  real(sp), parameter :: p0_sp    = 101325._sp
+  real(r1), parameter :: p0_r1    = 101325._r1
   !> standard density  [kg m^-3] in double precision
-  real(dp), parameter :: rho0_dp  = 1.225_dp        ! standard air density
+  real(r2), parameter :: rho0_r2  = 1.225_r2        ! standard air density
   !> standard density  [kg m^-3] in single precision
-  real(sp), parameter :: rho0_sp  = 1.225_sp
+  real(r1), parameter :: rho0_r1  = 1.225_r1
   !> specific heat capacity of air [J kg^-1 K^-1] in double precision
-  real(dp), parameter :: cp0_dp   = 1005.0_dp       ! standard specific heat of air
+  real(r2), parameter :: cp0_r2   = 1005.0_r2       ! standard specific heat of air
   !> specific heat capacity of air [J kg^-1 K^-1] in single precision
-  real(sp), parameter :: cp0_sp   = 1005.0_sp
+  real(r1), parameter :: cp0_r1   = 1005.0_r1
   !> standard temp at 0.0 m elevation (K)           ! standard temperature at 0 m asl
-  real(dp), parameter :: T_std_dp = 288.15_dp
+  real(r2), parameter :: T_std_r2 = 288.15_r2
   !> standard temp at 0.0 m elevation (K)
-  real(sp), parameter :: T_std_sp = 288.15_sp
+  real(r1), parameter :: T_std_r1 = 288.15_r1
 
   
   ! Numerical Recipes
   !> pi in double precision
-  real(dp), parameter :: pi_d    = 3.141592653589793238462643383279502884197_dp      ! pi
+  real(r2), parameter :: pi_d    = 3.141592653589793238462643383279502884197_r2      ! pi
   !> pi in single precision
-  real(sp), parameter :: pi      = 3.141592653589793238462643383279502884197_sp
+  real(r1), parameter :: pi      = 3.141592653589793238462643383279502884197_r1
   !> pi/2 in double precision
-  real(dp), parameter :: pio2_d  = 1.57079632679489661923132169163975144209858_dp    ! pi/2
+  real(r2), parameter :: pio2_d  = 1.57079632679489661923132169163975144209858_r2    ! pi/2
   !> pi/2 in single precision
-  real(sp), parameter :: pio2    = 1.57079632679489661923132169163975144209858_sp
+  real(r1), parameter :: pio2    = 1.57079632679489661923132169163975144209858_r1
   !> 2*pi in double precision
-  real(dp), parameter :: twopi_d = 6.283185307179586476925286766559005768394_dp      ! 2*pi
+  real(r2), parameter :: twopi_d = 6.283185307179586476925286766559005768394_r2      ! 2*pi
   !> 2*pi in single precision
-  real(sp), parameter :: twopi   = 6.283185307179586476925286766559005768394_sp
+  real(r1), parameter :: twopi   = 6.283185307179586476925286766559005768394_r1
   !> square root of 2 in double precision
-  real(dp), parameter :: sqrt2_d = 1.41421356237309504880168872420969807856967_dp    ! sqrt(2)
+  real(r2), parameter :: sqrt2_d = 1.41421356237309504880168872420969807856967_r2    ! sqrt(2)
   !> square root of 2 in single precision
-  real(sp), parameter :: sqrt2   = 1.41421356237309504880168872420969807856967_sp
+  real(r1), parameter :: sqrt2   = 1.41421356237309504880168872420969807856967_r1
   !> Euler's constant in double precision
-  real(dp), parameter :: euler_d = 0.5772156649015328606065120900824024310422_dp     ! Euler
+  real(r2), parameter :: euler_d = 0.5772156649015328606065120900824024310422_r2     ! Euler
   !> Euler's constant in single precision
-  real(sp), parameter :: euler   = 0.5772156649015328606065120900824024310422_sp
+  real(r1), parameter :: euler   = 0.5772156649015328606065120900824024310422_r1
 
   ! Standard file units
   !> standard input file unit

--- a/core/biogeophys/mo_isotope.f90
+++ b/core/biogeophys/mo_isotope.f90
@@ -34,8 +34,8 @@
 
 MODULE mo_isotope
 
-  use mo_kind,      only: dp
-  use mo_constants, only: Mw_dp, Ma_dp, twothird_dp
+  use cable_def_types_mod, only: r2
+  use mo_constants, only: Mw_r2, Ma_r2, twothird_r2
 
   implicit none
 
@@ -49,19 +49,19 @@ MODULE mo_isotope
 
   ! Public parameters
   ! ratio diffusion of air vs. water vapour ~ 1.6
-  real(dp), parameter, public :: ratio_diff_air2vap = Ma_dp / Mw_dp
+  real(r2), parameter, public :: ratio_diff_air2vap = Ma_r2 / Mw_r2
   ! ratio of "diffusion" of air vs. water vapour through boundary layer ~ 1.4
-  real(dp), parameter, public :: ratio_boundary_air2vap = ratio_diff_air2vap**twothird_dp
+  real(r2), parameter, public :: ratio_boundary_air2vap = ratio_diff_air2vap**twothird_r2
   ! ratio diffusion of water vapour vs. air ~ 0.62
-  real(dp), parameter, public :: ratio_diff_vap2air = Mw_dp / Ma_dp
+  real(r2), parameter, public :: ratio_diff_vap2air = Mw_r2 / Ma_r2
   ! ratio of "diffusion" of water vapour vs. air through boundary layer ~ 0.73
-  real(dp), parameter, public :: ratio_boundary_vap2air = ratio_diff_vap2air**twothird_dp
+  real(r2), parameter, public :: ratio_boundary_vap2air = ratio_diff_vap2air**twothird_r2
   ! 13C/12C VPDB standard
-  real(dp), parameter, public :: vpdbc13 = 0.0112372_dp
+  real(r2), parameter, public :: vpdbc13 = 0.0112372_r2
   ! molecular weight of 13C (kg mol-1)
-  real(dp), parameter, public :: Mc13   = 13.e-3_dp
+  real(r2), parameter, public :: Mc13   = 13.e-3_r2
   ! molecular weight of 13CO2 (kg mol-1)
-  real(dp), parameter, public :: Mc13o2 = 45.e-3_dp
+  real(r2), parameter, public :: Mc13o2 = 45.e-3_r2
 
 contains
 
@@ -84,17 +84,17 @@ contains
   !         del = delta(rare, abundant, standard, default, precision)
 
   !     PARAMETER
-  !>        \param[in] "real(dp) :: rare"                   Rare isotope concentration or isotope ratio
-  !>        \param[in] "real(dp), optional :: abundant"     Abundant isotope concentration if rare is rare isotope concentration
+  !>        \param[in] "real(r2) :: rare"                   Rare isotope concentration or isotope ratio
+  !>        \param[in] "real(r2), optional :: abundant"     Abundant isotope concentration if rare is rare isotope concentration
   !>                                                        Default: not used.
-  !>        \param[in] "real(dp), optional :: standard"     Isotop ratio of the standard material.
+  !>        \param[in] "real(r2), optional :: standard"     Isotop ratio of the standard material.
   !>                                                        Default: 1.
-  !>        \param[in] "real(dp), optional :: default"      Set isoratio default if abundant < precision.
+  !>        \param[in] "real(r2), optional :: default"      Set isoratio default if abundant < precision.
   !>                                                        Default: 0.
-  !>        \param[in] "real(dp), optional :: precision"    Set isoratio default if abundant < precision.
+  !>        \param[in] "real(r2), optional :: precision"    Set isoratio default if abundant < precision.
 
   !     RETURN
-  !>       \return      real(dp) :: delta &mdash; Isotopic delta value: rare / abundant / standard - 1.
+  !>       \return      real(r2) :: delta &mdash; Isotopic delta value: rare / abundant / standard - 1.
 
   !     HISTORY
   !>        \author Written Matthias Cuntz
@@ -103,43 +103,43 @@ contains
 
     implicit none
 
-    real(dp), intent(in)           :: rare
-    real(dp), intent(in), optional :: abundant
-    real(dp), intent(in), optional :: standard
-    real(dp), intent(in), optional :: default
-    real(dp), intent(in), optional :: precision
-    real(dp)                       :: delta
+    real(r2), intent(in)           :: rare
+    real(r2), intent(in), optional :: abundant
+    real(r2), intent(in), optional :: standard
+    real(r2), intent(in), optional :: default
+    real(r2), intent(in), optional :: precision
+    real(r2)                       :: delta
 
-    real(dp) :: istandard, idefault, iprecision
+    real(r2) :: istandard, idefault, iprecision
 
     ! default optionals
     if (present(standard)) then
        istandard = standard
     else
-       istandard = 0.0_dp
+       istandard = 0.0_r2
     endif
     if (present(default)) then
        idefault = default
     else
-       idefault = 0.0_dp
+       idefault = 0.0_r2
     endif
     if (present(precision)) then
        iprecision = precision
     else
-       iprecision = 0.0_dp
+       iprecision = 0.0_r2
     endif
 
     if (present(abundant)) then
        if (abs(abundant) > iprecision) then
-          delta = rare / abundant / istandard - 1.0_dp
+          delta = rare / abundant / istandard - 1.0_r2
        else
           delta = idefault
        end if
     else
-       delta = rare / istandard - 1.0_dp
+       delta = rare / istandard - 1.0_r2
     end if
     !MCTest
-    ! if (abs(delta) < 100.0_dp*epsilon(1.0_dp)) delta = 0.0_dp
+    ! if (abs(delta) < 100.0_r2*epsilon(1.0_r2)) delta = 0.0_r2
     !MCTest
 
   end function delta
@@ -164,17 +164,17 @@ contains
   !         del = delta1000(rare, abundant, standard, default, precision)
 
   !     PARAMETER
-  !>        \param[in] "real(dp) :: rare"                   Rare isotope concentration or isotope ratio
-  !>        \param[in] "real(dp), optional :: abundant"     Abundant isotope concentration if rare is rare isotope concentration
+  !>        \param[in] "real(r2) :: rare"                   Rare isotope concentration or isotope ratio
+  !>        \param[in] "real(r2), optional :: abundant"     Abundant isotope concentration if rare is rare isotope concentration
   !>                                                        Default: not used.
-  !>        \param[in] "real(dp), optional :: standard"     Isotop ratio of the standard material.
+  !>        \param[in] "real(r2), optional :: standard"     Isotop ratio of the standard material.
   !>                                                        Default: 1.
-  !>        \param[in] "real(dp), optional :: default"      Set isoratio default if abundant < precision.
+  !>        \param[in] "real(r2), optional :: default"      Set isoratio default if abundant < precision.
   !>                                                        Default: 0.
-  !>        \param[in] "real(dp), optional :: precision"    Set isoratio default if abundant < precision.
+  !>        \param[in] "real(r2), optional :: precision"    Set isoratio default if abundant < precision.
 
   !     RETURN
-  !>       \return      real(dp) :: delta &mdash; Isotopic delta value in permil: (rare / abundant / standard - 1.) * 1000.
+  !>       \return      real(r2) :: delta &mdash; Isotopic delta value in permil: (rare / abundant / standard - 1.) * 1000.
 
   !     HISTORY
   !>        \author Written Matthias Cuntz
@@ -183,45 +183,45 @@ contains
 
     implicit none
 
-    real(dp), intent(in)           :: rare
-    real(dp), intent(in), optional :: abundant
-    real(dp), intent(in), optional :: standard
-    real(dp), intent(in), optional :: default
-    real(dp), intent(in), optional :: precision
-    real(dp)                       :: delta1000
+    real(r2), intent(in)           :: rare
+    real(r2), intent(in), optional :: abundant
+    real(r2), intent(in), optional :: standard
+    real(r2), intent(in), optional :: default
+    real(r2), intent(in), optional :: precision
+    real(r2)                       :: delta1000
 
-    real(dp) :: istandard, idefault, iprecision
+    real(r2) :: istandard, idefault, iprecision
 
     ! default optionals
     if (present(standard)) then
        istandard = standard
     else
-       istandard = 0.0_dp
+       istandard = 0.0_r2
     endif
     if (present(default)) then
        idefault = default
     else
-       idefault = 0.0_dp
+       idefault = 0.0_r2
     endif
     if (present(precision)) then
        iprecision = precision
     else
-       iprecision = 0.0_dp
+       iprecision = 0.0_r2
     endif
 
     if (present(abundant)) then
        if (abs(abundant) > iprecision) then
-          delta1000 = (rare / abundant / istandard - 1.0_dp) * 1000.0_dp
+          delta1000 = (rare / abundant / istandard - 1.0_r2) * 1000.0_r2
           ! !MCTest
-          ! if (abs(delta1000) < 1000.0_dp*epsilon(1.0_dp)*1000.0_dp*(10._dp**abs(log10(abundant)))) delta1000 = 0.0_dp
+          ! if (abs(delta1000) < 1000.0_r2*epsilon(1.0_r2)*1000.0_r2*(10._r2**abs(log10(abundant)))) delta1000 = 0.0_r2
           ! !MCTest
        else
           delta1000 = idefault
        end if
     else
-       delta1000 = (rare / istandard - 1.0_dp) * 1000.0_dp
+       delta1000 = (rare / istandard - 1.0_r2) * 1000.0_r2
        ! !MCTest
-       ! if (abs(delta1000) < 1000.0_dp*epsilon(1.0_dp)*1000.0_dp*(10._dp**abs(log10(rare)))) delta1000 = 0.0_dp
+       ! if (abs(delta1000) < 1000.0_r2*epsilon(1.0_r2)*1000.0_r2*(10._r2**abs(log10(rare)))) delta1000 = 0.0_r2
        ! !MCTest
     end if
 
@@ -246,14 +246,14 @@ contains
   !         ratio = isoratio(rare, abundant, default, precision)
 
   !     PARAMETER
-  !>        \param[in] "real(dp) :: rare"                   Rare isotope concentration
-  !>        \param[in] "real(dp) :: abundant"               Abundant isotope concentration
-  !>        \param[in] "real(dp), optional :: default"      Set isoratio default if abundant < precision.
+  !>        \param[in] "real(r2) :: rare"                   Rare isotope concentration
+  !>        \param[in] "real(r2) :: abundant"               Abundant isotope concentration
+  !>        \param[in] "real(r2), optional :: default"      Set isoratio default if abundant < precision.
   !>                                                        Default: 0.
-  !>        \param[in] "real(dp), optional :: precision"    Set isoratio default if abundant < precision.
+  !>        \param[in] "real(r2), optional :: precision"    Set isoratio default if abundant < precision.
 
   !     RETURN
-  !>       \return      real(dp) :: isoratio &mdash; Isotope ratio: rare / abundant
+  !>       \return      real(r2) :: isoratio &mdash; Isotope ratio: rare / abundant
 
   !     HISTORY
   !>        \author Written Matthias Cuntz
@@ -262,24 +262,24 @@ contains
 
     implicit none
 
-    real(dp), intent(in)           :: rare
-    real(dp), intent(in)           :: abundant
-    real(dp), intent(in), optional :: default
-    real(dp), intent(in), optional :: precision
-    real(dp)                       :: isoratio
+    real(r2), intent(in)           :: rare
+    real(r2), intent(in)           :: abundant
+    real(r2), intent(in), optional :: default
+    real(r2), intent(in), optional :: precision
+    real(r2)                       :: isoratio
 
-    real(dp) :: idefault, iprecision
+    real(r2) :: idefault, iprecision
 
     ! default optionals
     if (present(default)) then
        idefault = default
     else
-       idefault = 0.0_dp
+       idefault = 0.0_r2
     endif
     if (present(precision)) then
        iprecision = precision
     else
-       iprecision = 0.0_dp
+       iprecision = 0.0_r2
     endif
 
     if (abs(abundant) > iprecision) then
@@ -312,10 +312,10 @@ contains
   !         call isosanity(rare, abundant, precision, absolute)
 
   !     PARAMETER
-  !>        \param[inout] "real(dp) :: rare"                   Rare isotope concentration
-  !>        \param[inout] "real(dp) :: abundant"               Abundant isotope concentration
-  !>        \param[in] "real(dp), optional :: precision"    Set rare and abundant to 0 if any of the two is < precision.
-  !>                                                        Default: epsilon(1.0_dp)
+  !>        \param[inout] "real(r2) :: rare"                   Rare isotope concentration
+  !>        \param[inout] "real(r2) :: abundant"               Abundant isotope concentration
+  !>        \param[in] "real(r2), optional :: precision"    Set rare and abundant to 0 if any of the two is < precision.
+  !>                                                        Default: epsilon(1.0_r2)
   !>        \param[in] "logical, optional :: absolute"      If .true.: check abs(rare) and abs(abundant) < precision
   !>                                                        Default: .false.
 
@@ -326,19 +326,19 @@ contains
 
     implicit none
 
-    real(dp), intent(inout)        :: rare
-    real(dp), intent(inout)        :: abundant
-    real(dp), intent(in), optional :: precision
+    real(r2), intent(inout)        :: rare
+    real(r2), intent(inout)        :: abundant
+    real(r2), intent(in), optional :: precision
     logical,  intent(in), optional :: absolute
 
-    real(dp) :: iprecision
+    real(r2) :: iprecision
     logical  :: iabsolute
 
     ! default optionals
     if (present(precision)) then
        iprecision = precision
     else
-       iprecision = epsilon(1.0_dp)
+       iprecision = epsilon(1.0_r2)
     endif
     if (present(absolute)) then
        iabsolute = absolute
@@ -348,13 +348,13 @@ contains
 
     if (iabsolute) then
        if ((abs(rare) < iprecision) .or. (abs(abundant) < iprecision)) then
-          rare     = 0.0_dp
-          abundant = 0.0_dp
+          rare     = 0.0_r2
+          abundant = 0.0_r2
        endif
     else
        if ((rare < iprecision) .or. (abundant < iprecision)) then
-          rare     = 0.0_dp
-          abundant = 0.0_dp
+          rare     = 0.0_r2
+          abundant = 0.0_r2
        endif
     endif
 

--- a/core/biogeophys/mo_isotope_luc_model.f90
+++ b/core/biogeophys/mo_isotope_luc_model.f90
@@ -92,24 +92,24 @@ MODULE mo_isotope_luc_model
   !         call isotope_luc_model(Ciso, A, dA, C=C, S=S, Rs=Rs, T=T, Rt=Rt, At=At, trash=trash)
 
   !     INTENT
-  !>        \param[inout] "real(dp) :: Ciso(1:n)"
+  !>        \param[inout] "real(r2) :: Ciso(1:n)"
   !>                                   On entry: isotope concentrations in land-use classes at time step t-1 [kg/m^2]
   !>                                   On exit:  updated isotope concentrations of land-use classes at time step t [kg/m^2]
-  !>        \param[in]    "real(dp) :: A(1:n)"                   Areas of land-use classes at time step t-1 [m^2]
-  !>        \param[in]    "real(dp) :: dA(1:n,1:n)"              Change from each land-use class to the others
+  !>        \param[in]    "real(r2) :: A(1:n)"                   Areas of land-use classes at time step t-1 [m^2]
+  !>        \param[in]    "real(r2) :: dA(1:n,1:n)"              Change from each land-use class to the others
   !>                                   during the time step [m^2]
-  !>        \param[in]    "real(dp), optional :: C(1:n)"         Non-isotope concentrations in land-use classes
+  !>        \param[in]    "real(r2), optional :: C(1:n)"         Non-isotope concentrations in land-use classes
   !>                                   at time step t-1 [kg/m^2] (default: not used)
-  !>        \param[in]    "real(dp), optional :: S(1:n)"         Sources other than contributions from other land use classes,
+  !>        \param[in]    "real(r2), optional :: S(1:n)"         Sources other than contributions from other land use classes,
   !>                                   for example from other carbon pool [kg/m^2] (default: 0.)
-  !>        \param[in]    "real(dp), optional :: Rs(1:n)"        Isotope ratio of sources (default: 1.)
-  !>        \param[in]    "real(dp), optional :: T(1:n)"         Sinks other than contributions from other land use classes,
+  !>        \param[in]    "real(r2), optional :: Rs(1:n)"        Isotope ratio of sources (default: 1.)
+  !>        \param[in]    "real(r2), optional :: T(1:n)"         Sinks other than contributions from other land use classes,
   !>                                   for example to other carbon pool [kg/m^2] (default: 0.)
-  !>        \param[in]    "real(dp), optional :: Rt(1:n)"        Isotope ratio of sinks
+  !>        \param[in]    "real(r2), optional :: Rt(1:n)"        Isotope ratio of sinks
   !>                                   (default: isotope ratio of pool and land use class)
-  !>        \param[in]    "real(dp), optional :: At(1:n)"         Areas of land-use classes at time step t [m^2]
+  !>        \param[in]    "real(r2), optional :: At(1:n)"         Areas of land-use classes at time step t [m^2]
   !>                                   (default: calculated from A and dA)
-  !>        \param[inout] "real(dp), optional :: trash(1:n)"     Container to store possible inconsistencies,
+  !>        \param[inout] "real(r2), optional :: trash(1:n)"     Container to store possible inconsistencies,
   !>                                   might be numeric, between non-isotope and isotope model [kg/m^2].
   !>                                   Consistency checks are only performed if trash is given in call.
 
@@ -128,7 +128,8 @@ contains
 
   subroutine isotope_luc_model_1d(Ciso, A, dA, C, S, Rs, T, Rt, At, trash)
 
-    use mo_kind,  only: dp, i4
+    use cable_def_types_mod, only: r2
+    use mo_kind,  only: i4
     use mo_utils, only: eq !, ne
 #ifdef __MPI__
     use mpi,      only: MPI_Abort
@@ -136,25 +137,25 @@ contains
 
     implicit none
 
-    real(dp), dimension(:),   intent(inout)           :: Ciso   ! Iso land-use class
-    real(dp), dimension(:),   intent(in)              :: A      ! Area land-use class
-    real(dp), dimension(:,:), intent(in)              :: dA     ! Area changes between land-use classes
-    real(dp), dimension(:),   intent(in),    optional :: C      ! Non-iso land-use class
-    real(dp), dimension(:),   intent(in),    optional :: S      ! Source
-    real(dp), dimension(:),   intent(in),    optional :: Rs     ! Isotope ratio of source
-    real(dp), dimension(:),   intent(in),    optional :: T      ! Sink
-    real(dp), dimension(:),   intent(in),    optional :: Rt     ! Isotope ratio of sink
-    real(dp), dimension(:),   intent(in),    optional :: At     ! New area land-use class
-    real(dp), dimension(:),   intent(inout), optional :: trash  ! garbage can for numerical inconsistencies
+    real(r2), dimension(:),   intent(inout)           :: Ciso   ! Iso land-use class
+    real(r2), dimension(:),   intent(in)              :: A      ! Area land-use class
+    real(r2), dimension(:,:), intent(in)              :: dA     ! Area changes between land-use classes
+    real(r2), dimension(:),   intent(in),    optional :: C      ! Non-iso land-use class
+    real(r2), dimension(:),   intent(in),    optional :: S      ! Source
+    real(r2), dimension(:),   intent(in),    optional :: Rs     ! Isotope ratio of source
+    real(r2), dimension(:),   intent(in),    optional :: T      ! Sink
+    real(r2), dimension(:),   intent(in),    optional :: Rt     ! Isotope ratio of sink
+    real(r2), dimension(:),   intent(in),    optional :: At     ! New area land-use class
+    real(r2), dimension(:),   intent(inout), optional :: trash  ! garbage can for numerical inconsistencies
 
     ! Local variables
     ! integer(i4) :: i  ! counter
     integer(i4) :: nn ! number of pools
-    ! real(dp), dimension(size(Ciso,1)) :: R    ! Isotope ratio of pool
+    ! real(r2), dimension(size(Ciso,1)) :: R    ! Isotope ratio of pool
     ! defaults for optional inputs
-    real(dp), dimension(size(Ciso,1)) :: iC, iS, iRs, iT, iRt
-    real(dp), dimension(size(Ciso,1)) :: Anew ! A at t+dt
-    real(dp), dimension(size(Ciso,1)) :: Cnew ! New C pools
+    real(r2), dimension(size(Ciso,1)) :: iC, iS, iRs, iT, iRt
+    real(r2), dimension(size(Ciso,1)) :: Anew ! A at t+dt
+    real(r2), dimension(size(Ciso,1)) :: Cnew ! New C pools
 #ifdef __MPI__
     integer :: ierr
 #endif
@@ -176,7 +177,7 @@ contains
     endif
 
     ! Check dA >= 0
-    if (any(dA < 0.0_dp)) then
+    if (any(dA < 0.0_r2)) then
        write(*,*) 'Error isotope_luc_model_1d: land area changes between land use classes must be >= 0.'
        write(*,*) '    dA: ', dA
 #ifdef __MPI__
@@ -187,10 +188,10 @@ contains
     endif
 
     ! ! Check dA(i,:) == 0. if Ciso(i) == 0.
-    ! if (any(eq(Ciso,0.0_dp))) then
+    ! if (any(eq(Ciso,0.0_r2))) then
     !    do i=1, nn
-    !       if (eq(Ciso(i),0.0_dp)) then
-    !          if (any(ne(dA(i,:),0.0_dp))) then
+    !       if (eq(Ciso(i),0.0_r2)) then
+    !          if (any(ne(dA(i,:),0.0_r2))) then
     !             write(*,*) 'Error isotope_luc_model_1d: land area changes from land-use class i must be 0'
     !             write(*,*) '                            if isotope carbon concentration of land-use class is 0.'
     !             write(*,*) '    i, Ciso(i): ', i, Ciso(i)
@@ -207,10 +208,10 @@ contains
 
     ! if (present(C)) then
     !    ! Check dA(i,:) == 0. if C(i) == 0.
-    !    if (any(eq(C,0.0_dp))) then
+    !    if (any(eq(C,0.0_r2))) then
     !       do i=1, nn
-    !          if (eq(C(i),0.0_dp)) then
-    !             if (any(ne(dA(i,:),0.0_dp))) then
+    !          if (eq(C(i),0.0_r2)) then
+    !             if (any(ne(dA(i,:),0.0_r2))) then
     !                write(*,*) 'Error isotope_luc_model_1d: land area changes from land-use class i must be 0'
     !                write(*,*) '                            if carbon concentration of land-use class is 0.'
     !                write(*,*) '     i, C(i): ', i, C(i)
@@ -232,28 +233,28 @@ contains
     if (present(C)) then
        iC = C
     else
-       iC = 1.0_dp
+       iC = 1.0_r2
     endif
     if (present(S)) then
        iS = S
     else
-       iS = 0.0_dp
+       iS = 0.0_r2
     endif
     if (present(Rs)) then
        iRs = Rs
     else
-       iRs = 1.0_dp
+       iRs = 1.0_r2
     endif
     if (present(T)) then
        iT = T
     else
-       iT = 0.0_dp
+       iT = 0.0_r2
     endif
     if (present(Rt)) then
        iRt = Rt
     else
-       iRt = 1.0_dp
-       where (iC > 0.0_dp) iRt = Ciso / iC
+       iRt = 1.0_r2
+       where (iC > 0.0_r2) iRt = Ciso / iC
     endif
     ! Land areas at t+dt
     if (present(At)) then
@@ -263,36 +264,36 @@ contains
     endif
 
     ! ! Isotope ratio - not used -> use Ciso=R*iC directly
-    ! R(:) = 1.0_dp
-    ! where (iC > 0.0_dp) R = Ciso / iC
+    ! R(:) = 1.0_r2
+    ! where (iC > 0.0_r2) R = Ciso / iC
 
     ! isotopic LUC model
     ! Ciso = R * iC * (A - sum(dA, dim=2)) + sum(dA * spread(R*iC, dim=2, ncopies=nn), dim=1) + iRs*iS - iRt*iT
     Cnew = Ciso * (A - sum(dA, dim=2)) + sum(dA * spread(Ciso, dim=2, ncopies=nn), dim=1) + iRs*iS - iRt*iT
     if (present(trash)) then
-       where (Anew > 0.0_dp)
+       where (Anew > 0.0_r2)
           Ciso = Cnew / Anew
        elsewhere
-          Ciso     = 0.0_dp
+          Ciso     = 0.0_r2
           trash = trash + Ciso
        endwhere
     else
-       where (Anew > 0.0_dp) Ciso = Cnew / Anew ! keep incoming Ciso if Anew=0.
+       where (Anew > 0.0_r2) Ciso = Cnew / Anew ! keep incoming Ciso if Anew=0.
     endif
 
     if (present(trash)) then
        ! Check final land-use classes
        ! Isotope land-use class became < 0.
-       if (any(Ciso < 0.0_dp)) then
-          trash = trash + merge(abs(Ciso), 0.0_dp, Ciso < 0.0_dp)
-          Ciso = merge(0.0_dp, Ciso, Ciso < 0.0_dp)
+       if (any(Ciso < 0.0_r2)) then
+          trash = trash + merge(abs(Ciso), 0.0_r2, Ciso < 0.0_r2)
+          Ciso = merge(0.0_r2, Ciso, Ciso < 0.0_r2)
        endif
        ! Non-isotope land-use class == 0. but isotope land-use class > 0.
        Cnew = iC * (A - sum(dA, dim=2)) + sum(dA * spread(iC, dim=2, ncopies=nn), dim=1) + iS - iT
-       where (Anew > 0.0_dp) Cnew = Cnew / Anew
-       if (any(eq(Cnew,0.0_dp) .and. (Ciso > 0.0_dp))) then
-          trash = trash + merge(Ciso, 0.0_dp, eq(Cnew,0.0_dp) .and. (Ciso > 0.0_dp))
-          Ciso = merge(0.0_dp, Ciso, eq(Cnew,0.0_dp) .and. (Ciso > 0.0_dp))
+       where (Anew > 0.0_r2) Cnew = Cnew / Anew
+       if (any(eq(Cnew,0.0_r2) .and. (Ciso > 0.0_r2))) then
+          trash = trash + merge(Ciso, 0.0_r2, eq(Cnew,0.0_r2) .and. (Ciso > 0.0_r2))
+          Ciso = merge(0.0_r2, Ciso, eq(Cnew,0.0_r2) .and. (Ciso > 0.0_r2))
        endif
        ! Non-isotope land-use class >0. but isotope land-use class == 0.
        ! ???

--- a/core/biogeophys/mo_isotope_pool_model.f90
+++ b/core/biogeophys/mo_isotope_pool_model.f90
@@ -73,31 +73,31 @@ MODULE mo_isotope_pool_model
   !         call isotope_pool_model(dt, Ciso, C, F, S=S, Rs=Rs, T=T, Rt=Rt, alpha=alpha, beta=beta, trash=trash)
 
   !     INTENT
-  !>        \param[in]    "real(dp) :: dt"                       Time step
-  !>        \param[inout] "real(dp) :: Ciso(1:n[,1:m])"          Isotope concentrations in pools
-  !>        \param[in]    "real(dp) :: C(1:n[,1:m])"             Non-isotope concentrations in pools at time step t-1
-  !>        \param[in]    "real(dp) :: F(1:n,1:n[,1:m])"         Non-isotope fluxes between pools (F(i,i)=0) \n
+  !>        \param[in]    "real(r2) :: dt"                       Time step
+  !>        \param[inout] "real(r2) :: Ciso(1:n[,1:m])"          Isotope concentrations in pools
+  !>        \param[in]    "real(r2) :: C(1:n[,1:m])"             Non-isotope concentrations in pools at time step t-1
+  !>        \param[in]    "real(r2) :: F(1:n,1:n[,1:m])"         Non-isotope fluxes between pools (F(i,i)=0) \n
   !>                                   F(i,j) positive flux from pool i to pool j \n
   !>                                   Isotope flux is alpha(i,j)*R(i)*F(i,j)
-  !>        \param[in]    "real(dp), optional :: S(1:n[,1:m])"   Non-isotope source fluxes to pools (other than between pools) \n
+  !>        \param[in]    "real(r2), optional :: S(1:n[,1:m])"   Non-isotope source fluxes to pools (other than between pools) \n
   !>                                   Default: 0.
-  !>        \param[in]    "real(dp), optional :: Rs(1:n[,1:m])"  Isotopic compositions of source fluxes \n
+  !>        \param[in]    "real(r2), optional :: Rs(1:n[,1:m])"  Isotopic compositions of source fluxes \n
   !>                                   Any fractionations during source processes should be included in Rs. \n
   !>                                   Default: 1.
-  !>        \param[in]    "real(dp), optional :: T(1:n[,1:m])"   Non-isotope sinks of pools (other than between pools) \n
+  !>        \param[in]    "real(r2), optional :: T(1:n[,1:m])"   Non-isotope sinks of pools (other than between pools) \n
   !>                                   Isotope flux is alpha(i,i)*Rt(i)*T(i) or alpha(i,i)*R(i)*T(i) \n
   !>                                   Default: 0.
-  !>        \param[in]    "real(dp), optional :: Rt(1:n[,1:m])"  Isotopic compositions of sink fluxes. \n
+  !>        \param[in]    "real(r2), optional :: Rt(1:n[,1:m])"  Isotopic compositions of sink fluxes. \n
   !>                                   If not given, the isotopic composition of the pool R(i) is taken. \n
   !>                                   Default: R(i)
-  !>        \param[in]    "real(dp), optional :: alpha(1:n,1:n[,1:m])" Isotopic fractionation factors associated with
+  !>        \param[in]    "real(r2), optional :: alpha(1:n,1:n[,1:m])" Isotopic fractionation factors associated with
   !>                                   fluxes F between pools (alpha(i,j) i/=j) and of 
   !>                                   sinks T (other than between pools) (alpha(i,i)) \n
   !>                                   Default: 1.
-  !>        \param[in]    "real(dp), optional :: beta(1:n[,1:m])"      Either T or beta can be given. \n
+  !>        \param[in]    "real(r2), optional :: beta(1:n[,1:m])"      Either T or beta can be given. \n
   !>                                   If beta is given then T(i) = beta(i)*C(i). \n
   !>                                   T supercedes beta, i.e. T will be taken if beta and T are given.
-  !>        \param[inout] "real(dp), optional :: trash(1:n[,1:m])"     Container to store possible inconsistencies,
+  !>        \param[inout] "real(r2), optional :: trash(1:n[,1:m])"     Container to store possible inconsistencies,
   !>                                   might be numeric, between non-isotope and isotope model. \n
   !>                                   Consistency checks are only performed if trash is given in call.
   !>        \param[inout] "logical,  optional :: trans"          Assumed order of pools and fluxes in 2D case \n
@@ -128,7 +128,8 @@ contains
   
   subroutine isotope_pool_model_1d(dt, Ciso, C, F, S, Rs, T, Rt, alpha, beta, trash)
 
-    use mo_kind,  only: dp, i4
+    use cable_def_types_mod, only: r2
+    use mo_kind,  only: i4
     use mo_utils, only: eq, ne
 #ifdef __MPI__
     use mpi,      only: MPI_Abort
@@ -136,31 +137,31 @@ contains
 
     implicit none
 
-    real(dp),                 intent(in)              :: dt     ! time step
-    real(dp), dimension(:),   intent(inout)           :: Ciso   ! Iso pool
-    real(dp), dimension(:),   intent(in)              :: C      ! Non-iso pool
-    real(dp), dimension(:,:), intent(in)              :: F      ! Fluxes between pools
-    real(dp), dimension(:),   intent(in),    optional :: S      ! Sources not between pools
-    real(dp), dimension(:),   intent(in),    optional :: Rs     ! Isotope ratio of S
-    real(dp), dimension(:),   intent(in),    optional :: T      ! Sinks not between pools
-    real(dp), dimension(:),   intent(in),    optional :: Rt     ! Isotope ratio of T
-    real(dp), dimension(:,:), intent(in),    optional :: alpha  ! Fractionation factors sinks and fluxes between pools
-    real(dp), dimension(:),   intent(in),    optional :: beta   ! Alternative to sinks = beta*Ct
-    real(dp), dimension(:),   intent(inout), optional :: trash  ! garbage can for numerical inconsistencies
+    real(r2),                 intent(in)              :: dt     ! time step
+    real(r2), dimension(:),   intent(inout)           :: Ciso   ! Iso pool
+    real(r2), dimension(:),   intent(in)              :: C      ! Non-iso pool
+    real(r2), dimension(:,:), intent(in)              :: F      ! Fluxes between pools
+    real(r2), dimension(:),   intent(in),    optional :: S      ! Sources not between pools
+    real(r2), dimension(:),   intent(in),    optional :: Rs     ! Isotope ratio of S
+    real(r2), dimension(:),   intent(in),    optional :: T      ! Sinks not between pools
+    real(r2), dimension(:),   intent(in),    optional :: Rt     ! Isotope ratio of T
+    real(r2), dimension(:,:), intent(in),    optional :: alpha  ! Fractionation factors sinks and fluxes between pools
+    real(r2), dimension(:),   intent(in),    optional :: beta   ! Alternative to sinks = beta*Ct
+    real(r2), dimension(:),   intent(inout), optional :: trash  ! garbage can for numerical inconsistencies
 
     ! Local variables
     integer(i4) :: i  ! counter
     integer(i4) :: nn ! number of pools
-    real(dp), dimension(size(Ciso,1)) :: R                   ! Isotope ratio of pool
+    real(r2), dimension(size(Ciso,1)) :: R                   ! Isotope ratio of pool
     ! defaults for optional inputs
-    real(dp), dimension(size(Ciso,1))            :: iS, iRs, iT, iRt
-    real(dp), dimension(size(Ciso,1),size(Ciso,1)) :: ialpha
-    real(dp), dimension(size(Ciso,1),size(Ciso,1)) :: alphaF ! alpha*F
-    real(dp), dimension(size(Ciso,1)) :: sink                ! not-between pools sink
-    real(dp), dimension(size(Ciso,1)) :: source              ! not-between pools source
-    real(dp), dimension(size(Ciso,1)) :: isink               ! between pools sink
-    real(dp), dimension(size(Ciso,1)) :: isource             ! between pools source
-    real(dp), dimension(size(Ciso,1)) :: Cnew                ! New pool size for check
+    real(r2), dimension(size(Ciso,1))            :: iS, iRs, iT, iRt
+    real(r2), dimension(size(Ciso,1),size(Ciso,1)) :: ialpha
+    real(r2), dimension(size(Ciso,1),size(Ciso,1)) :: alphaF ! alpha*F
+    real(r2), dimension(size(Ciso,1)) :: sink                ! not-between pools sink
+    real(r2), dimension(size(Ciso,1)) :: source              ! not-between pools source
+    real(r2), dimension(size(Ciso,1)) :: isink               ! between pools sink
+    real(r2), dimension(size(Ciso,1)) :: isource             ! between pools source
+    real(r2), dimension(size(Ciso,1)) :: Cnew                ! New pool size for check
 #ifdef __MPI__
     integer :: ierr
 #endif
@@ -182,7 +183,7 @@ contains
     endif
 
     ! Check F >= 0
-    if (any(F < 0.0_dp)) then
+    if (any(F < 0.0_r2)) then
        write(*,*) 'Error isotope_pool_model_1d: fluxes between pools must be >= 0.'
        write(*,*) '    F: ', F
 #ifdef __MPI__
@@ -193,10 +194,10 @@ contains
     endif
 
     ! Check F(i,:) == 0. if C(i) == 0.
-    if (any(eq(C,0.0_dp))) then
+    if (any(eq(C,0.0_r2))) then
        do i=1, nn
-          if (eq(C(i),0.0_dp)) then
-             if (any(ne(F(i,:),0.0_dp))) then
+          if (eq(C(i),0.0_r2)) then
+             if (any(ne(F(i,:),0.0_r2))) then
                 write(*,*) 'Error isotope_pool_model_1d: fluxes from pool i must be 0 if concentration in pool is 0.'
                 write(*,*) '    i, C(i): ', i, C(i)
                 write(*,*) '       F(i): ', F(i,:)
@@ -214,42 +215,42 @@ contains
     if (present(S)) then
        iS = S
     else
-       iS = 0.0_dp
+       iS = 0.0_r2
     endif
     if (present(Rs)) then
        iRs = Rs
     else
-       iRs = 1.0_dp
+       iRs = 1.0_r2
     endif
     if (present(T)) then
        iT = T
     else
-       iT = 0.0_dp
+       iT = 0.0_r2
     endif
     if (present(Rt)) then
        iRt = Rt
     else
-       iRt = 1.0_dp ! could be zero as well to assure no isotopic sink if C=0
-       where (C > 0.0_dp) iRt = Ciso / C
+       iRt = 1.0_r2 ! could be zero as well to assure no isotopic sink if C=0
+       where (C > 0.0_r2) iRt = Ciso / C
     endif
     if (present(alpha)) then
        ialpha = alpha
     else
-       ialpha = 1.0_dp
+       ialpha = 1.0_r2
     endif
     if (present(alpha)) then
        ialpha = alpha
     else
-       ialpha = 1.0_dp
+       ialpha = 1.0_r2
     endif
     if (present(beta) .and. (.not. present(T))) then
        iT = beta * C
     endif
 
     ! Isotope ratio
-    ! R(:) = 0.0_dp
-    R(:) = 1.0_dp ! could be zero as well to assure no isotopic fluxes if initial C=0
-    where (C > 0.0_dp) R = Ciso / C
+    ! R(:) = 0.0_r2
+    R(:) = 1.0_r2 ! could be zero as well to assure no isotopic fluxes if initial C=0
+    where (C > 0.0_r2) R = Ciso / C
 
     ! alpha * F
     alphaF = ialpha * F
@@ -266,15 +267,15 @@ contains
     if (present(trash)) then
        ! Check final pools
        ! Isotope pool became < 0.
-       if (any(Ciso < 0.0_dp)) then
-          trash = trash + merge(abs(Ciso), 0.0_dp, Ciso < 0.0_dp)
-          Ciso = merge(0.0_dp, Ciso, Ciso < 0.0_dp)
+       if (any(Ciso < 0.0_r2)) then
+          trash = trash + merge(abs(Ciso), 0.0_r2, Ciso < 0.0_r2)
+          Ciso = merge(0.0_r2, Ciso, Ciso < 0.0_r2)
        endif
        ! Non-isotope pool == 0. but isotope pool > 0.
        Cnew = C - iT * dt + iS * dt - sum(F, dim=2)* dt + sum(F, dim=1) * dt
-       if (any(eq(Cnew,0.0_dp) .and. (Ciso > 0.0_dp))) then
-          trash = trash + merge(Ciso, 0.0_dp, eq(Cnew,0.0_dp) .and. (Ciso > 0.0_dp))
-          Ciso = merge(0.0_dp, Ciso, eq(Cnew,0.0_dp) .and. (Ciso > 0.0_dp))
+       if (any(eq(Cnew,0.0_r2) .and. (Ciso > 0.0_r2))) then
+          trash = trash + merge(Ciso, 0.0_r2, eq(Cnew,0.0_r2) .and. (Ciso > 0.0_r2))
+          Ciso = merge(0.0_r2, Ciso, eq(Cnew,0.0_r2) .and. (Ciso > 0.0_r2))
        endif
        ! Non-isotope pool >0. but isotope pool == 0.
        ! ???
@@ -287,7 +288,8 @@ contains
   
   subroutine isotope_pool_model_2d(dt, Ciso, C, F, S, Rs, T, Rt, alpha, beta, trash, trans)
 
-    use mo_kind,  only: dp, i4
+    use cable_def_types_mod, only: r2
+    use mo_kind,  only: i4
     use mo_utils, only: eq, ne
 #ifdef __MPI__
     use mpi,      only: MPI_Abort
@@ -295,33 +297,33 @@ contains
 
     implicit none
 
-    real(dp),                   intent(in)              :: dt     ! time step
-    real(dp), dimension(:,:),   intent(inout)           :: Ciso   ! Iso pool
-    real(dp), dimension(:,:),   intent(in)              :: C      ! Non-iso pool
-    real(dp), dimension(:,:,:), intent(in)              :: F      ! Fluxes between pools
-    real(dp), dimension(:,:),   intent(in),    optional :: S      ! Sources not between pools
-    real(dp), dimension(:,:),   intent(in),    optional :: Rs     ! Isotope ratio of S
-    real(dp), dimension(:,:),   intent(in),    optional :: T      ! Sinks not between pools
-    real(dp), dimension(:,:),   intent(in),    optional :: Rt     ! Isotope ratio of T
-    real(dp), dimension(:,:,:), intent(in),    optional :: alpha  ! Fractionation factors sinks and fluxes between pools
-    real(dp), dimension(:,:),   intent(in),    optional :: beta   ! Alternative to sinks = beta*Ct
-    real(dp), dimension(:,:),   intent(inout), optional :: trash  ! garbage can for numerical inconsistencies
+    real(r2),                   intent(in)              :: dt     ! time step
+    real(r2), dimension(:,:),   intent(inout)           :: Ciso   ! Iso pool
+    real(r2), dimension(:,:),   intent(in)              :: C      ! Non-iso pool
+    real(r2), dimension(:,:,:), intent(in)              :: F      ! Fluxes between pools
+    real(r2), dimension(:,:),   intent(in),    optional :: S      ! Sources not between pools
+    real(r2), dimension(:,:),   intent(in),    optional :: Rs     ! Isotope ratio of S
+    real(r2), dimension(:,:),   intent(in),    optional :: T      ! Sinks not between pools
+    real(r2), dimension(:,:),   intent(in),    optional :: Rt     ! Isotope ratio of T
+    real(r2), dimension(:,:,:), intent(in),    optional :: alpha  ! Fractionation factors sinks and fluxes between pools
+    real(r2), dimension(:,:),   intent(in),    optional :: beta   ! Alternative to sinks = beta*Ct
+    real(r2), dimension(:,:),   intent(inout), optional :: trash  ! garbage can for numerical inconsistencies
     logical,                    intent(in),    optional :: trans  ! transposed order pools and fluxes
 
    ! Local variables
     integer(i4) :: i, j  ! counter
     integer(i4) :: nland ! number of land points
     integer(i4) :: nn    ! number of pools
-    real(dp), dimension(size(Ciso,1),size(Ciso,2)) :: R       ! Isotope ratio of pool
+    real(r2), dimension(size(Ciso,1),size(Ciso,2)) :: R       ! Isotope ratio of pool
     ! defaults for optional inputs
-    real(dp), dimension(size(Ciso,1),size(Ciso,2)) :: iS, iRs, iT, iRt
-    real(dp), dimension(:,:,:), allocatable :: ialpha
-    real(dp), dimension(:,:,:), allocatable :: alphaF         ! alpha*F
-    real(dp), dimension(size(Ciso,1),size(Ciso,2)) :: sink    ! not-between pools sink
-    real(dp), dimension(size(Ciso,1),size(Ciso,2)) :: source  ! not-between pools source
-    real(dp), dimension(size(Ciso,1),size(Ciso,2)) :: isink   ! between pools sink
-    real(dp), dimension(size(Ciso,1),size(Ciso,2)) :: isource ! between pools source
-    real(dp), dimension(size(Ciso,1),size(Ciso,2)) :: Cnew    ! New pool size for check
+    real(r2), dimension(size(Ciso,1),size(Ciso,2)) :: iS, iRs, iT, iRt
+    real(r2), dimension(:,:,:), allocatable :: ialpha
+    real(r2), dimension(:,:,:), allocatable :: alphaF         ! alpha*F
+    real(r2), dimension(size(Ciso,1),size(Ciso,2)) :: sink    ! not-between pools sink
+    real(r2), dimension(size(Ciso,1),size(Ciso,2)) :: source  ! not-between pools source
+    real(r2), dimension(size(Ciso,1),size(Ciso,2)) :: isink   ! between pools sink
+    real(r2), dimension(size(Ciso,1),size(Ciso,2)) :: isource ! between pools source
+    real(r2), dimension(size(Ciso,1),size(Ciso,2)) :: Cnew    ! New pool size for check
     logical :: itrans                                         ! transposed order pools and fluxes
 #ifdef __MPI__
     integer :: ierr
@@ -401,7 +403,7 @@ contains
     endif
     
     ! ! Check F >= 0
-    ! if (any(F < 0.0_dp)) then
+    ! if (any(F < 0.0_r2)) then
     !    write(*,*) 'Error isotope_pool_model_2d: fluxes between pools must be >= 0.'
     !    write(*,*) '    F: ', F
 ! #ifdef __MPI__
@@ -412,12 +414,12 @@ contains
     ! endif
 
     ! Check F(i,:) == 0. if C(i) == 0.
-    if (any(eq(C,0.0_dp))) then
+    if (any(eq(C,0.0_r2))) then
        do j=1, nland
           do i=1, nn
              if (itrans) then
-                if (eq(C(j,i),0.0_dp)) then
-                   if (any(ne(F(j,i,:),0.0_dp))) then
+                if (eq(C(j,i),0.0_r2)) then
+                   if (any(ne(F(j,i,:),0.0_r2))) then
                       write(*,*) 'Error isotope_pool_model_2d:'
                       write(*,*) '    fluxes from pool i at land point j must be 0 if concentration in pool is 0.'
                       write(*,*) '    i, j, C(j,i):   ', j, i, C(j,i)
@@ -430,8 +432,8 @@ contains
                    endif
                 endif
              else
-                if (eq(C(i,j),0.0_dp)) then
-                   if (any(ne(F(i,:,j),0.0_dp))) then
+                if (eq(C(i,j),0.0_r2)) then
+                   if (any(ne(F(i,:,j),0.0_r2))) then
                       write(*,*) 'Error isotope_pool_model_2d:'
                       write(*,*) '    fluxes from pool i at land point j must be 0 if concentration in pool is 0.'
                       write(*,*) '    i, j, C(i,j):   ', i, j, C(i,j)
@@ -452,43 +454,43 @@ contains
     if (present(S)) then
        iS = S
     else
-       iS = 0.0_dp
+       iS = 0.0_r2
     endif
     if (present(Rs)) then
        iRs = Rs
     else
-       iRs = 1.0_dp
+       iRs = 1.0_r2
     endif
     if (present(T)) then
        iT = T
     else
-       iT = 0.0_dp
+       iT = 0.0_r2
     endif
     if (present(Rt)) then
        iRt = Rt
     else
-       ! iRt = 0.0_dp
-       iRt = 1.0_dp ! could be zero as well to assure no isotopic sink if C=0
-       where (C > 0.0_dp) iRt = Ciso / C
+       ! iRt = 0.0_r2
+       iRt = 1.0_r2 ! could be zero as well to assure no isotopic sink if C=0
+       where (C > 0.0_r2) iRt = Ciso / C
     endif
     if (present(alpha)) then
        ialpha = alpha
     else
-       ialpha = 1.0_dp
+       ialpha = 1.0_r2
     endif
     if (present(alpha)) then
        ialpha = alpha
     else
-       ialpha = 1.0_dp
+       ialpha = 1.0_r2
     endif
     if (present(beta) .and. (.not. present(T))) then
        iT = beta * C
     endif
 
     ! Isotope ratio
-    ! R(:,:) = 0.0_dp
-    R(:,:) = 1.0_dp ! could be zero as well to assure no isotopic fluxes if initial C=0
-    where (C > 0.0_dp) R = Ciso / C
+    ! R(:,:) = 0.0_r2
+    R(:,:) = 1.0_r2 ! could be zero as well to assure no isotopic fluxes if initial C=0
+    where (C > 0.0_r2) R = Ciso / C
 
     ! alpha * F
     alphaF = ialpha * F
@@ -509,9 +511,9 @@ contains
     if (present(trash)) then
         ! Check final pools
         ! Isotope pool became < 0.
-        if (any(Ciso < 0.0_dp)) then
-           trash = trash + merge(abs(Ciso), 0.0_dp, Ciso < 0.0_dp)
-           Ciso = merge(0.0_dp, Ciso, Ciso < 0.0_dp)
+        if (any(Ciso < 0.0_r2)) then
+           trash = trash + merge(abs(Ciso), 0.0_r2, Ciso < 0.0_r2)
+           Ciso = merge(0.0_r2, Ciso, Ciso < 0.0_r2)
         endif
         ! Non-isotope pool == 0. but isotope pool > 0.
         if (itrans) then
@@ -519,9 +521,9 @@ contains
         else
            Cnew = C - iT * dt + iS * dt - sum(F, dim=2)* dt + sum(F, dim=1) * dt
         endif
-        if (any(eq(Cnew,0.0_dp) .and. (Ciso > 0.0_dp))) then
-           trash = trash + merge(Ciso, 0.0_dp, eq(Cnew,0.0_dp) .and. (Ciso > 0.0_dp))
-           Ciso = merge(0.0_dp, Ciso, eq(Cnew,0.0_dp) .and. (Ciso > 0.0_dp))
+        if (any(eq(Cnew,0.0_r2) .and. (Ciso > 0.0_r2))) then
+           trash = trash + merge(Ciso, 0.0_r2, eq(Cnew,0.0_r2) .and. (Ciso > 0.0_r2))
+           Ciso = merge(0.0_r2, Ciso, eq(Cnew,0.0_r2) .and. (Ciso > 0.0_r2))
         endif
         ! Non-isotope pool >0. but isotope pool == 0.
         ! ???
@@ -539,15 +541,16 @@ contains
   ! Diagonal elements of a matrix
   function diag_2d(matrix)
 
-    use mo_kind, only: dp, i4
+    use cable_def_types_mod, only: r2
+    use mo_kind, only: i4
 #ifdef __MPI__
     use mpi,     only: MPI_Abort
 #endif
 
     implicit none
 
-    real(dp), dimension(:,:), intent(in) :: matrix
-    real(dp), dimension(:), allocatable  :: diag_2d
+    real(r2), dimension(:,:), intent(in) :: matrix
+    real(r2), dimension(:), allocatable  :: diag_2d
 
     integer(i4) :: i
 #ifdef __MPI__
@@ -571,16 +574,17 @@ contains
   ! Diagonal elements of the two first or two last dimensions of a matrix
   function diag_3d(matrix, trans)
 
-    use mo_kind, only: dp, i4
+    use cable_def_types_mod, only: r2
+    use mo_kind, only: i4
 #ifdef __MPI__
     use mpi,     only: MPI_Abort
 #endif
 
     implicit none
 
-    real(dp), dimension(:,:,:), intent(in)           :: matrix
+    real(r2), dimension(:,:,:), intent(in)           :: matrix
     logical,                    intent(in), optional :: trans   ! two first or two last dimensions
-    real(dp), dimension(:,:),   allocatable          :: diag_3d
+    real(r2), dimension(:,:),   allocatable          :: diag_3d
 
     integer(i4) :: i, j
     logical :: itrans

--- a/core/biogeophys/mo_kind.f90
+++ b/core/biogeophys/mo_kind.f90
@@ -50,7 +50,8 @@ MODULE mo_kind
 
   ! iso_fortran_env does not work with compilers intel v11 and sun v12.2
   ! use, intrinsic :: iso_fortran_env, only: int8, int16, int32, int64, real32, real64, real128
-  use, intrinsic :: iso_c_binding,   only: &
+  use cable_def_types_mod, only: r1, r2
+  use, intrinsic :: iso_c_binding, only: &
        c_short, c_int, c_long_long, &
        c_float, c_double, c_long_double, &
        c_float_complex, c_double_complex, c_long_double_complex, &
@@ -77,11 +78,13 @@ MODULE mo_kind
   !> Single Precision Real Kind
   ! INTEGER, PARAMETER :: sp  = SELECTED_REAL_KIND(6,37)
   ! INTEGER, PARAMETER :: sp  = real32
-  INTEGER, PARAMETER :: sp  = c_float
+  ! INTEGER, PARAMETER :: sp  = c_float
+  INTEGER, PARAMETER :: sp  = r1
   !> Double Precision Real Kind
   ! INTEGER, PARAMETER :: dp  = SELECTED_REAL_KIND(15,307)
   ! INTEGER, PARAMETER :: dp  = real64
-  INTEGER, PARAMETER :: dp  = c_double
+  ! INTEGER, PARAMETER :: dp  = c_double
+  INTEGER, PARAMETER :: dp  = r2
   !> Quadruple Precision Real Kind
   ! INTEGER, PARAMETER :: qp  = SELECTED_REAL_KIND(33,4931)
   ! INTEGER, PARAMETER :: qp  = real128

--- a/core/biogeophys/mo_utils.f90
+++ b/core/biogeophys/mo_utils.f90
@@ -43,7 +43,8 @@ MODULE mo_utils
   ! OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
   ! SOFTWARE.
 
-  USE mo_kind, only: sp, dp, i4, i8, spc, dpc
+  use cable_def_types_mod, only: i4, sp => r1, dp => r2
+  USE mo_kind, only: i8, spc, dpc
 
   IMPLICIT NONE
 

--- a/core/blaze/blaze.F90
+++ b/core/blaze/blaze.F90
@@ -42,7 +42,7 @@ INTEGER, PARAMETER :: METB    = 1
 INTEGER, PARAMETER :: STR     = 2
 INTEGER, PARAMETER :: CWD     = 3
 
-INTEGER, PARAMETER :: r_2     = 4
+INTEGER, PARAMETER :: r2      = 4
 INTEGER, PARAMETER :: T_AVG   = 5
 
 REAL,    PARAMETER :: fbranch = 0.05 ! fraction of CPLANT_w(wood) attributed to branches

--- a/core/blaze/blaze_driver.F90
+++ b/core/blaze/blaze_driver.F90
@@ -11,7 +11,7 @@ contains
   SUBROUTINE BLAZE_DRIVER(NCELLS, BLAZE, SF, casapool,  casaflux, casamet, &
        climate, shootfrac, idoy, curyear, CTLFLAG, POP, veg)
 
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
     USE CABLE_COMMON_MODULE, ONLY: IS_LEAPYEAR, DOYSOD2YMDHMS !, Esatf
     USE CASAVARIABLE,        ONLY: casa_pool, casa_flux, casa_met
     USE BLAZE_MOD,           ONLY: RUN_BLAZE, TYPE_TURNOVER, BLAZE_TURNOVER, &
@@ -21,7 +21,7 @@ contains
     USE cable_IO_vars_module, ONLY: landpt, patch
     USE CABLE_DEF_TYPES_MOD, ONLY:  climate_type
     USE POPMODULE,            ONLY: ADJUST_POP_FOR_FIRE
-    USE POP_TYPES,            ONLY: POP_TYPE, i4b, dp
+    USE POP_TYPES,            ONLY: POP_TYPE, i4, dp
     USE cable_def_types_mod, ONLY: veg_parameter_type
 
     IMPLICIT NONE
@@ -91,7 +91,7 @@ contains
 !!$  ! set heights at which tree mortality is calculated
 !!$  nbins = mheights
 !!$  DO i=1,nbins
-!!$     casaflux%fire_mortality_vs_height(:,i,1) = real(BIN_POWER**i, r_2)
+!!$     casaflux%fire_mortality_vs_height(:,i,1) = real(BIN_POWER**i, r2)
 !!$  ENDDO
 
 
@@ -157,10 +157,10 @@ contains
 
     !CVH
     ! set casa fire turnover rates and partitioning of fire losses here!
-    casaflux%kplant_fire = 0.0_r_2
-    casaflux%klitter_fire = 0.0_r_2
-    casaflux%fromPtoL_fire = 0.0_r_2
-    !casaflux%fire_mortality_vs_height(:,:,2) = 0.0_r_2
+    casaflux%kplant_fire = 0.0_r2
+    casaflux%klitter_fire = 0.0_r2
+    casaflux%fromPtoL_fire = 0.0_r2
+    !casaflux%fire_mortality_vs_height(:,:,2) = 0.0_r2
 
 
 
@@ -176,10 +176,10 @@ contains
 !!$           DO nh = 1,mheights
 !!$              hgt = real(casaflux%fire_mortality_vs_height(patch_index,nh,1))
 !!$              casaflux%fire_mortality_vs_height(patch_index,nh,2) = &
-!!$                   (1._r_2 - real(p_surv_OzSavanna(hgt,BLAZE%FLI(i)),r_2)) * BLAZE%AB(i) !*
+!!$                   (1._r2 - real(p_surv_OzSavanna(hgt,BLAZE%FLI(i)),r2)) * BLAZE%AB(i) !*
 !!$
 !!$
-!!$              ! (1._r_2 - casaflux%fire_mortality_vs_height(patch_index,nh,2))  &
+!!$              ! (1._r2 - casaflux%fire_mortality_vs_height(patch_index,nh,2))  &
 !!$
 !!$           ENDDO
 !!$        ENDIF
@@ -194,14 +194,14 @@ contains
     ! print*, 'IW', POP%Iwood
     ! print*, 'fire_mort',  casaflux%fire_mortality_vs_height(Iw,:,:)
     ! print*, 'BA: ', BLAZE%AB
-    ! print*, 'dist: ', int(veg%disturbance_interval(Iw,:), i4b)
+    ! print*, 'dist: ', int(veg%disturbance_interval(Iw,:), i4)
 
     POP%pop_grid(:)%fire_mortality = 0.0_dp
-!!$  CALL ADJUST_POP_FOR_FIRE(pop,int(veg%disturbance_interval(Iw,:), i4b), &
+!!$  CALL ADJUST_POP_FOR_FIRE(pop,int(veg%disturbance_interval(Iw,:), i4), &
 !!$       casaflux%fire_mortality_vs_height(Iw,:,:))
-    CALL ADJUST_POP_FOR_FIRE(pop,int(veg%disturbance_interval(Iw,:), i4b), &
+    CALL ADJUST_POP_FOR_FIRE(pop,int(veg%disturbance_interval(Iw,:), i4), &
          veg%disturbance_intensity(Iw,1), veg%disturbance_intensity(Iw,2)  )
-    print*,"CLN ADJUST_POP_FOR_FIRE" ,int(veg%disturbance_interval(Iw,:), i4b), &
+    print*,"CLN ADJUST_POP_FOR_FIRE" ,int(veg%disturbance_interval(Iw,:), i4), &
          veg%disturbance_intensity(Iw,1), veg%disturbance_intensity(Iw,2)
     casaflux%kplant_fire(Iw,WOOD) = max(min(POP%pop_grid(:)%fire_mortality/POP%pop_grid(:)%cmass_sum, &
          0.99_dp),0.0_dp)
@@ -217,55 +217,55 @@ contains
 
           IF ( casamet%lnonwood(patch_index) == 1 ) THEN ! Here non-wood
 
-             casaflux%kplant_fire(patch_index,LEAF)  = real(BLAZE%AB(i), r_2) !CLN ???
-             casaflux%kplant_fire(patch_index,FROOT) =  real(BLAZE%AB(i), r_2) !CLN ???
-             casaflux%kplant_fire(patch_index,WOOD)  = 0.0_r_2
+             casaflux%kplant_fire(patch_index,LEAF)  = real(BLAZE%AB(i), r2) !CLN ???
+             casaflux%kplant_fire(patch_index,FROOT) =  real(BLAZE%AB(i), r2) !CLN ???
+             casaflux%kplant_fire(patch_index,WOOD)  = 0.0_r2
 
-             casaflux%klitter_fire(patch_index,METB) = real(BLAZE%AB(i) * ag_litter_frac, r_2)
-             casaflux%klitter_fire(patch_index,STR)  =  real(BLAZE%AB(i) * ag_litter_frac, r_2)
-             casaflux%klitter_fire(patch_index,CWD)  = 0.0_r_2
+             casaflux%klitter_fire(patch_index,METB) = real(BLAZE%AB(i) * ag_litter_frac, r2)
+             casaflux%klitter_fire(patch_index,STR)  =  real(BLAZE%AB(i) * ag_litter_frac, r2)
+             casaflux%klitter_fire(patch_index,CWD)  = 0.0_r2
 
-             casaflux%fromPtoL_fire(patch_index,METB,LEAF)  = 0.0_r_2
-             casaflux%fromPtoL_fire(patch_index,METB,FROOT) = 0.0_r_2
-             casaflux%fromPtoL_fire(patch_index,METB,WOOD)  = 0.0_r_2
+             casaflux%fromPtoL_fire(patch_index,METB,LEAF)  = 0.0_r2
+             casaflux%fromPtoL_fire(patch_index,METB,FROOT) = 0.0_r2
+             casaflux%fromPtoL_fire(patch_index,METB,WOOD)  = 0.0_r2
 
-             casaflux%fromPtoL_fire(patch_index,STR,LEAF)  = 0.0_r_2
-             casaflux%fromPtoL_fire(patch_index,STR,FROOT) = 0.0_r_2
-             casaflux%fromPtoL_fire(patch_index,STR,WOOD)  = 0.0_r_2
+             casaflux%fromPtoL_fire(patch_index,STR,LEAF)  = 0.0_r2
+             casaflux%fromPtoL_fire(patch_index,STR,FROOT) = 0.0_r2
+             casaflux%fromPtoL_fire(patch_index,STR,WOOD)  = 0.0_r2
 
-             casaflux%fromPtoL_fire(patch_index,CWD,LEAF)  = 0.0_r_2
-             casaflux%fromPtoL_fire(patch_index,CWD,FROOT) = 0.0_r_2
-             casaflux%fromPtoL_fire(patch_index,CWD,WOOD)  = 0.0_r_2
+             casaflux%fromPtoL_fire(patch_index,CWD,LEAF)  = 0.0_r2
+             casaflux%fromPtoL_fire(patch_index,CWD,FROOT) = 0.0_r2
+             casaflux%fromPtoL_fire(patch_index,CWD,WOOD)  = 0.0_r2
 
           ELSEIF ( casamet%lnonwood(patch_index) == 0 ) THEN ! Here woody patches
              casaflux%kplant_fire(patch_index,LEAF) =  real(BLAZE%AB(i) * &
-                  (TO(i, LEAF )%TO_ATM + TO(i, LEAF )%TO_STR), r_2)
+                  (TO(i, LEAF )%TO_ATM + TO(i, LEAF )%TO_STR), r2)
              casaflux%kplant_fire(patch_index,FROOT) = real(BLAZE%AB(i) * &
-                  (TO(i, FROOT )%TO_ATM + TO(i, FROOT )%TO_STR), r_2)
+                  (TO(i, FROOT )%TO_ATM + TO(i, FROOT )%TO_STR), r2)
 
 
              casaflux%klitter_fire(patch_index,METB) = real(BLAZE%AB(i) * &
-                  (TO(i, MLIT )%TO_ATM) * ag_litter_frac, r_2)
+                  (TO(i, MLIT )%TO_ATM) * ag_litter_frac, r2)
              casaflux%klitter_fire(patch_index,STR) =  real(BLAZE%AB(i) * &
-                  (TO(i, SLIT )%TO_ATM) * ag_litter_frac, r_2)
+                  (TO(i, SLIT )%TO_ATM) * ag_litter_frac, r2)
              casaflux%klitter_fire(patch_index,CWD) =  real(BLAZE%AB(i) * &
-                  (TO(i, CLIT )%TO_ATM) * ag_litter_frac, r_2)
+                  (TO(i, CLIT )%TO_ATM) * ag_litter_frac, r2)
 
              casaflux%fromPtoL_fire(patch_index,STR,LEAF) = real(TO(i, LEAF )%TO_STR/ &
-                  MAX((TO(i, LEAF )%TO_STR + TO(i, LEAF )%TO_ATM),1.e-5), r_2)
+                  MAX((TO(i, LEAF )%TO_STR + TO(i, LEAF )%TO_ATM),1.e-5), r2)
 
              casaflux%fromPtoL_fire(patch_index,STR,FROOT) = real(TO(i, FROOT )%TO_STR/ &
-                  MAX((TO(i, FROOT )%TO_STR + TO(i, FROOT )%TO_ATM),1.e-5), r_2)
+                  MAX((TO(i, FROOT )%TO_STR + TO(i, FROOT )%TO_ATM),1.e-5), r2)
 
              ! maintain look-up table values for partitioning flux from woody biomass, but assume
              ! flux to atm only applies to above-ground wood (70% of total)
 
              casaflux%fromPtoL_fire(patch_index,CWD,WOOD) = real(TO(i, WOOD )%TO_CWD/ &
-                  MAX((TO(i, WOOD )%TO_CWD + TO(i, WOOD )%TO_ATM*0.7 +  TO(i, WOOD )%TO_STR ),1.e-5), r_2)
+                  MAX((TO(i, WOOD )%TO_CWD + TO(i, WOOD )%TO_ATM*0.7 +  TO(i, WOOD )%TO_STR ),1.e-5), r2)
 
              casaflux%fromPtoL_fire(patch_index,STR,WOOD) = real(TO(i, WOOD )%TO_STR/ &
                   MAX((TO(i, WOOD )%TO_CWD + TO(i, WOOD )%TO_ATM + &
-                  TO(i, WOOD )%TO_STR ),1e-5), r_2)
+                  TO(i, WOOD )%TO_STR ),1e-5), r2)
 
 
 

--- a/core/utils/minpack.f90
+++ b/core/utils/minpack.f90
@@ -1,7 +1,7 @@
 
 MODULE minpack
 
-  use cable_def_types_mod, only: r_2
+  use cable_def_types_mod, only: r2
   use mo_utils,            only: eq, ge, le, ne
 
 !License:
@@ -65,7 +65,7 @@ MODULE minpack
 !to the following functions: lmdif1, lmdif, fdjac2, fcn
 !
 !Matthias Cuntz, Apr 2020:
-! all double precision to Cable notation, i.e. 12D+34 to 12e+34_r_2
+! all double precision to Cable notation, i.e. 12D+34 to 12e+34_r2
 
   CONTAINS
 
@@ -131,28 +131,28 @@ MODULE minpack
       !
       !    Input, integer :: N, is the number of variables.
       !
-      !    Input, real(r_2) :: X(N), the point at which the jacobian is to be
+      !    Input, real(r2) :: X(N), the point at which the jacobian is to be
       !    evaluated.
       !
-      !    Input, real(r_2) :: FVEC(M), is used only when MODE = 2.
+      !    Input, real(r2) :: FVEC(M), is used only when MODE = 2.
       !    In that case, it should contain the function values at X.
       !
-      !    Input, real(r_2) :: FJAC(LDFJAC,N), an M by N array.  When MODE = 2,
+      !    Input, real(r2) :: FJAC(LDFJAC,N), an M by N array.  When MODE = 2,
       !    FJAC(I,J) should contain the value of dF(I)/dX(J).
       !
       !    Input, integer :: LDFJAC, the leading dimension of FJAC.
       !    LDFJAC must be at least M.
       !
-      !    Output, real(r_2) :: XP(N), on output with MODE = 1, is a neighboring
+      !    Output, real(r2) :: XP(N), on output with MODE = 1, is a neighboring
       !    point of X, at which the function is to be evaluated.
       !
-      !    Input, real(r_2) :: FVECP(M), on input with MODE = 2, is the function
+      !    Input, real(r2) :: FVECP(M), on input with MODE = 2, is the function
       !    value at XP.
       !
       !    Input, integer :: MODE, should be set to 1 on the first call, and
       !    2 on the second.
       !
-      !    Output, real(r_2) :: ERR(M).  On output when MODE = 2, ERR contains
+      !    Output, real(r2) :: ERR(M).  On output when MODE = 2, ERR contains
       !    measures of correctness of the respective gradients.  If there is no
       !    severe loss of significance, then if ERR(I):
       !      = 1.0D+00, the I-th gradient is correct,
@@ -166,20 +166,20 @@ MODULE minpack
       integer :: m
       integer :: n
 
-      real(r_2) :: eps
-      real(r_2) :: epsf
-      real(r_2) :: epslog
-      real(r_2) :: epsmch
-      real(r_2) :: err(m)
-      real(r_2) :: fjac(ldfjac,n)
-      real(r_2) :: fvec(m)
-      real(r_2) :: fvecp(m)
+      real(r2) :: eps
+      real(r2) :: epsf
+      real(r2) :: epslog
+      real(r2) :: epsmch
+      real(r2) :: err(m)
+      real(r2) :: fjac(ldfjac,n)
+      real(r2) :: fvec(m)
+      real(r2) :: fvecp(m)
       integer :: i
       integer :: j
       integer :: mode
-      real(r_2) :: temp
-      real(r_2) :: x(n)
-      real(r_2) :: xp(n)
+      real(r2) :: temp
+      real(r2) :: x(n)
+      real(r2) :: xp(n)
 
       epsmch = epsilon ( epsmch )
       eps = sqrt ( epsmch )
@@ -190,7 +190,7 @@ MODULE minpack
 
          do j = 1, n
             temp = eps * abs ( x(j) )
-            if ( eq(temp, 0.0_r_2) ) then
+            if ( eq(temp, 0.0_r2) ) then
                temp = eps
             end if
             xp(j) = x(j) + temp
@@ -200,37 +200,37 @@ MODULE minpack
          !
       else if ( mode == 2 ) then
 
-         epsf = 100.0_r_2 * epsmch
+         epsf = 100.0_r2 * epsmch
          epslog = log10 ( eps )
 
-         err = 0.0_r_2
+         err = 0.0_r2
 
          do j = 1, n
             temp = abs ( x(j) )
-            if ( eq(temp, 0.0_r_2) ) then
-               temp = 1.0_r_2
+            if ( eq(temp, 0.0_r2) ) then
+               temp = 1.0_r2
             end if
             err(1:m) = err(1:m) + temp * fjac(1:m,j)
          end do
 
          do i = 1, m
 
-            temp = 1.0_r_2
+            temp = 1.0_r2
 
-            if ( ne(fvec(i), 0.0_r_2) .and. ne(fvecp(i), 0.0_r_2) .and. &
+            if ( ne(fvec(i), 0.0_r2) .and. ne(fvecp(i), 0.0_r2) .and. &
                  ge(abs(fvecp(i)-fvec(i)), epsf * abs(fvec(i))) ) then
                temp = eps * abs ( (fvecp(i)-fvec(i)) / eps - err(i) ) &
                     / ( abs ( fvec(i) ) + abs ( fvecp(i) ) )
             end if
 
-            err(i) = 1.0_r_2
+            err(i) = 1.0_r2
 
             if ( epsmch < temp .and. temp < eps ) then
                err(i) = ( log10 ( temp ) - epslog ) / epslog
             end if
 
             if ( le(eps, temp) ) then
-               err(i) = 0.0_r_2
+               err(i) = 0.0_r2
             end if
 
          end do
@@ -285,20 +285,20 @@ MODULE minpack
       !
       !    Input, integer :: N, the order of the matrix R.
       !
-      !    Input, real(r_2) :: R(LR), the upper triangular matrix R stored
+      !    Input, real(r2) :: R(LR), the upper triangular matrix R stored
       !    by rows.
       !
       !    Input, integer :: LR, the size of the R array, which must be 
       !    no less than (N*(N+1))/2.
       !
-      !    Input, real(r_2) :: DIAG(N), the diagonal elements of the matrix D.
+      !    Input, real(r2) :: DIAG(N), the diagonal elements of the matrix D.
       !
-      !    Input, real(r_2) :: QTB(N), the first N elements of the vector Q'* B.
+      !    Input, real(r2) :: QTB(N), the first N elements of the vector Q'* B.
       !
-      !    Input, real(r_2) :: DELTA, is a positive upper bound on the
+      !    Input, real(r2) :: DELTA, is a positive upper bound on the
       !    euclidean norm of D*X(1:N).
       !
-      !    Output, real(r_2) :: X(N), the desired convex combination of the
+      !    Output, real(r2) :: X(N), the desired convex combination of the
       !    Gauss-Newton direction and the scaled gradient direction.
       !
       implicit none
@@ -306,27 +306,27 @@ MODULE minpack
       integer :: lr
       integer :: n
 
-      real(r_2) :: alpha
-      real(r_2) :: bnorm
-      real(r_2) :: delta
-      real(r_2) :: diag(n)
-      ! real(r_2) :: enorm
-      real(r_2) :: epsmch
-      real(r_2) :: gnorm
+      real(r2) :: alpha
+      real(r2) :: bnorm
+      real(r2) :: delta
+      real(r2) :: diag(n)
+      ! real(r2) :: enorm
+      real(r2) :: epsmch
+      real(r2) :: gnorm
       integer :: i
       integer :: j
       integer :: jj
       integer :: k
       integer :: l
-      real(r_2) :: qnorm
-      real(r_2) :: qtb(n)
-      real(r_2) :: r(lr)
-      real(r_2) :: sgnorm
-      real(r_2) :: sum2
-      real(r_2) :: temp
-      real(r_2) :: wa1(n)
-      real(r_2) :: wa2(n)
-      real(r_2) :: x(n)
+      real(r2) :: qnorm
+      real(r2) :: qtb(n)
+      real(r2) :: r(lr)
+      real(r2) :: sgnorm
+      real(r2) :: sum2
+      real(r2) :: temp
+      real(r2) :: wa1(n)
+      real(r2) :: wa2(n)
+      real(r2) :: x(n)
 
       epsmch = epsilon ( epsmch )
       !
@@ -339,7 +339,7 @@ MODULE minpack
          j = n - k + 1
          jj = jj - k
          l = jj + 1
-         sum2 = 0.0_r_2
+         sum2 = 0.0_r2
 
          do i = j + 1, n
             sum2 = sum2 + r(l) * x(i)
@@ -348,7 +348,7 @@ MODULE minpack
 
          temp = r(jj)
 
-         if ( eq(temp, 0.0_r_2) ) then
+         if ( eq(temp, 0.0_r2) ) then
 
             l = j
             do i = 1, j
@@ -356,7 +356,7 @@ MODULE minpack
                l = l + n - i
             end do
 
-            if ( eq(temp, 0.0_r_2) ) then
+            if ( eq(temp, 0.0_r2) ) then
                temp = epsmch
             else
                temp = epsmch * temp
@@ -370,7 +370,7 @@ MODULE minpack
       !
       !  Test whether the Gauss-Newton direction is acceptable.
       !
-      wa1(1:n) = 0.0_r_2
+      wa1(1:n) = 0.0_r2
       wa2(1:n) = diag(1:n) * x(1:n)
       qnorm = enorm ( n, wa2 )
 
@@ -395,10 +395,10 @@ MODULE minpack
       !  Test for the special case in which the scaled gradient is zero.
       !
       gnorm = enorm ( n, wa1 )
-      sgnorm = 0.0_r_2
+      sgnorm = 0.0_r2
       alpha = delta / qnorm
 
-      if ( ne(gnorm, 0.0_r_2) ) then
+      if ( ne(gnorm, 0.0_r2) ) then
          !
          !  Calculate the point along the scaled gradient which minimizes the quadratic.
          !
@@ -406,7 +406,7 @@ MODULE minpack
 
          l = 1
          do j = 1, n
-            sum2 = 0.0_r_2
+            sum2 = 0.0_r2
             do i = j, n
                sum2 = sum2 + r(l) * wa1(i)
                l = l + 1
@@ -419,7 +419,7 @@ MODULE minpack
          !
          !  Test whether the scaled gradient direction is acceptable.
          !
-         alpha = 0.0_r_2
+         alpha = 0.0_r2
          !
          !  The scaled gradient direction is not acceptable.
          !  Calculate the point along the dogleg at which the quadratic is minimized.
@@ -430,10 +430,10 @@ MODULE minpack
             temp = ( bnorm / gnorm ) * ( bnorm / qnorm ) * ( sgnorm / delta )
             temp = temp - ( delta / qnorm ) * ( sgnorm / delta) ** 2 &
                  + sqrt ( ( temp - ( delta / qnorm ) ) ** 2 &
-                 + ( 1.0_r_2 - ( delta / qnorm ) ** 2 ) &
-                 * ( 1.0_r_2 - ( sgnorm / delta ) ** 2 ) )
+                 + ( 1.0_r2 - ( delta / qnorm ) ** 2 ) &
+                 * ( 1.0_r2 - ( sgnorm / delta ) ** 2 ) )
 
-            alpha = ( ( delta / qnorm ) * ( 1.0_r_2 - ( sgnorm / delta ) ** 2 ) ) &
+            alpha = ( ( delta / qnorm ) * ( 1.0_r2 - ( sgnorm / delta ) ** 2 ) ) &
                  / temp
 
          end if
@@ -443,7 +443,7 @@ MODULE minpack
       !  Form appropriate convex combination of the Gauss-Newton
       !  direction and the scaled gradient direction.
       !
-      temp = ( 1.0_r_2 - alpha ) * min ( sgnorm, delta )
+      temp = ( 1.0_r2 - alpha ) * min ( sgnorm, delta )
 
       x(1:n) = temp * wa1(1:n) + alpha * x(1:n)
 
@@ -485,15 +485,15 @@ MODULE minpack
       !
       !    Input, integer :: N, is the length of the vector.
       !
-      !    Input, real(r_2) :: X(N), the vector whose norm is desired.
+      !    Input, real(r2) :: X(N), the vector whose norm is desired.
       !
-      !    Output, real(r_2) :: ENORM, the Euclidean norm of the vector.
+      !    Output, real(r2) :: ENORM, the Euclidean norm of the vector.
       !
       implicit none
 
       integer :: n
-      real(r_2) :: x(n)
-      real(r_2) :: enorm
+      real(r2) :: x(n)
+      real(r2) :: enorm
 
       enorm = sqrt ( sum ( x(1:n) ** 2 ))
 
@@ -547,36 +547,36 @@ MODULE minpack
       !
       !    Input, integer :: N, is the length of the vector.
       !
-      !    Input, real(r_2) :: X(N), the vector whose norm is desired.
+      !    Input, real(r2) :: X(N), the vector whose norm is desired.
       !
-      !    Output, real(r_2) :: ENORM2, the Euclidean norm of the vector.
+      !    Output, real(r2) :: ENORM2, the Euclidean norm of the vector.
       !
       implicit none
 
       integer :: n
 
-      real(r_2) :: agiant
-      real(r_2) :: enorm2
+      real(r2) :: agiant
+      real(r2) :: enorm2
       integer :: i
-      real(r_2) :: rdwarf
-      real(r_2) :: rgiant
-      real(r_2) :: s1
-      real(r_2) :: s2
-      real(r_2) :: s3
-      real(r_2) :: x(n)
-      real(r_2) :: xabs
-      real(r_2) :: x1max
-      real(r_2) :: x3max
+      real(r2) :: rdwarf
+      real(r2) :: rgiant
+      real(r2) :: s1
+      real(r2) :: s2
+      real(r2) :: s3
+      real(r2) :: x(n)
+      real(r2) :: xabs
+      real(r2) :: x1max
+      real(r2) :: x3max
 
       rdwarf = sqrt ( tiny ( rdwarf ) )
       rgiant = sqrt ( huge ( rgiant ) )
 
-      s1 = 0.0_r_2
-      s2 = 0.0_r_2
-      s3 = 0.0_r_2
-      x1max = 0.0_r_2
-      x3max = 0.0_r_2
-      agiant = rgiant / real (n, r_2)
+      s1 = 0.0_r2
+      s2 = 0.0_r2
+      s3 = 0.0_r2
+      x1max = 0.0_r2
+      x3max = 0.0_r2
+      agiant = rgiant / real (n, r2)
 
       do i = 1, n
 
@@ -585,16 +585,16 @@ MODULE minpack
          if ( le(xabs, rdwarf) ) then
 
             if ( x3max < xabs ) then
-               s3 = 1.0_r_2 + s3 * ( x3max / xabs ) ** 2
+               s3 = 1.0_r2 + s3 * ( x3max / xabs ) ** 2
                x3max = xabs
-            else if ( ne(xabs, 0.0_r_2) ) then
+            else if ( ne(xabs, 0.0_r2) ) then
                s3 = s3 + ( xabs / x3max ) ** 2
             end if
 
          else if ( le(agiant, xabs) ) then
 
             if ( x1max < xabs ) then
-               s1 = 1.0_r_2 + s1 * ( x1max / xabs ) ** 2
+               s1 = 1.0_r2 + s1 * ( x1max / xabs ) ** 2
                x1max = xabs
             else
                s1 = s1 + ( xabs / x1max ) ** 2
@@ -610,14 +610,14 @@ MODULE minpack
       !
       !  Calculation of norm.
       !
-      if ( ne(s1, 0.0_r_2) ) then
+      if ( ne(s1, 0.0_r2) ) then
 
          enorm2 = x1max * sqrt ( s1 + ( s2 / x1max ) / x1max )
 
-      else if ( ne(s2, 0.0_r_2) ) then
+      else if ( ne(s2, 0.0_r2) ) then
 
          if ( le(x3max, s2) ) then
-            enorm2 = sqrt ( s2 * ( 1.0_r_2 + ( x3max / s2 ) * ( x3max * s3 ) ) )
+            enorm2 = sqrt ( s2 * ( 1.0_r2 + ( x3max / s2 ) * ( x3max * s3 ) ) )
          else
             enorm2 = sqrt ( x3max * ( ( s2 / x3max ) + ( x3max * s3 ) ) )
          end if
@@ -670,9 +670,9 @@ MODULE minpack
       !    calculates the functions.  The routine should have the form:
       !      subroutine fcn ( n, x, fvec, iflag )
       !      integer :: n
-      !      real(r_2) :: fvec(n)
+      !      real(r2) :: fvec(n)
       !      integer :: iflag
-      !      real(r_2) :: x(n)
+      !      real(r2) :: x(n)
       !    If IFLAG = 0 on input, then FCN is only being called to allow the user
       !    to print out the current iterate.
       !    If IFLAG = 1 on input, FCN should calculate the functions at X and
@@ -681,11 +681,11 @@ MODULE minpack
       !
       !    Input, integer :: N, the number of functions and variables.
       !
-      !    Input, real(r_2) :: X(N), the point where the jacobian is evaluated.
+      !    Input, real(r2) :: X(N), the point where the jacobian is evaluated.
       !
-      !    Input, real(r_2) :: FVEC(N), the functions evaluated at X.
+      !    Input, real(r2) :: FVEC(N), the functions evaluated at X.
       !
-      !    Output, real(r_2) :: FJAC(LDFJAC,N), the N by N approximate
+      !    Output, real(r2) :: FJAC(LDFJAC,N), the N by N approximate
       !    jacobian matrix.
       !
       !    Input, integer :: LDFJAC, the leading dimension of FJAC, which
@@ -699,7 +699,7 @@ MODULE minpack
       !    superdiagonals within the band of the jacobian matrix.  If the
       !    jacobian is not banded, set ML and MU to N-1.
       !
-      !    Input, real(r_2) :: EPSFCN, is used in determining a suitable step
+      !    Input, real(r2) :: EPSFCN, is used in determining a suitable step
       !    length for the forward-difference approximation.  This approximation
       !    assumes that the relative errors in the functions are of the order of
       !    EPSFCN.  If EPSFCN is less than the machine precision, it is assumed that
@@ -711,13 +711,13 @@ MODULE minpack
       integer :: ldfjac
       integer :: n
 
-      real(r_2) :: eps
-      real(r_2) :: epsfcn
-      real(r_2) :: epsmch
+      real(r2) :: eps
+      real(r2) :: epsfcn
+      real(r2) :: epsmch
       external fcn
-      real(r_2) :: fjac(ldfjac,n)
-      real(r_2) :: fvec(n)
-      real(r_2) :: h
+      real(r2) :: fjac(ldfjac,n)
+      real(r2) :: fvec(n)
+      real(r2) :: h
       integer :: i
       integer :: iflag
       integer :: j
@@ -725,10 +725,10 @@ MODULE minpack
       integer :: ml
       integer :: msum
       integer :: mu
-      real(r_2) :: temp
-      real(r_2) :: wa1(n)
-      real(r_2) :: wa2(n)
-      real(r_2) :: x(n)
+      real(r2) :: temp
+      real(r2) :: wa1(n)
+      real(r2) :: wa2(n)
+      real(r2) :: x(n)
 
       epsmch = epsilon ( epsmch )
 
@@ -743,7 +743,7 @@ MODULE minpack
 
             temp = x(j)
             h = eps * abs ( temp )
-            if ( eq(h, 0.0_r_2) ) then
+            if ( eq(h, 0.0_r2) ) then
                h = eps
             end if
 
@@ -769,7 +769,7 @@ MODULE minpack
             do j = k, n, msum
                wa2(j) = x(j)
                h = eps * abs ( wa2(j) )
-               if ( eq(h, 0.0_r_2) ) then
+               if ( eq(h, 0.0_r2) ) then
                   h = eps
                end if
                x(j) = wa2(j) + h
@@ -787,11 +787,11 @@ MODULE minpack
                x(j) = wa2(j)
 
                h = eps * abs ( wa2(j) )
-               if ( eq(h, 0.0_r_2) ) then
+               if ( eq(h, 0.0_r2) ) then
                   h = eps
                end if
 
-               fjac(1:n,j) = 0.0_r_2
+               fjac(1:n,j) = 0.0_r2
 
                do i = 1, n
                   if ( j - mu <= i .and. i <= j + ml ) then
@@ -846,9 +846,9 @@ MODULE minpack
       !    calculates the functions.  The routine should have the form:
       !      subroutine fcn ( m, n, x, fvec, iflag )
       !      integer :: n
-      !      real(r_2) :: fvec(m)
+      !      real(r2) :: fvec(m)
       !      integer :: iflag
-      !      real(r_2) :: x(n)
+      !      real(r2) :: x(n)
       !
       !    If IFLAG = 0 on input, then FCN is only being called to allow the user
       !    to print out the current iterate.
@@ -861,11 +861,11 @@ MODULE minpack
       !    Input, integer :: N, is the number of variables.  
       !    N must not exceed M.
       !
-      !    Input, real(r_2) :: X(N), the point where the jacobian is evaluated.
+      !    Input, real(r2) :: X(N), the point where the jacobian is evaluated.
       !
-      !    Input, real(r_2) :: FVEC(M), the functions evaluated at X.
+      !    Input, real(r2) :: FVEC(M), the functions evaluated at X.
       !
-      !    Output, real(r_2) :: FJAC(LDFJAC,N), the M by N approximate
+      !    Output, real(r2) :: FJAC(LDFJAC,N), the M by N approximate
       !    jacobian matrix.
       !
       !    Input, integer :: LDFJAC, the leading dimension of FJAC, 
@@ -875,7 +875,7 @@ MODULE minpack
       !    If FCN returns a nonzero value of IFLAG, then this routine returns 
       !    immediately to the calling program, with the value of IFLAG.
       !
-      !    Input, real(r_2) :: EPSFCN, is used in determining a suitable
+      !    Input, real(r2) :: EPSFCN, is used in determining a suitable
       !    step length for the forward-difference approximation.  This approximation
       !    assumes that the relative errors in the functions are of the order of
       !    EPSFCN.  If EPSFCN is less than the machine precision, it is assumed that
@@ -888,23 +888,23 @@ MODULE minpack
       integer :: m
       integer :: n
 
-      real(r_2) :: eps
-      real(r_2) :: epsfcn
-      real(r_2) :: epsmch
+      real(r2) :: eps
+      real(r2) :: epsfcn
+      real(r2) :: epsmch
       external fcn
-      real(r_2) :: fjac(ldfjac,n)
-      real(r_2) :: fvec(m)
-      real(r_2) :: h
+      real(r2) :: fjac(ldfjac,n)
+      real(r2) :: fvec(m)
+      real(r2) :: h
       integer :: iflag
       integer :: j
-      real(r_2) :: temp
-      real(r_2) :: wa(m)
-      real(r_2) :: x(n)
-      real(r_2) :: An(m)
-      real(r_2) :: Ci(m)
-      real(r_2) :: Rd
-      real(r_2) :: Km
-      real(r_2) :: gammastar
+      real(r2) :: temp
+      real(r2) :: wa(m)
+      real(r2) :: x(n)
+      real(r2) :: An(m)
+      real(r2) :: Ci(m)
+      real(r2) :: Rd
+      real(r2) :: Km
+      real(r2) :: gammastar
 
       epsmch = epsilon ( epsmch )
 
@@ -914,7 +914,7 @@ MODULE minpack
 
          temp = x(j)
          h = eps * abs ( temp )
-         if ( eq(h, 0.0_r_2) ) then
+         if ( eq(h, 0.0_r2) ) then
             h = eps
          end if
 
@@ -974,9 +974,9 @@ MODULE minpack
       !    calculates the functions.  The routine should have the form:
       !      subroutine fcn ( n, x, fvec, iflag )
       !      integer :: n
-      !      real(r_2) :: fvec(n)
+      !      real(r2) :: fvec(n)
       !      integer :: iflag
-      !      real(r_2) :: x(n)
+      !      real(r2) :: x(n)
       !
       !    If IFLAG = 0 on input, then FCN is only being called to allow the user
       !    to print out the current iterate.
@@ -986,13 +986,13 @@ MODULE minpack
       !
       !    Input, integer :: N, the number of functions and variables.
       !
-      !    Input/output, real(r_2) :: X(N).  On input, X must contain an initial
+      !    Input/output, real(r2) :: X(N).  On input, X must contain an initial
       !    estimate of the solution vector.  On output X contains the final
       !    estimate of the solution vector.
       !
-      !    Output, real(r_2) :: FVEC(N), the functions evaluated at the output X.
+      !    Output, real(r2) :: FVEC(N), the functions evaluated at the output X.
       !
-      !    Input, real(r_2) :: XTOL.  Termination occurs when the relative error
+      !    Input, real(r2) :: XTOL.  Termination occurs when the relative error
       !    between two consecutive iterates is at most XTOL.  XTOL should be
       !    nonnegative.
       !
@@ -1003,14 +1003,14 @@ MODULE minpack
       !    superdiagonals within the band of the jacobian matrix.  If the jacobian
       !    is not banded, set ML and MU to at least n - 1.
       !
-      !    Input, real(r_2) :: EPSFCN, is used in determining a suitable step
+      !    Input, real(r2) :: EPSFCN, is used in determining a suitable step
       !    length for the forward-difference approximation.  This approximation
       !    assumes that the relative errors in the functions are of the order of
       !    EPSFCN.  If EPSFCN is less than the machine precision, it is assumed that
       !    the relative errors in the functions are of the order of the machine
       !    precision.
       !
-      !    Input/output, real(r_2) :: DIAG(N).  If MODE = 1, then DIAG is set
+      !    Input/output, real(r2) :: DIAG(N).  If MODE = 1, then DIAG is set
       !    internally.  If MODE = 2, then DIAG must contain positive entries that
       !    serve as multiplicative scale factors for the variables.
       !
@@ -1018,7 +1018,7 @@ MODULE minpack
       !    1, variables will be scaled internally.
       !    2, scaling is specified by the input DIAG vector.
       !
-      !    Input, real(r_2) :: FACTOR, determines the initial step bound.  This
+      !    Input, real(r2) :: FACTOR, determines the initial step bound.  This
       !    bound is set to the product of FACTOR and the euclidean norm of DIAG*X if
       !    nonzero, or else to FACTOR itself.  In most cases, FACTOR should lie
       !    in the interval (0.1, 100) with 100 the recommended value.
@@ -1046,20 +1046,20 @@ MODULE minpack
       !
       !    Output, integer :: NFEV, the number of calls to FCN.
       !
-      !    Output, real(r_2) :: FJAC(LDFJAC,N), an N by N array which contains
+      !    Output, real(r2) :: FJAC(LDFJAC,N), an N by N array which contains
       !    the orthogonal matrix Q produced by the QR factorization of the final
       !    approximate jacobian.
       !
       !    Input, integer :: LDFJAC, the leading dimension of FJAC.
       !    LDFJAC must be at least N.
       !
-      !    Output, real(r_2) :: R(LR), the upper triangular matrix produced by
+      !    Output, real(r2) :: R(LR), the upper triangular matrix produced by
       !    the QR factorization of the final approximate jacobian, stored rowwise.
       !
       !    Input, integer :: LR, the size of the R array, which must be no
       !    less than (N*(N+1))/2.
       !
-      !    Output, real(r_2) :: QTF(N), contains the vector Q'*FVEC.
+      !    Output, real(r2) :: QTF(N), contains the vector Q'*FVEC.
       !
       implicit none
 
@@ -1067,18 +1067,18 @@ MODULE minpack
       integer :: lr
       integer :: n
 
-      real(r_2) :: actred
-      real(r_2) :: delta
-      real(r_2) :: diag(n)
-      !real(r_2) :: enorm
-      real(r_2) :: epsfcn
-      real(r_2) :: epsmch
-      real(r_2) :: factor
+      real(r2) :: actred
+      real(r2) :: delta
+      real(r2) :: diag(n)
+      !real(r2) :: enorm
+      real(r2) :: epsfcn
+      real(r2) :: epsmch
+      real(r2) :: factor
       external fcn
-      real(r_2) :: fjac(ldfjac,n)
-      real(r_2) :: fnorm
-      real(r_2) :: fnorm1
-      real(r_2) :: fvec(n)
+      real(r2) :: fjac(ldfjac,n)
+      real(r2) :: fnorm
+      real(r2) :: fnorm1
+      real(r2) :: fvec(n)
       integer :: i
       integer :: iflag
       integer :: info
@@ -1099,21 +1099,21 @@ MODULE minpack
       integer :: nfev
       integer :: nprint
       logical pivot
-      real(r_2) :: pnorm
-      real(r_2) :: prered
-      real(r_2) :: qtf(n)
-      real(r_2) :: r(lr)
-      real(r_2) :: ratio
+      real(r2) :: pnorm
+      real(r2) :: prered
+      real(r2) :: qtf(n)
+      real(r2) :: r(lr)
+      real(r2) :: ratio
       logical sing
-      real(r_2) :: sum2
-      real(r_2) :: temp
-      real(r_2) :: wa1(n)
-      real(r_2) :: wa2(n)
-      real(r_2) :: wa3(n)
-      real(r_2) :: wa4(n)
-      real(r_2) :: x(n)
-      real(r_2) :: xnorm
-      real(r_2) :: xtol
+      real(r2) :: sum2
+      real(r2) :: temp
+      real(r2) :: wa1(n)
+      real(r2) :: wa2(n)
+      real(r2) :: wa3(n)
+      real(r2) :: wa4(n)
+      real(r2) :: x(n)
+      real(r2) :: xnorm
+      real(r2) :: xtol
 
       epsmch = epsilon ( epsmch )
 
@@ -1125,7 +1125,7 @@ MODULE minpack
       !
       if ( n <= 0 ) then
          return
-      else if ( xtol < 0.0_r_2 ) then
+      else if ( xtol < 0.0_r2 ) then
          return
       else if ( maxfev <= 0 ) then
          return
@@ -1133,7 +1133,7 @@ MODULE minpack
          return
       else if ( mu < 0 ) then
          return
-      else if ( le(factor, 0.0_r_2) ) then
+      else if ( le(factor, 0.0_r2) ) then
          return
       else if ( ldfjac < n ) then
          return
@@ -1144,7 +1144,7 @@ MODULE minpack
       if ( mode == 2 ) then
 
          do j = 1, n
-            if ( le(diag(j), 0.0_r_2) ) then
+            if ( le(diag(j), 0.0_r2) ) then
                go to 300
             end if
          end do
@@ -1207,8 +1207,8 @@ MODULE minpack
 
             diag(1:n) = wa2(1:n)
             do j = 1, n
-               if ( eq(wa2(j), 0.0_r_2) ) then
-                  diag(j) = 1.0_r_2
+               if ( eq(wa2(j), 0.0_r2) ) then
+                  diag(j) = 1.0_r2
                end if
             end do
 
@@ -1220,7 +1220,7 @@ MODULE minpack
          wa3(1:n) = diag(1:n) * x(1:n)
          xnorm = enorm ( n, wa3 )
          delta = factor * xnorm
-         if ( eq(delta, 0.0_r_2) ) then
+         if ( eq(delta, 0.0_r2) ) then
             delta = factor
          end if
 
@@ -1232,7 +1232,7 @@ MODULE minpack
 
       do j = 1, n
 
-         if ( ne(fjac(j,j), 0.0_r_2) ) then
+         if ( ne(fjac(j,j), 0.0_r2) ) then
             temp = - dot_product ( qtf(j:n), fjac(j:n,j) ) / fjac(j,j)
             qtf(j:n) = qtf(j:n) + fjac(j:n,j) * temp
          end if
@@ -1250,7 +1250,7 @@ MODULE minpack
             l = l + n - i
          end do
          r(l) = wa1(j)
-         if ( eq(wa1(j), 0.0_r_2) ) then
+         if ( eq(wa1(j), 0.0_r2) ) then
             sing = .true.
          end if
       end do
@@ -1316,16 +1316,16 @@ MODULE minpack
       !
       !  Compute the scaled actual reduction.
       !
-      actred = -1.0_r_2
+      actred = -1.0_r2
       if ( fnorm1 < fnorm ) then
-         actred = 1.0_r_2 - ( fnorm1 / fnorm ) ** 2
+         actred = 1.0_r2 - ( fnorm1 / fnorm ) ** 2
       endif
       !
       !  Compute the scaled predicted reduction.
       !
       l = 1
       do i = 1, n
-         sum2 = 0.0_r_2
+         sum2 = 0.0_r2
          do j = i, n
             sum2 = sum2 + r(l) * wa1(j)
             l = l + 1
@@ -1334,37 +1334,37 @@ MODULE minpack
       end do
 
       temp = enorm ( n, wa3 )
-      prered = 0.0_r_2
+      prered = 0.0_r2
       if ( temp < fnorm ) then
-         prered = 1.0_r_2 - ( temp / fnorm ) ** 2
+         prered = 1.0_r2 - ( temp / fnorm ) ** 2
       end if
       !
       !  Compute the ratio of the actual to the predicted reduction.
       !
-      ratio = 0.0_r_2
-      if ( 0.0_r_2 < prered ) then
+      ratio = 0.0_r2
+      if ( 0.0_r2 < prered ) then
          ratio = actred / prered
       end if
       !
       !  Update the step bound.
       !
-      if ( ratio < 0.1_r_2 ) then
+      if ( ratio < 0.1_r2 ) then
 
          ncsuc = 0
          ncfail = ncfail + 1
-         delta = 0.5_r_2 * delta
+         delta = 0.5_r2 * delta
 
       else
 
          ncfail = 0
          ncsuc = ncsuc + 1
 
-         if ( le(0.5_r_2, ratio) .or. 1 < ncsuc ) then
-            delta = max ( delta, pnorm / 0.5_r_2 )
+         if ( le(0.5_r2, ratio) .or. 1 < ncsuc ) then
+            delta = max ( delta, pnorm / 0.5_r2 )
          end if
 
-         if ( le(abs(ratio - 1.0_r_2), 0.1_r_2) ) then
-            delta = pnorm / 0.5_r_2
+         if ( le(abs(ratio - 1.0_r2), 0.1_r2) ) then
+            delta = pnorm / 0.5_r2
          end if
 
       end if
@@ -1374,7 +1374,7 @@ MODULE minpack
       !  Successful iteration.
       !  Update X, FVEC, and their norms.
       !
-      if ( le(0.0001_r_2, ratio) ) then
+      if ( le(0.0001_r2, ratio) ) then
          x(1:n) = wa2(1:n)
          wa2(1:n) = diag(1:n) * x(1:n)
          fvec(1:n) = wa4(1:n)
@@ -1386,7 +1386,7 @@ MODULE minpack
       !  Determine the progress of the iteration.
       !
       nslow1 = nslow1 + 1
-      if ( le(0.001_r_2, actred) ) then
+      if ( le(0.001_r2, actred) ) then
          nslow1 = 0
       end if
 
@@ -1394,13 +1394,13 @@ MODULE minpack
          nslow2 = nslow2 + 1
       end if
 
-      if ( le(0.1_r_2, actred) ) then
+      if ( le(0.1_r2, actred) ) then
          nslow2 = 0
       end if
       !
       !  Test for convergence.
       !
-      if ( le(delta, xtol * xnorm) .or. eq(fnorm, 0.0_r_2) ) then
+      if ( le(delta, xtol * xnorm) .or. eq(fnorm, 0.0_r2) ) then
          info = 1
       end if
 
@@ -1414,7 +1414,7 @@ MODULE minpack
          info = 2
       end if
 
-      if ( le(0.1_r_2 * max(0.1_r_2 * delta, pnorm), epsmch * xnorm) ) then
+      if ( le(0.1_r2 * max(0.1_r2 * delta, pnorm), epsmch * xnorm) ) then
          info = 3
       end if
 
@@ -1444,7 +1444,7 @@ MODULE minpack
          sum2 = dot_product ( wa4(1:n), fjac(1:n,j) )
          wa2(j) = ( sum2 - wa3(j) ) / pnorm
          wa1(j) = diag(j) * ( ( diag(j) * wa1(j) ) / pnorm )
-         if ( le(0.0001_r_2, ratio) ) then
+         if ( le(0.0001_r2, ratio) ) then
             qtf(j) = sum2
          end if
       end do
@@ -1523,9 +1523,9 @@ MODULE minpack
       !    calculates the functions.  The routine should have the form:
       !      subroutine fcn ( n, x, fvec, iflag )
       !      integer :: n
-      !      real(r_2) :: fvec(n)
+      !      real(r2) :: fvec(n)
       !      integer :: iflag
-      !      real(r_2) :: x(n)
+      !      real(r2) :: x(n)
       !    If IFLAG = 0 on input, then FCN is only being called to allow the user
       !    to print out the current iterate.
       !    If IFLAG = 1 on input, FCN should calculate the functions at X and
@@ -1534,13 +1534,13 @@ MODULE minpack
       !
       !    Input, integer :: N, the number of functions and variables.
       !
-      !    Input/output, real(r_2) :: X(N).  On input, X must contain an initial
+      !    Input/output, real(r2) :: X(N).  On input, X must contain an initial
       !    estimate of the solution vector.  On output X contains the final
       !    estimate of the solution vector.
       !
-      !    Output, real(r_2) :: FVEC(N), the functions evaluated at the output X.
+      !    Output, real(r2) :: FVEC(N), the functions evaluated at the output X.
       !
-      !    Input, real(r_2) :: TOL.  Termination occurs when the algorithm
+      !    Input, real(r2) :: TOL.  Termination occurs when the algorithm
       !    estimates that the relative error between X and the solution is at
       !    most TOL.  TOL should be nonnegative.
       !
@@ -1560,12 +1560,12 @@ MODULE minpack
 
       integer :: n
 
-      real(r_2) :: diag(n)
-      real(r_2) :: epsfcn
-      real(r_2) :: factor
+      real(r2) :: diag(n)
+      real(r2) :: epsfcn
+      real(r2) :: factor
       external fcn
-      real(r_2) :: fjac(n,n)
-      real(r_2) :: fvec(n)
+      real(r2) :: fjac(n,n)
+      real(r2) :: fvec(n)
       integer :: info
       integer :: ldfjac
       integer :: lr
@@ -1575,18 +1575,18 @@ MODULE minpack
       integer :: mu
       integer :: nfev
       integer :: nprint
-      real(r_2) :: qtf(n)
-      real(r_2) :: r((n*(n+1))/2)
-      real(r_2) :: tol
-      real(r_2) :: x(n)
-      real(r_2) :: xtol
+      real(r2) :: qtf(n)
+      real(r2) :: r((n*(n+1))/2)
+      real(r2) :: tol
+      real(r2) :: x(n)
+      real(r2) :: xtol
 
       if ( n <= 0 ) then
          info = 0
          return
       end if
 
-      if ( tol < 0.0_r_2 ) then
+      if ( tol < 0.0_r2 ) then
          info = 0
          return
       end if
@@ -1595,18 +1595,18 @@ MODULE minpack
       maxfev = 200 * ( n + 1 )
       ml = n - 1
       mu = n - 1
-      epsfcn = 0.0_r_2
-      diag(1:n) = 1.0_r_2
+      epsfcn = 0.0_r2
+      diag(1:n) = 1.0_r2
       mode = 2
-      factor = 100.0_r_2
+      factor = 100.0_r2
       nprint = 0
       info = 0
       nfev = 0
-      fjac(1:n,1:n) = 0.0_r_2
+      fjac(1:n,1:n) = 0.0_r2
       ldfjac = n
-      r(1:(n*(n+1))/2) = 0.0_r_2
+      r(1:(n*(n+1))/2) = 0.0_r2
       lr = ( n * ( n + 1 ) ) / 2
-      qtf(1:n) = 0.0_r_2
+      qtf(1:n) = 0.0_r2
 
       call hybrd ( fcn, n, x, fvec, xtol, maxfev, ml, mu, epsfcn, diag, mode, &
            factor, nprint, info, nfev, fjac, ldfjac, r, lr, qtf )
@@ -1658,10 +1658,10 @@ MODULE minpack
       !      subroutine fcn ( n, x, fvec, fjac, ldfjac, iflag )
       !      integer :: ldfjac
       !      integer :: n
-      !      real(r_2) :: fjac(ldfjac,n)
-      !      real(r_2) :: fvec(n)
+      !      real(r2) :: fjac(ldfjac,n)
+      !      real(r2) :: fvec(n)
       !      integer :: iflag
-      !      real(r_2) :: x(n)
+      !      real(r2) :: x(n)
       !
       !    If IFLAG = 0 on input, then FCN is only being called to allow the user
       !    to print out the current iterate.
@@ -1673,27 +1673,27 @@ MODULE minpack
       !
       !    Input, integer :: N, the number of functions and variables.
       !
-      !    Input/output, real(r_2) :: X(N).  On input, X must contain an initial
+      !    Input/output, real(r2) :: X(N).  On input, X must contain an initial
       !    estimate of the solution vector.  On output X contains the final
       !    estimate of the solution vector.
       !
-      !    Output, real(r_2) :: FVEC(N), the functions evaluated at the output X.
+      !    Output, real(r2) :: FVEC(N), the functions evaluated at the output X.
       !
-      !    Output, real(r_2) :: FJAC(LDFJAC,N), an N by N matrix, containing
+      !    Output, real(r2) :: FJAC(LDFJAC,N), an N by N matrix, containing
       !    the orthogonal matrix Q produced by the QR factorization
       !    of the final approximate jacobian.
       !
       !    Input, integer :: LDFJAC, the leading dimension of the
       !    array FJAC.  LDFJAC must be at least N.
       !
-      !    Input, real(r_2) :: XTOL.  Termination occurs when the relative error
+      !    Input, real(r2) :: XTOL.  Termination occurs when the relative error
       !    between two consecutive iterates is at most XTOL.  XTOL should be
       !    nonnegative.
       !
       !    Input, integer :: MAXFEV.  Termination occurs when the number of
       !    calls to FCN is at least MAXFEV by the end of an iteration.
       !
-      !    Input/output, real(r_2) :: DIAG(N).  If MODE = 1, then DIAG is set
+      !    Input/output, real(r2) :: DIAG(N).  If MODE = 1, then DIAG is set
       !    internally.  If MODE = 2, then DIAG must contain positive entries that
       !    serve as multiplicative scale factors for the variables.
       !
@@ -1701,7 +1701,7 @@ MODULE minpack
       !    1, variables will be scaled internally.
       !    2, scaling is specified by the input DIAG vector.
       !
-      !    Input, real(r_2) :: FACTOR, determines the initial step bound.  This
+      !    Input, real(r2) :: FACTOR, determines the initial step bound.  This
       !    bound is set to the product of FACTOR and the euclidean norm of DIAG*X if
       !    nonzero, or else to FACTOR itself.  In most cases, FACTOR should lie
       !    in the interval (0.1, 100) with 100 the recommended value.
@@ -1732,13 +1732,13 @@ MODULE minpack
       !    Output, integer :: NJEV, the number of calls to FCN 
       !    with IFLAG = 2.
       !
-      !    Output, real(r_2) :: R(LR), the upper triangular matrix produced
+      !    Output, real(r2) :: R(LR), the upper triangular matrix produced
       !    by the QR factorization of the final approximate jacobian, stored rowwise.
       !
       !    Input, integer :: LR, the size of the R array, which must 
       !    be no less than (N*(N+1))/2.
       !
-      !    Output, real(r_2) :: QTF(N), contains the vector Q'*FVEC.
+      !    Output, real(r2) :: QTF(N), contains the vector Q'*FVEC.
       !
       implicit none
 
@@ -1746,17 +1746,17 @@ MODULE minpack
       integer :: lr
       integer :: n
 
-      real(r_2) :: actred
-      real(r_2) :: delta
-      real(r_2) :: diag(n)
-      !real(r_2) :: enorm
-      real(r_2) :: epsmch
-      real(r_2) :: factor
+      real(r2) :: actred
+      real(r2) :: delta
+      real(r2) :: diag(n)
+      !real(r2) :: enorm
+      real(r2) :: epsmch
+      real(r2) :: factor
       external fcn
-      real(r_2) :: fjac(ldfjac,n)
-      real(r_2) :: fnorm
-      real(r_2) :: fnorm1
-      real(r_2) :: fvec(n)
+      real(r2) :: fjac(ldfjac,n)
+      real(r2) :: fnorm
+      real(r2) :: fnorm1
+      real(r2) :: fvec(n)
       integer :: i
       integer :: iflag
       integer :: info
@@ -1775,21 +1775,21 @@ MODULE minpack
       integer :: njev
       integer :: nprint
       logical pivot
-      real(r_2) :: pnorm
-      real(r_2) :: prered
-      real(r_2) :: qtf(n)
-      real(r_2) :: r(lr)
-      real(r_2) :: ratio
+      real(r2) :: pnorm
+      real(r2) :: prered
+      real(r2) :: qtf(n)
+      real(r2) :: r(lr)
+      real(r2) :: ratio
       logical sing
-      real(r_2) :: sum2
-      real(r_2) :: temp
-      real(r_2) :: wa1(n)
-      real(r_2) :: wa2(n)
-      real(r_2) :: wa3(n)
-      real(r_2) :: wa4(n)
-      real(r_2) :: x(n)
-      real(r_2) :: xnorm
-      real(r_2) :: xtol
+      real(r2) :: sum2
+      real(r2) :: temp
+      real(r2) :: wa1(n)
+      real(r2) :: wa2(n)
+      real(r2) :: wa3(n)
+      real(r2) :: wa4(n)
+      real(r2) :: x(n)
+      real(r2) :: xnorm
+      real(r2) :: xtol
 
       epsmch = epsilon ( epsmch )
 
@@ -1812,9 +1812,9 @@ MODULE minpack
       end if
 
       if ( ldfjac < n .or. &
-           xtol < 0.0_r_2 .or. &
+           xtol < 0.0_r2 .or. &
            maxfev <= 0 .or. &
-           le(factor, 0.0_r_2) .or. &
+           le(factor, 0.0_r2) .or. &
            lr < ( n * ( n + 1 ) ) / 2 ) then
          if ( iflag < 0 ) then
             info = iflag
@@ -1828,7 +1828,7 @@ MODULE minpack
 
       if ( mode == 2 ) then
          do j = 1, n
-            if ( le(diag(j), 0.0_r_2) ) then
+            if ( le(diag(j), 0.0_r2) ) then
                if ( iflag < 0 ) then
                   info = iflag
                end if
@@ -1902,8 +1902,8 @@ MODULE minpack
             if ( mode /= 2 ) then
                diag(1:n) = wa2(1:n)
                do j = 1, n
-                  if ( eq(wa2(j), 0.0_r_2) ) then
-                     diag(j) = 1.0_r_2
+                  if ( eq(wa2(j), 0.0_r2) ) then
+                     diag(j) = 1.0_r2
                   end if
                end do
             end if
@@ -1914,7 +1914,7 @@ MODULE minpack
             wa3(1:n) = diag(1:n) * x(1:n)
             xnorm = enorm ( n, wa3 )
             delta = factor * xnorm
-            if ( eq(delta, 0.0_r_2) ) then
+            if ( eq(delta, 0.0_r2) ) then
                delta = factor
             end if
 
@@ -1925,8 +1925,8 @@ MODULE minpack
          qtf(1:n) = fvec(1:n)
 
          do j = 1, n
-            if ( ne(fjac(j,j), 0.0_r_2) ) then
-               sum2 = 0.0_r_2
+            if ( ne(fjac(j,j), 0.0_r2) ) then
+               sum2 = 0.0_r2
                do i = j, n
                   sum2 = sum2 + fjac(i,j) * qtf(i)
                end do
@@ -1948,7 +1948,7 @@ MODULE minpack
                l = l + n - i
             end do
             r(l) = wa1(j)
-            if ( eq(wa1(j), 0.0_r_2) ) then
+            if ( eq(wa1(j), 0.0_r2) ) then
                sing = .true.
             end if
          end do
@@ -2026,16 +2026,16 @@ MODULE minpack
             !
             !  Compute the scaled actual reduction.
             !
-            actred = -1.0_r_2
+            actred = -1.0_r2
             if ( fnorm1 < fnorm ) then
-               actred = 1.0_r_2 - ( fnorm1 / fnorm ) ** 2
+               actred = 1.0_r2 - ( fnorm1 / fnorm ) ** 2
             end if
             !
             !  Compute the scaled predicted reduction.
             !
             l = 1
             do i = 1, n
-               sum2 = 0.0_r_2
+               sum2 = 0.0_r2
                do j = i, n
                   sum2 = sum2 + r(l) * wa1(j)
                   l = l + 1
@@ -2044,38 +2044,38 @@ MODULE minpack
             end do
 
             temp = enorm ( n, wa3 )
-            prered = 0.0_r_2
+            prered = 0.0_r2
             if ( temp < fnorm ) then
-               prered = 1.0_r_2 - ( temp / fnorm ) ** 2
+               prered = 1.0_r2 - ( temp / fnorm ) ** 2
             end if
             !
             !  Compute the ratio of the actual to the predicted reduction.
             !
-            if ( 0.0_r_2 < prered ) then
+            if ( 0.0_r2 < prered ) then
                ratio = actred / prered
             else
-               ratio = 0.0_r_2
+               ratio = 0.0_r2
             end if
             !
             !  Update the step bound.
             !
-            if ( ratio < 0.1_r_2 ) then
+            if ( ratio < 0.1_r2 ) then
 
                ncsuc = 0
                ncfail = ncfail + 1
-               delta = 0.5_r_2 * delta
+               delta = 0.5_r2 * delta
 
             else
 
                ncfail = 0
                ncsuc = ncsuc + 1
 
-               if ( le(0.5_r_2, ratio) .or. 1 < ncsuc ) then
-                  delta = max ( delta, pnorm / 0.5_r_2 )
+               if ( le(0.5_r2, ratio) .or. 1 < ncsuc ) then
+                  delta = max ( delta, pnorm / 0.5_r2 )
                end if
 
-               if ( le(abs( ratio - 1.0_r_2 ), 0.1_r_2) ) then
-                  delta = pnorm / 0.5_r_2
+               if ( le(abs( ratio - 1.0_r2 ), 0.1_r2) ) then
+                  delta = pnorm / 0.5_r2
                end if
 
             end if
@@ -2087,7 +2087,7 @@ MODULE minpack
             !  Successful iteration.
             !  Update X, FVEC, and their norms.
             !
-            if ( le(0.0001_r_2, ratio) ) then
+            if ( le(0.0001_r2, ratio) ) then
                x(1:n) = wa2(1:n)
                wa2(1:n) = diag(1:n) * x(1:n)
                fvec(1:n) = wa4(1:n)
@@ -2099,7 +2099,7 @@ MODULE minpack
             !  Determine the progress of the iteration.
             !
             nslow1 = nslow1 + 1
-            if ( le(0.001_r_2, actred) ) then
+            if ( le(0.001_r2, actred) ) then
                nslow1 = 0
             end if
 
@@ -2107,13 +2107,13 @@ MODULE minpack
                nslow2 = nslow2 + 1
             end if
 
-            if ( le(0.1_r_2, actred) ) then
+            if ( le(0.1_r2, actred) ) then
                nslow2 = 0
             end if
             !
             !  Test for convergence.
             !
-            if ( le(delta, xtol * xnorm) .or. eq(fnorm, 0.0_r_2) ) then
+            if ( le(delta, xtol * xnorm) .or. eq(fnorm, 0.0_r2) ) then
                info = 1
             end if
 
@@ -2131,7 +2131,7 @@ MODULE minpack
                info = 2
             end if
 
-            if ( le(0.1_r_2 * max( 0.1_r_2 * delta, pnorm ), epsmch * xnorm) ) then
+            if ( le(0.1_r2 * max( 0.1_r2 * delta, pnorm ), epsmch * xnorm) ) then
                info = 3
             end if
 
@@ -2164,7 +2164,7 @@ MODULE minpack
                sum2 = dot_product ( wa4(1:n), fjac(1:n,j) )
                wa2(j) = ( sum2 - wa3(j) ) / pnorm
                wa1(j) = diag(j) * ( ( diag(j) * wa1(j) ) / pnorm )
-               if ( le(0.0001_r_2, ratio) ) then
+               if ( le(0.0001_r2, ratio) ) then
                   qtf(j) = sum2
                end if
             end do
@@ -2227,10 +2227,10 @@ MODULE minpack
       !      subroutine fcn ( n, x, fvec, fjac, ldfjac, iflag )
       !      integer :: ldfjac
       !      integer :: n
-      !      real(r_2) :: fjac(ldfjac,n)
-      !      real(r_2) :: fvec(n)
+      !      real(r2) :: fjac(ldfjac,n)
+      !      real(r2) :: fvec(n)
       !      integer :: iflag
-      !      real(r_2) :: x(n)
+      !      real(r2) :: x(n)
       !
       !    If IFLAG = 0 on input, then FCN is only being called to allow the user
       !    to print out the current iterate.
@@ -2242,20 +2242,20 @@ MODULE minpack
       !
       !    Input, integer :: N, the number of functions and variables.
       !
-      !    Input/output, real(r_2) :: X(N).  On input, X must contain an initial
+      !    Input/output, real(r2) :: X(N).  On input, X must contain an initial
       !    estimate of the solution vector.  On output X contains the final
       !    estimate of the solution vector.
       !
-      !    Output, real(r_2) :: FVEC(N), the functions evaluated at the output X.
+      !    Output, real(r2) :: FVEC(N), the functions evaluated at the output X.
       !
-      !    Output, real(r_2) :: FJAC(LDFJAC,N), an N by N array which contains
+      !    Output, real(r2) :: FJAC(LDFJAC,N), an N by N array which contains
       !    the orthogonal matrix Q produced by the QR factorization of the final
       !    approximate jacobian.
       !
       !    Input, integer :: LDFJAC, the leading dimension of  FJAC.
       !    LDFJAC must be at least N.
       !
-      !    Input, real(r_2) :: TOL.  Termination occurs when the algorithm
+      !    Input, real(r2) :: TOL.  Termination occurs when the algorithm
       !    estimates that the relative error between X and the solution is at most
       !    TOL.  TOL should be nonnegative.
       !
@@ -2275,11 +2275,11 @@ MODULE minpack
       integer :: ldfjac
       integer :: n
 
-      real(r_2) :: diag(n)
-      real(r_2) :: factor
+      real(r2) :: diag(n)
+      real(r2) :: factor
       external fcn
-      real(r_2) :: fjac(ldfjac,n)
-      real(r_2) :: fvec(n)
+      real(r2) :: fjac(ldfjac,n)
+      real(r2) :: fvec(n)
       integer :: info
       integer :: lr
       integer :: maxfev
@@ -2287,11 +2287,11 @@ MODULE minpack
       integer :: nfev
       integer :: njev
       integer :: nprint
-      real(r_2) :: qtf(n)
-      real(r_2) :: r((n*(n+1))/2)
-      real(r_2) :: tol
-      real(r_2) :: x(n)
-      real(r_2) :: xtol
+      real(r2) :: qtf(n)
+      real(r2) :: r((n*(n+1))/2)
+      real(r2) :: tol
+      real(r2) :: x(n)
+      real(r2) :: xtol
 
       info = 0
 
@@ -2299,15 +2299,15 @@ MODULE minpack
          return
       else if ( ldfjac < n ) then
          return
-      else if ( tol < 0.0_r_2 ) then
+      else if ( tol < 0.0_r2 ) then
          return
       end if
 
       maxfev = 100 * ( n + 1 )
       xtol = tol
       mode = 2
-      diag(1:n) = 1.0_r_2
-      factor = 100.0_r_2
+      diag(1:n) = 1.0_r2
+      factor = 100.0_r2
       nprint = 0
       lr = ( n * ( n + 1 ) ) / 2
 
@@ -2361,10 +2361,10 @@ MODULE minpack
       !      subroutine fcn ( m, n, x, fvec, fjac, ldfjac, iflag )
       !      integer :: ldfjac
       !      integer :: n
-      !      real(r_2) :: fjac(ldfjac,n)
-      !      real(r_2) :: fvec(m)
+      !      real(r2) :: fjac(ldfjac,n)
+      !      real(r2) :: fvec(m)
       !      integer :: iflag
-      !      real(r_2) :: x(n)
+      !      real(r2) :: x(n)
       !
       !    If IFLAG = 0 on input, then FCN is only being called to allow the user
       !    to print out the current iterate.
@@ -2379,13 +2379,13 @@ MODULE minpack
       !    Input, integer :: N, is the number of variables.  
       !    N must not exceed M.
       !
-      !    Input/output, real(r_2) :: X(N).  On input, X must contain an initial
+      !    Input/output, real(r2) :: X(N).  On input, X must contain an initial
       !    estimate of the solution vector.  On output X contains the final
       !    estimate of the solution vector.
       !
-      !    Output, real(r_2) :: FVEC(M), the functions evaluated at the output X.
+      !    Output, real(r2) :: FVEC(M), the functions evaluated at the output X.
       !
-      !    Output, real(r_2) :: FJAC(LDFJAC,N), an M by N array.  The upper
+      !    Output, real(r2) :: FJAC(LDFJAC,N), an M by N array.  The upper
       !    N by N submatrix of FJAC contains an upper triangular matrix R with
       !    diagonal elements of nonincreasing magnitude such that
       !      P' * ( JAC' * JAC ) * P = R' * R,
@@ -2397,16 +2397,16 @@ MODULE minpack
       !    Input, integer :: LDFJAC, the leading dimension of FJAC.
       !    LDFJAC must be at least M.
       !
-      !    Input, real(r_2) :: FTOL.  Termination occurs when both the actual
+      !    Input, real(r2) :: FTOL.  Termination occurs when both the actual
       !    and predicted relative reductions in the sum of squares are at most FTOL.
       !    Therefore, FTOL measures the relative error desired in the sum of
       !    squares.  FTOL should be nonnegative.
       !
-      !    Input, real(r_2) :: XTOL.  Termination occurs when the relative error
+      !    Input, real(r2) :: XTOL.  Termination occurs when the relative error
       !    between two consecutive iterates is at most XTOL.  XTOL should be
       !    nonnegative.
       !
-      !    Input, real(r_2) :: GTOL.  Termination occurs when the cosine of the
+      !    Input, real(r2) :: GTOL.  Termination occurs when the cosine of the
       !    angle between FVEC and any column of the jacobian is at most GTOL in
       !    absolute value.  Therefore, GTOL measures the orthogonality desired
       !    between the function vector and the columns of the jacobian.  GTOL should
@@ -2415,7 +2415,7 @@ MODULE minpack
       !    Input, integer :: MAXFEV.  Termination occurs when the number of
       !    calls to FCN with IFLAG = 1 is at least MAXFEV by the end of an iteration.
       !
-      !    Input/output, real(r_2) :: DIAG(N).  If MODE = 1, then DIAG is set
+      !    Input/output, real(r2) :: DIAG(N).  If MODE = 1, then DIAG is set
       !    internally.  If MODE = 2, then DIAG must contain positive entries that
       !    serve as multiplicative scale factors for the variables.
       !
@@ -2423,7 +2423,7 @@ MODULE minpack
       !    1, variables will be scaled internally.
       !    2, scaling is specified by the input DIAG vector.
       !
-      !    Input, real(r_2) :: FACTOR, determines the initial step bound.  This
+      !    Input, real(r2) :: FACTOR, determines the initial step bound.  This
       !    bound is set to the product of FACTOR and the euclidean norm of DIAG*X if
       !    nonzero, or else to FACTOR itself.  In most cases, FACTOR should lie
       !    in the interval (0.1, 100) with 100 the recommended value.
@@ -2465,7 +2465,7 @@ MODULE minpack
       !    elements of nonincreasing magnitude.  Column J of P is column
       !    IPVT(J) of the identity matrix.
       !
-      !    Output, real(r_2) :: QTF(N), contains the first N elements of Q'*FVEC.
+      !    Output, real(r2) :: QTF(N), contains the first N elements of Q'*FVEC.
       !
       implicit none
 
@@ -2473,21 +2473,21 @@ MODULE minpack
       integer :: m
       integer :: n
 
-      real(r_2) :: actred
-      real(r_2) :: delta
-      real(r_2) :: diag(n)
-      real(r_2) :: dirder
-      !real(r_2) :: enorm
-      real(r_2) :: epsmch
-      real(r_2) :: factor
+      real(r2) :: actred
+      real(r2) :: delta
+      real(r2) :: diag(n)
+      real(r2) :: dirder
+      !real(r2) :: enorm
+      real(r2) :: epsmch
+      real(r2) :: factor
       external fcn
-      real(r_2) :: fjac(ldfjac,n)
-      real(r_2) :: fnorm
-      real(r_2) :: fnorm1
-      real(r_2) :: ftol
-      real(r_2) :: fvec(m)
-      real(r_2) :: gnorm
-      real(r_2) :: gtol
+      real(r2) :: fjac(ldfjac,n)
+      real(r2) :: fnorm
+      real(r2) :: fnorm1
+      real(r2) :: ftol
+      real(r2) :: fvec(m)
+      real(r2) :: gnorm
+      real(r2) :: gtol
       integer :: iflag
       integer :: info
       integer :: ipvt(n)
@@ -2499,23 +2499,23 @@ MODULE minpack
       integer :: nfev
       integer :: njev
       integer :: nprint
-      real(r_2) :: par
+      real(r2) :: par
       logical pivot
-      real(r_2) :: pnorm
-      real(r_2) :: prered
-      real(r_2) :: qtf(n)
-      real(r_2) :: ratio
-      real(r_2) :: sum2
-      real(r_2) :: temp
-      real(r_2) :: temp1
-      real(r_2) :: temp2
-      real(r_2) :: wa1(n)
-      real(r_2) :: wa2(n)
-      real(r_2) :: wa3(n)
-      real(r_2) :: wa4(m)
-      real(r_2) :: xnorm
-      real(r_2) :: x(n)
-      real(r_2) :: xtol
+      real(r2) :: pnorm
+      real(r2) :: prered
+      real(r2) :: qtf(n)
+      real(r2) :: ratio
+      real(r2) :: sum2
+      real(r2) :: temp
+      real(r2) :: temp1
+      real(r2) :: temp2
+      real(r2) :: wa1(n)
+      real(r2) :: wa2(n)
+      real(r2) :: wa3(n)
+      real(r2) :: wa4(m)
+      real(r2) :: xnorm
+      real(r2) :: x(n)
+      real(r2) :: xtol
 
       epsmch = epsilon ( epsmch )
 
@@ -2535,14 +2535,14 @@ MODULE minpack
       end if
 
       if ( ldfjac < m &
-           .or. ftol < 0.0_r_2 .or. xtol < 0.0_r_2 .or. gtol < 0.0_r_2 &
-           .or. maxfev <= 0 .or. le(factor, 0.0_r_2) ) then
+           .or. ftol < 0.0_r2 .or. xtol < 0.0_r2 .or. gtol < 0.0_r2 &
+           .or. maxfev <= 0 .or. le(factor, 0.0_r2) ) then
          go to 300
       end if
 
       if ( mode == 2 ) then
          do j = 1, n
-            if ( le(diag(j), 0.0_r_2) ) then
+            if ( le(diag(j), 0.0_r2) ) then
                go to 300
             end if
          end do
@@ -2561,7 +2561,7 @@ MODULE minpack
       !
       !  Initialize Levenberg-Marquardt parameter and iteration counter.
       !
-      par = 0.0_r_2
+      par = 0.0_r2
       iter = 1
       !
       !  Beginning of the outer loop.
@@ -2604,8 +2604,8 @@ MODULE minpack
             if ( mode /= 2 ) then
                diag(1:n) = wa2(1:n)
                do j = 1, n
-                  if ( eq(wa2(j), 0.0_r_2) ) then
-                     diag(j) = 1.0_r_2
+                  if ( eq(wa2(j), 0.0_r2) ) then
+                     diag(j) = 1.0_r2
                   end if
                end do
             end if
@@ -2617,7 +2617,7 @@ MODULE minpack
 
             xnorm = enorm ( n, wa3 )
 
-            if ( eq(xnorm, 0.0_r_2) ) then
+            if ( eq(xnorm, 0.0_r2) ) then
                delta = factor
             else
                delta = factor * xnorm
@@ -2631,7 +2631,7 @@ MODULE minpack
 
          do j = 1, n
 
-            if ( ne(fjac(j,j), 0.0_r_2) ) then
+            if ( ne(fjac(j,j), 0.0_r2) ) then
                sum2 = dot_product ( wa4(j:m), fjac(j:m,j) )
                temp = - sum2 / fjac(j,j)
                wa4(j:m) = wa4(j:m) + fjac(j:m,j) * temp
@@ -2644,13 +2644,13 @@ MODULE minpack
          !
          !  Compute the norm of the scaled gradient.
          !
-         gnorm = 0.0_r_2
+         gnorm = 0.0_r2
 
-         if ( ne(fnorm, 0.0_r_2) ) then
+         if ( ne(fnorm, 0.0_r2) ) then
 
             do j = 1, n
                l = ipvt(j)
-               if ( ne(wa2(l), 0.0_r_2) ) then
+               if ( ne(wa2(l), 0.0_r2) ) then
                   sum2 = dot_product ( qtf(1:j), fjac(1:j,j) ) / fnorm
                   gnorm = max ( gnorm, abs ( sum2 / wa2(l) ) )
                end if
@@ -2710,17 +2710,17 @@ MODULE minpack
             !
             !  Compute the scaled actual reduction.
             !
-            if ( 0.1_r_2 * fnorm1 < fnorm ) then
-               actred = 1.0_r_2 - ( fnorm1 / fnorm ) ** 2
+            if ( 0.1_r2 * fnorm1 < fnorm ) then
+               actred = 1.0_r2 - ( fnorm1 / fnorm ) ** 2
             else
-               actred = - 1.0_r_2
+               actred = - 1.0_r2
             end if
             !
             !  Compute the scaled predicted reduction and
             !  the scaled directional derivative.
             !
             do j = 1, n
-               wa3(j) = 0.0_r_2
+               wa3(j) = 0.0_r2
                l = ipvt(j)
                temp = wa1(l)
                wa3(1:j) = wa3(1:j) + fjac(1:j,j) * temp
@@ -2728,41 +2728,41 @@ MODULE minpack
 
             temp1 = enorm ( n, wa3 ) / fnorm
             temp2 = ( sqrt ( par ) * pnorm ) / fnorm
-            prered = temp1 ** 2 + temp2 ** 2 / 0.5_r_2
+            prered = temp1 ** 2 + temp2 ** 2 / 0.5_r2
             dirder = - ( temp1 ** 2 + temp2 ** 2 )
             !
             !  Compute the ratio of the actual to the predicted reduction.
             !
-            if ( ne(prered, 0.0_r_2) ) then
+            if ( ne(prered, 0.0_r2) ) then
                ratio = actred / prered
             else
-               ratio = 0.0_r_2
+               ratio = 0.0_r2
             end if
             !
             !  Update the step bound.
             !
-            if ( le(ratio, 0.25_r_2) ) then
+            if ( le(ratio, 0.25_r2) ) then
 
-               if ( le(0.0_r_2, actred) ) then
-                  temp = 0.5_r_2
+               if ( le(0.0_r2, actred) ) then
+                  temp = 0.5_r2
                end if
 
-               if ( actred < 0.0_r_2 ) then
-                  temp = 0.5_r_2 * dirder / ( dirder + 0.5_r_2 * actred )
+               if ( actred < 0.0_r2 ) then
+                  temp = 0.5_r2 * dirder / ( dirder + 0.5_r2 * actred )
                end if
 
-               if ( ge(0.1_r_2 * fnorm1, fnorm) .or. temp < 0.1_r_2 ) then
-                  temp = 0.1_r_2
+               if ( ge(0.1_r2 * fnorm1, fnorm) .or. temp < 0.1_r2 ) then
+                  temp = 0.1_r2
                end if
 
-               delta = temp * min ( delta, pnorm / 0.1_r_2 )
+               delta = temp * min ( delta, pnorm / 0.1_r2 )
                par = par / temp
 
             else
 
-               if ( eq(par, 0.0_r_2) .or. ge(ratio, 0.75_r_2) ) then
-                  delta = 2.0_r_2 * pnorm
-                  par = 0.5_r_2 * par
+               if ( eq(par, 0.0_r2) .or. ge(ratio, 0.75_r2) ) then
+                  delta = 2.0_r2 * pnorm
+                  par = 0.5_r2 * par
                end if
 
             end if
@@ -2771,7 +2771,7 @@ MODULE minpack
             !
             !  Update X, FVEC, and their norms.
             !
-            if ( le(0.0001_r_2, ratio) ) then
+            if ( le(0.0001_r2, ratio) ) then
                x(1:n) = wa2(1:n)
                wa2(1:n) = diag(1:n) * x(1:n)
                fvec(1:m) = wa4(1:m)
@@ -2784,7 +2784,7 @@ MODULE minpack
             !
             if ( le(abs(actred), ftol) .and. &
                  le(prered, ftol) .and. &
-                 le(0.5_r_2 * ratio, 1.0_r_2) ) then
+                 le(0.5_r2 * ratio, 1.0_r2) ) then
                info = 1
             end if
 
@@ -2793,7 +2793,7 @@ MODULE minpack
             end if
 
             if ( le(abs ( actred), ftol) .and. le(prered, ftol) &
-                 .and. le(0.5_r_2 * ratio, 1.0_r_2) .and. info == 2 ) then
+                 .and. le(0.5_r2 * ratio, 1.0_r2) .and. info == 2 ) then
                info = 3
             end if
 
@@ -2808,7 +2808,7 @@ MODULE minpack
             end if
 
             if ( le(abs ( actred ), epsmch) .and. le(prered, epsmch) &
-                 .and. le(0.5_r_2 * ratio, 1.0_r_2) ) then
+                 .and. le(0.5_r2 * ratio, 1.0_r2) ) then
                info = 6
             end if
 
@@ -2826,7 +2826,7 @@ MODULE minpack
             !
             !  End of the inner loop. repeat if iteration unsuccessful.
             !
-            if ( le(0.0001_r_2, ratio) ) then
+            if ( le(0.0001_r2, ratio) ) then
                exit
             end if
 
@@ -2893,10 +2893,10 @@ MODULE minpack
       !      subroutine fcn ( m, n, x, fvec, fjac, ldfjac, iflag )
       !      integer :: ldfjac
       !      integer :: n
-      !      real(r_2) :: fjac(ldfjac,n)
-      !      real(r_2) :: fvec(m)
+      !      real(r2) :: fjac(ldfjac,n)
+      !      real(r2) :: fvec(m)
       !      integer :: iflag
-      !      real(r_2) :: x(n)
+      !      real(r2) :: x(n)
       !
       !    If IFLAG = 0 on input, then FCN is only being called to allow the user
       !    to print out the current iterate.
@@ -2911,13 +2911,13 @@ MODULE minpack
       !    Input, integer :: N, is the number of variables.  
       !    N must not exceed M.
       !
-      !    Input/output, real(r_2) :: X(N).  On input, X must contain an initial
+      !    Input/output, real(r2) :: X(N).  On input, X must contain an initial
       !    estimate of the solution vector.  On output X contains the final
       !    estimate of the solution vector.
       !
-      !    Output, real(r_2) :: FVEC(M), the functions evaluated at the output X.
+      !    Output, real(r2) :: FVEC(M), the functions evaluated at the output X.
       !
-      !    Output, real(r_2) :: FJAC(LDFJAC,N), an M by N array.  The upper
+      !    Output, real(r2) :: FJAC(LDFJAC,N), an M by N array.  The upper
       !    N by N submatrix contains an upper triangular matrix R with
       !    diagonal elements of nonincreasing magnitude such that
       !      P' * ( JAC' * JAC ) * P = R' * R,
@@ -2929,7 +2929,7 @@ MODULE minpack
       !    Input, integer :: LDFJAC, is the leading dimension of FJAC,
       !    which must be no less than M.
       !
-      !    Input, real(r_2) :: TOL.  Termination occurs when the algorithm
+      !    Input, real(r2) :: TOL.  Termination occurs when the algorithm
       !    estimates either that the relative error in the sum of squares is at
       !    most TOL or that the relative error between X and the solution is at
       !    most TOL.
@@ -2956,13 +2956,13 @@ MODULE minpack
       integer :: m
       integer :: n
 
-      real(r_2) :: diag(n)
-      real(r_2) :: factor
+      real(r2) :: diag(n)
+      real(r2) :: factor
       external fcn
-      real(r_2) :: fjac(ldfjac,n)
-      real(r_2) :: ftol
-      real(r_2) :: fvec(m)
-      real(r_2) :: gtol
+      real(r2) :: fjac(ldfjac,n)
+      real(r2) :: ftol
+      real(r2) :: fvec(m)
+      real(r2) :: gtol
       integer :: info
       integer :: ipvt(n)
       integer :: maxfev
@@ -2970,10 +2970,10 @@ MODULE minpack
       integer :: nfev
       integer :: njev
       integer :: nprint
-      real(r_2) :: qtf(n)
-      real(r_2) :: tol
-      real(r_2) :: x(n)
-      real(r_2) :: xtol
+      real(r2) :: qtf(n)
+      real(r2) :: tol
+      real(r2) :: x(n)
+      real(r2) :: xtol
 
       info = 0
 
@@ -2983,15 +2983,15 @@ MODULE minpack
          return
       else if ( ldfjac < m ) then
          return
-      else if ( tol < 0.0_r_2 ) then
+      else if ( tol < 0.0_r2 ) then
          return
       end if
 
-      factor = 100.0_r_2
+      factor = 100.0_r2
       maxfev = 100 * ( n + 1 )
       ftol = tol
       xtol = tol
-      gtol = 0.0_r_2
+      gtol = 0.0_r2
       mode = 1
       nprint = 0
 
@@ -3046,9 +3046,9 @@ MODULE minpack
       !      subroutine fcn ( m, n, x, fvec, iflag )
       !      integer :: m
       !      integer :: n
-      !      real(r_2) :: fvec(m)
+      !      real(r2) :: fvec(m)
       !      integer :: iflag
-      !      real(r_2) :: x(n)
+      !      real(r2) :: x(n)
       !    If IFLAG = 0 on input, then FCN is only being called to allow the user
       !    to print out the current iterate.
       !    If IFLAG = 1 on input, FCN should calculate the functions at X and
@@ -3060,23 +3060,23 @@ MODULE minpack
       !    Input, integer :: N, the number of variables.  
       !    N must not exceed M.
       !
-      !    Input/output, real(r_2) :: X(N).  On input, X must contain an initial
+      !    Input/output, real(r2) :: X(N).  On input, X must contain an initial
       !    estimate of the solution vector.  On output X contains the final
       !    estimate of the solution vector.
       !
-      !    Output, real(r_2) :: FVEC(M), the functions evaluated at the output X.
+      !    Output, real(r2) :: FVEC(M), the functions evaluated at the output X.
       !
-      !    Input, real(r_2) :: FTOL.  Termination occurs when both the actual
+      !    Input, real(r2) :: FTOL.  Termination occurs when both the actual
       !    and predicted relative reductions in the sum of squares are at most FTOL.
       !    Therefore, FTOL measures the relative error desired in the sum of
       !    squares.  FTOL should be nonnegative.
       !
-      !    Input, real(r_2) :: XTOL.  Termination occurs when the relative error
+      !    Input, real(r2) :: XTOL.  Termination occurs when the relative error
       !    between two consecutive iterates is at most XTOL.  Therefore, XTOL
       !    measures the relative error desired in the approximate solution.  XTOL
       !    should be nonnegative.
       !
-      !    Input, real(r_2) :: GTOL. termination occurs when the cosine of the
+      !    Input, real(r2) :: GTOL. termination occurs when the cosine of the
       !    angle between FVEC and any column of the jacobian is at most GTOL in
       !    absolute value.  Therefore, GTOL measures the orthogonality desired
       !    between the function vector and the columns of the jacobian.  GTOL should
@@ -3085,14 +3085,14 @@ MODULE minpack
       !    Input, integer :: MAXFEV.  Termination occurs when the number of
       !    calls to FCN is at least MAXFEV by the end of an iteration.
       !
-      !    Input, real(r_2) :: EPSFCN, is used in determining a suitable step 
+      !    Input, real(r2) :: EPSFCN, is used in determining a suitable step 
       !    length for the forward-difference approximation.  This approximation 
       !    assumes that the relative errors in the functions are of the order of 
       !    EPSFCN.  If EPSFCN is less than the machine precision, it is assumed that
       !    the relative errors in the functions are of the order of the machine
       !    precision.
       !
-      !    Input/output, real(r_2) :: DIAG(N).  If MODE = 1, then DIAG is set
+      !    Input/output, real(r2) :: DIAG(N).  If MODE = 1, then DIAG is set
       !    internally.  If MODE = 2, then DIAG must contain positive entries that
       !    serve as multiplicative scale factors for the variables.
       !
@@ -3100,7 +3100,7 @@ MODULE minpack
       !    1, variables will be scaled internally.
       !    2, scaling is specified by the input DIAG vector.
       !
-      !    Input, real(r_2) :: FACTOR, determines the initial step bound.  
+      !    Input, real(r2) :: FACTOR, determines the initial step bound.  
       !    This bound is set to the product of FACTOR and the euclidean norm of
       !    DIAG*X if nonzero, or else to FACTOR itself.  In most cases, FACTOR should 
       !    lie in the interval (0.1, 100) with 100 the recommended value.
@@ -3132,7 +3132,7 @@ MODULE minpack
       !
       !    Output, integer :: NFEV, the number of calls to FCN.
       !
-      !    Output, real(r_2) :: FJAC(LDFJAC,N), an M by N array.  The upper
+      !    Output, real(r2) :: FJAC(LDFJAC,N), an M by N array.  The upper
       !    N by N submatrix of FJAC contains an upper triangular matrix R with
       !    diagonal elements of nonincreasing magnitude such that
       !
@@ -3152,7 +3152,7 @@ MODULE minpack
       !    elements of nonincreasing magnitude.  Column J of P is column IPVT(J)
       !    of the identity matrix.
       !
-      !    Output, real(r_2) :: QTF(N), the first N elements of Q'*FVEC.
+      !    Output, real(r2) :: QTF(N), the first N elements of Q'*FVEC.
       !
       implicit none
 
@@ -3160,22 +3160,22 @@ MODULE minpack
       integer :: m
       integer :: n
 
-      real(r_2) :: actred
-      real(r_2) :: delta
-      real(r_2) :: diag(n)
-      real(r_2) :: dirder
-      !real(r_2) :: enorm
-      real(r_2) :: epsfcn
-      real(r_2) :: epsmch
-      real(r_2) :: factor
+      real(r2) :: actred
+      real(r2) :: delta
+      real(r2) :: diag(n)
+      real(r2) :: dirder
+      !real(r2) :: enorm
+      real(r2) :: epsfcn
+      real(r2) :: epsmch
+      real(r2) :: factor
       external fcn
-      real(r_2) :: fjac(ldfjac,n)
-      real(r_2) :: fnorm
-      real(r_2) :: fnorm1
-      real(r_2) :: ftol
-      real(r_2) :: fvec(m)
-      real(r_2) :: gnorm
-      real(r_2) :: gtol
+      real(r2) :: fjac(ldfjac,n)
+      real(r2) :: fnorm
+      real(r2) :: fnorm1
+      real(r2) :: ftol
+      real(r2) :: fvec(m)
+      real(r2) :: gnorm
+      real(r2) :: gtol
       integer :: i
       integer :: iflag
       integer :: iter
@@ -3187,28 +3187,28 @@ MODULE minpack
       integer :: mode
       integer :: nfev
       integer :: nprint
-      real(r_2) :: par
+      real(r2) :: par
       logical pivot
-      real(r_2) :: pnorm
-      real(r_2) :: prered
-      real(r_2) :: qtf(n)
-      real(r_2) :: ratio
-      real(r_2) :: sum2
-      real(r_2) :: temp
-      real(r_2) :: temp1
-      real(r_2) :: temp2
-      real(r_2) :: wa1(n)
-      real(r_2) :: wa2(n)
-      real(r_2) :: wa3(n)
-      real(r_2) :: wa4(m)
-      real(r_2) :: x(n)
-      real(r_2) :: xnorm
-      real(r_2) :: xtol
-      real(r_2) :: An(m)
-      real(r_2) :: Ci(m)
-      real(r_2) :: Rd
-      real(r_2) :: Km
-      real(r_2) :: gammastar
+      real(r2) :: pnorm
+      real(r2) :: prered
+      real(r2) :: qtf(n)
+      real(r2) :: ratio
+      real(r2) :: sum2
+      real(r2) :: temp
+      real(r2) :: temp1
+      real(r2) :: temp2
+      real(r2) :: wa1(n)
+      real(r2) :: wa2(n)
+      real(r2) :: wa3(n)
+      real(r2) :: wa4(m)
+      real(r2) :: x(n)
+      real(r2) :: xnorm
+      real(r2) :: xtol
+      real(r2) :: An(m)
+      real(r2) :: Ci(m)
+      real(r2) :: Rd
+      real(r2) :: Km
+      real(r2) :: gammastar
 
       epsmch = epsilon ( epsmch )
 
@@ -3222,21 +3222,21 @@ MODULE minpack
          go to 300
       else if ( ldfjac < m ) then
          go to 300
-      else if ( ftol < 0.0_r_2 ) then
+      else if ( ftol < 0.0_r2 ) then
          go to 300
-      else if ( xtol < 0.0_r_2 ) then
+      else if ( xtol < 0.0_r2 ) then
          go to 300
-      else if ( gtol < 0.0_r_2 ) then
+      else if ( gtol < 0.0_r2 ) then
          go to 300
       else if ( maxfev <= 0 ) then
          go to 300
-      else if ( le(factor, 0.0_r_2) ) then
+      else if ( le(factor, 0.0_r2) ) then
          go to 300
       end if
 
       if ( mode == 2 ) then
          do j = 1, n
-            if ( le(diag(j), 0.0_r_2) ) then
+            if ( le(diag(j), 0.0_r2) ) then
                go to 300
             end if
          end do
@@ -3256,7 +3256,7 @@ MODULE minpack
       !
       !  Initialize Levenberg-Marquardt parameter and iteration counter.
       !
-      par = 0.0_r_2
+      par = 0.0_r2
       iter = 1
       !
       !  Beginning of the outer loop.
@@ -3299,8 +3299,8 @@ MODULE minpack
          if ( mode /= 2 ) then
             diag(1:n) = wa2(1:n)
             do j = 1, n
-               if ( eq(wa2(j), 0.0_r_2) ) then
-                  diag(j) = 1.0_r_2
+               if ( eq(wa2(j), 0.0_r2) ) then
+                  diag(j) = 1.0_r2
                end if
             end do
          end if
@@ -3311,7 +3311,7 @@ MODULE minpack
          wa3(1:n) = diag(1:n) * x(1:n)
          xnorm = enorm ( n, wa3 )
          delta = factor * xnorm
-         if ( eq(delta, 0.0_r_2) ) then
+         if ( eq(delta, 0.0_r2) ) then
             delta = factor
          end if
       end if
@@ -3322,7 +3322,7 @@ MODULE minpack
 
       do j = 1, n
 
-         if ( ne(fjac(j,j), 0.0_r_2) ) then
+         if ( ne(fjac(j,j), 0.0_r2) ) then
             sum2 = dot_product ( wa4(j:m), fjac(j:m,j) )
             temp = - sum2 / fjac(j,j)
             wa4(j:m) = wa4(j:m) + fjac(j:m,j) * temp
@@ -3335,16 +3335,16 @@ MODULE minpack
       !
       !  Compute the norm of the scaled gradient.
       !
-      gnorm = 0.0_r_2
+      gnorm = 0.0_r2
 
-      if ( ne(fnorm, 0.0_r_2) ) then
+      if ( ne(fnorm, 0.0_r2) ) then
 
          do j = 1, n
 
             l = ipvt(j)
 
-            if ( ne(wa2(l), 0.0_r_2) ) then
-               sum2 = 0.0_r_2
+            if ( ne(wa2(l), 0.0_r2) ) then
+               sum2 = 0.0_r2
                do i = 1, j
                   sum2 = sum2 + fjac(i,j) * ( qtf(i) / fnorm )
                end do
@@ -3405,16 +3405,16 @@ MODULE minpack
       !
       !  Compute the scaled actual reduction.
       !
-      if ( 0.1_r_2 * fnorm1 < fnorm ) then
-         actred = 1.0_r_2 - ( fnorm1 / fnorm ) ** 2
+      if ( 0.1_r2 * fnorm1 < fnorm ) then
+         actred = 1.0_r2 - ( fnorm1 / fnorm ) ** 2
       else
-         actred = -1.0_r_2
+         actred = -1.0_r2
       end if
       !
       !  Compute the scaled predicted reduction and the scaled directional derivative.
       !
       do j = 1, n
-         wa3(j) = 0.0_r_2
+         wa3(j) = 0.0_r2
          l = ipvt(j)
          temp = wa1(l)
          wa3(1:j) = wa3(1:j) + fjac(1:j,j) * temp
@@ -3422,40 +3422,40 @@ MODULE minpack
 
       temp1 = enorm ( n, wa3 ) / fnorm
       temp2 = ( sqrt ( par ) * pnorm ) / fnorm
-      prered = temp1 ** 2 + temp2 ** 2 / 0.5_r_2
+      prered = temp1 ** 2 + temp2 ** 2 / 0.5_r2
       dirder = - ( temp1 ** 2 + temp2 ** 2 )
       !
       !  Compute the ratio of the actual to the predicted reduction.
       !
-      ratio = 0.0_r_2
-      if ( ne(prered, 0.0_r_2) ) then
+      ratio = 0.0_r2
+      if ( ne(prered, 0.0_r2) ) then
          ratio = actred / prered
       end if
       !
       !  Update the step bound.
       !
-      if ( le(ratio, 0.25_r_2) ) then
+      if ( le(ratio, 0.25_r2) ) then
 
-         if ( ge(actred, 0.0_r_2) ) then
-            temp = 0.5_r_2
+         if ( ge(actred, 0.0_r2) ) then
+            temp = 0.5_r2
          endif
 
-         if ( actred < 0.0_r_2 ) then
-            temp = 0.5_r_2 * dirder / ( dirder + 0.5_r_2 * actred )
+         if ( actred < 0.0_r2 ) then
+            temp = 0.5_r2 * dirder / ( dirder + 0.5_r2 * actred )
          end if
 
-         if ( ge(0.1_r_2 * fnorm1, fnorm) .or. temp < 0.1_r_2 ) then
-            temp = 0.1_r_2
+         if ( ge(0.1_r2 * fnorm1, fnorm) .or. temp < 0.1_r2 ) then
+            temp = 0.1_r2
          end if
 
-         delta = temp * min ( delta, pnorm / 0.1_r_2  )
+         delta = temp * min ( delta, pnorm / 0.1_r2  )
          par = par / temp
 
       else
 
-         if ( eq(par, 0.0_r_2) .or. ge(ratio, 0.75_r_2) ) then
-            delta = 2.0_r_2 * pnorm
-            par = 0.5_r_2 * par
+         if ( eq(par, 0.0_r2) .or. ge(ratio, 0.75_r2) ) then
+            delta = 2.0_r2 * pnorm
+            par = 0.5_r2 * par
          end if
 
       end if
@@ -3466,7 +3466,7 @@ MODULE minpack
       !
       !  Successful iteration. update X, FVEC, and their norms.
       !
-      if ( le(0.0001_r_2, ratio) ) then
+      if ( le(0.0001_r2, ratio) ) then
          x(1:n) = wa2(1:n)
          wa2(1:n) = diag(1:n) * x(1:n)
          fvec(1:m) = wa4(1:m)
@@ -3478,7 +3478,7 @@ MODULE minpack
       !  Tests for convergence.
       !
       if ( le(abs ( actred), ftol) .and. le(prered, ftol) &
-           .and. le(0.5_r_2 * ratio, 1.0_r_2) ) then
+           .and. le(0.5_r2 * ratio, 1.0_r2) ) then
          info = 1
       end if
 
@@ -3487,7 +3487,7 @@ MODULE minpack
       end if
 
       if ( le(abs(actred), ftol) .and. le(prered, ftol) &
-           .and. le(0.5_r_2 * ratio, 1.0_r_2) .and. info == 2 ) info = 3
+           .and. le(0.5_r2 * ratio, 1.0_r2) .and. info == 2 ) info = 3
 
       if ( info /= 0 ) then
          go to 300
@@ -3500,7 +3500,7 @@ MODULE minpack
       end if
 
       if ( le(abs(actred), epsmch) .and. le(prered, epsmch) &
-           .and. le(0.5_r_2 * ratio, 1.0_r_2) ) then
+           .and. le(0.5_r2 * ratio, 1.0_r2) ) then
          info = 6
       end if
 
@@ -3518,7 +3518,7 @@ MODULE minpack
       !
       !  End of the inner loop.  Repeat if iteration unsuccessful.
       !
-      if ( ratio < 0.0001_r_2 ) then
+      if ( ratio < 0.0001_r2 ) then
          go to 200
       end if
       !
@@ -3582,9 +3582,9 @@ MODULE minpack
       !    calculates the functions.  The routine should have the form:
       !      subroutine fcn ( m, n, x, fvec, iflag )
       !      integer :: n
-      !      real(r_2) :: fvec(m)
+      !      real(r2) :: fvec(m)
       !      integer :: iflag
-      !      real(r_2) :: x(n)
+      !      real(r2) :: x(n)
       !
       !    If IFLAG = 0 on input, then FCN is only being called to allow the user
       !    to print out the current iterate.
@@ -3597,13 +3597,13 @@ MODULE minpack
       !    Input, integer :: N, the number of variables.  
       !    N must not exceed M.
       !
-      !    Input/output, real(r_2) :: X(N).  On input, X must contain an initial
+      !    Input/output, real(r2) :: X(N).  On input, X must contain an initial
       !    estimate of the solution vector.  On output X contains the final
       !    estimate of the solution vector.
       !
-      !    Output, real(r_2) :: FVEC(M), the functions evaluated at the output X.
+      !    Output, real(r2) :: FVEC(M), the functions evaluated at the output X.
       !
-      !    Input, real(r_2) :: TOL.  Termination occurs when the algorithm
+      !    Input, real(r2) :: TOL.  Termination occurs when the algorithm
       !    estimates either that the relative error in the sum of squares is at
       !    most TOL or that the relative error between X and the solution is at
       !    most TOL.  TOL should be nonnegative.
@@ -3629,14 +3629,14 @@ MODULE minpack
       integer :: m
       integer :: n
 
-      real(r_2) :: diag(n)
-      real(r_2) :: epsfcn
-      real(r_2) :: factor
+      real(r2) :: diag(n)
+      real(r2) :: epsfcn
+      real(r2) :: factor
       external fcn
-      real(r_2) :: fjac(m,n)
-      real(r_2) :: ftol
-      real(r_2) :: fvec(m)
-      real(r_2) :: gtol
+      real(r2) :: fjac(m,n)
+      real(r2) :: ftol
+      real(r2) :: fvec(m)
+      real(r2) :: gtol
       integer :: info
       integer :: ipvt(n)
       integer :: ldfjac
@@ -3644,15 +3644,15 @@ MODULE minpack
       integer :: mode
       integer :: nfev
       integer :: nprint
-      real(r_2) :: qtf(n)
-      real(r_2) :: tol
-      real(r_2) :: x(n)
-      real(r_2) :: xtol
-      real(r_2) :: An(m)
-      real(r_2) :: Ci(m)
-      real(r_2) :: Rd
-      real(r_2) :: Km
-      real(r_2) :: gammastar
+      real(r2) :: qtf(n)
+      real(r2) :: tol
+      real(r2) :: x(n)
+      real(r2) :: xtol
+      real(r2) :: An(m)
+      real(r2) :: Ci(m)
+      real(r2) :: Rd
+      real(r2) :: Km
+      real(r2) :: gammastar
 
       info = 0
 
@@ -3660,16 +3660,16 @@ MODULE minpack
          return
       else if ( m < n ) then
          return
-      else if ( tol < 0.0_r_2 ) then
+      else if ( tol < 0.0_r2 ) then
          return
       end if
 
-      factor = 100.0_r_2
+      factor = 100.0_r2
       maxfev = 200 * ( n + 1 )
       ftol = tol
       xtol = tol
-      gtol = 0.0_r_2
-      epsfcn = 0.0_r_2
+      gtol = 0.0_r2
+      epsfcn = 0.0_r2
       mode = 1
       nprint = 0
       ldfjac = m
@@ -3753,7 +3753,7 @@ MODULE minpack
       !
       !    Input, integer :: N, the order of R.
       !
-      !    Input/output, real(r_2) :: R(LDR,N),the N by N matrix.  The full
+      !    Input/output, real(r2) :: R(LDR,N),the N by N matrix.  The full
       !    upper triangle must contain the full upper triangle of the matrix R.
       !    On output the full upper triangle is unaltered, and the strict lower
       !    triangle contains the strict upper triangle (transposed) of the upper
@@ -3766,21 +3766,21 @@ MODULE minpack
       !    such that A*P = Q*R.  Column J of P is column IPVT(J) of the 
       !    identity matrix.
       !
-      !    Input, real(r_2) :: DIAG(N), the diagonal elements of the matrix D.
+      !    Input, real(r2) :: DIAG(N), the diagonal elements of the matrix D.
       !
-      !    Input, real(r_2) :: QTB(N), the first N elements of the vector Q'*B.
+      !    Input, real(r2) :: QTB(N), the first N elements of the vector Q'*B.
       !
-      !    Input, real(r_2) :: DELTA, an upper bound on the euclidean norm
+      !    Input, real(r2) :: DELTA, an upper bound on the euclidean norm
       !    of D*X.  DELTA should be positive.
       !
-      !    Input/output, real(r_2) :: PAR.  On input an initial estimate of the
+      !    Input/output, real(r2) :: PAR.  On input an initial estimate of the
       !    Levenberg-Marquardt parameter.  On output the final estimate.
       !    PAR should be nonnegative.
       !
-      !    Output, real(r_2) :: X(N), the least squares solution of the system
+      !    Output, real(r2) :: X(N), the least squares solution of the system
       !    A*X = B, sqrt(PAR)*D*X = 0, for the output value of PAR.
       !
-      !    Output, real(r_2) :: SDIAG(N), the diagonal elements of the upper
+      !    Output, real(r2) :: SDIAG(N), the diagonal elements of the upper
       !    triangular matrix S.
       !
       implicit none
@@ -3788,31 +3788,31 @@ MODULE minpack
       integer :: ldr
       integer :: n
 
-      real(r_2) :: delta
-      real(r_2) :: diag(n)
-      real(r_2) :: dwarf
-      real(r_2) :: dxnorm
-      !real(r_2) :: enorm
-      real(r_2) :: gnorm
-      real(r_2) :: fp
+      real(r2) :: delta
+      real(r2) :: diag(n)
+      real(r2) :: dwarf
+      real(r2) :: dxnorm
+      !real(r2) :: enorm
+      real(r2) :: gnorm
+      real(r2) :: fp
       integer :: ipvt(n)
       integer :: iter
       integer :: j
       integer :: k
       integer :: l
       integer :: nsing
-      real(r_2) :: par
-      real(r_2) :: parc
-      real(r_2) :: parl
-      real(r_2) :: paru
-      real(r_2) :: qtb(n)
-      real(r_2) :: r(ldr,n)
-      real(r_2) :: sdiag(n)
-      real(r_2) :: sum2
-      real(r_2) :: temp
-      real(r_2) :: wa1(n)
-      real(r_2) :: wa2(n)
-      real(r_2) :: x(n)
+      real(r2) :: par
+      real(r2) :: parc
+      real(r2) :: parl
+      real(r2) :: paru
+      real(r2) :: qtb(n)
+      real(r2) :: r(ldr,n)
+      real(r2) :: sdiag(n)
+      real(r2) :: sum2
+      real(r2) :: temp
+      real(r2) :: wa1(n)
+      real(r2) :: wa2(n)
+      real(r2) :: x(n)
       !
       !  DWARF is the smallest positive magnitude.
       !
@@ -3826,11 +3826,11 @@ MODULE minpack
 
       do j = 1, n
          wa1(j) = qtb(j)
-         if ( eq(r(j,j), 0.0_r_2) .and. nsing == n ) then
+         if ( eq(r(j,j), 0.0_r2) .and. nsing == n ) then
             nsing = j - 1
          end if
          if ( nsing < n ) then
-            wa1(j) = 0.0_r_2
+            wa1(j) = 0.0_r2
          end if
       end do
 
@@ -3855,9 +3855,9 @@ MODULE minpack
       dxnorm = enorm ( n, wa2 )
       fp = dxnorm - delta
 
-      if ( le(fp, 0.1_r_2 * delta) ) then
+      if ( le(fp, 0.1_r2 * delta) ) then
          if ( iter == 0 ) then
-            par = 0.0_r_2
+            par = 0.0_r2
          end if
          return
       end if
@@ -3868,7 +3868,7 @@ MODULE minpack
       !
       !  Otherwise set this bound to zero.
       !
-      parl = 0.0_r_2
+      parl = 0.0_r2
 
       if ( n <= nsing ) then
 
@@ -3898,8 +3898,8 @@ MODULE minpack
       gnorm = enorm ( n, wa1 )
       paru = gnorm / delta
 
-      if ( eq(paru, 0.0_r_2) ) then
-         paru = dwarf / min ( delta, 0.1_r_2 )
+      if ( eq(paru, 0.0_r2) ) then
+         paru = dwarf / min ( delta, 0.1_r2 )
       end if
       !
       !  If the input PAR lies outside of the interval (PARL, PARU),
@@ -3907,7 +3907,7 @@ MODULE minpack
       !
       par = max ( par, parl )
       par = min ( par, paru )
-      if ( eq(par, 0.0_r_2) ) then
+      if ( eq(par, 0.0_r2) ) then
          par = gnorm / dxnorm
       end if
       !
@@ -3919,8 +3919,8 @@ MODULE minpack
          !
          !  Evaluate the function at the current value of PAR.
          !
-         if ( eq(par, 0.0_r_2) ) then
-            par = max ( dwarf, 0.001_r_2 * paru )
+         if ( eq(par, 0.0_r2) ) then
+            par = max ( dwarf, 0.001_r2 * paru )
          end if
 
          wa1(1:n) = sqrt ( par ) * diag(1:n)
@@ -3934,14 +3934,14 @@ MODULE minpack
          !
          !  If the function is small enough, accept the current value of PAR.
          !
-         if ( le(abs(fp), 0.1_r_2 * delta) ) then
+         if ( le(abs(fp), 0.1_r2 * delta) ) then
             exit
          end if
          !
          !  Test for the exceptional cases where PARL
          !  is zero or the number of iterations has reached 10.
          !
-         if ( eq(parl, 0.0_r_2) .and. le(fp, temp) .and. temp < 0.0_r_2 ) then
+         if ( eq(parl, 0.0_r2) .and. le(fp, temp) .and. temp < 0.0_r2 ) then
             exit
          else if ( iter == 10 ) then
             exit
@@ -3965,9 +3965,9 @@ MODULE minpack
          !
          !  Depending on the sign of the function, update PARL or PARU.
          !
-         if ( 0.0_r_2 < fp ) then
+         if ( 0.0_r2 < fp ) then
             parl = max ( parl, par )
-         else if ( fp < 0.0_r_2 ) then
+         else if ( fp < 0.0_r2 ) then
             paru = min ( paru, par )
          end if
          !
@@ -3982,7 +3982,7 @@ MODULE minpack
       !  Termination.
       !
       if ( iter == 0 ) then
-         par = 0.0_r_2
+         par = 0.0_r2
       end if
 
       return
@@ -4031,10 +4031,10 @@ MODULE minpack
       !      subroutine fcn ( m, n, x, fvec, fjrow, iflag )
       !      integer :: m
       !      integer :: n
-      !      real(r_2) :: fjrow(n)
-      !      real(r_2) :: fvec(m)
+      !      real(r2) :: fjrow(n)
+      !      real(r2) :: fvec(m)
       !      integer :: iflag
-      !      real(r_2) :: x(n)
+      !      real(r2) :: x(n)
       !    If IFLAG = 0 on input, then FCN is only being called to allow the user
       !    to print out the current iterate.
       !    If IFLAG = 1 on input, FCN should calculate the functions at X and
@@ -4048,13 +4048,13 @@ MODULE minpack
       !    Input, integer :: N, the number of variables.  
       !    N must not exceed M.
       !
-      !    Input/output, real(r_2) :: X(N).  On input, X must contain an initial
+      !    Input/output, real(r2) :: X(N).  On input, X must contain an initial
       !    estimate of the solution vector.  On output X contains the final
       !    estimate of the solution vector.
       !
-      !    Output, real(r_2) :: FVEC(M), the functions evaluated at the output X.
+      !    Output, real(r2) :: FVEC(M), the functions evaluated at the output X.
       !
-      !    Output, real(r_2) :: FJAC(LDFJAC,N), an N by N array.  The upper
+      !    Output, real(r2) :: FJAC(LDFJAC,N), an N by N array.  The upper
       !    triangle of FJAC contains an upper triangular matrix R such that
       !
       !      P' * ( JAC' * JAC ) * P = R' * R,
@@ -4067,16 +4067,16 @@ MODULE minpack
       !    Input, integer :: LDFJAC, the leading dimension of FJAC.
       !    LDFJAC must be at least N.
       !
-      !    Input, real(r_2) :: FTOL.  Termination occurs when both the actual and
+      !    Input, real(r2) :: FTOL.  Termination occurs when both the actual and
       !    predicted relative reductions in the sum of squares are at most FTOL.
       !    Therefore, FTOL measures the relative error desired in the sum of
       !    squares.  FTOL should be nonnegative.
       !
-      !    Input, real(r_2) :: XTOL.  Termination occurs when the relative error 
+      !    Input, real(r2) :: XTOL.  Termination occurs when the relative error 
       !    between two consecutive iterates is at most XTOL.  XTOL should be 
       !    nonnegative.
       !
-      !    Input, real(r_2) :: GTOL. termination occurs when the cosine of the 
+      !    Input, real(r2) :: GTOL. termination occurs when the cosine of the 
       !    angle between FVEC and any column of the jacobian is at most GTOL in 
       !    absolute value.  Therefore, GTOL measures the orthogonality desired 
       !    between the function vector and the columns of the jacobian.  GTOL should
@@ -4086,7 +4086,7 @@ MODULE minpack
       !    of calls to FCN with IFLAG = 1 is at least MAXFEV by the end of 
       !    an iteration.
       !
-      !    Input/output, real(r_2) :: DIAG(N).  If MODE = 1, then DIAG is set 
+      !    Input/output, real(r2) :: DIAG(N).  If MODE = 1, then DIAG is set 
       !    internally.  If MODE = 2, then DIAG must contain positive entries that 
       !    serve as multiplicative scale factors for the variables.
       !
@@ -4094,7 +4094,7 @@ MODULE minpack
       !    1, variables will be scaled internally.
       !    2, scaling is specified by the input DIAG vector.
       !
-      !    Input, real(r_2) :: FACTOR, determines the initial step bound.  This 
+      !    Input, real(r2) :: FACTOR, determines the initial step bound.  This 
       !    bound is set to the product of FACTOR and the euclidean norm of DIAG*X if
       !    nonzero, or else to FACTOR itself.  In most cases, FACTOR should lie
       !    in the interval (0.1, 100) with 100 the recommended value.
@@ -4135,7 +4135,7 @@ MODULE minpack
       !    orthogonal (not stored), and R is upper triangular.
       !    Column J of P is column IPVT(J) of the identity matrix.
       !
-      !    Output, real(r_2) :: QTF(N), contains the first N elements of Q'*FVEC.
+      !    Output, real(r2) :: QTF(N), contains the first N elements of Q'*FVEC.
       !
       implicit none
 
@@ -4143,21 +4143,21 @@ MODULE minpack
       integer :: m
       integer :: n
 
-      real(r_2) :: actred
-      real(r_2) :: delta
-      real(r_2) :: diag(n)
-      real(r_2) :: dirder
-      !real(r_2) :: enorm
-      real(r_2) :: epsmch
-      real(r_2) :: factor
+      real(r2) :: actred
+      real(r2) :: delta
+      real(r2) :: diag(n)
+      real(r2) :: dirder
+      !real(r2) :: enorm
+      real(r2) :: epsmch
+      real(r2) :: factor
       external fcn
-      real(r_2) :: fjac(ldfjac,n)
-      real(r_2) :: fnorm
-      real(r_2) :: fnorm1
-      real(r_2) :: ftol
-      real(r_2) :: fvec(m)
-      real(r_2) :: gnorm
-      real(r_2) :: gtol
+      real(r2) :: fjac(ldfjac,n)
+      real(r2) :: fnorm
+      real(r2) :: fnorm1
+      real(r2) :: ftol
+      real(r2) :: fvec(m)
+      real(r2) :: gnorm
+      real(r2) :: gtol
       integer :: i
       integer :: iflag
       integer :: info
@@ -4170,24 +4170,24 @@ MODULE minpack
       integer :: nfev
       integer :: njev
       integer :: nprint
-      real(r_2) :: par
+      real(r2) :: par
       logical pivot
-      real(r_2) :: pnorm
-      real(r_2) :: prered
-      real(r_2) :: qtf(n)
-      real(r_2) :: ratio
+      real(r2) :: pnorm
+      real(r2) :: prered
+      real(r2) :: qtf(n)
+      real(r2) :: ratio
       logical sing
-      real(r_2) :: sum2
-      real(r_2) :: temp
-      real(r_2) :: temp1
-      real(r_2) :: temp2
-      real(r_2) :: wa1(n)
-      real(r_2) :: wa2(n)
-      real(r_2) :: wa3(n)
-      real(r_2) :: wa4(m)
-      real(r_2) :: x(n)
-      real(r_2) :: xnorm
-      real(r_2) :: xtol
+      real(r2) :: sum2
+      real(r2) :: temp
+      real(r2) :: temp1
+      real(r2) :: temp2
+      real(r2) :: wa1(n)
+      real(r2) :: wa2(n)
+      real(r2) :: wa3(n)
+      real(r2) :: wa4(m)
+      real(r2) :: x(n)
+      real(r2) :: xnorm
+      real(r2) :: xtol
 
       epsmch = epsilon ( epsmch )
 
@@ -4204,21 +4204,21 @@ MODULE minpack
          go to 340
       else if ( ldfjac < n ) then
          go to 340
-      else if ( ftol < 0.0_r_2 ) then
+      else if ( ftol < 0.0_r2 ) then
          go to 340
-      else if ( xtol < 0.0_r_2 ) then
+      else if ( xtol < 0.0_r2 ) then
          go to 340
-      else if ( gtol < 0.0_r_2 ) then
+      else if ( gtol < 0.0_r2 ) then
          go to 340
       else if ( maxfev <= 0 ) then
          go to 340
-      else if ( le(factor, 0.0_r_2) ) then
+      else if ( le(factor, 0.0_r2) ) then
          go to 340
       end if
 
       if ( mode == 2 ) then
          do j = 1, n
-            if ( le(diag(j), 0.0_r_2) ) then
+            if ( le(diag(j), 0.0_r2) ) then
                go to 340
             end if
          end do
@@ -4238,7 +4238,7 @@ MODULE minpack
       !
       !  Initialize Levenberg-Marquardt parameter and iteration counter.
       !
-      par = 0.0_r_2
+      par = 0.0_r2
       iter = 1
       !
       !  Beginning of the outer loop.
@@ -4261,8 +4261,8 @@ MODULE minpack
       !  at a time, while simultaneously forming Q'* FVEC and storing
       !  the first N components in QTF.
       !
-      qtf(1:n) = 0.0_r_2
-      fjac(1:n,1:n) = 0.0_r_2
+      qtf(1:n) = 0.0_r2
+      fjac(1:n,1:n) = 0.0_r2
       iflag = 2
 
       do i = 1, m
@@ -4282,7 +4282,7 @@ MODULE minpack
       !
       sing = .false.
       do j = 1, n
-         if ( eq(fjac(j,j), 0.0_r_2) ) then
+         if ( eq(fjac(j,j), 0.0_r2) ) then
             sing = .true.
          end if
          ipvt(j) = j
@@ -4296,7 +4296,7 @@ MODULE minpack
 
          do j = 1, n
 
-            if ( ne(fjac(j,j), 0.0_r_2) ) then
+            if ( ne(fjac(j,j), 0.0_r2) ) then
 
                sum2 = dot_product ( qtf(j:n), fjac(j:n,j) )
                temp = - sum2 / fjac(j,j)
@@ -4322,8 +4322,8 @@ MODULE minpack
 
             diag(1:n) = wa2(1:n)
             do j = 1, n
-               if ( eq(wa2(j), 0.0_r_2) ) then
-                  diag(j) = 1.0_r_2
+               if ( eq(wa2(j), 0.0_r2) ) then
+                  diag(j) = 1.0_r2
                end if
             end do
 
@@ -4332,7 +4332,7 @@ MODULE minpack
          wa3(1:n) = diag(1:n) * x(1:n)
          xnorm = enorm ( n, wa3 )
          delta = factor * xnorm
-         if ( eq(delta, 0.0_r_2) ) then
+         if ( eq(delta, 0.0_r2) ) then
             delta = factor
          end if
 
@@ -4340,13 +4340,13 @@ MODULE minpack
       !
       !  Compute the norm of the scaled gradient.
       !
-      gnorm = 0.0_r_2
+      gnorm = 0.0_r2
 
-      if ( ne(fnorm, 0.0_r_2) ) then
+      if ( ne(fnorm, 0.0_r2) ) then
 
          do j = 1, n
             l = ipvt(j)
-            if ( ne(wa2(l), 0.0_r_2) ) then
+            if ( ne(wa2(l), 0.0_r2) ) then
                sum2 = dot_product ( qtf(1:j), fjac(1:j,j) ) / fnorm
                gnorm = max ( gnorm, abs ( sum2 / wa2(l) ) )
             end if
@@ -4403,17 +4403,17 @@ MODULE minpack
       !
       !  Compute the scaled actual reduction.
       !
-      if ( 0.1_r_2 * fnorm1 < fnorm ) then
-         actred = 1.0_r_2 - ( fnorm1 / fnorm ) ** 2
+      if ( 0.1_r2 * fnorm1 < fnorm ) then
+         actred = 1.0_r2 - ( fnorm1 / fnorm ) ** 2
       else
-         actred = -1.0_r_2
+         actred = -1.0_r2
       end if
       !
       !  Compute the scaled predicted reduction and
       !  the scaled directional derivative.
       !
       do j = 1, n
-         wa3(j) = 0.0_r_2
+         wa3(j) = 0.0_r2
          l = ipvt(j)
          temp = wa1(l)
          wa3(1:j) = wa3(1:j) + fjac(1:j,j) * temp
@@ -4421,46 +4421,46 @@ MODULE minpack
 
       temp1 = enorm ( n, wa3 ) / fnorm
       temp2 = ( sqrt(par) * pnorm ) / fnorm
-      prered = temp1 ** 2 + temp2 ** 2 / 0.5_r_2
+      prered = temp1 ** 2 + temp2 ** 2 / 0.5_r2
       dirder = - ( temp1 ** 2 + temp2 ** 2 )
       !
       !  Compute the ratio of the actual to the predicted reduction.
       !
-      if ( ne(prered, 0.0_r_2) ) then
+      if ( ne(prered, 0.0_r2) ) then
          ratio = actred / prered
       else
-         ratio = 0.0_r_2
+         ratio = 0.0_r2
       end if
       !
       !  Update the step bound.
       !
-      if ( le(ratio, 0.25_r_2) ) then
+      if ( le(ratio, 0.25_r2) ) then
 
-         if ( ge(actred, 0.0_r_2) ) then
-            temp = 0.5_r_2
+         if ( ge(actred, 0.0_r2) ) then
+            temp = 0.5_r2
          else
-            temp = 0.5_r_2 * dirder / ( dirder + 0.5_r_2 * actred )
+            temp = 0.5_r2 * dirder / ( dirder + 0.5_r2 * actred )
          end if
 
-         if ( ge(0.1_r_2 * fnorm1, fnorm) .or. temp < 0.1_r_2 ) then
-            temp = 0.1_r_2
+         if ( ge(0.1_r2 * fnorm1, fnorm) .or. temp < 0.1_r2 ) then
+            temp = 0.1_r2
          end if
 
-         delta = temp * min ( delta, pnorm / 0.1_r_2 )
+         delta = temp * min ( delta, pnorm / 0.1_r2 )
          par = par / temp
 
       else
 
-         if ( eq(par, 0.0_r_2) .or. ge(ratio, 0.75_r_2) ) then
-            delta = pnorm / 0.5_r_2
-            par = 0.5_r_2 * par
+         if ( eq(par, 0.0_r2) .or. ge(ratio, 0.75_r2) ) then
+            delta = pnorm / 0.5_r2
+            par = 0.5_r2 * par
          end if
 
       end if
       !
       !  Test for successful iteration.
       !
-      if ( ge(ratio, 0.0001_r_2) ) then
+      if ( ge(ratio, 0.0001_r2) ) then
          x(1:n) = wa2(1:n)
          wa2(1:n) = diag(1:n) * x(1:n)
          fvec(1:m) = wa4(1:m)
@@ -4472,7 +4472,7 @@ MODULE minpack
       !  Tests for convergence, termination and stringent tolerances.
       !
       if ( le(abs(actred), ftol) .and. le(prered, ftol) &
-           .and. le(0.5_r_2 * ratio, 1.0_r_2) ) then
+           .and. le(0.5_r2 * ratio, 1.0_r2) ) then
          info = 1
       end if
 
@@ -4481,7 +4481,7 @@ MODULE minpack
       end if
 
       if ( le(abs(actred), ftol) .and. le(prered, ftol) &
-           .and. le(0.5_r_2 * ratio, 1.0_r_2) .and. info == 2 ) then
+           .and. le(0.5_r2 * ratio, 1.0_r2) .and. info == 2 ) then
          info = 3
       end if
 
@@ -4494,7 +4494,7 @@ MODULE minpack
       end if
 
       if ( le(abs(actred), epsmch) .and. le(prered, epsmch) &
-           .and. le(0.5_r_2 * ratio, 1.0_r_2) ) then
+           .and. le(0.5_r2 * ratio, 1.0_r2) ) then
          info = 6
       end if
 
@@ -4512,7 +4512,7 @@ MODULE minpack
       !
       !  End of the inner loop.  Repeat if iteration unsuccessful.
       !
-      if ( ratio < 0.0001_r_2 ) then
+      if ( ratio < 0.0001_r2 ) then
          go to 240
       end if
       !
@@ -4580,10 +4580,10 @@ MODULE minpack
       !      subroutine fcn ( m, n, x, fvec, fjrow, iflag )
       !      integer :: m
       !      integer :: n
-      !      real(r_2) :: fjrow(n)
-      !      real(r_2) :: fvec(m)
+      !      real(r2) :: fjrow(n)
+      !      real(r2) :: fvec(m)
       !      integer :: iflag
-      !      real(r_2) :: x(n)
+      !      real(r2) :: x(n)
       !    If IFLAG = 0 on input, then FCN is only being called to allow the user
       !    to print out the current iterate.
       !    If IFLAG = 1 on input, FCN should calculate the functions at X and
@@ -4597,13 +4597,13 @@ MODULE minpack
       !    Input, integer :: N, the number of variables.  
       !    N must not exceed M.
       !
-      !    Input/output, real(r_2) :: X(N).  On input, X must contain an initial
+      !    Input/output, real(r2) :: X(N).  On input, X must contain an initial
       !    estimate of the solution vector.  On output X contains the final
       !    estimate of the solution vector.
       !
-      !    Output, real(r_2) :: FVEC(M), the functions evaluated at the output X.
+      !    Output, real(r2) :: FVEC(M), the functions evaluated at the output X.
       !
-      !    Output, real(r_2) :: FJAC(LDFJAC,N), an N by N array.  The upper
+      !    Output, real(r2) :: FJAC(LDFJAC,N), an N by N array.  The upper
       !    triangle contains an upper triangular matrix R such that
       !
       !      P' * ( JAC' * JAC ) * P = R' * R,
@@ -4616,7 +4616,7 @@ MODULE minpack
       !    Input, integer :: LDFJAC, the leading dimension of FJAC.
       !    LDFJAC must be at least N.
       !
-      !    Input, real(r_2) :: TOL. Termination occurs when the algorithm 
+      !    Input, real(r2) :: TOL. Termination occurs when the algorithm 
       !    estimates either that the relative error in the sum of squares is at 
       !    most TOL or that the relative error between X and the solution is at 
       !    most TOL.  TOL should be nonnegative.
@@ -4643,13 +4643,13 @@ MODULE minpack
       integer :: m
       integer :: n
 
-      real(r_2) :: diag(n)
-      real(r_2) :: factor
+      real(r2) :: diag(n)
+      real(r2) :: factor
       external fcn
-      real(r_2) :: fjac(ldfjac,n)
-      real(r_2) :: ftol
-      real(r_2) :: fvec(m)
-      real(r_2) :: gtol
+      real(r2) :: fjac(ldfjac,n)
+      real(r2) :: ftol
+      real(r2) :: fvec(m)
+      real(r2) :: gtol
       integer :: info
       integer :: ipvt(n)
       integer :: maxfev
@@ -4657,10 +4657,10 @@ MODULE minpack
       integer :: nfev
       integer :: njev
       integer :: nprint
-      real(r_2) :: qtf(n)
-      real(r_2) :: tol
-      real(r_2) :: x(n)
-      real(r_2) :: xtol
+      real(r2) :: qtf(n)
+      real(r2) :: tol
+      real(r2) :: x(n)
+      real(r2) :: xtol
 
       if ( n <= 0 ) then
          info = 0
@@ -4677,26 +4677,26 @@ MODULE minpack
          return
       end if
 
-      if ( tol < 0.0_r_2 ) then
+      if ( tol < 0.0_r2 ) then
          info = 0
          return
       end if
 
-      fvec(1:n) = 0.0_r_2
-      fjac(1:ldfjac,1:n) = 0.0_r_2
+      fvec(1:n) = 0.0_r2
+      fjac(1:ldfjac,1:n) = 0.0_r2
       ftol = tol
       xtol = tol
-      gtol = 0.0_r_2
+      gtol = 0.0_r2
       maxfev = 100 * ( n + 1 )
-      diag(1:n) = 0.0_r_2
+      diag(1:n) = 0.0_r2
       mode = 1
-      factor = 100.0_r_2
+      factor = 100.0_r2
       nprint = 0
       info = 0
       nfev = 0
       njev = 0
       ipvt(1:n) = 0
-      qtf(1:n) = 0.0_r_2
+      qtf(1:n) = 0.0_r2
 
       call lmstr ( fcn, m, n, x, fvec, fjac, ldfjac, ftol, xtol, gtol, maxfev, &
            diag, mode, factor, nprint, info, nfev, njev, ipvt, qtf )
@@ -4748,7 +4748,7 @@ MODULE minpack
       !    Input, integer :: N, is a positive integer input variable set
       !    to the number of columns of A.
       !
-      !    Input/output, real(r_2) :: Q(LDQ,M).  Q is an M by M array.
+      !    Input/output, real(r2) :: Q(LDQ,M).  Q is an M by M array.
       !    On input the full lower trapezoid in the first min(M,N) columns of Q
       !    contains the factored form.
       !    On output, Q has been accumulated into a square matrix.
@@ -4766,22 +4766,22 @@ MODULE minpack
       integer :: k
       integer :: l
       integer :: minmn
-      real(r_2) :: q(ldq,m)
-      real(r_2) :: temp
-      real(r_2) :: wa(m)
+      real(r2) :: q(ldq,m)
+      real(r2) :: temp
+      real(r2) :: wa(m)
 
       minmn = min ( m, n )
 
       do j = 2, minmn
-         q(1:j-1,j) = 0.0_r_2
+         q(1:j-1,j) = 0.0_r2
       end do
       !
       !  Initialize remaining columns to those of the identity matrix.
       !
-      q(1:m,n+1:m) = 0.0_r_2
+      q(1:m,n+1:m) = 0.0_r2
 
       do j = n + 1, m
-         q(j,j) = 1.0_r_2
+         q(j,j) = 1.0_r2
       end do
       !
       !  Accumulate Q from its factored form.
@@ -4792,10 +4792,10 @@ MODULE minpack
 
          wa(k:m) = q(k:m,k)
 
-         q(k:m,k) = 0.0_r_2
-         q(k,k) = 1.0_r_2
+         q(k:m,k) = 0.0_r2
+         q(k,k) = 1.0_r2
 
-         if ( ne(wa(k), 0.0_r_2) ) then
+         if ( ne(wa(k), 0.0_r2) ) then
 
             do j = k, m
                temp = dot_product ( wa(k:m), q(k:m,j) ) / wa(k)
@@ -4859,7 +4859,7 @@ MODULE minpack
       !
       !    Input, integer :: N, the number of columns of A.
       !
-      !    Input/output, real(r_2) :: A(LDA,N), the M by N array.
+      !    Input/output, real(r2) :: A(LDA,N), the M by N array.
       !    On input, A contains the matrix for which the QR factorization is to
       !    be computed.  On output, the strict upper trapezoidal part of A contains
       !    the strict upper trapezoidal part of R, and the lower trapezoidal
@@ -4878,9 +4878,9 @@ MODULE minpack
       !    Input, integer :: LIPVT, the dimension of IPVT, which should 
       !    be N if pivoting is used.
       !
-      !    Output, real(r_2) :: RDIAG(N), contains the diagonal elements of R.
+      !    Output, real(r2) :: RDIAG(N), contains the diagonal elements of R.
       !
-      !    Output, real(r_2) :: ACNORM(N), the norms of the corresponding
+      !    Output, real(r2) :: ACNORM(N), the norms of the corresponding
       !    columns of the input matrix A.  If this information is not needed,
       !    then ACNORM can coincide with RDIAG.
       !
@@ -4891,11 +4891,11 @@ MODULE minpack
       integer :: m
       integer :: n
 
-      real(r_2) :: a(lda,n)
-      real(r_2) :: acnorm(n)
-      real(r_2) :: ajnorm
-      !real(r_2) :: enorm
-      real(r_2) :: epsmch
+      real(r2) :: a(lda,n)
+      real(r2) :: acnorm(n)
+      real(r2) :: ajnorm
+      !real(r2) :: enorm
+      real(r2) :: epsmch
       integer :: i4_temp
       integer :: ipvt(lipvt)
       integer :: j
@@ -4903,10 +4903,10 @@ MODULE minpack
       integer :: kmax
       integer :: minmn
       logical pivot
-      real(r_2) :: r8_temp(m)
-      real(r_2) :: rdiag(n)
-      real(r_2) :: temp
-      real(r_2) :: wa(n)
+      real(r2) :: r8_temp(m)
+      real(r2) :: rdiag(n)
+      real(r2) :: temp
+      real(r2) :: wa(n)
 
       epsmch = epsilon ( epsmch )
       !
@@ -4965,14 +4965,14 @@ MODULE minpack
          !
          ajnorm = enorm ( m-j+1, a(j,j) )
 
-         if ( ne(ajnorm, 0.0_r_2) ) then
+         if ( ne(ajnorm, 0.0_r2) ) then
 
-            if ( a(j,j) < 0.0_r_2 ) then
+            if ( a(j,j) < 0.0_r2 ) then
                ajnorm = -ajnorm
             end if
 
             a(j:m,j) = a(j:m,j) / ajnorm
-            a(j,j) = a(j,j) + 1.0_r_2
+            a(j,j) = a(j,j) + 1.0_r2
             !
             !  Apply the transformation to the remaining columns and update the norms.
             !
@@ -4982,12 +4982,12 @@ MODULE minpack
 
                a(j:m,k) = a(j:m,k) - temp * a(j:m,j)
 
-               if ( pivot .and. ne(rdiag(k), 0.0_r_2) ) then
+               if ( pivot .and. ne(rdiag(k), 0.0_r2) ) then
 
                   temp = a(j,k) / rdiag(k)
-                  rdiag(k) = rdiag(k) * sqrt ( max ( 0.0_r_2, 1.0_r_2-temp ** 2 ) )
+                  rdiag(k) = rdiag(k) * sqrt ( max ( 0.0_r2, 1.0_r2-temp ** 2 ) )
 
-                  if ( le(0.05_r_2 * ( rdiag(k) / wa(k) )**2, epsmch) ) then
+                  if ( le(0.05_r2 * ( rdiag(k) / wa(k) )**2, epsmch) ) then
                      rdiag(k) = enorm ( m-j, a(j+1,k) )
                      wa(k) = rdiag(k)
                   end if
@@ -5067,7 +5067,7 @@ MODULE minpack
       !
       !    Input, integer :: N, the order of R.
       !
-      !    Input/output, real(r_2) :: R(LDR,N), the N by N matrix.
+      !    Input/output, real(r2) :: R(LDR,N), the N by N matrix.
       !    On input the full upper triangle must contain the full upper triangle
       !    of the matrix R.  On output the full upper triangle is unaltered, and
       !    the strict lower triangle contains the strict upper triangle
@@ -5079,13 +5079,13 @@ MODULE minpack
       !    Input, integer :: IPVT(N), defines the permutation matrix P such 
       !    that A*P = Q*R.  Column J of P is column IPVT(J) of the identity matrix.
       !
-      !    Input, real(r_2) :: DIAG(N), the diagonal elements of the matrix D.
+      !    Input, real(r2) :: DIAG(N), the diagonal elements of the matrix D.
       !
-      !    Input, real(r_2) :: QTB(N), the first N elements of the vector Q'*B.
+      !    Input, real(r2) :: QTB(N), the first N elements of the vector Q'*B.
       !
-      !    Output, real(r_2) :: X(N), the least squares solution.
+      !    Output, real(r2) :: X(N), the least squares solution.
       !
-      !    Output, real(r_2) :: SDIAG(N), the diagonal elements of the upper
+      !    Output, real(r2) :: SDIAG(N), the diagonal elements of the upper
       !    triangular matrix S.
       !
       implicit none
@@ -5093,25 +5093,25 @@ MODULE minpack
       integer :: ldr
       integer :: n
 
-      real(r_2) :: c
-      real(r_2) :: cotan
-      real(r_2) :: diag(n)
+      real(r2) :: c
+      real(r2) :: cotan
+      real(r2) :: diag(n)
       integer :: i
       integer :: ipvt(n)
       integer :: j
       integer :: k
       integer :: l
       integer :: nsing
-      real(r_2) :: qtb(n)
-      real(r_2) :: qtbpj
-      real(r_2) :: r(ldr,n)
-      real(r_2) :: s
-      real(r_2) :: sdiag(n)
-      real(r_2) :: sum2
-      real(r_2) :: t
-      real(r_2) :: temp
-      real(r_2) :: wa(n)
-      real(r_2) :: x(n)
+      real(r2) :: qtb(n)
+      real(r2) :: qtbpj
+      real(r2) :: r(ldr,n)
+      real(r2) :: s
+      real(r2) :: sdiag(n)
+      real(r2) :: sum2
+      real(r2) :: t
+      real(r2) :: temp
+      real(r2) :: wa(n)
+      real(r2) :: x(n)
       !
       !  Copy R and Q'*B to preserve input and initialize S.
       !
@@ -5133,31 +5133,31 @@ MODULE minpack
          !
          l = ipvt(j)
 
-         if ( ne(diag(l), 0.0_r_2) ) then
+         if ( ne(diag(l), 0.0_r2) ) then
 
-            sdiag(j:n) = 0.0_r_2
+            sdiag(j:n) = 0.0_r2
             sdiag(j) = diag(l)
             !
             !  The transformations to eliminate the row of D
             !  modify only a single element of Q'*B
             !  beyond the first N, which is initially zero.
             !
-            qtbpj = 0.0_r_2
+            qtbpj = 0.0_r2
 
             do k = j, n
                !
                !  Determine a Givens rotation which eliminates the
                !  appropriate element in the current row of D.
                !
-               if ( ne(sdiag(k), 0.0_r_2) ) then
+               if ( ne(sdiag(k), 0.0_r2) ) then
 
                   if ( abs ( r(k,k) ) < abs ( sdiag(k) ) ) then
                      cotan = r(k,k) / sdiag(k)
-                     s = 0.5_r_2 / sqrt ( 0.25_r_2 + 0.25_r_2 * cotan ** 2 )
+                     s = 0.5_r2 / sqrt ( 0.25_r2 + 0.25_r2 * cotan ** 2 )
                      c = s * cotan
                   else
                      t = sdiag(k) / r(k,k)
-                     c = 0.5_r_2 / sqrt ( 0.25_r_2 + 0.25_r_2 * t ** 2 )
+                     c = 0.5_r2 / sqrt ( 0.25_r2 + 0.25_r2 * t ** 2 )
                      s = c * t
                   end if
                   !
@@ -5198,12 +5198,12 @@ MODULE minpack
 
       do j = 1, n
 
-         if ( eq(sdiag(j), 0.0_r_2) .and. nsing == n ) then
+         if ( eq(sdiag(j), 0.0_r2) .and. nsing == n ) then
             nsing = j - 1
          end if
 
          if ( nsing < n ) then
-            wa(j) = 0.0_r_2
+            wa(j) = 0.0_r2
          end if
 
       end do
@@ -5266,14 +5266,14 @@ MODULE minpack
       !
       !    Input, integer :: N, the number of columns of A.
       !
-      !    Input/output, real(r_2) :: A(LDA,N), the M by N array.
+      !    Input/output, real(r2) :: A(LDA,N), the M by N array.
       !    On input, the matrix A to be postmultiplied by the orthogonal matrix Q.
       !    On output, the value of A*Q.
       !
       !    Input, integer :: LDA, the leading dimension of A, which must not
       !    be less than M.
       !
-      !    Input, real(r_2) :: V(N), W(N), contain the information necessary
+      !    Input, real(r2) :: V(N), W(N), contain the information necessary
       !    to recover the Givens rotations GV and GW.
       !
       implicit none
@@ -5282,25 +5282,25 @@ MODULE minpack
       integer :: m
       integer :: n
 
-      real(r_2) :: a(lda,n)
-      real(r_2) :: c
+      real(r2) :: a(lda,n)
+      real(r2) :: c
       integer :: i
       integer :: j
-      real(r_2) :: s
-      real(r_2) :: temp
-      real(r_2) :: v(n)
-      real(r_2) :: w(n)
+      real(r2) :: s
+      real(r2) :: temp
+      real(r2) :: v(n)
+      real(r2) :: w(n)
       !
       !  Apply the first set of Givens rotations to A.
       !
       do j = n - 1, 1, -1
 
-         if ( 1.0_r_2 < abs ( v(j) ) ) then
-            c = 1.0_r_2 / v(j)
-            s = sqrt ( 1.0_r_2 - c ** 2 )
+         if ( 1.0_r2 < abs ( v(j) ) ) then
+            c = 1.0_r2 / v(j)
+            s = sqrt ( 1.0_r2 - c ** 2 )
          else
             s = v(j)
-            c = sqrt ( 1.0_r_2 - s ** 2 )
+            c = sqrt ( 1.0_r2 - s ** 2 )
          end if
 
          do i = 1, m
@@ -5315,12 +5315,12 @@ MODULE minpack
       !
       do j = 1, n - 1
 
-         if ( abs ( w(j) ) > 1.0_r_2 ) then
-            c = 1.0_r_2 / w(j)
-            s = sqrt ( 1.0_r_2 - c ** 2 )
+         if ( abs ( w(j) ) > 1.0_r2 ) then
+            c = 1.0_r2 / w(j)
+            s = sqrt ( 1.0_r2 - c ** 2 )
          else
             s = w(j)
-            c = sqrt ( 1.0_r_2 - s ** 2 )
+            c = sqrt ( 1.0_r2 - s ** 2 )
          end if
 
          do i = 1, m
@@ -5385,20 +5385,20 @@ MODULE minpack
       !    Input, integer :: N, the number of columns of S.  
       !    N must not exceed M.
       !
-      !    Input/output, real(r_2) :: S(LS).  On input, the lower trapezoidal
+      !    Input/output, real(r2) :: S(LS).  On input, the lower trapezoidal
       !    matrix S stored by columns.  On output S contains the lower trapezoidal
       !    matrix produced as described above.
       !
       !    Input, integer :: LS, the length of the S array.  LS must be at
       !    least (N*(2*M-N+1))/2.
       !
-      !    Input, real(r_2) :: U(M), the U vector.
+      !    Input, real(r2) :: U(M), the U vector.
       !
-      !    Input/output, real(r_2) :: V(N).  On input, V must contain the 
+      !    Input/output, real(r2) :: V(N).  On input, V must contain the 
       !    vector V.  On output V contains the information necessary to recover the
       !    Givens rotations GV described above.
       !
-      !    Output, real(r_2) :: W(M), contains information necessary to
+      !    Output, real(r2) :: W(M), contains information necessary to
       !    recover the Givens rotations GW described above.
       !
       !    Output, logical SING, is set to TRUE if any of the diagonal elements
@@ -5410,22 +5410,22 @@ MODULE minpack
       integer :: m
       integer :: n
 
-      real(r_2) :: cos
-      real(r_2) :: cotan
-      real(r_2) :: giant
+      real(r2) :: cos
+      real(r2) :: cotan
+      real(r2) :: giant
       integer :: i
       integer :: j
       integer :: jj
       integer :: l
-      real(r_2) :: s(ls)
-      real(r_2) :: sin
+      real(r2) :: s(ls)
+      real(r2) :: sin
       logical sing
-      real(r_2) :: tan
-      real(r_2) :: tau
-      real(r_2) :: temp
-      real(r_2) :: u(m)
-      real(r_2) :: v(n)
-      real(r_2) :: w(m)
+      real(r2) :: tan
+      real(r2) :: tau
+      real(r2) :: temp
+      real(r2) :: u(m)
+      real(r2) :: v(n)
+      real(r2) :: w(m)
       !
       !  GIANT is the largest magnitude.
       !
@@ -5449,24 +5449,24 @@ MODULE minpack
       do j = n - 1, 1, -1
 
          jj = jj - ( m - j + 1 )
-         w(j) = 0.0_r_2
+         w(j) = 0.0_r2
 
-         if ( ne(v(j), 0.0_r_2) ) then
+         if ( ne(v(j), 0.0_r2) ) then
             !
             !  Determine a Givens rotation which eliminates the
             !  J-th element of V.
             !
             if ( abs ( v(n) ) < abs ( v(j) ) ) then
                cotan = v(n) / v(j)
-               sin = 0.5_r_2 / sqrt ( 0.25_r_2 + 0.25_r_2 * cotan ** 2 )
+               sin = 0.5_r2 / sqrt ( 0.25_r2 + 0.25_r2 * cotan ** 2 )
                cos = sin * cotan
-               tau = 1.0_r_2
-               if ( abs ( cos ) * giant > 1.0_r_2 ) then
-                  tau = 1.0_r_2 / cos
+               tau = 1.0_r2
+               if ( abs ( cos ) * giant > 1.0_r2 ) then
+                  tau = 1.0_r2 / cos
                end if
             else
                tan = v(j) / v(n)
-               cos = 0.5_r_2 / sqrt ( 0.25_r_2 + 0.25_r_2 * tan ** 2 )
+               cos = 0.5_r2 / sqrt ( 0.25_r2 + 0.25_r2 * tan ** 2 )
                sin = cos * tan
                tau = sin
             end if
@@ -5501,7 +5501,7 @@ MODULE minpack
 
       do j = 1, n-1
 
-         if ( ne(w(j), 0.0_r_2) ) then
+         if ( ne(w(j), 0.0_r2) ) then
             !
             !  Determine a Givens rotation which eliminates the
             !  J-th element of the spike.
@@ -5509,19 +5509,19 @@ MODULE minpack
             if ( abs ( s(jj) ) < abs ( w(j) ) ) then
 
                cotan = s(jj) / w(j)
-               sin = 0.5_r_2 / sqrt ( 0.25_r_2 + 0.25_r_2 * cotan ** 2 )
+               sin = 0.5_r2 / sqrt ( 0.25_r2 + 0.25_r2 * cotan ** 2 )
                cos = sin * cotan
 
-               if ( 1.0_r_2 < abs ( cos ) * giant ) then
-                  tau = 1.0_r_2 / cos
+               if ( 1.0_r2 < abs ( cos ) * giant ) then
+                  tau = 1.0_r2 / cos
                else
-                  tau = 1.0_r_2
+                  tau = 1.0_r2
                end if
 
             else
 
                tan = w(j) / s(jj)
-               cos = 0.5_r_2 / sqrt ( 0.25_r_2 + 0.25_r_2 * tan ** 2 )
+               cos = 0.5_r2 / sqrt ( 0.25_r2 + 0.25_r2 * tan ** 2 )
                sin = cos * tan
                tau = sin
 
@@ -5545,7 +5545,7 @@ MODULE minpack
          !
          !  Test for zero diagonal elements in the output S.
          !
-         if ( eq(s(jj), 0.0_r_2) ) then
+         if ( eq(s(jj), 0.0_r2) ) then
             sing = .true.
          end if
 
@@ -5561,7 +5561,7 @@ MODULE minpack
          l = l + 1
       end do
 
-      if ( eq(s(jj), 0.0_r_2) ) then
+      if ( eq(s(jj), 0.0_r2) ) then
          sing = .true.
       end if
 
@@ -5575,7 +5575,7 @@ MODULE minpack
       !
       !  Discussion:
       !
-      !    An R8 is a real(r_2) :: value.
+      !    An R8 is a real(r2) :: value.
       !
       !    For now, the input quantity SEED is an integer variable.
       !
@@ -5637,7 +5637,7 @@ MODULE minpack
       !    Input/output, integer :: SEED, the "seed" value, which should
       !    NOT be 0. On output, SEED has been updated.
       !
-      !    Output, real(r_2) :: R8_UNIFORM_01, a new pseudorandom variate,
+      !    Output, real(r2) :: R8_UNIFORM_01, a new pseudorandom variate,
       !    strictly between 0 and 1.
       !
 #ifdef __MPI__
@@ -5648,7 +5648,7 @@ MODULE minpack
 
       integer, parameter :: i4_huge = 2147483647
       integer :: k
-      real(r_2) :: r8_uniform_01
+      real(r2) :: r8_uniform_01
       integer :: seed
 #ifdef __MPI__
       integer :: ierr
@@ -5673,7 +5673,7 @@ MODULE minpack
          seed = seed + i4_huge
       end if
 
-      r8_uniform_01 = real(seed, r_2) * 4.656612875e-10_r_2
+      r8_uniform_01 = real(seed, r2) * 4.656612875e-10_r2
 
       return
     end function r8_uniform_01
@@ -5705,7 +5705,7 @@ MODULE minpack
       !
       !    Input, integer :: N, the number of columns in A.
       !
-      !    Input, real(r_2) :: A(M,N), the matrix.
+      !    Input, real(r2) :: A(M,N), the matrix.
       !
       !    Input, character ( len = * ) TITLE, a title.
       !
@@ -5714,7 +5714,7 @@ MODULE minpack
       integer :: m
       integer :: n
 
-      real(r_2) :: a(m,n)
+      real(r2) :: a(m,n)
       character ( len = * ) title
 
       call r8mat_print_some ( m, n, a, 1, 1, m, n, title )
@@ -5747,7 +5747,7 @@ MODULE minpack
       !
       !    Input, integer :: M, N, the number of rows and columns.
       !
-      !    Input, real(r_2) :: A(M,N), an M by N matrix to be printed.
+      !    Input, real(r2) :: A(M,N), an M by N matrix to be printed.
       !
       !    Input, integer :: ILO, JLO, the first row and column to print.
       !
@@ -5761,7 +5761,7 @@ MODULE minpack
       integer :: m
       integer :: n
 
-      real(r_2) :: a(m,n)
+      real(r2) :: a(m,n)
       character ( len = 14 ) ctemp(incx)
       integer :: i
       integer :: i2hi
@@ -5814,7 +5814,7 @@ MODULE minpack
 
                j = j2lo - 1 + j2
 
-               if ( eq(a(i,j), real(int(a(i,j)), r_2)) ) then
+               if ( eq(a(i,j), real(int(a(i,j)), r2)) ) then
                   write ( ctemp(j2), '(f8.0,6x)' ) a(i,j)
                else
                   write ( ctemp(j2), '(g14.6)' ) a(i,j)
@@ -5856,7 +5856,7 @@ MODULE minpack
       !
       !    Input, integer :: N, the number of components of the vector.
       !
-      !    Input, real(r_2) :: A(N), the vector to be printed.
+      !    Input, real(r2) :: A(N), the vector to be printed.
       !
       !    Input, character ( len = * ) TITLE, a title.
       !
@@ -5864,7 +5864,7 @@ MODULE minpack
 
       integer :: n
 
-      real(r_2) :: a(n)
+      real(r2) :: a(n)
       integer :: i
       character ( len = * ) title
 
@@ -5927,22 +5927,22 @@ MODULE minpack
       !
       !    Input, integer :: N, the order of R.
       !
-      !    Input/output, real(r_2) :: R(LDR,N).  On input the upper triangular
+      !    Input/output, real(r2) :: R(LDR,N).  On input the upper triangular
       !    part of R must contain the matrix to be updated.  On output R contains the
       !    updated triangular matrix.
       !
       !    Input, integer :: LDR, the leading dimension of the array R.
       !    LDR must not be less than N.
       !
-      !    Input, real(r_2) :: W(N), the row vector to be added to R.
+      !    Input, real(r2) :: W(N), the row vector to be added to R.
       !
-      !    Input/output, real(r_2) :: B(N).  On input, the first N elements
+      !    Input/output, real(r2) :: B(N).  On input, the first N elements
       !    of the vector C.  On output the first N elements of the vector Q'*C.
       !
-      !    Input/output, real(r_2) :: ALPHA.  On input, the (N+1)-st element
+      !    Input/output, real(r2) :: ALPHA.  On input, the (N+1)-st element
       !    of the vector C.  On output the (N+1)-st element of the vector Q'*C.
       !
-      !    Output, real(r_2) :: C(N), S(N), the cosines and sines of the
+      !    Output, real(r2) :: C(N), S(N), the cosines and sines of the
       !    transforming Givens rotations.
       !
       implicit none
@@ -5950,18 +5950,18 @@ MODULE minpack
       integer :: ldr
       integer :: n
 
-      real(r_2) :: alpha
-      real(r_2) :: b(n)
-      real(r_2) :: c(n)
-      real(r_2) :: cotan
+      real(r2) :: alpha
+      real(r2) :: b(n)
+      real(r2) :: c(n)
+      real(r2) :: cotan
       integer :: i
       integer :: j
-      real(r_2) :: r(ldr,n)
-      real(r_2) :: rowj
-      real(r_2) :: s(n)
-      real(r_2) :: tan
-      real(r_2) :: temp
-      real(r_2) :: w(n)
+      real(r2) :: r(ldr,n)
+      real(r2) :: rowj
+      real(r2) :: s(n)
+      real(r2) :: tan
+      real(r2) :: temp
+      real(r2) :: w(n)
 
       do j = 1, n
 
@@ -5977,18 +5977,18 @@ MODULE minpack
          !
          !  Determine a Givens rotation which eliminates W(J).
          !
-         c(j) = 1.0_r_2
-         s(j) = 0.0_r_2
+         c(j) = 1.0_r2
+         s(j) = 0.0_r2
 
-         if ( ne(rowj, 0.0_r_2) ) then
+         if ( ne(rowj, 0.0_r2) ) then
 
             if ( abs ( r(j,j) ) < abs ( rowj ) ) then
                cotan = r(j,j) / rowj
-               s(j) = 0.5_r_2 / sqrt ( 0.25_r_2 + 0.25_r_2 * cotan ** 2 )
+               s(j) = 0.5_r2 / sqrt ( 0.25_r2 + 0.25_r2 * cotan ** 2 )
                c(j) = s(j) * cotan
             else
                tan = rowj / r(j,j)
-               c(j) = 0.5_r_2 / sqrt ( 0.25_r_2 + 0.25_r_2 * tan ** 2 )
+               c(j) = 0.5_r2 / sqrt ( 0.25_r2 + 0.25_r2 * tan ** 2 )
                s(j) = c(j) * tan
             end if
             !

--- a/offline/cable_LUC_EXPT.F90
+++ b/offline/cable_LUC_EXPT.F90
@@ -818,7 +818,7 @@ CONTAINS
 !     ! 1 dim arrays (integer) (npt )
 !     CHARACTER(len=20),DIMENSION(2) :: AI1
 
-!     ! REAL(r_2), DIMENSION(mland) :: LAT, LON, TMP
+!     ! REAL(r2), DIMENSION(mland) :: LAT, LON, TMP
 !     REAL, DIMENSION(mland) :: LAT, LON, TMP
 !     INTEGER(KIND=4) :: TMPI(mland)
 !     LOGICAL         :: EXISTFILE

--- a/offline/cable_bios_met_obs_params.F90
+++ b/offline/cable_bios_met_obs_params.F90
@@ -11,9 +11,9 @@ MODULE bios_type_def
   save
 ! Define integer kind parameters to accommodate the range of numbers usually 
 ! associated with 4, 2, and 1 byte integers. 
-  integer,parameter :: i4b = selected_int_kind(9) 
-  integer,parameter :: i2b = selected_int_kind(4)
-  integer,parameter :: i1b = selected_int_kind(2)
+  integer,parameter :: i4 = selected_int_kind(9) 
+  integer,parameter :: i2 = selected_int_kind(4)
+  integer,parameter :: i1 = selected_int_kind(2)
 ! Define single and double precision real kind parameters: 
 ! * Kind(1.0)   defines sp as the machine's default size for single precision
 ! * Kind(1.0d0) defines dp as the machine's default size for double precision
@@ -45,9 +45,9 @@ SAVE
 ! Assign as Date = dmydate(iday,imth,iyear)
 ! Access components as iday=Date%Day, imth=Date%Month, iyear=Date%Year
 TYPE dmydate
-  INTEGER(i4b):: Day
-  INTEGER(i4b):: Month
-  INTEGER(i4b):: Year
+  INTEGER(i4):: Day
+  INTEGER(i4):: Month
+  INTEGER(i4):: Year
 END TYPE dmydate
 ! Define interfaces for the +, -, ==, /=, <, >, <=, >= operators to:
 ! * add, subtract an integer number of days from a dmydate, with AddDay, SubDay; 
@@ -90,7 +90,7 @@ CONTAINS
   IMPLICIT NONE
   TYPE (dmydate)              :: AddDay    ! Date with days added (FUNCTION name)
   TYPE (dmydate), INTENT(IN)  :: Today     ! Current date
-  INTEGER(i4b),   INTENT(IN)  :: Days2Add  ! Days to add to current date
+  INTEGER(i4),   INTENT(IN)  :: Days2Add  ! Days to add to current date
   REAL(dp)                    :: JDay      ! Julian Day
 !-------------------------------------------------------------------------------
   JDay = JulianDay(Today)
@@ -107,7 +107,7 @@ CONTAINS
   IMPLICIT NONE
   TYPE (dmydate)              :: SubDay    ! Date with days added (FUNCTION name)
   TYPE (dmydate), INTENT(IN)  :: Today     ! Current date
-  INTEGER(i4b),   INTENT(IN)  :: Days2Sub  ! Days to add to current date
+  INTEGER(i4),   INTENT(IN)  :: Days2Sub  ! Days to add to current date
   REAL(dp)                    :: JDay      ! Julian Day
 !-------------------------------------------------------------------------------
   JDay = JulianDay(Today)
@@ -308,8 +308,8 @@ CONTAINS
 ! Returns 1 if leap year, 0 if not.  Add it to the length of February.
 !-------------------------------------------------------------------------------
   IMPLICIT NONE
-  INTEGER(i4b)               :: LeapDay  
-  INTEGER(i4b), INTENT(IN)   :: Year
+  INTEGER(i4)               :: LeapDay  
+  INTEGER(i4), INTENT(IN)   :: Year
 !-------------------------------------------------------------------------------
   IF (MOD(Year,4)/=0) THEN
     LeapDay = 0
@@ -330,8 +330,8 @@ FUNCTION DaysInMonth(Date)
 ! MRR, 12-oct-2005: return 0 if month not legal
 !-------------------------------------------------------------------------------
 TYPE(dmydate),INTENT(IN):: Date
-INTEGER(i4b)          :: DaysInMonth  
-INTEGER(i4b),PARAMETER:: MonthDays(12) = (/31,28,31,30,31,30,31,31,30,31,30,31/)
+INTEGER(i4)          :: DaysInMonth  
+INTEGER(i4),PARAMETER:: MonthDays(12) = (/31,28,31,30,31,30,31,31,30,31,30,31/)
 !-------------------------------------------------------------------------------
 IF (Date%Month >= 1 .AND. Date%Month <= 12) THEN
   IF (Date%Month==2) THEN
@@ -349,8 +349,8 @@ END FUNCTION DaysInMonth
   FUNCTION YearDay(Date)
 !-------------------------------------------------------------------------------
   TYPE(dmydate), INTENT(IN)   :: Date
-  INTEGER(i4b)                :: YearDay 
-  INTEGER(i4b), DIMENSION(12) :: MonthDays
+  INTEGER(i4)                :: YearDay 
+  INTEGER(i4), DIMENSION(12) :: MonthDays
 !-------------------------------------------------------------------------------
   MonthDays = (/31,28,31,30,31,30,31,31,30,31,30,31/)
   MonthDays(2) = 28 + LeapDay(Date%Year)
@@ -371,7 +371,7 @@ FUNCTION DayDifference (Date1,Date0)
 USE bios_type_def
 IMPLICIT NONE
 TYPE(dmydate),INTENT(IN):: Date1, Date0
-INTEGER(i4b):: DayDifference
+INTEGER(i4):: DayDifference
 !-------------------------------------------------------------------------------
 DayDifference = nint(JulianDay(Date1) - JulianDay(Date0))
 END FUNCTION DayDifference
@@ -462,9 +462,9 @@ CONTAINS
 ! read. Return the grid dimensions and no data value.  
 !-------------------------------------------------------------------------------
   implicit none
-  integer(i4b)    ,intent(in) :: iunit
+  integer(i4)    ,intent(in) :: iunit
   character(200)  ,intent(in) :: Filename
-  integer(i4b)    ,intent(out):: Cols, Rows
+  integer(i4)    ,intent(out):: Cols, Rows
   real(sp)        ,intent(out):: xLL, yLL, CellSize, NoDataVal
   character(12)               :: Head
 !-------------------------------------------------------------------------------
@@ -550,16 +550,16 @@ MODULE cable_bios_met_obs_params
 
   REAL(sp)                  :: co2air_year          ! Single global value of co2 (ppm)
   
-  INTEGER(i4b),  SAVE :: rain_unit, swdown_unit, tairmax_unit, tairmin_unit, co2_unit ! Met file unit numbers
-  INTEGER(i4b),  SAVE :: wind_unit, vp1500_unit, vp0900_unit
+  INTEGER(i4),  SAVE :: rain_unit, swdown_unit, tairmax_unit, tairmin_unit, co2_unit ! Met file unit numbers
+  INTEGER(i4),  SAVE :: wind_unit, vp1500_unit, vp0900_unit
   TYPE(dmydate), SAVE :: previous_date ! The day before the current date, for noting changes of year
   TYPE(dmydate), SAVE :: bios_rundate  ! The day before the current date, for noting changes of year
   TYPE(dmydate)       :: dummydate     ! Dummy date for when keeping the date is not required
   TYPE(dmydate),SAVE  :: MetDate       ! Date of met to access (equals current date for normals runs, but
                                        ! must be calculated for spinup and initialisation runs (for dates before 1900)
-  INTEGER(i4b),PARAMETER :: recycle_met_startdate = 1981 ! range for met to be recycled for spinup and initialisation
-  INTEGER(i4b),PARAMETER :: recycle_met_enddate = 2010
-  INTEGER(i4b)   :: skipdays                        ! Days of met to skip when user_startdate is after bios_startdate
+  INTEGER(i4),PARAMETER :: recycle_met_startdate = 1981 ! range for met to be recycled for spinup and initialisation
+  INTEGER(i4),PARAMETER :: recycle_met_enddate = 2010
+  INTEGER(i4)   :: skipdays                        ! Days of met to skip when user_startdate is after bios_startdate
   TYPE(dmydate), SAVE  :: bios_startdate, bios_enddate    ! First and last dates found in bios met files (read from rain file)
   REAL(sp), PRIVATE, PARAMETER :: SecDay = 86400.
   TYPE(WEATHER_GENERATOR_TYPE), SAVE :: WG
@@ -587,24 +587,24 @@ CONTAINS
   ! Local variables
   
   LOGICAL,  SAVE :: call1 = .TRUE.
-  INTEGER(i4b)   :: iunit  
-  INTEGER(i4b)   :: MaskCols, MaskRows  ! Landmask col and row dimensions
+  INTEGER(i4)   :: iunit  
+  INTEGER(i4)   :: MaskCols, MaskRows  ! Landmask col and row dimensions
   REAL(sp)       :: MaskBndW, MaskBndS  ! Landmask outer bound dimensions in decimal degrees (West & South)
   REAL(sp)       :: MaskCtrW, MaskCtrS
   REAL(sp)       :: MaskRes, NoDataVal  ! Landmask resolution (dec deg) and no-data value
   
-  INTEGER(i4b)   :: icol, irow, iland   ! Loop counters for cols, rows, land cells
+  INTEGER(i4)   :: icol, irow, iland   ! Loop counters for cols, rows, land cells
   
   LOGICAL(lgt), ALLOCATABLE :: LandMaskLogical(:,:) ! Logical land mask for vector packing
   REAL(sp),     ALLOCATABLE :: LandMaskReal(:,:)    ! Real land mask as read from landmask file
-  INTEGER(i4b), ALLOCATABLE :: ColRowGrid(:,:)      ! Temp grid to hold col or row numbers for packing to land_x or land_y
+  INTEGER(i4), ALLOCATABLE :: ColRowGrid(:,:)      ! Temp grid to hold col or row numbers for packing to land_x or land_y
   
  ! TYPE(dmydate)  :: bios_startdate, bios_enddate    ! First and last dates found in bios met files (read from rain file)
   TYPE(dmydate)  :: user_startdate, user_enddate    ! First and last run dates specified by user (read from cable_user%)
-  INTEGER(i4b)   :: bios_rundays                    ! Days in run, from bios_startdate or user_startdate to bios_enddate 
-  INTEGER(i4b)   :: co2_startyear, co2_endyear      ! First and last years found in bios global CO2 files 
-  INTEGER(i4b)   :: co2_skipyears                   ! Years of annual CO2 to skip to position for reading the current year
-  INTEGER(i4b)   :: iday, iyear ! counters
+  INTEGER(i4)   :: bios_rundays                    ! Days in run, from bios_startdate or user_startdate to bios_enddate 
+  INTEGER(i4)   :: co2_startyear, co2_endyear      ! First and last years found in bios global CO2 files 
+  INTEGER(i4)   :: co2_skipyears                   ! Years of annual CO2 to skip to position for reading the current year
+  INTEGER(i4)   :: iday, iyear ! counters
   INTEGER :: error_status
   NAMELIST /biosnml/ Run, met_path, param_path, landmaskflt_file, landmaskhdr_file, &
        rain_file, swdown_file, tairmax_file, tairmin_file, &
@@ -636,12 +636,12 @@ USE cable_def_types_mod,  ONLY: mland, climate_type
   IMPLICIT NONE
 
 
-INTEGER(i4b) :: is, ie ! Index start/end points within cable spatial vectors
+INTEGER(i4) :: is, ie ! Index start/end points within cable spatial vectors
                                 ! for the current land-cell's tiles. These are just 
                                 ! aliases to improve code readability
-INTEGER(i4b) :: iland         ! loop counter through mland land cells
-INTEGER(i4b) :: param_unit    ! Unit number for reading (all) parameter files.
-INTEGER(i4b) :: error_status  ! Error status returned by OPENs
+INTEGER(i4) :: iland         ! loop counter through mland land cells
+INTEGER(i4) :: param_unit    ! Unit number for reading (all) parameter files.
+INTEGER(i4) :: error_status  ! Error status returned by OPENs
 TYPE(climate_type), INTENT(INOUT)       :: climate ! climate variables
 
 REAL(sp), ALLOCATABLE :: vegtypeigbp(:)

--- a/offline/cable_checks.F90
+++ b/offline/cable_checks.F90
@@ -212,8 +212,8 @@ SUBROUTINE mass_balance(dels, ktau, ssnow, soil, canopy, met, air, bal)
    TYPE(balances_type),INTENT(INOUT)        :: bal
 
    ! Local variables
-   REAL(r_2), DIMENSION(:,:,:),POINTER, SAVE :: bwb => null() ! volumetric soil moisture
-   REAL(r_2), DIMENSION(mp)                  :: delwb         ! change in soilmoisture b/w tsteps
+   REAL(r2), DIMENSION(:,:,:),POINTER, SAVE :: bwb => null() ! volumetric soil moisture
+   REAL(r2), DIMENSION(mp)                  :: delwb         ! change in soilmoisture b/w tsteps
    REAL, DIMENSION(mp)                  :: canopy_wbal !canopy water balance
    INTEGER                              :: k           ! do loop counter
 
@@ -261,7 +261,7 @@ SUBROUTINE mass_balance(dels, ktau, ssnow, soil, canopy, met, air, bal)
 
    ENDIF
    ! write(*,"(100e16.6)")  REAL(canopy%through(1) - ssnow%delwcol(1)-ssnow%runoff(1) &
-   !                   - ssnow%evap(1) - max(canopy%fevc(1),0.0)*dels/air%rlam(1), r_2), &
+   !                   - ssnow%evap(1) - max(canopy%fevc(1),0.0)*dels/air%rlam(1), r2), &
    ! canopy%through(1),  ssnow%delwcol(1), ssnow%runoff(1),  ssnow%evap(1),  max(canopy%fevc(1),0.0)*dels/air%rlam(1)
 
    if (ktau == 1) then

--- a/offline/cable_cru_TRENDY.F90
+++ b/offline/cable_cru_TRENDY.F90
@@ -20,7 +20,7 @@ USE cable_io_vars_module,   ONLY: logn, land_x, land_y, exists, nMetPatches,&
 USE cable_input_module,     ONLY: SPATIO_TEMPORAL_DATASET, find_variable_ID,&
                                 prepare_spatiotemporal_dataset, read_metvals,&
                                 open_at_first_file
-USE cable_def_types_mod,    ONLY: MET_TYPE, r_2, mLand
+USE cable_def_types_mod,    ONLY: MET_TYPE, r2, mLand
 USE cable_weathergenerator, ONLY: WEATHER_GENERATOR_TYPE, WGEN_INIT,&
                                 WGEN_DAILY_CONSTANTS, WGEN_SUBDIURNAL_MET
 USE mo_utils,               ONLY: eq
@@ -269,19 +269,19 @@ SUBROUTINE CRU_GET_SUBDIURNAL_MET(CRU, MET, CurYear, ktau)
 
      ! Convert wind from u and v components to wind speed by Pythagorean Theorem
      WG%WindDay        = real(sqrt((CRU%MET(uwind)%METVALS * CRU%MET(uwind)%METVALS) +  &
-          (CRU%MET(vwind)%METVALS * CRU%MET(vwind)%METVALS)), r_2)
+          (CRU%MET(vwind)%METVALS * CRU%MET(vwind)%METVALS)), r2)
      ! Convert all temperatures from K to C
-     WG%TempMinDay     = real(CRU%MET(  Tmin  )%METVALS - 273.15, r_2)
-     WG%TempMaxDay     = real(CRU%MET(  Tmax  )%METVALS - 273.15, r_2)
-     WG%TempMinDayNext = real(CRU%MET(NextTmin)%METVALS - 273.15, r_2)
-     WG%TempMaxDayPrev = real(CRU%MET(PrevTmax)%METVALS - 273.15, r_2)
+     WG%TempMinDay     = real(CRU%MET(  Tmin  )%METVALS - 273.15, r2)
+     WG%TempMaxDay     = real(CRU%MET(  Tmax  )%METVALS - 273.15, r2)
+     WG%TempMinDayNext = real(CRU%MET(NextTmin)%METVALS - 273.15, r2)
+     WG%TempMaxDayPrev = real(CRU%MET(PrevTmax)%METVALS - 273.15, r2)
      ! Convert solar radiation from J /m2/s to MJ/m2/d
-     WG%SolarMJDay     = real(CRU%MET(swdn)%METVALS * 1.e-6 * SecDay, r_2) ! ->[MJ/m2/d]
+     WG%SolarMJDay     = real(CRU%MET(swdn)%METVALS * 1.e-6 * SecDay, r2) ! ->[MJ/m2/d]
      ! Convert precip from mm to m/day
-     WG%PrecipDay      = real(max(CRU%MET(rain)%METVALS  / 1000., 0.0), r_2) ! ->[m/d]
+     WG%PrecipDay      = real(max(CRU%MET(rain)%METVALS  / 1000., 0.0), r2) ! ->[m/d]
      !WG%PrecipDay      = max(CRU%MET(rain)%METVALS  / 1000., 0.0)/2.0 ! ->[m/d] ! test vh !
-     WG%SnowDay        = 0.0_r_2
-     WG%VapPmbDay = real(esatf(real(WG%TempMinDay, sp)), r_2)
+     WG%SnowDay        = 0.0_r2
+     WG%VapPmbDay = real(esatf(real(WG%TempMinDay, sp)), r2)
      call WGEN_DAILY_CONSTANTS(WG, CRU%mland, int(met%doy(1))+1)
 
      ! To get the diurnal cycle for lwdn get whole day and scale with
@@ -313,15 +313,15 @@ SUBROUTINE CRU_GET_SUBDIURNAL_MET(CRU, MET, CurYear, ktau)
 
      ! Cable's swdown is split into two components, visible and nir, which
      ! get half of the CRU-NCEP swdown each.
-     met%fsd(is:ie,1) = real(WG%PhiSD(iland) * 0.5_r_2)  ! Visible
-     met%fsd(is:ie,2) = real(WG%PhiSD(iland) * 0.5_r_2)  ! NIR
+     met%fsd(is:ie,1) = real(WG%PhiSD(iland) * 0.5_r2)  ! Visible
+     met%fsd(is:ie,2) = real(WG%PhiSD(iland) * 0.5_r2)  ! NIR
 
      if (.NOT. cable_user%calc_fdiff) then ! read from met forcing, otherwise calculated in cable_radiation.F90
         met%fdiff(is:ie) = CRU%MET(fdiff)%METVALS(iland)
      endif
 
      ! Convert C to K for cable's tk
-     met%tk(is:ie)     = real(WG%Temp(iland) + 273.15_r_2)
+     met%tk(is:ie)     = real(WG%Temp(iland) + 273.15_r2)
 
      met%ua(is:ie)     = real(WG%Wind(iland))
      met%coszen(is:ie) = real(WG%coszen(iland))
@@ -355,7 +355,7 @@ SUBROUTINE CRU_GET_SUBDIURNAL_MET(CRU, MET, CurYear, ktau)
      !       met%precip_sn(is:ie) = met%precip(is:ie)
      !    endif
 
-     if (WG%Temp(iland) <= 0.0_r_2) then
+     if (WG%Temp(iland) <= 0.0_r2) then
         met%precip_sn(is:ie) = met%precip(is:ie)
      else
         met%precip_sn(is:ie) = 0.0
@@ -392,6 +392,8 @@ SUBROUTINE BIOS_GET_SUBDIURNAL_MET(CRU, Met, CurYear, ktau)
   ! Uses the current date to retrieve the relevant entry from the respective
   ! variable datasets, and process them into quantities appropriate for the
   ! subdiurnal weather generator.
+
+  USE cable_def_types_mod, ONLY: r1, r2
 
   TYPE(CRU_TYPE), INTENT(INOUT) :: CRU  ! Meta information about the Met config
   TYPE(MET_TYPE), INTENT(INOUT) :: Met  ! The Met data storage
@@ -482,22 +484,22 @@ SUBROUTINE BIOS_GET_SUBDIURNAL_MET(CRU, Met, CurYear, ktau)
     is = LandPt(iLand)%cStart
     ie = LandPt(iLand)%cEnd
 
-    Met%Precip(is:ie)     = REAL(WG%Precip(iLand), sp)
-    Met%Precip_sn(is:ie)  = REAL(WG%Snow(iLand), sp)
+    Met%Precip(is:ie)     = REAL(WG%Precip(iLand), r1)
+    Met%Precip_sn(is:ie)  = REAL(WG%Snow(iLand), r1)
     ! Why is it done this way? Doesn't make much sense
     Met%Precip(is:ie)     = Met%Precip(is:ie) + Met%Precip_sn(is:ie)
-    Met%fld(is:ie)        = REAL(WG%PhilD(iLand), sp)
-    Met%fsd(is:ie,1)      = REAL(WG%PhiSD(iLand) * 0.5_dp, sp)
-    Met%fsd(is:ie,2)      = REAL(WG%PhiSD(iLand) * 0.5_dp, sp)
-    Met%tk(is:ie)         = REAL(WG%Temp(iLand) + 273.15_dp, sp)
+    Met%fld(is:ie)        = REAL(WG%PhilD(iLand), r1)
+    Met%fsd(is:ie,1)      = REAL(WG%PhiSD(iLand) * 0.5_r2, r1)
+    Met%fsd(is:ie,2)      = REAL(WG%PhiSD(iLand) * 0.5_r2, r1)
+    Met%tk(is:ie)         = REAL(WG%Temp(iLand) + 273.15_r2, r1)
     ! Factor of 2 to convert 2m screen height to 40m zref (??)
-    Met%ua(is:ie)         = REAL(WG%Wind(iLand) * 2.0_dp, sp)
-    Met%coszen(is:ie)     = REAL(WG%coszen(iLand), sp)
-    Met%qv(is:ie)         = REAL(WG%VapPmb(iLand) / WG%Pmb(iLand), sp) *&
+    Met%ua(is:ie)         = REAL(WG%Wind(iLand) * 2.0_r2, r1)
+    Met%coszen(is:ie)     = REAL(WG%coszen(iLand), r1)
+    Met%qv(is:ie)         = REAL(WG%VapPmb(iLand) / WG%Pmb(iLand), r1) *&
                             RMWbyRMA
-    Met%Pmb(is:ie)        = REAL(WG%Pmb(iLand), sp)
-    Met%rhum(is:ie)       = REAL(WG%VapPmb(iLand), sp) /&
-                            ESATF(REAL(WG%Temp(iLand), sp)) * 100.0
+    Met%Pmb(is:ie)        = REAL(WG%Pmb(iLand), r1)
+    Met%rhum(is:ie)       = REAL(WG%VapPmb(iLand), r1) /&
+                            ESATF(REAL(WG%Temp(iLand), r1)) * 100.0
     Met%u10(is:ie)        = Met%ua(is:ie)
     Met%tvair(is:ie)      = Met%tk(is:ie)
     Met%tvrad(is:ie)      = Met%tk(is:ie)

--- a/offline/cable_driver.F90
+++ b/offline/cable_driver.F90
@@ -225,16 +225,16 @@ PROGRAM cable_offline_driver
   type(c13o2_flux) :: c13o2flux
   type(c13o2_pool) :: c13o2pools, sum_c13o2pools
   type(c13o2_luc)  :: c13o2luc
-  real(r_2), dimension(:,:), allocatable :: casasave
-  real(r_2), dimension(:,:), allocatable :: lucsave
+  real(r2), dimension(:,:), allocatable :: casasave
+  real(r2), dimension(:,:), allocatable :: lucsave
   ! I/O
   integer :: c13o2_outfile_id
   character(len=40), dimension(c13o2_nvars_output) :: c13o2_vars
   integer,           dimension(c13o2_nvars_output) :: c13o2_var_ids
   ! discrimination
   ! integer :: ileaf
-  real(r_2), dimension(:,:), allocatable :: gpp ! , diff
-  real(r_2), dimension(:),   allocatable :: Ra
+  real(r2), dimension(:,:), allocatable :: gpp ! , diff
+  real(r2), dimension(:),   allocatable :: Ra
   ! delta-13C of atmospheric CO2
   integer            :: iunit, ios
   real               :: iyear
@@ -319,11 +319,11 @@ PROGRAM cable_offline_driver
        Ftrunk_sumbal = ".trunk_sumbal", &
        Fnew_sumbal   = "new_sumbal"
 
-  real(r_2) :: &
-       trunk_sumbal = 0.0_r_2, & !
-       new_sumbal   = 0.0_r_2, &
-       new_sumfpn   = 0.0_r_2, &
-       new_sumfe    = 0.0_r_2
+  real(r2) :: &
+       trunk_sumbal = 0.0_r2, & !
+       new_sumbal   = 0.0_r2, &
+       new_sumfpn   = 0.0_r2, &
+       new_sumfe    = 0.0_r2
 
   integer :: nkend=0
   integer :: ioerror
@@ -503,7 +503,7 @@ PROGRAM cable_offline_driver
         read(iunit, fmt=*, iostat=ios) iyear, c13o2_delta_atm(floor(iyear))
      end do
      close(iunit)
-     c13o2_delta_atm = c13o2_delta_atm / 1000._r_2
+     c13o2_delta_atm = c13o2_delta_atm / 1000._r2
   end if
 
   ! outer loop - spinup loop no. ktau_tot :
@@ -718,7 +718,7 @@ PROGRAM cable_offline_driver
                  end if
               end if
 
-              canopy%fes_cor = 0.0_r_2
+              canopy%fes_cor = 0.0_r2
               canopy%fhs_cor = 0.0
               met%ofsd       = 0.1 ! not used
 
@@ -740,8 +740,8 @@ PROGRAM cable_offline_driver
 
               !MC - do we need that? casamet also set only if icycle>0
               ! if (trim(cable_user%MetType) .eq. 'cru') then
-              !    casamet%glai = 1.0_r_2 ! initialise glai for use in cable_roughness
-              !    where (veg%iveg(:) .ge. 14) casamet%glai = 0.0_r_2
+              !    casamet%glai = 1.0_r2 ! initialise glai for use in cable_roughness
+              !    where (veg%iveg(:) .ge. 14) casamet%glai = 0.0_r2
               ! end if
               if ((trim(cable_user%MetType) == 'cru') .and. (icycle > 0)) then
                  if (all(eq(real(casamet%glai(:)), 0.))) then
@@ -777,7 +777,7 @@ PROGRAM cable_offline_driver
                       BLAZE, SIMFIRE)
                  if (cable_user%c13o2) &
                       call c13o2_sanity_pools(casapool, casaflux, c13o2pools)
-                 ! Set 13C and 12C LUC pools to 0 if any < epsilon(1.0_dp)
+                 ! Set 13C and 12C LUC pools to 0 if any < epsilon(1.0_r2)
                  SPINon   = .false.
                  SPINconv = .false.
                  !MC - MPI sets CASAONLY = .true. here
@@ -882,7 +882,7 @@ PROGRAM cable_offline_driver
               where (veg%iveg(:) >= 14) veg%vlai = 0.
 
               ! 13C
-              ! if (cable_user%c13o2) c13o2flux%ca = 0.992_r_2 * real(met%ca,r_2) ! * vpdbc13 / vpdbc13 ! -8 permil
+              ! if (cable_user%c13o2) c13o2flux%ca = 0.992_r2 * real(met%ca,r2) ! * vpdbc13 / vpdbc13 ! -8 permil
               if (cable_user%c13o2) then
                  if ((CurYear < c13o2_atm_syear) .or. (CurYear > c13o2_atm_eyear)) then
                     write(*,*) 'Current year ', CurYear, &
@@ -890,8 +890,8 @@ PROGRAM cable_offline_driver
                          c13o2_atm_syear, c13o2_atm_eyear
                     stop 203
                  end if
-                 c13o2flux%ca = (c13o2_delta_atm(CurYear) + 1.0_r_2) * &
-                      real(met%ca, r_2) ! * vpdbc13 / vpdbc13
+                 c13o2flux%ca = (c13o2_delta_atm(CurYear) + 1.0_r2) * &
+                      real(met%ca, r2) ! * vpdbc13 / vpdbc13
               end if
 
               ! At first time step of year, set tile area according to
@@ -951,14 +951,14 @@ PROGRAM cable_offline_driver
                  ! 13C
                  if (cable_user%c13o2) then
                     gpp  = canopy%An + canopy%Rd
-                    Ra   = isoratio(c13o2flux%ca, real(met%ca,r_2), 1.0_r_2)
-                    ! diff = canopy%An - (spread(real(met%ca,r_2),2,mf)-canopy%ci) * &
-                    !      (1.0_r_2/(1.0_r_2/canopy%gac+1.0_r_2/canopy%gbc+1.0_r_2/canopy%gsc))
+                    Ra   = isoratio(c13o2flux%ca, real(met%ca,r2), 1.0_r2)
+                    ! diff = canopy%An - (spread(real(met%ca,r2),2,mf)-canopy%ci) * &
+                    !      (1.0_r2/(1.0_r2/canopy%gac+1.0_r2/canopy%gbc+1.0_r2/canopy%gsc))
                     !MCTest
                     c13o2flux%An       = canopy%An
-                    ! c13o2flux%An       = 1.005_r_2 * canopy%An !  * vpdbc13 / vpdbc13 ! Test 5 permil
-                    c13o2flux%Disc     = 0.0_r_2
-                    c13o2flux%Vstarch  = c13o2flux%Vstarch + 1.0e-6_r_2
+                    ! c13o2flux%An       = 1.005_r2 * canopy%An !  * vpdbc13 / vpdbc13 ! Test 5 permil
+                    c13o2flux%Disc     = 0.0_r2
+                    c13o2flux%Vstarch  = c13o2flux%Vstarch + 1.0e-6_r2
                     c13o2flux%Rstarch  = c13o2flux%Rstarch
                     c13o2flux%Rsucrose = c13o2flux%Rsucrose
                     c13o2flux%Rphoto   = c13o2flux%Rphoto
@@ -967,13 +967,13 @@ PROGRAM cable_offline_driver
                     !       call c13o2_discrimination_simple( &
                     !            ! -- Input
                     !            ! isc3
-                    !            real(dels,r_2), canopy%isc3, &
+                    !            real(dels,r2), canopy%isc3, &
                     !            ! GPP and Leaf respiration
                     !            gpp(:,ileaf), canopy%Rd(:,ileaf), &
                     !            ! Ambient and stomatal CO2 concentration
-                    !            real(met%ca,r_2), canopy%ci(:,ileaf), &
+                    !            real(met%ca,r2), canopy%ci(:,ileaf), &
                     !            ! leaf temperature
-                    !            real(canopy%tlf,r_2), &
+                    !            real(canopy%tlf,r2), &
                     !            ! Ambient isotope ratio
                     !            Ra, &
                     !            ! -- Inout
@@ -987,18 +987,18 @@ PROGRAM cable_offline_driver
                     !    else
                     !       call c13o2_discrimination( &
                     !            ! -- Input
-                    !            real(dels,r_2), canopy%isc3, &
+                    !            real(dels,r2), canopy%isc3, &
                     !            ! Photosynthesis variables
                     !            ! Vcmax<< because of temperature dependence of Vcmax
                     !            canopy%vcmax(:,ileaf), gpp(:,ileaf), canopy%Rd(:,ileaf), canopy%gammastar(:,ileaf), &
                     !            ! Could use Vcmax25?
-                    !            ! real(veg%vcmax,r_2), gpp(:,ileaf), canopy%Rd(:,ileaf), canopy%gammastar(:,ileaf), &
+                    !            ! real(veg%vcmax,r2), gpp(:,ileaf), canopy%Rd(:,ileaf), canopy%gammastar(:,ileaf), &
                     !            ! CO2 concentrations
-                    !            real(met%ca,r_2), canopy%ci(:,ileaf), &
+                    !            real(met%ca,r2), canopy%ci(:,ileaf), &
                     !            ! Conductances
                     !            canopy%gac(:,ileaf), canopy%gbc(:,ileaf), canopy%gsc(:,ileaf), &
                     !            ! leaf temperature
-                    !            real(canopy%tlf,r_2), &
+                    !            real(canopy%tlf,r2), &
                     !            ! Ambient isotope ratio
                     !            Ra, &
                     !            ! -- Inout
@@ -1057,10 +1057,10 @@ PROGRAM cable_offline_driver
                       LALLOC, c13o2flux, c13o2pools)
                  if (cable_user%c13o2) &
                       call c13o2_sanity_pools(casapool, casaflux, c13o2pools)
-                 ! if (any(delta1000(c13o2pools%cplant, casapool%cplant, 1.0_r_2, 0.0_r_2, tiny(1.0_r_2)) > 0.0_r_2)) then
+                 ! if (any(delta1000(c13o2pools%cplant, casapool%cplant, 1.0_r2, 0.0_r2, tiny(1.0_r2)) > 0.0_r2)) then
                  !    print*, 'CC04.01 ', casapool%cplant
                  !    print*, 'CC04.02 ', c13o2pools%cplant
-                 !    print*, 'CC04.03 ', delta1000(c13o2pools%cplant, casapool%cplant, 1.0_r_2, 0.0_r_2, tiny(1.0_r_2))
+                 !    print*, 'CC04.03 ', delta1000(c13o2pools%cplant, casapool%cplant, 1.0_r2, 0.0_r2, tiny(1.0_r2))
                  ! end if
                  ! if ((ktau == kstart) .or. (ktau == kend)) then
                  ! if ((ktau == 9) .or. (ktau == kend)) then
@@ -1393,11 +1393,11 @@ PROGRAM cable_offline_driver
 
            if ((icycle > 0) .and. (.not. casaonly)) then
               ! re-initalise annual flux sums
-              casabal%FCgppyear = 0.0_r_2
-              casabal%FCrpyear  = 0.0_r_2
-              casabal%FCnppyear = 0.0_r_2
-              casabal%FCrsyear  = 0.0_r_2
-              casabal%FCneeyear = 0.0_r_2
+              casabal%FCgppyear = 0.0_r2
+              casabal%FCrpyear  = 0.0_r2
+              casabal%FCnppyear = 0.0_r2
+              casabal%FCrsyear  = 0.0_r2
+              casabal%FCneeyear = 0.0_r2
            end if
 
            call CPU_time(etime)
@@ -1531,7 +1531,7 @@ END SUBROUTINE renameFiles
 ! and tranferring LUC-based age weights for secondary forest to POP structure
 SUBROUTINE LUCdriver( casabiome, casapool, casaflux, POP, LUC_EXPT, POPLUC, veg, c13o2pools )
 
-  USE cable_def_types_mod,  ONLY: r_2, veg_parameter_type, mland
+  USE cable_def_types_mod,  ONLY: r2, veg_parameter_type, mland
   USE cable_carbon_module
   USE cable_common_module,  ONLY: CABLE_USER, CurYear
   USE cable_IO_vars_module, ONLY: landpt
@@ -1571,28 +1571,28 @@ SUBROUTINE LUCdriver( casabiome, casapool, casaflux, POP, LUC_EXPT, POPLUC, veg,
   CALL READ_LUH2(LUC_EXPT)
 
   DO k=1,mland
-     POPLUC%ptos(k)   = real(LUC_EXPT%INPUT(ptos)%VAL(k), r_2)
-     POPLUC%ptog(k)   = real(LUC_EXPT%INPUT(ptog)%VAL(k), r_2)
-     POPLUC%stog(k)   = real(LUC_EXPT%INPUT(stog)%VAL(k), r_2)
-     POPLUC%gtop(k)   = 0.0_r_2
-     POPLUC%gtos(k)   = real(LUC_EXPT%INPUT(gtos)%VAL(k),   r_2)
-     POPLUC%pharv(k)  = real(LUC_EXPT%INPUT(pharv)%VAL(k),  r_2)
-     POPLUC%smharv(k) = real(LUC_EXPT%INPUT(smharv)%VAL(k), r_2)
-     POPLUC%syharv(k) = real(LUC_EXPT%INPUT(syharv)%VAL(k), r_2)
+     POPLUC%ptos(k)   = real(LUC_EXPT%INPUT(ptos)%VAL(k), r2)
+     POPLUC%ptog(k)   = real(LUC_EXPT%INPUT(ptog)%VAL(k), r2)
+     POPLUC%stog(k)   = real(LUC_EXPT%INPUT(stog)%VAL(k), r2)
+     POPLUC%gtop(k)   = 0.0_r2
+     POPLUC%gtos(k)   = real(LUC_EXPT%INPUT(gtos)%VAL(k),   r2)
+     POPLUC%pharv(k)  = real(LUC_EXPT%INPUT(pharv)%VAL(k),  r2)
+     POPLUC%smharv(k) = real(LUC_EXPT%INPUT(smharv)%VAL(k), r2)
+     POPLUC%syharv(k) = real(LUC_EXPT%INPUT(syharv)%VAL(k), r2)
 
-     POPLUC%ptoc(k) = real(LUC_EXPT%INPUT(ptoc)%VAL(k), r_2)
-     POPLUC%ptoq(k) = real(LUC_EXPT%INPUT(ptoq)%VAL(k), r_2)
-     POPLUC%stoc(k) = real(LUC_EXPT%INPUT(stoc)%VAL(k), r_2)
-     POPLUC%stoq(k) = real(LUC_EXPT%INPUT(stoq)%VAL(k), r_2)
-     POPLUC%ctos(k) = real(LUC_EXPT%INPUT(ctos)%VAL(k), r_2)
-     POPLUC%qtos(k) = real(LUC_EXPT%INPUT(qtos)%VAL(k), r_2)
+     POPLUC%ptoc(k) = real(LUC_EXPT%INPUT(ptoc)%VAL(k), r2)
+     POPLUC%ptoq(k) = real(LUC_EXPT%INPUT(ptoq)%VAL(k), r2)
+     POPLUC%stoc(k) = real(LUC_EXPT%INPUT(stoc)%VAL(k), r2)
+     POPLUC%stoq(k) = real(LUC_EXPT%INPUT(stoq)%VAL(k), r2)
+     POPLUC%ctos(k) = real(LUC_EXPT%INPUT(ctos)%VAL(k), r2)
+     POPLUC%qtos(k) = real(LUC_EXPT%INPUT(qtos)%VAL(k), r2)
 
-     POPLUC%ctor(k) = real(LUC_EXPT%INPUT(ctor)%VAL(k), r_2)
-     POPLUC%qtor(k) = real(LUC_EXPT%INPUT(qtor)%VAL(k), r_2)
-     POPLUC%rtoc(k) = real(LUC_EXPT%INPUT(rtoc)%VAL(k), r_2)
-     POPLUC%rtoq(k) = real(LUC_EXPT%INPUT(rtoq)%VAL(k), r_2)
-     POPLUC%qtoc(k) = real(LUC_EXPT%INPUT(qtoc)%VAL(k), r_2)
-     POPLUC%ctoq(k) = real(LUC_EXPT%INPUT(ctoq)%VAL(k), r_2)
+     POPLUC%ctor(k) = real(LUC_EXPT%INPUT(ctor)%VAL(k), r2)
+     POPLUC%qtor(k) = real(LUC_EXPT%INPUT(qtor)%VAL(k), r2)
+     POPLUC%rtoc(k) = real(LUC_EXPT%INPUT(rtoc)%VAL(k), r2)
+     POPLUC%rtoq(k) = real(LUC_EXPT%INPUT(rtoq)%VAL(k), r2)
+     POPLUC%qtoc(k) = real(LUC_EXPT%INPUT(qtoc)%VAL(k), r2)
+     POPLUC%ctoq(k) = real(LUC_EXPT%INPUT(ctoq)%VAL(k), r2)
 
      POPLUC%thisyear  = yyyy
 
@@ -1600,7 +1600,7 @@ SUBROUTINE LUCdriver( casabiome, casapool, casaflux, POP, LUC_EXPT, POPLUC, veg,
 
   ! zero secondary forest tiles in POP where secondary forest area is zero
   DO k=1,mland
-     if ( eq((POPLUC%frac_primf(k)-POPLUC%frac_forest(k)), 0.0_r_2) &
+     if ( eq((POPLUC%frac_primf(k)-POPLUC%frac_forest(k)), 0.0_r2) &
           .and. (.not. LUC_EXPT%prim_only(k)) ) then
         j = landpt(k)%cstart+1
         do l=1,size(POP%Iwood)
@@ -1610,24 +1610,24 @@ SUBROUTINE LUCdriver( casabiome, casapool, casaflux, POP, LUC_EXPT, POPLUC, veg,
            end if
         end do
 
-        casapool%cplant(j,leaf) = 0.01_r_2
+        casapool%cplant(j,leaf) = 0.01_r2
         casapool%nplant(j,leaf)= casabiome%ratioNCplantmin(veg%iveg(j),leaf)* casapool%cplant(j,leaf)
         casapool%pplant(j,leaf)= casabiome%ratioPCplantmin(veg%iveg(j),leaf)* casapool%cplant(j,leaf)
 
-        casapool%cplant(j,froot) = 0.01_r_2
+        casapool%cplant(j,froot) = 0.01_r2
         casapool%nplant(j,froot)= casabiome%ratioNCplantmin(veg%iveg(j),froot)* casapool%cplant(j,froot)
         casapool%pplant(j,froot)= casabiome%ratioPCplantmin(veg%iveg(j),froot)* casapool%cplant(j,froot)
 
-        casapool%cplant(j,wood) = 0.01_r_2
+        casapool%cplant(j,wood) = 0.01_r2
         casapool%nplant(j,wood)= casabiome%ratioNCplantmin(veg%iveg(j),wood)* casapool%cplant(j,wood)
         casapool%pplant(j,wood)= casabiome%ratioPCplantmin(veg%iveg(j),wood)* casapool%cplant(j,wood)
-        casaflux%frac_sapwood(j) = 1.0_r_2
+        casaflux%frac_sapwood(j) = 1.0_r2
 
         ! 13C
         if (cable_user%c13o2) then
-           c13o2pools%cplant(j,leaf)  = 0.01_r_2 ! * vpdbc13 / vpdbc13 ! Divide by 13C
-           c13o2pools%cplant(j,wood)  = 0.01_r_2 ! * vpdbc13 / vpdbc13 ! so that about same numerical precision as 12C
-           c13o2pools%cplant(j,froot) = 0.01_r_2 ! * vpdbc13 / vpdbc13 !
+           c13o2pools%cplant(j,leaf)  = 0.01_r2 ! * vpdbc13 / vpdbc13 ! Divide by 13C
+           c13o2pools%cplant(j,wood)  = 0.01_r2 ! * vpdbc13 / vpdbc13 ! so that about same numerical precision as 12C
+           c13o2pools%cplant(j,froot) = 0.01_r2 ! * vpdbc13 / vpdbc13 !
         end if
      end if
   END DO

--- a/offline/cable_initialise.F90
+++ b/offline/cable_initialise.F90
@@ -141,39 +141,39 @@ CONTAINS
     canopy%fwsoil  = 1.0   ! water limitation factor
 
     ! GPP_components
-    canopy%A_shC          = 0.0_r_2
-    canopy%A_shJ          = 0.0_r_2
-    canopy%A_slC          = 0.0_r_2
-    canopy%A_slJ          = 0.0_r_2
-    canopy%GPP_sh         = 0.0_r_2
-    canopy%GPP_sl         = 0.0_r_2
-    canopy%eta_A_cs       = 0.0_r_2
-    canopy%eta_GPP_cs     = 0.0_r_2
-    canopy%eta_fevc_cs    = 0.0_r_2
-    canopy%eta_A_cs_sl    = 0.0_r_2
-    canopy%eta_fevc_cs_sl = 0.0_r_2
-    canopy%GPP_sh         = 0.0_r_2
-    canopy%eta_A_cs_sh    = 0.0_r_2
-    canopy%eta_fevc_cs_sh = 0.0_r_2
+    canopy%A_shC          = 0.0_r2
+    canopy%A_shJ          = 0.0_r2
+    canopy%A_slC          = 0.0_r2
+    canopy%A_slJ          = 0.0_r2
+    canopy%GPP_sh         = 0.0_r2
+    canopy%GPP_sl         = 0.0_r2
+    canopy%eta_A_cs       = 0.0_r2
+    canopy%eta_GPP_cs     = 0.0_r2
+    canopy%eta_fevc_cs    = 0.0_r2
+    canopy%eta_A_cs_sl    = 0.0_r2
+    canopy%eta_fevc_cs_sl = 0.0_r2
+    canopy%GPP_sh         = 0.0_r2
+    canopy%eta_A_cs_sh    = 0.0_r2
+    canopy%eta_fevc_cs_sh = 0.0_r2
 
-    canopy%dAdcs   = 0.0_r_2
-    canopy%cs      = real(met%ca,r_2)
-    canopy%cs_sl   = real(met%ca,r_2)
-    canopy%cs_sh   = real(met%ca,r_2)
-    canopy%tlf     = 0.0_r_2
-    canopy%dlf     = 0.0_r_2
-    canopy%evapfbl = 0.0_r_2
+    canopy%dAdcs   = 0.0_r2
+    canopy%cs      = real(met%ca,r2)
+    canopy%cs_sl   = real(met%ca,r2)
+    canopy%cs_sh   = real(met%ca,r2)
+    canopy%tlf     = 0.0_r2
+    canopy%dlf     = 0.0_r2
+    canopy%evapfbl = 0.0_r2
 
     ! 13C
-    canopy%An        = 0.0_r_2
-    canopy%Rd        = 0.0_r_2
+    canopy%An        = 0.0_r2
+    canopy%Rd        = 0.0_r2
     canopy%isc3      = .true.
-    canopy%vcmax     = 0.0_r_2
-    canopy%gammastar = 40.0_r_2
-    canopy%gsc       = 0.0_r_2
-    canopy%gbc       = 0.0_r_2
-    canopy%gac       = 0.0_r_2
-    canopy%ci        = spread(real(met%ca,r_2),2,mf)
+    canopy%vcmax     = 0.0_r2
+    canopy%gammastar = 40.0_r2
+    canopy%gsc       = 0.0_r2
+    canopy%gbc       = 0.0_r2
+    canopy%gac       = 0.0_r2
+    canopy%ci        = spread(real(met%ca,r2),2,mf)
 
   END SUBROUTINE get_default_inits
 
@@ -228,7 +228,7 @@ CONTAINS
          from_restart = .TRUE., & ! insist variables/params load
          dummy                    ! To replace completeSet in parameter read; unused
     ! REAL,      ALLOCATABLE :: var_r(:)
-    ! REAL(r_2), ALLOCATABLE :: var_r2(:)
+    ! REAL(r2), ALLOCATABLE :: var_r2(:)
 
     ! Write to screen the restart file is found:
     WRITE(*,*) 'Reading restart data from: ', TRIM(filename%restart_in)
@@ -495,7 +495,7 @@ CONTAINS
          max_vegpatches, 'def', from_restart, mp)
     CALL readpar(ncid_rin, 'us', dummy, canopy%us, filename%restart_in, &
          max_vegpatches, 'def', from_restart, mp)
-    !jhan:hack - elimiinate call as r_2 now
+    !jhan:hack - elimiinate call as r2 now
     ! CALL readpar(ncid_rin,'fes',dummy,canopy%fes,filename%restart_in, &
     !      max_vegpatches,'def',from_restart,mp)
     CALL readpar(ncid_rin,'fhs',dummy,canopy%fhs,filename%restart_in, &
@@ -551,7 +551,7 @@ CONTAINS
     !    dummy = .true.
     !    CALL readpar(ncid_rin,'patchfrac',dummy,var_r,filename%restart_in, &
     !         max_vegpatches,'def',from_restart,mp)
-    !    if (dummy) patch(:)%frac = real(var_r,r_2)
+    !    if (dummy) patch(:)%frac = real(var_r,r2)
     !    deallocate(var_r)
     ! ENDIF
     !    DO i=1, mland
@@ -710,15 +710,15 @@ CONTAINS
          //TRIM(filename%restart_in)//' (SUBROUTINE get_restart)')
 
     ! 13C - not in restart
-    canopy%An        = 0.0_r_2
-    canopy%Rd        = 0.0_r_2
+    canopy%An        = 0.0_r2
+    canopy%Rd        = 0.0_r2
     canopy%isc3      = (1.0-veg%frac4) > epsilon(1.0)
-    canopy%vcmax     = 0.0_r_2
-    canopy%gammastar = 40.e-6_r_2
-    canopy%gsc       = 0.0_r_2
-    canopy%gbc       = 0.0_r_2
-    canopy%gac       = 0.0_r_2
-    canopy%ci        = 400.e-6_r_2
+    canopy%vcmax     = 0.0_r2
+    canopy%gammastar = 40.e-6_r2
+    canopy%gsc       = 0.0_r2
+    canopy%gbc       = 0.0_r2
+    canopy%gac       = 0.0_r2
+    canopy%ci        = 400.e-6_r2
 
   END SUBROUTINE get_restart_data
 
@@ -761,9 +761,9 @@ CONTAINS
          nap, &
          var_i
     REAL,    ALLOCATABLE, DIMENSION(:)   :: var_r
-    REAL(r_2),    ALLOCATABLE, DIMENSION(:)   :: var_rd
+    REAL(r2),    ALLOCATABLE, DIMENSION(:)   :: var_rd
     REAL,    ALLOCATABLE, DIMENSION(:,:) :: var_r2
-    REAL(r_2),    ALLOCATABLE, DIMENSION(:,:) :: var_r2d
+    REAL(r2),    ALLOCATABLE, DIMENSION(:,:) :: var_r2d
     LOGICAL                                   :: &
          from_restart = .TRUE., & ! insist variables/params load
          dummy = .TRUE.              ! To replace completeSet in parameter read; unused
@@ -888,7 +888,7 @@ CONTAINS
     CALL readpar(ncid_rin, 'us', dummy, var_r, filename%restart_in, &
          max_vegpatches, 'def', from_restart, INpatch)
     CALL redistr_r(INpatch, nap, var_r, canopy%us, 'us')
-    !jhan:hack - elimiinate call as r_2 now
+    !jhan:hack - elimiinate call as r2 now
     !    CALL readpar(ncid_rin,'fes',dummy,var_r,filename%restart_in, &
     !         max_vegpatches,'def',from_restart,INpatch)
     !    CALL redistr_r(INpatch,nap,var_r,canopy%fes,'fes')

--- a/offline/cable_input.F90
+++ b/offline/cable_input.F90
@@ -35,7 +35,7 @@
 !==============================================================================
 
 MODULE cable_input_module
-! Note that any precision changes from r_1 to REAL(4) enable running with -r8
+! Note that any precision changes from r1 to REAL(4) enable running with -r8
 !
    USE cable_abort_module,      ONLY: cable_abort, nc_abort
    USE cable_def_types_mod
@@ -401,13 +401,13 @@ SUBROUTINE open_met_file(dels,koffset,kend,spinup, TFRZ)
         precipTot,              & ! used for spinup adj
         avPrecipInMet             ! used for spinup adj
    CHARACTER(LEN=10)                :: todaydate, nowtime ! used to timestamp log file
-   REAL(r_1),DIMENSION(1)             :: data1 ! temp variable for netcdf reading
-   REAL(r_1),DIMENSION(1,1)           :: data2 ! temp variable for netcdf reading
-   REAL(r_1), DIMENSION(:),     ALLOCATABLE :: temparray1  ! temp read in variable
-   REAL(r_1), DIMENSION(:,:),   ALLOCATABLE :: &
+   REAL(r1),DIMENSION(1)             :: data1 ! temp variable for netcdf reading
+   REAL(r1),DIMENSION(1,1)           :: data2 ! temp variable for netcdf reading
+   REAL(r1), DIMENSION(:),     ALLOCATABLE :: temparray1  ! temp read in variable
+   REAL(r1), DIMENSION(:,:),   ALLOCATABLE :: &
         tempPrecip2,            & ! used for spinup adj
         temparray2                ! temp read in variable
-   REAL(r_1), DIMENSION(:,:,:), ALLOCATABLE :: tempPrecip3 ! used for spinup adj
+   REAL(r1), DIMENSION(:,:,:), ALLOCATABLE :: tempPrecip3 ! used for spinup adj
    LOGICAL                          ::                                         &
         all_met     ! ALL required met in met file (no synthesis)?
 #ifdef __MPI__
@@ -531,7 +531,7 @@ SUBROUTINE open_met_file(dels,koffset,kend,spinup, TFRZ)
     IF(ok /= NF90_NOERR) CALL nc_abort &
          (ok,'Error reading latitude variable in met data file ' &
          //TRIM(filename%met)//' (SUBROUTINE open_met_file)')
-    ! Needed since r_1 will be double precision with -r8:
+    ! Needed since r1 will be double precision with -r8:
     lat_all = REAL(temparray2)
     ! Find longitude variable (try 'longitude' and 'nav_lon'(ALMA)):
     ok = NF90_INQ_VARID(ncid_met, 'longitude', longitudeID)
@@ -548,7 +548,7 @@ SUBROUTINE open_met_file(dels,koffset,kend,spinup, TFRZ)
     IF(ok /= NF90_NOERR) CALL nc_abort &
          (ok,'Error reading longitude variable in met data file ' &
          //TRIM(filename%met)//' (SUBROUTINE open_met_file)')
-    ! Needed since r_1 will be double precision with -r8:
+    ! Needed since r1 will be double precision with -r8:
     lon_all = REAL(temparray2)
     DEALLOCATE(temparray2)
 
@@ -598,7 +598,7 @@ SUBROUTINE open_met_file(dels,koffset,kend,spinup, TFRZ)
           IF(ok /= NF90_NOERR) CALL nc_abort &
                (ok,'Error reading "land" variable in ' &
                //TRIM(filename%met)//' (SUBROUTINE open_met_file)')
-          ! Needed since r_1 will be double precision with -r8:
+          ! Needed since r1 will be double precision with -r8:
           landGrid = nint(temparray1)
           DEALLOCATE(temparray1)
           ! Allocate latitude and longitude variables:
@@ -744,7 +744,7 @@ SUBROUTINE open_met_file(dels,koffset,kend,spinup, TFRZ)
     IF (ncciy > 0) THEN
       write(*,*) 'original timevar(kend) = ', timevar(kend)
       DO i = 1, kend - 1
-        timevar(i+1) = timevar(i) + real(dels,r_2)
+        timevar(i+1) = timevar(i) + real(dels,r2)
       ENDDO
       write(*,*) 'New      timevar(kend) = ', timevar(kend)
     END IF
@@ -761,11 +761,11 @@ SUBROUTINE open_met_file(dels,koffset,kend,spinup, TFRZ)
     !****** PALS met file has timevar(1)=0 while timeunits from 00:30:00 ******
     !!CLN CRITICAL! From my point of view, the information in the file is correct...
     !!CLN WHY DO the input files all have bugs???
-    IF (eq(timevar(1), 0.0_r_2)) THEN
+    IF (eq(timevar(1), 0.0_r2)) THEN
       READ(timeunits(29:30),*) tsmin
       IF (tsmin*60.0 >= dels) THEN
         tsmin = tsmin - INT(dels / 60)
-        timevar = timevar + real(dels,r_2)
+        timevar = timevar + real(dels,r2)
         WRITE(timeunits(29:30),'(i2.2)') tsmin
       ENDIF
     ENDIF
@@ -1296,7 +1296,7 @@ SUBROUTINE open_met_file(dels,koffset,kend,spinup, TFRZ)
              IF(ok /= NF90_NOERR) CALL nc_abort &
                   (ok,'Error reading avPrecip in met data file ' &
                   //TRIM(filename%met)//' (SUBROUTINE open_met_file)')
-             ! Needed since r_1 will be double precision with -r8:
+             ! Needed since r1 will be double precision with -r8:
              avPrecip = REAL(temparray1)
              DEALLOCATE(temparray1)
           END IF
@@ -1546,7 +1546,7 @@ END SUBROUTINE open_met_file
 
 SUBROUTINE get_met_data(spinup, spinConv, met, rad, &
      veg, dels, TFRZ, ktau, kstart)
-   ! Precision changes from REAL(4) to r_1 enable running with -r8
+   ! Precision changes from REAL(4) to r1 enable running with -r8
 
    use mo_utils, only: eq
 #ifdef __MPI__
@@ -1569,10 +1569,10 @@ SUBROUTINE get_met_data(spinup, spinConv, met, rad, &
 
    ! Local variables
    INTEGER                           :: i,j ! do loop counter
-   REAL(KIND=r_1),ALLOCATABLE,DIMENSION(:)       :: tmpDat1
-   REAL(KIND=r_1),ALLOCATABLE,DIMENSION(:,:)     :: tmpDat2, tmpDat2x
-   REAL(KIND=r_1),ALLOCATABLE,DIMENSION(:,:,:)   :: tmpDat3, tmpDat3x
-   REAL(KIND=r_1),ALLOCATABLE,DIMENSION(:,:,:,:) :: tmpDat4, tmpDat4x
+   REAL(KIND=r1),ALLOCATABLE,DIMENSION(:)       :: tmpDat1
+   REAL(KIND=r1),ALLOCATABLE,DIMENSION(:,:)     :: tmpDat2, tmpDat2x
+   REAL(KIND=r1),ALLOCATABLE,DIMENSION(:,:,:)   :: tmpDat3, tmpDat3x
+   REAL(KIND=r1),ALLOCATABLE,DIMENSION(:,:,:,:) :: tmpDat4, tmpDat4x
 #ifdef __MPI__
    integer :: ierr
 #endif
@@ -2779,7 +2779,7 @@ SUBROUTINE get_parameters_met(soil,veg,bgc,rough,completeSet)
    CALL readpar(ncid_met, 'patchfrac', completeSet, tmp, filename%met, nmetpatches, 'def')
 
 
-   if (completeSet) patch(:)%frac = real(tmp,r_2)
+   if (completeSet) patch(:)%frac = real(tmp,r2)
    deallocate(tmp)
    ! CALL readpar(ncid_met,'isoil',completeSet,soil%isoilm,filename%met, &
    !      nmetpatches,'def')

--- a/offline/cable_iovars.F90
+++ b/offline/cable_iovars.F90
@@ -19,13 +19,13 @@
 ! ==============================================================================
 MODULE cable_IO_vars_module
 
-   USE cable_def_types_mod, ONLY : r_2, mvtype, mstype
+   USE cable_def_types_mod, ONLY : r2, mvtype, mstype
 
    IMPLICIT NONE
 
    PUBLIC
 
-   PRIVATE :: r_2, mvtype, mstype
+   PRIVATE :: r2, mvtype, mstype
 
 
    ! ============ Timing variables =====================
@@ -39,7 +39,7 @@ MODULE cable_IO_vars_module
 
    CHARACTER(LEN=3) :: time_coord ! GMT or LOCal time variables
 
-   REAL(r_2),POINTER,DIMENSION(:) :: timevar => null() ! time variable from file
+   REAL(r2),POINTER,DIMENSION(:) :: timevar => null() ! time variable from file
 
    INTEGER,DIMENSION(12) ::                                                    &
       daysm = (/31,28,31,30,31,30,31,31,30,31,30,31/),                         &
@@ -67,7 +67,7 @@ MODULE cable_IO_vars_module
    ! For vegetated surface type
    TYPE patch_type
 
-      REAL(r_2) :: frac ! fractional cover of each veg patch
+      REAL(r2) :: frac ! fractional cover of each veg patch
       REAL :: latitude, longitude
 
    END TYPE patch_type

--- a/offline/cable_output.F90
+++ b/offline/cable_output.F90
@@ -90,190 +90,190 @@ MODULE cable_output_module
   TYPE(parID_type) :: opid ! netcdf variable IDs for output variables
 
   TYPE output_temporary_type
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: SWdown => null()   ! 5 downward short-wave radiation [W/m2]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: FracDiff => null() ! 6 Fraction of diffuse radiation
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: LWdown => null()   ! 7 downward long-wave radiation [W/m2]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: Rainf => null()    ! 8 rainfall [kg/m2/s]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: Snowf => null()    ! 9 snowfall [kg/m2/s]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: PSurf => null()    ! 10 surface pressure [Pa]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: Tair => null()     ! 11 surface air temperature
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: SWdown => null()   ! 5 downward short-wave radiation [W/m2]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: FracDiff => null() ! 6 Fraction of diffuse radiation
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: LWdown => null()   ! 7 downward long-wave radiation [W/m2]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: Rainf => null()    ! 8 rainfall [kg/m2/s]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: Snowf => null()    ! 9 snowfall [kg/m2/s]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: PSurf => null()    ! 10 surface pressure [Pa]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: Tair => null()     ! 11 surface air temperature
      ! [K]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: Qair => null()   ! 12 specific humidity [kg/kg]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: CO2air => null() ! 13 CO2 concentration [ppmv]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: Wind => null()   ! 14 windspeed [m/s]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: Wind_N => null() ! 15 surface wind speed, N component [m/s]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: Wind_E => null() ! 16 surface wind speed, E component [m/s]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: LAI => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: Qh => null()     ! 17 sensible heat flux [W/m2]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: Qle => null()    ! 18 latent heat flux [W/m2]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: Qg => null()     ! 19 ground heat flux [W/m2]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: fbeam => null()  ! 20 fracion of direct radiation
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: SWnet => null()  ! 20 net shortwave [W/m2]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: LWnet => null()  ! 21 net longwave [W/m2]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: Evap => null()   ! 22 total evapotranspiration [kg/m2/s]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: Ewater => null() ! 23 evap. from surface water storage [kg/m2/s]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: ESoil => null()  ! 24 bare soil evaporation [kg/m2/s]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: TVeg => null()   ! 25 vegetation transpiration [kg/m2/s]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: ECanop => null() ! 26 interception evaporation [kg/m2/s]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: Qair => null()   ! 12 specific humidity [kg/kg]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: CO2air => null() ! 13 CO2 concentration [ppmv]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: Wind => null()   ! 14 windspeed [m/s]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: Wind_N => null() ! 15 surface wind speed, N component [m/s]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: Wind_E => null() ! 16 surface wind speed, E component [m/s]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: LAI => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: Qh => null()     ! 17 sensible heat flux [W/m2]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: Qle => null()    ! 18 latent heat flux [W/m2]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: Qg => null()     ! 19 ground heat flux [W/m2]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: fbeam => null()  ! 20 fracion of direct radiation
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: SWnet => null()  ! 20 net shortwave [W/m2]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: LWnet => null()  ! 21 net longwave [W/m2]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: Evap => null()   ! 22 total evapotranspiration [kg/m2/s]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: Ewater => null() ! 23 evap. from surface water storage [kg/m2/s]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: ESoil => null()  ! 24 bare soil evaporation [kg/m2/s]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: TVeg => null()   ! 25 vegetation transpiration [kg/m2/s]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: ECanop => null() ! 26 interception evaporation [kg/m2/s]
      ! 27 potential evapotranspiration [kg/m2/s]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: PotEvap => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: ACond => null()   ! 28 aerodynamic conductance [m/s]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: SoilWet => null() ! 29 total soil wetness [-]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: Albedo => null()  ! 30 albedo [-]
-     REAL(KIND=r_1), POINTER, DIMENSION(:,:) :: visAlbedo => null()  ! vars intro for Ticket #27
-     REAL(KIND=r_1), POINTER, DIMENSION(:,:) :: nirAlbedo => null()  ! vars intro for Ticket #27
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: VegT => null()    ! 31 vegetation temperature [K]
-     REAL(KIND=r_1), POINTER, DIMENSION(:,:) :: SoilTemp => null()  ! 32 av.layer soil temperature [K]
-     REAL(KIND=r_1), POINTER, DIMENSION(:,:) :: SoilMoist => null() ! 33 av.layer soil moisture [kg/m2]
-     REAL(KIND=r_1), POINTER, DIMENSION(:)   :: SoilMoistPFT => null() ! 33 soil moisture per PFT [kg/m2]
-     REAL(KIND=r_1), POINTER, DIMENSION(:,:) :: SoilMoistIce => null() ! 33 av.layer soil frozen moisture [kg/m2]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: Qs => null()  ! 34 surface runoff [kg/m2/s]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: Qsb => null() ! 35 subsurface runoff [kg/m2/s]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: PotEvap => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: ACond => null()   ! 28 aerodynamic conductance [m/s]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: SoilWet => null() ! 29 total soil wetness [-]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: Albedo => null()  ! 30 albedo [-]
+     REAL(KIND=r1), POINTER, DIMENSION(:,:) :: visAlbedo => null()  ! vars intro for Ticket #27
+     REAL(KIND=r1), POINTER, DIMENSION(:,:) :: nirAlbedo => null()  ! vars intro for Ticket #27
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: VegT => null()    ! 31 vegetation temperature [K]
+     REAL(KIND=r1), POINTER, DIMENSION(:,:) :: SoilTemp => null()  ! 32 av.layer soil temperature [K]
+     REAL(KIND=r1), POINTER, DIMENSION(:,:) :: SoilMoist => null() ! 33 av.layer soil moisture [kg/m2]
+     REAL(KIND=r1), POINTER, DIMENSION(:)   :: SoilMoistPFT => null() ! 33 soil moisture per PFT [kg/m2]
+     REAL(KIND=r1), POINTER, DIMENSION(:,:) :: SoilMoistIce => null() ! 33 av.layer soil frozen moisture [kg/m2]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: Qs => null()  ! 34 surface runoff [kg/m2/s]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: Qsb => null() ! 35 subsurface runoff [kg/m2/s]
      ! 36 change in soilmoisture (sum layers) [kg/m2]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: DelSoilMoist => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: DelSoilMoist => null()
      ! 37 change in snow water equivalent [kg/m2]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: DelSWE => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: DelSWE => null()
      ! 38 change in interception storage [kg/m2]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: DelIntercept => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: SnowT => null()     ! 39 snow surface temp [K]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: BaresoilT => null() ! 40 surface bare soil temp [K]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: AvgSurfT => null()  ! 41 Average surface temperature [K]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: RadT => null()      ! 42 Radiative surface temperature [K]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: SWE => null()       ! 43 snow water equivalent [kg/m2]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: RootMoist => null() ! 44 root zone soil moisture [kg/m2]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: CanopInt => null()  ! 45 total canopy water storage [kg/m2]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: NEE => null()       ! 46 net ecosystem exchange [umol/m2/s]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: NPP => null()       ! 47 net primary production of C by veg [umol/m2/s]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: DelIntercept => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: SnowT => null()     ! 39 snow surface temp [K]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: BaresoilT => null() ! 40 surface bare soil temp [K]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: AvgSurfT => null()  ! 41 Average surface temperature [K]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: RadT => null()      ! 42 Radiative surface temperature [K]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: SWE => null()       ! 43 snow water equivalent [kg/m2]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: RootMoist => null() ! 44 root zone soil moisture [kg/m2]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: CanopInt => null()  ! 45 total canopy water storage [kg/m2]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: NEE => null()       ! 46 net ecosystem exchange [umol/m2/s]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: NPP => null()       ! 47 net primary production of C by veg [umol/m2/s]
      ! 48 gross primary production C by veg [umol/m2/s]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: GPP => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: AutoResp => null()   ! 49 autotrophic respiration [umol/m2/s]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: LeafResp => null()   ! 51 autotrophic respiration [umol/m2/s]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: HeteroResp => null() ! 50 heterotrophic respiration [umol/m2/s]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: SnowDepth => null()  ! actual depth of snow in [m]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: GPP => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: AutoResp => null()   ! 49 autotrophic respiration [umol/m2/s]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: LeafResp => null()   ! 51 autotrophic respiration [umol/m2/s]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: HeteroResp => null() ! 50 heterotrophic respiration [umol/m2/s]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: SnowDepth => null()  ! actual depth of snow in [m]
      ! vh_mc ! additional variables for ESM-SnowMIP
-     real(kind=r_1), pointer, dimension(:)   :: hfds => null()  ! downward heat flux at ground surface [W/m2]
-     real(kind=r_1), pointer, dimension(:)   :: hfdsn => null() ! downward heat flux into snowpack [W/m2]
-     real(kind=r_1), pointer, dimension(:)   :: hfls => null()  ! surface upward latent heat flux [W/m2]
-     real(kind=r_1), pointer, dimension(:)   :: hfmlt => null() ! energy of fusion [W/m2]
-     real(kind=r_1), pointer, dimension(:)   :: hfrs => null()  ! heat transferred to snowpack by rain [W/m2]
-     real(kind=r_1), pointer, dimension(:)   :: hfsbl => null() ! energy of sublimation [W/m2]
-     real(kind=r_1), pointer, dimension(:)   :: hfss => null()  ! surface upward sensible heat flux [W/m2]
-     real(kind=r_1), pointer, dimension(:)   :: rlus => null()  ! surface upwelling longwave radiation [W/m2]
-     real(kind=r_1), pointer, dimension(:)   :: rsus => null()  ! surface upwelling shortwave radiation [W/m2]
-     real(kind=r_1), pointer, dimension(:)   :: esn => null()   ! liquid water evaporation from snowpack [kg/m2/s]
+     real(kind=r1), pointer, dimension(:)   :: hfds => null()  ! downward heat flux at ground surface [W/m2]
+     real(kind=r1), pointer, dimension(:)   :: hfdsn => null() ! downward heat flux into snowpack [W/m2]
+     real(kind=r1), pointer, dimension(:)   :: hfls => null()  ! surface upward latent heat flux [W/m2]
+     real(kind=r1), pointer, dimension(:)   :: hfmlt => null() ! energy of fusion [W/m2]
+     real(kind=r1), pointer, dimension(:)   :: hfrs => null()  ! heat transferred to snowpack by rain [W/m2]
+     real(kind=r1), pointer, dimension(:)   :: hfsbl => null() ! energy of sublimation [W/m2]
+     real(kind=r1), pointer, dimension(:)   :: hfss => null()  ! surface upward sensible heat flux [W/m2]
+     real(kind=r1), pointer, dimension(:)   :: rlus => null()  ! surface upwelling longwave radiation [W/m2]
+     real(kind=r1), pointer, dimension(:)   :: rsus => null()  ! surface upwelling shortwave radiation [W/m2]
+     real(kind=r1), pointer, dimension(:)   :: esn => null()   ! liquid water evaporation from snowpack [kg/m2/s]
      ! total water vapour flux from the surface to the atmosphere [kg/m2/s]
-     real(kind=r_1), pointer, dimension(:)   :: evspsbl => null()
-     real(kind=r_1), pointer, dimension(:)   :: evspsblsoi => null() ! evaporation and sublimation from soil [kg/m2/s]
-     real(kind=r_1), pointer, dimension(:)   :: evspsblveg => null() ! evaporation and sublimation from canopy [kg/m2/s]
-     real(kind=r_1), pointer, dimension(:)   :: mrrob => null()   ! subsurface runoff [kg/m2/s]
-     real(kind=r_1), pointer, dimension(:)   :: mrros => null()   ! surface runoff [kg/m2/s]
-     real(kind=r_1), pointer, dimension(:)   :: sbl => null()     ! sublimation of snow [kg/m2/s]
-     real(kind=r_1), pointer, dimension(:)   :: snm => null()     ! surface snow melt [kg/m2/s]
-     real(kind=r_1), pointer, dimension(:)   :: snmsl => null()   ! water flowing out of snowpack [kg/m2/s]
-     real(kind=r_1), pointer, dimension(:)   :: tran => null()    ! transpiration [kg/m2/s]
-     real(kind=r_1), pointer, dimension(:)   :: albs => null()    ! surface albedo [-]
-     real(kind=r_1), pointer, dimension(:)   :: albsn => null()   ! snow albedo [-]
-     real(kind=r_1), pointer, dimension(:)   :: cw => null()      ! total canopy water storage [kg/m2]
-     real(kind=r_1), pointer, dimension(:)   :: lqsn => null()    ! mass fraction of liquid water in snowpack [-]
-     real(kind=r_1), pointer, dimension(:)   :: lwsnl => null()   ! liquid water content of snowpack [kg/m2]
-     real(kind=r_1), pointer, dimension(:,:) :: mrfsofr => null() ! mass fractions of frozen water in soil layers [-]
-     real(kind=r_1), pointer, dimension(:,:) :: mrlqso => null()  ! mass fractions of unfrozen water in soil layers [-]
-     real(kind=r_1), pointer, dimension(:,:) :: mrlsl => null()   ! masses of frozen and unfrozen moisture in soil layers [kg/m2]
-     real(kind=r_1), pointer, dimension(:)   :: snc => null()     ! snow area fraction [-]
-     real(kind=r_1), pointer, dimension(:)   :: snd => null()     ! snowdepth [m]
-     real(kind=r_1), pointer, dimension(:)   :: snw => null()     ! mass of snowpack [kg/m2]
-     real(kind=r_1), pointer, dimension(:)   :: snwc => null()    ! mass of snow intercepted by vegetation [kg/m2]
-     real(kind=r_1), pointer, dimension(:)   :: tcs => null()     ! vegetation canopy temperature [K]
-     real(kind=r_1), pointer, dimension(:)   :: tgs => null()     ! temperature of bare soil [K]
-     real(kind=r_1), pointer, dimension(:)   :: ts => null()      ! surface temperature [K]
-     real(kind=r_1), pointer, dimension(:,:) :: tsl => null()     ! temperatures of soil layers [K]
-     real(kind=r_1), pointer, dimension(:)   :: tsn => null()     ! snow internal temperature [K]
-     real(kind=r_1), pointer, dimension(:)   :: tsns => null()    ! snow surface temperature [K]
+     real(kind=r1), pointer, dimension(:)   :: evspsbl => null()
+     real(kind=r1), pointer, dimension(:)   :: evspsblsoi => null() ! evaporation and sublimation from soil [kg/m2/s]
+     real(kind=r1), pointer, dimension(:)   :: evspsblveg => null() ! evaporation and sublimation from canopy [kg/m2/s]
+     real(kind=r1), pointer, dimension(:)   :: mrrob => null()   ! subsurface runoff [kg/m2/s]
+     real(kind=r1), pointer, dimension(:)   :: mrros => null()   ! surface runoff [kg/m2/s]
+     real(kind=r1), pointer, dimension(:)   :: sbl => null()     ! sublimation of snow [kg/m2/s]
+     real(kind=r1), pointer, dimension(:)   :: snm => null()     ! surface snow melt [kg/m2/s]
+     real(kind=r1), pointer, dimension(:)   :: snmsl => null()   ! water flowing out of snowpack [kg/m2/s]
+     real(kind=r1), pointer, dimension(:)   :: tran => null()    ! transpiration [kg/m2/s]
+     real(kind=r1), pointer, dimension(:)   :: albs => null()    ! surface albedo [-]
+     real(kind=r1), pointer, dimension(:)   :: albsn => null()   ! snow albedo [-]
+     real(kind=r1), pointer, dimension(:)   :: cw => null()      ! total canopy water storage [kg/m2]
+     real(kind=r1), pointer, dimension(:)   :: lqsn => null()    ! mass fraction of liquid water in snowpack [-]
+     real(kind=r1), pointer, dimension(:)   :: lwsnl => null()   ! liquid water content of snowpack [kg/m2]
+     real(kind=r1), pointer, dimension(:,:) :: mrfsofr => null() ! mass fractions of frozen water in soil layers [-]
+     real(kind=r1), pointer, dimension(:,:) :: mrlqso => null()  ! mass fractions of unfrozen water in soil layers [-]
+     real(kind=r1), pointer, dimension(:,:) :: mrlsl => null()   ! masses of frozen and unfrozen moisture in soil layers [kg/m2]
+     real(kind=r1), pointer, dimension(:)   :: snc => null()     ! snow area fraction [-]
+     real(kind=r1), pointer, dimension(:)   :: snd => null()     ! snowdepth [m]
+     real(kind=r1), pointer, dimension(:)   :: snw => null()     ! mass of snowpack [kg/m2]
+     real(kind=r1), pointer, dimension(:)   :: snwc => null()    ! mass of snow intercepted by vegetation [kg/m2]
+     real(kind=r1), pointer, dimension(:)   :: tcs => null()     ! vegetation canopy temperature [K]
+     real(kind=r1), pointer, dimension(:)   :: tgs => null()     ! temperature of bare soil [K]
+     real(kind=r1), pointer, dimension(:)   :: ts => null()      ! surface temperature [K]
+     real(kind=r1), pointer, dimension(:,:) :: tsl => null()     ! temperatures of soil layers [K]
+     real(kind=r1), pointer, dimension(:)   :: tsn => null()     ! snow internal temperature [K]
+     real(kind=r1), pointer, dimension(:)   :: tsns => null()    ! snow surface temperature [K]
      ! Non-Alma variables
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: Rnet => null()  ! net absorbed radiation [W/m2]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: HVeg => null()  ! sensible heat from vegetation [W/m2]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: HSoil => null() ! sensible heat from soil [W/m2]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: RnetSoil => null() ! latent heat from soil [kg/m2/s]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: SnowMelt => null() ! snow melt [W/m2]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: Ebal => null()  ! cumulative energy balance [W/m2]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: Wbal => null()  ! cumulative water balance [W/m2]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: CanT => null()  ! within-canopy temperature [K]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: Fwsoil => null()  ! soil-moisture modfier to stomatal conductance [-]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: Rnet => null()  ! net absorbed radiation [W/m2]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: HVeg => null()  ! sensible heat from vegetation [W/m2]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: HSoil => null() ! sensible heat from soil [W/m2]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: RnetSoil => null() ! latent heat from soil [kg/m2/s]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: SnowMelt => null() ! snow melt [W/m2]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: Ebal => null()  ! cumulative energy balance [W/m2]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: Wbal => null()  ! cumulative water balance [W/m2]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: CanT => null()  ! within-canopy temperature [K]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: Fwsoil => null()  ! soil-moisture modfier to stomatal conductance [-]
 
      ! [umol/m2/s]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: NBP => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: dCdt => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: NBP => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: dCdt => null()
      ! [kg C /m2]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: TotSoilCarb => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: TotLivBiomass => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: TotLittCarb => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: SoilCarbFast => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: SoilCarbSlow => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: SoilCarbPassive => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: LittCarbMetabolic => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: LittCarbStructural => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: LittCarbCWD => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: PlantCarbLeaf => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: PlantCarbFineRoot => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: PlantCarbWood => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: PlantTurnover => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: PlantTurnoverLeaf => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: PlantTurnoverFineRoot => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: PlantTurnoverWood => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: PlantTurnoverWoodDist => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: PlantTurnoverWoodCrowding => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: PlantTurnoverWoodResourceLim => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: Area => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: LandUseFlux => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: vcmax => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: ejmax => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: patchfrac => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: hc => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: GPP_sl => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: GPP_sh => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: GPP_slC => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: GPP_shC => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: GPP_slJ => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: GPP_shJ => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: An_sl => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: An_sh=> null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: ci_sl => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: ci_sh => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: scalex_sl => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: scalex_sh => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: dlf => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: eta_GPP_cs => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: eta_TVeg_cs => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: dGPPdcs => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: CO2s => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: gsw_TVeg => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: vcmax_ts => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: jmax_ts => null()
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: gsw_sl => null()   ! stomatal conductance (sunlit leaves)
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: gsw_sh => null()   ! stomatal conductance (shaded leaves)
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: RootResp => null()   ! autotrophic root respiration [umol/m2/s]
-     REAL(KIND=r_1), POINTER, DIMENSION(:) :: StemResp => null()   ! autotrophic stem respiration [umol/m2/s]
-     REAL(KIND=r_1), POINTER, DIMENSION(:,:) :: qcan_sl => null()   ! absorbed radiation by canopy (sunlit leaves) [W/m2]
-     REAL(KIND=r_1), POINTER, DIMENSION(:,:) :: qcan_sh => null()   ! absorbed radiation by canopy (shaded leaves) [W/m2]
-     REAL(KIND=r_2), POINTER, DIMENSION(:)   :: An => null()        ! total net assimilation
-     REAL(KIND=r_2), POINTER, DIMENSION(:)   :: Rd => null()        ! total leaf respiration
-     REAL(KIND=r_2), POINTER, DIMENSION(:,:) :: cplant => null()    ! plant carbon pools
-     REAL(KIND=r_2), POINTER, DIMENSION(:,:) :: clitter => null()   ! litter carbon pools
-     REAL(KIND=r_2), POINTER, DIMENSION(:,:) :: csoil => null()     ! soil carbon pools
-     REAL(KIND=r_2), POINTER, DIMENSION(:)   :: clabile => null()   ! excess carbon pools
-     REAL(KIND=r_2), POINTER, DIMENSION(:)   :: A13n => null()      ! total 13C net assimilation
-     REAL(KIND=r_2), POINTER, DIMENSION(:)   :: aDisc13 => null()   ! 13C discrimination times gross assimilation
-     REAL(KIND=r_2), POINTER, DIMENSION(:,:) :: c13plant => null()  ! 13C plant carbon pools
-     REAL(KIND=r_2), POINTER, DIMENSION(:,:) :: c13litter => null() ! 13C litter carbon pools
-     REAL(KIND=r_2), POINTER, DIMENSION(:,:) :: c13soil => null()   ! 13C soil carbon pools
-     REAL(KIND=r_2), POINTER, DIMENSION(:)   :: c13labile => null() ! 13C excess carbon pools
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: TotSoilCarb => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: TotLivBiomass => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: TotLittCarb => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: SoilCarbFast => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: SoilCarbSlow => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: SoilCarbPassive => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: LittCarbMetabolic => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: LittCarbStructural => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: LittCarbCWD => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: PlantCarbLeaf => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: PlantCarbFineRoot => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: PlantCarbWood => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: PlantTurnover => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: PlantTurnoverLeaf => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: PlantTurnoverFineRoot => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: PlantTurnoverWood => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: PlantTurnoverWoodDist => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: PlantTurnoverWoodCrowding => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: PlantTurnoverWoodResourceLim => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: Area => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: LandUseFlux => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: vcmax => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: ejmax => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: patchfrac => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: hc => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: GPP_sl => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: GPP_sh => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: GPP_slC => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: GPP_shC => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: GPP_slJ => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: GPP_shJ => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: An_sl => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: An_sh=> null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: ci_sl => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: ci_sh => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: scalex_sl => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: scalex_sh => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: dlf => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: eta_GPP_cs => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: eta_TVeg_cs => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: dGPPdcs => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: CO2s => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: gsw_TVeg => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: vcmax_ts => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: jmax_ts => null()
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: gsw_sl => null()   ! stomatal conductance (sunlit leaves)
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: gsw_sh => null()   ! stomatal conductance (shaded leaves)
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: RootResp => null()   ! autotrophic root respiration [umol/m2/s]
+     REAL(KIND=r1), POINTER, DIMENSION(:) :: StemResp => null()   ! autotrophic stem respiration [umol/m2/s]
+     REAL(KIND=r1), POINTER, DIMENSION(:,:) :: qcan_sl => null()   ! absorbed radiation by canopy (sunlit leaves) [W/m2]
+     REAL(KIND=r1), POINTER, DIMENSION(:,:) :: qcan_sh => null()   ! absorbed radiation by canopy (shaded leaves) [W/m2]
+     REAL(KIND=r2), POINTER, DIMENSION(:)   :: An => null()        ! total net assimilation
+     REAL(KIND=r2), POINTER, DIMENSION(:)   :: Rd => null()        ! total leaf respiration
+     REAL(KIND=r2), POINTER, DIMENSION(:,:) :: cplant => null()    ! plant carbon pools
+     REAL(KIND=r2), POINTER, DIMENSION(:,:) :: clitter => null()   ! litter carbon pools
+     REAL(KIND=r2), POINTER, DIMENSION(:,:) :: csoil => null()     ! soil carbon pools
+     REAL(KIND=r2), POINTER, DIMENSION(:)   :: clabile => null()   ! excess carbon pools
+     REAL(KIND=r2), POINTER, DIMENSION(:)   :: A13n => null()      ! total 13C net assimilation
+     REAL(KIND=r2), POINTER, DIMENSION(:)   :: aDisc13 => null()   ! 13C discrimination times gross assimilation
+     REAL(KIND=r2), POINTER, DIMENSION(:,:) :: c13plant => null()  ! 13C plant carbon pools
+     REAL(KIND=r2), POINTER, DIMENSION(:,:) :: c13litter => null() ! 13C litter carbon pools
+     REAL(KIND=r2), POINTER, DIMENSION(:,:) :: c13soil => null()   ! 13C soil carbon pools
+     REAL(KIND=r2), POINTER, DIMENSION(:)   :: c13labile => null() ! 13C excess carbon pools
   END TYPE output_temporary_type
   TYPE(output_temporary_type), SAVE :: out
 
   INTEGER :: ok   ! netcdf error status
 
   interface toreal4
-     module procedure dp2sp, i2sp, sp2sp
+     module procedure r2tor1, itor1, rtor1
   end interface toreal4
 
 CONTAINS
@@ -300,7 +300,7 @@ CONTAINS
     integer :: nplantid, nlitterid, nsoilid
     real, dimension(size(patch, 1)) :: frac
 
-    real(kind=r_1), parameter :: zero4 = real(0.0,r_1)
+    real(kind=r1), parameter :: zero4 = real(0.0,r1)
 
     ! Create output file:
 #ifdef __NETCDF3__
@@ -1403,19 +1403,19 @@ CONTAINS
        allocate(out%c13soil(mp,msoil))
        allocate(out%c13labile(mp))
        ! 12C
-       out%An      = 0.0_r_2
-       out%Rd      = 0.0_r_2
-       out%cplant  = 0.0_r_2
-       out%clitter = 0.0_r_2
-       out%csoil   = 0.0_r_2
-       out%clabile = 0.0_r_2
+       out%An      = 0.0_r2
+       out%Rd      = 0.0_r2
+       out%cplant  = 0.0_r2
+       out%clitter = 0.0_r2
+       out%csoil   = 0.0_r2
+       out%clabile = 0.0_r2
        ! 13C
-       out%A13n      = 0.0_r_2
-       out%aDisc13   = 0.0_r_2
-       out%c13plant  = 0.0_r_2
-       out%c13litter = 0.0_r_2
-       out%c13soil   = 0.0_r_2
-       out%c13labile = 0.0_r_2
+       out%A13n      = 0.0_r2
+       out%aDisc13   = 0.0_r2
+       out%c13plant  = 0.0_r2
+       out%c13litter = 0.0_r2
+       out%c13soil   = 0.0_r2
+       out%c13labile = 0.0_r2
        ! all defined as float
        ! 12C
        call define_ovar(ncid_out, ovid%An, 'An', 'mol/m^2/s', &
@@ -1863,7 +1863,7 @@ CONTAINS
     TYPE(c13o2_pool), INTENT(IN) :: c13o2pools ! 13CO2 pools
     TYPE(c13o2_flux), INTENT(IN) :: c13o2flux  ! 13CO2 fluxes
 
-    REAL(r_2), DIMENSION(1) :: timetemp ! temporary variable for storing time
+    REAL(r2), DIMENSION(1) :: timetemp ! temporary variable for storing time
     ! value
     LOGICAL :: writenow ! write to output file during this time step?
     INTEGER, SAVE :: out_timestep ! counter for output time steps
@@ -1875,15 +1875,15 @@ CONTAINS
     INTEGER :: iy   ! Counter
     INTEGER, SAVE   :: YearStart
     INTEGER :: ok ! for netcdf sync
-    real(kind=r_1) :: rinterval
-    real(r_2)    :: r2interval, gd2umols
-    real(kind=r_1), parameter :: zero4 = real(0.0,r_1)
+    real(kind=r1) :: rinterval
+    real(r2)    :: r2interval, gd2umols
+    real(kind=r1), parameter :: zero4 = real(0.0,r1)
     real, dimension(mp) :: totlai
     real, dimension(size(patch, 1)) :: frac
 
     ! logical :: opened
     ! integer :: varid
-    gd2umols = 1.0_r_2 / (86400.0_r_2 * 1.201e-5_r_2)
+    gd2umols = 1.0_r2 / (86400.0_r2 * 1.201e-5_r2)
 
     ! IF asked to check mass/water balance:
     IF (check%mass_bal) CALL mass_balance(dels, ktau, ssnow, soil, canopy, met, air, bal)
@@ -1999,7 +1999,7 @@ CONTAINS
     ! If this time step is an output time step:
     IF (writenow) THEN
        ! Write to temporary time variable:
-       timetemp(1) = real(ktau - backtrack, r_2) * real(dels, r_2)
+       timetemp(1) = real(ktau - backtrack, r2) * real(dels, r2)
        ! inquire(unit=ncid_out, opened=opened)
        ! if (.not. opened) ok = NF90_OPEN(filename%out, NF90_WRITE, ncid_out)
        ! ok = NF90_INQ_VARID(ncid_out, 'time', varid)
@@ -2010,7 +2010,7 @@ CONTAINS
             'Error writing time variable to ' &
             //TRIM(filename%out)// '(SUBROUTINE write_output)')
        rinterval  = toreal4(1) / toreal4(output%interval)
-       r2interval = 1.0_r_2 / real(output%interval,r_2)
+       r2interval = 1.0_r2 / real(output%interval,r2)
 
     END IF
 
@@ -2406,7 +2406,7 @@ CONTAINS
     IF(output%soil .OR. output%SoilMoist) THEN
        ! Add current timestep's value to total of temporary output variable:
        out%SoilMoist = out%SoilMoist + toreal4(ssnow%wb)
-       out%SoilMoistPFT = out%SoilMoistPFT + toreal4(sum(ssnow%wb * 1000.0_r_2 * real(spread(soil%zse,1,mp),r_2),2))
+       out%SoilMoistPFT = out%SoilMoistPFT + toreal4(sum(ssnow%wb * 1000.0_r2 * real(spread(soil%zse,1,mp),r2),2))
        out%SoilMoistIce = out%SoilMoistIce + toreal4(ssnow%wbice)
        IF(writenow) THEN
           ! Divide accumulated variable by number of accumulated time steps:
@@ -2791,20 +2791,20 @@ CONTAINS
        out%scalex_sl   = out%scalex_sl   + toreal4(rad%scalex(:,1))
        out%scalex_sh   = out%scalex_sh   + toreal4(rad%scalex(:,2))
        out%dlf         = out%dlf         + toreal4(canopy%dlf)
-       out%An_sl       = out%An_sl       + toreal4(canopy%A_sl*1.0e6_r_2)
-       out%An_sh       = out%An_sh       + toreal4(canopy%A_sh*1.0e6_r_2)
-       out%ci_sl       = out%ci_sl       + toreal4(canopy%ci(:,1)*1.0e6_r_2)
-       out%ci_sh       = out%ci_sh       + toreal4(canopy%ci(:,2)*1.0e6_r_2)
-       out%GPP_sl      = out%GPP_sl      + toreal4(canopy%GPP_sl*1.0e6_r_2)
-       out%GPP_sh      = out%GPP_sh      + toreal4(canopy%GPP_sh*1.0e6_r_2)
-       out%GPP_slC     = out%GPP_slC     + toreal4(canopy%A_slC*1.0e6_r_2)
-       out%GPP_shC     = out%GPP_shC     + toreal4(canopy%A_shC*1.0e6_r_2)
-       out%GPP_slJ     = out%GPP_slJ     + toreal4(canopy%A_slJ*1.0e6_r_2)
-       out%GPP_shJ     = out%GPP_shJ     + toreal4(canopy%A_shJ*1.0e6_r_2)
-       out%eta_GPP_cs  = out%eta_GPP_cs  + toreal4(canopy%eta_A_cs*1.0e6_r_2)
+       out%An_sl       = out%An_sl       + toreal4(canopy%A_sl*1.0e6_r2)
+       out%An_sh       = out%An_sh       + toreal4(canopy%A_sh*1.0e6_r2)
+       out%ci_sl       = out%ci_sl       + toreal4(canopy%ci(:,1)*1.0e6_r2)
+       out%ci_sh       = out%ci_sh       + toreal4(canopy%ci(:,2)*1.0e6_r2)
+       out%GPP_sl      = out%GPP_sl      + toreal4(canopy%GPP_sl*1.0e6_r2)
+       out%GPP_sh      = out%GPP_sh      + toreal4(canopy%GPP_sh*1.0e6_r2)
+       out%GPP_slC     = out%GPP_slC     + toreal4(canopy%A_slC*1.0e6_r2)
+       out%GPP_shC     = out%GPP_shC     + toreal4(canopy%A_shC*1.0e6_r2)
+       out%GPP_slJ     = out%GPP_slJ     + toreal4(canopy%A_slJ*1.0e6_r2)
+       out%GPP_shJ     = out%GPP_shJ     + toreal4(canopy%A_shJ*1.0e6_r2)
+       out%eta_GPP_cs  = out%eta_GPP_cs  + toreal4(canopy%eta_A_cs*1.0e6_r2)
        out%eta_TVeg_cs = out%eta_TVeg_cs + toreal4(canopy%eta_fevc_cs/air%rlam)
-       out%dGPPdcs     = out%dGPPdcs     + toreal4(canopy%dAdcs*1.0e6_r_2)
-       out%CO2s        = out%CO2s        + toreal4(canopy%cs*1.0e6_r_2)
+       out%dGPPdcs     = out%dGPPdcs     + toreal4(canopy%dAdcs*1.0e6_r2)
+       out%CO2s        = out%CO2s        + toreal4(canopy%cs*1.0e6_r2)
        totlai(:) = rad%fvlai(:,1) + rad%fvlai(:,2)
        where (totlai(:) .gt. 0.01)
           out%gsw_TVeg =  out%gsw_TVeg + &
@@ -3053,7 +3053,7 @@ CONTAINS
 
     ! output patch area
     IF(output%casa) THEN
-       out%Area = toreal4(casamet%areacell / 1.0e6_r_2) ! km2
+       out%Area = toreal4(casamet%areacell / 1.0e6_r2) ! km2
        IF(writenow) THEN
           ! Write value to file:
           CALL write_ovar(out_timestep, ncid_out, ovid%Area, 'Area', out%Area, &
@@ -3094,7 +3094,7 @@ CONTAINS
        IF (cable_user%soil_struc=='sli') THEN
           out%evspsblsoi = out%evspsblsoi  + toreal4(ssnow%evap / dels)
        ELSE
-          out%evspsblsoi = out%evspsblsoi  + toreal4(canopy%fes / real(air%rlam,r_2))
+          out%evspsblsoi = out%evspsblsoi  + toreal4(canopy%fes / real(air%rlam,r2))
        ENDIF
        out%evspsblveg = out%evspsblveg  + toreal4(canopy%fevw / air%rlam)
        out%mrrob      = out%mrrob       + toreal4(ssnow%rnof2 / dels)
@@ -3102,7 +3102,7 @@ CONTAINS
        out%sbl        = out%sbl         + toreal4(ssnow%E_sublimation_sn)
        out%snm        = out%snm         + toreal4(ssnow%surface_melt)
        out%snmsl      = out%snmsl       + toreal4(ssnow%smelt)
-       out%tran       = out%tran        + toreal4(canopy%fevc / real(air%rlam,r_2))
+       out%tran       = out%tran        + toreal4(canopy%fevc / real(air%rlam,r2))
        out%albs       = out%albs        + toreal4((rad%albedo(:,1) + rad%albedo(:,2)) * 0.5)
        out%albsn      = out%albsn       + toreal4((ssnow%albsoilsn(:,1) + ssnow%albsoilsn(:,2)) * 0.5)
        out%cw         = out%cw          + toreal4(canopy%cansto)
@@ -3114,7 +3114,7 @@ CONTAINS
        out%lwsnl      = out%lwsnl       + toreal4(sum(ssnow%snowliq,2))
        out%mrfsofr    = out%mrfsofr     + toreal4(ssnow%wbice/ssnow%wb)
        out%mrlqso     = out%mrlqso      + toreal4((ssnow%wb-ssnow%wbice)/ssnow%wb)
-       out%mrlsl      = out%mrlsl       + toreal4(ssnow%wb*1000.0_r_2*real(spread(soil%zse,1,mp),r_2))
+       out%mrlsl      = out%mrlsl       + toreal4(ssnow%wb*1000.0_r2*real(spread(soil%zse,1,mp),r2))
        out%snc        = out%snc         + toreal4(merge(1.,0.,sum(ssnow%sdepth,2)>0.))
        out%snd        = out%snd         + toreal4(sum(ssnow%sdepth, 2))
        out%snw        = out%snw         + toreal4(ssnow%snowd)
@@ -3288,8 +3288,8 @@ CONTAINS
        IF (cable_user%POPLUC) THEN
           out%NBP = out%NBP + (-toreal4((casaflux%Crsoil-casaflux%cnpp &
                - casapool%dClabiledt) * gd2umols)) !- &
-          !REAL((casaflux%FluxCtohwp + casaflux%FluxCtoclear  )/86400.0_r_2 &
-          !/ 1.201E-5_r_2, 4)
+          !REAL((casaflux%FluxCtohwp + casaflux%FluxCtoclear  )/86400.0_r2 &
+          !/ 1.201E-5_r2, 4)
        ELSE
           out%NBP = out%NBP + (-toreal4((casaflux%Crsoil-casaflux%cnpp &
                - casapool%dClabiledt) * gd2umols))
@@ -3434,8 +3434,8 @@ CONTAINS
 
     ! plant carbon [kg C m-2]
     IF (output%casa) THEN
-       !out%TotSoilCarb = out%TotSoilCarb + toreal4((SUM(casapool%csoil,2)+SUM(casapool%clitter,2)) / 1000.0_r_2)
-       out%TotSoilCarb = out%TotSoilCarb + toreal4(SUM(casapool%csoil,2) / 1000.0_r_2)
+       !out%TotSoilCarb = out%TotSoilCarb + toreal4((SUM(casapool%csoil,2)+SUM(casapool%clitter,2)) / 1000.0_r2)
+       out%TotSoilCarb = out%TotSoilCarb + toreal4(SUM(casapool%csoil,2) / 1000.0_r2)
        IF (writenow) THEN
           ! Divide accumulated variable by number of accumulated time steps:
           out%TotSoilCarb = out%TotSoilCarb * rinterval
@@ -3446,7 +3446,7 @@ CONTAINS
           out%TotSoilCarb = zero4
        END IF
 
-       out%TotLittCarb = out%TotLittCarb + toreal4(SUM(casapool%clitter,2) / 1000.0_r_2)
+       out%TotLittCarb = out%TotLittCarb + toreal4(SUM(casapool%clitter,2) / 1000.0_r2)
        IF (writenow) THEN
           ! Divide accumulated variable by number of accumulated time steps:
           out%TotLittCarb = out%TotLittCarb * rinterval
@@ -3457,7 +3457,7 @@ CONTAINS
           out%TotLittCarb = zero4
        END IF
 
-       out%SoilCarbFast = out%SoilCarbFast + toreal4(casapool%csoil(:,1) / 1000.0_r_2)
+       out%SoilCarbFast = out%SoilCarbFast + toreal4(casapool%csoil(:,1) / 1000.0_r2)
        IF (writenow) THEN
           ! Divide accumulated variable by number of accumulated time steps:
           out%SoilCarbFast = out%SoilCarbFast * rinterval
@@ -3469,7 +3469,7 @@ CONTAINS
           out%SoilCarbFast = zero4
        END IF
 
-       out%SoilCarbSlow = out%SoilCarbSlow + toreal4(casapool%csoil(:,2)/ 1000.0_r_2)
+       out%SoilCarbSlow = out%SoilCarbSlow + toreal4(casapool%csoil(:,2)/ 1000.0_r2)
        IF (writenow) THEN
           ! Divide accumulated variable by number of accumulated time steps:
           out%SoilCarbSlow = out%SoilCarbSlow * rinterval
@@ -3481,7 +3481,7 @@ CONTAINS
           out%SoilCarbSlow = zero4
        END IF
 
-       out%SoilCarbPassive = out%SoilCarbPassive + toreal4(casapool%csoil(:,3) / 1000.0_r_2)
+       out%SoilCarbPassive = out%SoilCarbPassive + toreal4(casapool%csoil(:,3) / 1000.0_r2)
        IF (writenow) THEN
           ! Divide accumulated variable by number of accumulated time steps:
           out%SoilCarbPassive = out%SoilCarbPassive * rinterval
@@ -3493,7 +3493,7 @@ CONTAINS
           out%SoilCarbPassive = zero4
        END IF
 
-       out%LittCarbMetabolic = out%LittCarbMetabolic + toreal4(casapool%clitter(:,1) / 1000.0_r_2)
+       out%LittCarbMetabolic = out%LittCarbMetabolic + toreal4(casapool%clitter(:,1) / 1000.0_r2)
        IF (writenow) THEN
           ! Divide accumulated variable by number of accumulated time steps:
           out%LittCarbMetabolic = out%LittCarbMetabolic * rinterval
@@ -3504,7 +3504,7 @@ CONTAINS
           out%LittCarbMetabolic = zero4
        END IF
 
-       out%LittCarbStructural = out%LittCarbStructural + toreal4(casapool%clitter(:,2) / 1000.0_r_2)
+       out%LittCarbStructural = out%LittCarbStructural + toreal4(casapool%clitter(:,2) / 1000.0_r2)
        IF (writenow) THEN
           ! Divide accumulated variable by number of accumulated time steps:
           out%LittCarbStructural = out%LittCarbStructural * rinterval
@@ -3515,7 +3515,7 @@ CONTAINS
           out%LittCarbStructural = zero4
        END IF
 
-       out%LittCarbCWD = out%LittCarbCWD + toreal4(casapool%clitter(:,3) / 1000.0_r_2)
+       out%LittCarbCWD = out%LittCarbCWD + toreal4(casapool%clitter(:,3) / 1000.0_r2)
        IF (writenow) THEN
           ! Divide accumulated variable by number of accumulated time steps:
           out%LittCarbCWD = out%LittCarbCWD * rinterval
@@ -3526,7 +3526,7 @@ CONTAINS
           out%LittCarbCWD = zero4
        END IF
 
-       out%PlantCarbLeaf = out%PlantCarbLeaf + toreal4(casapool%cplant(:,1) / 1000.0_r_2)
+       out%PlantCarbLeaf = out%PlantCarbLeaf + toreal4(casapool%cplant(:,1) / 1000.0_r2)
        IF (writenow) THEN
           ! Divide accumulated variable by number of accumulated time steps:
           out%PlantCarbLeaf = out%PlantCarbLeaf * rinterval
@@ -3537,7 +3537,7 @@ CONTAINS
           out%PlantCarbLeaf = zero4
        END IF
 
-       out%PlantCarbFineRoot = out%PlantCarbFineRoot + toreal4(casapool%cplant(:,3) / 1000.0_r_2)
+       out%PlantCarbFineRoot = out%PlantCarbFineRoot + toreal4(casapool%cplant(:,3) / 1000.0_r2)
        IF (writenow) THEN
           ! Divide accumulated variable by number of accumulated time steps:
           out%PlantCarbFineRoot = out%PlantCarbFineRoot * rinterval
@@ -3549,7 +3549,7 @@ CONTAINS
           out%PlantCarbFineRoot = zero4
        END IF
 
-       out%PlantCarbWood = out%PlantCarbWood + toreal4(casapool%cplant(:,2) / 1000.0_r_2)
+       out%PlantCarbWood = out%PlantCarbWood + toreal4(casapool%cplant(:,2) / 1000.0_r2)
        IF (writenow) THEN
           ! Divide accumulated variable by number of accumulated time steps:
           out%PlantCarbWood = out%PlantCarbWood * rinterval
@@ -3560,7 +3560,7 @@ CONTAINS
           out%PlantCarbWood = zero4
        END IF
 
-       out%TotLivBiomass = out%TotLivBiomass + toreal4((SUM(casapool%cplant,2)) / 1000.0_r_2)
+       out%TotLivBiomass = out%TotLivBiomass + toreal4((SUM(casapool%cplant,2)) / 1000.0_r2)
        IF (writenow) THEN
           ! Divide accumulated variable by number of accumulated time steps:
           out%TotLivBiomass = out%TotLivBiomass * rinterval
@@ -3636,19 +3636,19 @@ CONTAINS
                toreal4(out%c13labile), ranges%TotLivBiomass, patchout%c13o2, 'default', met)
           ! Reset temporary output variable
           ! 12C
-          out%An      = 0.0_r_2
-          out%Rd      = 0.0_r_2
-          out%cplant  = 0.0_r_2
-          out%clitter = 0.0_r_2
-          out%csoil   = 0.0_r_2
-          out%clabile = 0.0_r_2
+          out%An      = 0.0_r2
+          out%Rd      = 0.0_r2
+          out%cplant  = 0.0_r2
+          out%clitter = 0.0_r2
+          out%csoil   = 0.0_r2
+          out%clabile = 0.0_r2
           ! 13C
-          out%A13n      = 0.0_r_2
-          out%aDisc13   = 0.0_r_2
-          out%c13plant  = 0.0_r_2
-          out%c13litter = 0.0_r_2
-          out%c13soil   = 0.0_r_2
-          out%c13labile = 0.0_r_2
+          out%A13n      = 0.0_r2
+          out%aDisc13   = 0.0_r2
+          out%c13plant  = 0.0_r2
+          out%c13litter = 0.0_r2
+          out%c13soil   = 0.0_r2
+          out%c13labile = 0.0_r2
        endif
     endif
 
@@ -3740,7 +3740,7 @@ CONTAINS
     character(len=10) :: todaydate, nowtime ! used to timestamp netcdf file
     ! character         :: FRST_OUT*100, CYEAR*4
     character :: frst_out*200, cyear*4
-    real(r_2), dimension(size(patch, 1)) :: frac
+    real(r2), dimension(size(patch, 1)) :: frac
 
     dummy = 0 ! initialise
 
@@ -4163,7 +4163,7 @@ CONTAINS
        CALL define_ovar(ncid_restart, TsoilID, 'Tsoil', 'degC', &
             'Tsoil', &
             .TRUE., soilID, 'r2soil', 0, 0, 0, mpID, dummy, .TRUE.)
-       !MC - Should be r_2 but specific subroutine not coded yet in cable_write
+       !MC - Should be r2 but specific subroutine not coded yet in cable_write
        CALL define_ovar(ncid_restart, snowliqID, 'snowliq', 'mm', &
             'liquid water content of snowpack', &
             .TRUE., snowID, 'r2snow', 0, 0, 0, mpID, dummy, .TRUE.)
@@ -4204,7 +4204,7 @@ CONTAINS
          //TRIM(frst_out)// '(SUBROUTINE create_restart)')
 
     ! Write time variable:
-    ok = NF90_PUT_VAR(ncid_restart, tvarID, real(ktau,r_2)*real(dels,r_2))
+    ok = NF90_PUT_VAR(ncid_restart, tvarID, real(ktau,r2)*real(dels,r2))
     IF(ok /= NF90_NOERR) CALL nc_abort(ok, 'Error time variable to ' &
          //TRIM(frst_out)// '(SUBROUTINE create_restart)')
 
@@ -4468,62 +4468,62 @@ CONTAINS
 
   ! ------------------------------------------------------------------
 
-  elemental pure function dp2sp(var)
+  elemental pure function r2tor1(var)
 
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
-    real(r_2),   intent(in) :: var
-    real(kind=r_1)            :: dp2sp
+    real(r2), intent(in) :: var
+    real(kind=r1)        :: r2tor1
 
-    real(r_2),    parameter :: tini = real(tiny(1.0),r_2)
-    real(kind=r_1), parameter :: zero = real(0.0,r_1)
+    real(r2),    parameter :: tini = real(tiny(1.0),r2)
+    real(kind=r1), parameter :: zero = real(0.0,r1)
 
     if (abs(var) > tini) then
-       dp2sp = real(var,r_1)
+       r2tor1 = real(var,r1)
     else
-       dp2sp = zero
+       r2tor1 = zero
     endif
 
     return
 
-  end function dp2sp
+  end function r2tor1
 
 
-  elemental pure function i2sp(var)
+  elemental pure function itor1(var)
 
     implicit none
 
-    integer  ,   intent(in) :: var
-    real(kind=r_1)            :: i2sp
+    integer, intent(in) :: var
+    real(kind=r1)       :: itor1
 
-    i2sp = real(var,r_1)
+    itor1 = real(var,r1)
 
     return
 
-  end function i2sp
+  end function itor1
 
 
-  elemental pure function sp2sp(var)
+  elemental pure function rtor1(var)
 
     implicit none
 
-    real,        intent(in) :: var
-    real(kind=r_1)            :: sp2sp
+    real, intent(in) :: var
+    real(kind=r1)    :: rtor1
 
-    real,         parameter :: tini = tiny(1.0)
-    real(kind=r_1), parameter :: zero = real(0.0,r_1)
+    real,          parameter :: tini = tiny(1.0)
+    real(kind=r1), parameter :: zero = real(0.0,r1)
 
     if (abs(var) > tini) then
-       sp2sp = real(var,r_1)
+       rtor1 = real(var,r1)
     else
-       sp2sp = zero
+       rtor1 = zero
     endif
 
     return
 
-  end function sp2sp
+  end function rtor1
 
   ! ------------------------------------------------------------------
 

--- a/offline/cable_parameters.F90
+++ b/offline/cable_parameters.F90
@@ -1142,7 +1142,7 @@ CONTAINS
     INTEGER :: is       ! YP oct07
     INTEGER :: ir       ! BP sep2010
     REAL :: totdepth    ! YP oct07
-    REAL(r_2) :: tmp    ! BP sep2010
+    REAL(r2) :: tmp    ! BP sep2010
 #ifdef __MPI__
     integer :: ierr
 #endif
@@ -1166,7 +1166,7 @@ CONTAINS
     ssnow%osnowd   = 0.0   ! snow depth prev timestep (mm or kg/m2)
     ssnow%sdepth   = 0.0   ! snow depth for each snow layer (BP jul2010)
     ssnow%snage    = 0.0   ! snow age
-    ssnow%wbice    = 0.0_r_2 ! soil ice
+    ssnow%wbice    = 0.0_r2 ! soil ice
     ssnow%thetai   = 0.0   ! soil ice
     ssnow%smass    = 0.0   ! snow mass per layer (kg/m^2)
     ssnow%runoff   = 0.0   ! runoff total = subsurface + surface runoff
@@ -1188,13 +1188,13 @@ CONTAINS
     canopy%fh      = 0.0  ! sensible heat flux
     canopy%fe      = 0.0  ! sensible heat flux
     ! IF (hide%Ticket49Bug2) THEN
-    canopy%ofes   = 0.0_r_2 ! latent heat flux from soil (W/m2)
-    canopy%fevc   = 0.0_r_2 !vh!
+    canopy%ofes   = 0.0_r2 ! latent heat flux from soil (W/m2)
+    canopy%fevc   = 0.0_r2 !vh!
     canopy%fevw   = 0.0     !vh!
     canopy%fns    = 0.0
     canopy%fnv    = 0.0
     canopy%fhv    = 0.0
-    canopy%fwsoil = 1.0_r_2 ! vh -should be calculated from soil moisture
+    canopy%fwsoil = 1.0_r2 ! vh -should be calculated from soil moisture
     rad%fvlai     = 0.0
 
     ! parameters that are not spatially dependent
@@ -1246,7 +1246,7 @@ CONTAINS
        veg%iveg(landpt(e)%cstart:landpt(e)%cend) = &
             inVeg(landpt(e)%ilon, landpt(e)%ilat, 1:landpt(e)%nap)
        patch(landpt(e)%cstart:landpt(e)%cend)%frac = &
-            real(inPFrac(landpt(e)%ilon, landpt(e)%ilat, 1:landpt(e)%nap), r_2)
+            real(inPFrac(landpt(e)%ilon, landpt(e)%ilat, 1:landpt(e)%nap), r2)
        ! set land use (1 = primary; 2 = secondary, 3 = open)
        veg%iLU(landpt(e)%cstart:landpt(e)%cend)= 1
        veg%ivegp(landpt(e)%cstart:landpt(e)%cend) = veg%iveg(landpt(e)%cstart:landpt(e)%cend)
@@ -1264,15 +1264,15 @@ CONTAINS
 
        endif
        ! Check that patch fractions total to 1
-       tmp = 0.0_r_2
+       tmp = 0.0_r2
        IF (landpt(e)%cstart == landpt(e)%cend) THEN
-          patch(landpt(e)%cstart)%frac = 1.0_r_2
+          patch(landpt(e)%cstart)%frac = 1.0_r2
        ELSE
           DO is = landpt(e)%cstart, landpt(e)%cend
              tmp = tmp + patch(is)%frac
           END DO
-          IF (ABS(1.0_r_2 - tmp) > 0.001_r_2) THEN
-             IF ((1.0_r_2 - tmp) < -0.001_r_2 .OR. (1.0_r_2 - tmp) > 0.5_r_2) THEN
+          IF (ABS(1.0_r2 - tmp) > 0.001_r2) THEN
+             IF ((1.0_r2 - tmp) < -0.001_r2 .OR. (1.0_r2 - tmp) > 0.5_r2) THEN
                 write(*,*) 'Investigate the discrepancy in patch fractions:'
                 write(*,*) 'patch%frac = ', patch(landpt(e)%cstart:landpt(e)%cend)%frac
                 write(*,*) 'landpoint # ', e
@@ -1283,7 +1283,7 @@ CONTAINS
                 stop 76
 #endif
              END IF
-             patch(landpt(e)%cstart)%frac = patch(landpt(e)%cstart)%frac + 1.0_r_2 - tmp
+             patch(landpt(e)%cstart)%frac = patch(landpt(e)%cstart)%frac + 1.0_r2 - tmp
           END IF
        END IF
 
@@ -1301,7 +1301,7 @@ CONTAINS
           ssnow%tgg(landpt(e)%cstart:landpt(e)%cend, is) = &
                inTGG(landpt(e)%ilon,landpt(e)%ilat, min(is,size(inTGG,3)), month)
           ssnow%wb(landpt(e)%cstart:landpt(e)%cend, is) = &
-               real(inWB(landpt(e)%ilon, landpt(e)%ilat, min(is,size(inTGG,3)), month), r_2)
+               real(inWB(landpt(e)%ilon, landpt(e)%ilat, min(is,size(inTGG,3)), month), r2)
        END DO
        ssnow%tss(landpt(e)%cstart:landpt(e)%cend) = ssnow%tgg(landpt(e)%cstart:landpt(e)%cend, 1)
        ssnow%otss(landpt(e)%cstart:landpt(e)%cend) = ssnow%tgg(landpt(e)%cstart:landpt(e)%cend, 1)
@@ -1397,10 +1397,10 @@ CONTAINS
 
           ! In case gridinfo file provides more patches than met file(BP may08)
           DO f = nmetpatches+1, landpt(e)%nap
-             IF (patch(landpt(e)%cstart + f - 1)%frac > 0.0_r_2) THEN
+             IF (patch(landpt(e)%cstart + f - 1)%frac > 0.0_r2) THEN
                 patch(landpt(e)%cstart)%frac = patch(landpt(e)%cstart)%frac &
                      + patch(landpt(e)%cstart + f - 1)%frac
-                patch(landpt(e)%cstart + f - 1)%frac = 0.0_r_2
+                patch(landpt(e)%cstart + f - 1)%frac = 0.0_r2
              END IF
           END DO
        END IF
@@ -1431,8 +1431,8 @@ CONTAINS
           veg%hc(h)      = vegin%hc(veg%iveg(h))
           veg%xfang(h)   = vegin%xfang(veg%iveg(h))
           veg%vbeta(h)   = vegin%vbeta(veg%iveg(h))
-          veg%zr(h)      = real(vegin%zr(veg%iveg(h)), r_2)
-          veg%clitt(h)   = real(vegin%clitt(veg%iveg(h)), r_2)
+          veg%zr(h)      = real(vegin%zr(veg%iveg(h)), r2)
+          veg%clitt(h)   = real(vegin%clitt(veg%iveg(h)), r2)
           veg%g0(h)      = vegin%g0(veg%iveg(h))
           veg%g1(h)      = vegin%g1(veg%iveg(h))
           veg%xalbnir(h) = vegin%xalbnir(veg%iveg(h))
@@ -1461,7 +1461,7 @@ CONTAINS
 
           veg%convex(h)   = vegin%convex(veg%iveg(h))
           ! Alexis, adding gamma
-          veg%gamma(h)    = real(vegin%gamma(veg%iveg(h)),r_2)
+          veg%gamma(h)    = real(vegin%gamma(veg%iveg(h)),r2)
           veg%cfrd(h)     = vegin%cfrd(veg%iveg(h))
           veg%gswmin(h)   = vegin%gswmin(veg%iveg(h))
           veg%conkc0(h)   = vegin%conkc0(veg%iveg(h))
@@ -1583,9 +1583,9 @@ CONTAINS
     ENDWHERE
     ! Soil ice:
     WHERE(ssnow%tgg(:, :) < 273.15)
-       ssnow%wbice(:,:)  = ssnow%wb(:, :) * 0.8_r_2
+       ssnow%wbice(:,:)  = ssnow%wb(:, :) * 0.8_r2
     ELSEWHERE
-       ssnow%wbice(:, :) = 0.0_r_2
+       ssnow%wbice(:, :) = 0.0_r2
     END WHERE
 
     ! IF(hide%Ticket49Bug5) THEN
@@ -1594,64 +1594,64 @@ CONTAINS
 
     ! SLI specific initialisations:
     !  IF(cable_user%SOIL_STRUC=='sli') THEN
-    ssnow%h0(:)        = 0.0_r_2
-    ssnow%S(:,:)       = ssnow%wb(:,:)/SPREAD(real(soil%ssat,r_2),2,ms)
-    ssnow%snowliq(:,:) = 0.0_r_2
-    ssnow%Tsurface     = 25.0_r_2
+    ssnow%h0(:)        = 0.0_r2
+    ssnow%S(:,:)       = ssnow%wb(:,:)/SPREAD(real(soil%ssat,r2),2,ms)
+    ssnow%snowliq(:,:) = 0.0_r2
+    ssnow%Tsurface     = 25.0_r2
     ssnow%nsnow        = 0
-    ssnow%Tsoil        = real(ssnow%tgg,r_2) - 273.15_r_2
-    ssnow%thetai       = 0.0_r_2
-    soil%zeta          = 0.0_r_2
-    soil%fsatmax       = 0.0_r_2
+    ssnow%Tsoil        = real(ssnow%tgg,r2) - 273.15_r2
+    ssnow%thetai       = 0.0_r2
+    soil%zeta          = 0.0_r2
+    soil%fsatmax       = 0.0_r2
     !   END IF
 
     IF(cable_user%SOIL_STRUC=='sli') THEN
        soil%nhorizons = 1 ! use 1 soil horizon globally
-       ! veg%clitt = 5.0_r_2 ! (tC / ha)
-       ! veg%F10 = 0.85_r_2
-       ! veg%ZR = 5.0_r_2
+       ! veg%clitt = 5.0_r2 ! (tC / ha)
+       ! veg%F10 = 0.85_r2
+       ! veg%ZR = 5.0_r2
     END IF
 
     !! vh_js !!
     IF(cable_user%CALL_POP) THEN
        veg%disturbance_interval  = 100
-       veg%disturbance_intensity = 0.0_r_2
+       veg%disturbance_intensity = 0.0_r2
     ENDIF
 
     ! GPP_components
-    canopy%A_shC          = 0.0_r_2
-    canopy%A_shJ          = 0.0_r_2
-    canopy%A_slC          = 0.0_r_2
-    canopy%A_slJ          = 0.0_r_2
-    canopy%GPP_sh         = 0.0_r_2
-    canopy%GPP_sl         = 0.0_r_2
-    canopy%eta_A_cs       = 0.0_r_2
-    canopy%eta_GPP_cs     = 0.0_r_2
-    canopy%eta_fevc_cs    = 0.0_r_2
-    canopy%eta_A_cs_sl    = 0.0_r_2
-    canopy%eta_fevc_cs_sl = 0.0_r_2
-    canopy%GPP_sh         = 0.0_r_2
-    canopy%eta_A_cs_sh    = 0.0_r_2
-    canopy%eta_fevc_cs_sh = 0.0_r_2
+    canopy%A_shC          = 0.0_r2
+    canopy%A_shJ          = 0.0_r2
+    canopy%A_slC          = 0.0_r2
+    canopy%A_slJ          = 0.0_r2
+    canopy%GPP_sh         = 0.0_r2
+    canopy%GPP_sl         = 0.0_r2
+    canopy%eta_A_cs       = 0.0_r2
+    canopy%eta_GPP_cs     = 0.0_r2
+    canopy%eta_fevc_cs    = 0.0_r2
+    canopy%eta_A_cs_sl    = 0.0_r2
+    canopy%eta_fevc_cs_sl = 0.0_r2
+    canopy%GPP_sh         = 0.0_r2
+    canopy%eta_A_cs_sh    = 0.0_r2
+    canopy%eta_fevc_cs_sh = 0.0_r2
 
-    canopy%dAdcs   = 0.0_r_2
-    canopy%cs      = real(met%ca,r_2)
-    canopy%cs_sl   = real(met%ca,r_2)
-    canopy%cs_sh   = real(met%ca,r_2)
-    canopy%tlf     = 0.0_r_2
-    canopy%dlf     = 0.0_r_2
-    canopy%evapfbl = 0.0_r_2
+    canopy%dAdcs   = 0.0_r2
+    canopy%cs      = real(met%ca,r2)
+    canopy%cs_sl   = real(met%ca,r2)
+    canopy%cs_sh   = real(met%ca,r2)
+    canopy%tlf     = 0.0_r2
+    canopy%dlf     = 0.0_r2
+    canopy%evapfbl = 0.0_r2
 
     ! 13C
-    canopy%An        = 0.0_r_2
-    canopy%Rd        = 0.0_r_2
+    canopy%An        = 0.0_r2
+    canopy%Rd        = 0.0_r2
     canopy%isc3      = (1.0-veg%frac4) > epsilon(1.0)
-    canopy%vcmax     = spread(real(veg%vcmax,r_2),2,mf)
-    canopy%gammastar = 40.e-6_r_2
-    canopy%gsc       = 0.0_r_2
-    canopy%gbc       = 0.0_r_2
-    canopy%gac       = 0.0_r_2
-    canopy%ci        = spread(real(met%ca,r_2),2,mf)
+    canopy%vcmax     = spread(real(veg%vcmax,r2),2,mf)
+    canopy%gammastar = 40.e-6_r2
+    canopy%gsc       = 0.0_r2
+    canopy%gbc       = 0.0_r2
+    canopy%gac       = 0.0_r2
+    canopy%ci        = spread(real(met%ca,r2),2,mf)
 
   END SUBROUTINE write_default_params
 
@@ -1681,23 +1681,23 @@ CONTAINS
       casamet%isorder(landpt(ee)%cstart:landpt(ee)%cend) = &
                                        inSorder(landpt(ee)%ilon,landpt(ee)%ilat)
       DO hh = landpt(ee)%cstart, landpt(ee)%cend  ! each patch in current grid
-        casamet%lon(hh) = real(patch(hh)%longitude, r_2)
-        casamet%lat(hh) = real(patch(hh)%latitude, r_2)
-        ! MC - casamet%areacell should also be r_2 but it is not really used except for output in single precision
+        casamet%lon(hh) = real(patch(hh)%longitude, r2)
+        casamet%lat(hh) = real(patch(hh)%latitude, r2)
+        ! MC - casamet%areacell should also be r2 but it is not really used except for output in single precision
         casamet%areacell(hh) = real(patch(hh)%frac) &
                                * inArea(landpt(ee)%ilon, landpt(ee)%ilat)
         casaflux%Nmindep(hh) = patch(hh)%frac &
-                               * real(inNdep(landpt(ee)%ilon, landpt(ee)%ilat), r_2)
+                               * real(inNdep(landpt(ee)%ilon, landpt(ee)%ilat), r2)
         casaflux%Nminfix(hh) = patch(hh)%frac &
-                               * real(inNfix(landpt(ee)%ilon, landpt(ee)%ilat), r_2)
+                               * real(inNfix(landpt(ee)%ilon, landpt(ee)%ilat), r2)
         casaflux%Pdep(hh)    = patch(hh)%frac &
-                               * real(inPdust(landpt(ee)%ilon, landpt(ee)%ilat), r_2)
+                               * real(inPdust(landpt(ee)%ilon, landpt(ee)%ilat), r2)
         casaflux%Pwea(hh)    = patch(hh)%frac &
-                               * real(inPwea(landpt(ee)%ilon, landpt(ee)%ilat), r_2)
+                               * real(inPwea(landpt(ee)%ilon, landpt(ee)%ilat), r2)
         !! vh !! fluxes shouldn't be weighted by patch frac.
      !   IF (CABLE_USER%POPLUC) then
            casaflux%Nmindep(hh) =  inNdep(landpt(ee)%ilon, landpt(ee)%ilat)
-           casaflux%Nminfix(hh) = max(real(inNfix(landpt(ee)%ilon, landpt(ee)%ilat),r_2), 8.0e-4_r_2)
+           casaflux%Nminfix(hh) = max(real(inNfix(landpt(ee)%ilon, landpt(ee)%ilat),r2), 8.0e-4_r2)
            !vh ! minimum fixation rate of 3 kg N ha-1y-1 (8e-4 g N m-2 d-1)
            ! Cleveland, Cory C., et al. "Global patterns of terrestrial biological nitrogen (N2) &
            !fixation in natural ecosystems." Global biogeochemical cycles 13.2 (1999): 623-645.
@@ -1710,9 +1710,9 @@ CONTAINS
         IF (veg%iveg(hh) == cropland .OR. veg%iveg(hh) == croplnd2) then
           ! P fertilizer =13 Mt P globally in 1994
           casaflux%Pdep(hh)    = casaflux%Pdep(hh) &
-                                 + patch(hh)%frac * 0.7_r_2 / 365.0_r_2
+                                 + patch(hh)%frac * 0.7_r2 / 365.0_r2
           casaflux%Nmindep(hh) = casaflux%Nmindep(hh) &
-                                 + patch(hh)%frac * 4.0_r_2 / 365.0_r_2
+                                 + patch(hh)%frac * 4.0_r2 / 365.0_r2
         ENDIF
       ENDDO
     ENDDO
@@ -1732,7 +1732,7 @@ CONTAINS
     TYPE (roughness_type),      INTENT(INOUT) :: rough
 
     ! INTEGER :: j ! do loop counter
-    REAL(r_2) :: temp(mp)
+    REAL(r2) :: temp(mp)
     REAL      :: tmp2(mp)
 
     ! Construct derived parameters and zero initialisations,
@@ -1760,9 +1760,9 @@ CONTAINS
     ssnow%owetfac = MAX(0.0, MIN(1.0, &
                    (REAL(ssnow%wb(:, 1)) - soil%swilt) / &
                    (soil%sfc - soil%swilt)))
-    temp(:) = 0.0_r_2
+    temp(:) = 0.0_r2
     tmp2(:) = 0.0
-    WHERE ( ssnow%wbice(:, 1) > 0.0_r_2 ) ! Prevents divide by zero at glaciated
+    WHERE ( ssnow%wbice(:, 1) > 0.0_r2 ) ! Prevents divide by zero at glaciated
                                           ! points where wb and wbice=0.
       temp(:) = ssnow%wbice(:, 1) / ssnow%wb(:, 1)
       tmp2(:) = REAL(temp(:))
@@ -1801,10 +1801,10 @@ CONTAINS
 
     !! vh_js !! comment out hide% condition
     ! IF (hide%Ticket49Bug6) THEN
-    soil%swilt_vec = SPREAD(real(soil%swilt,r_2),2,ms)
-    soil%ssat_vec = SPREAD(real(soil%ssat,r_2),2,ms)
+    soil%swilt_vec = SPREAD(real(soil%swilt,r2),2,ms)
+    soil%ssat_vec = SPREAD(real(soil%ssat,r2),2,ms)
     IF(cable_user%SOIL_STRUC=='sli') THEN
-       soil%sfc_vec = SPREAD(real(soil%sfc,r_2),2,ms)
+       soil%sfc_vec = SPREAD(real(soil%sfc,r2),2,ms)
        ! Only 1 horizon by default !
        soil%nhorizons = 1
        soil%ishorizon = 1
@@ -1842,8 +1842,8 @@ CONTAINS
           CALL cable_abort('Unknown soil type! Aborting.')
        END IF
        ! Check patch fractions sum to 1 in each grid cell:
-       IF((SUM(patch(landpt(i)%cstart:landpt(i)%cend)%frac) - 1.0_r_2) &
-          > 1.0E-6_r_2) THEN
+       IF((SUM(patch(landpt(i)%cstart:landpt(i)%cend)%frac) - 1.0_r2) &
+          > 1.0E-6_r2) THEN
           WRITE(*,*) 'SUBROUTINE load_parameters:'
           WRITE(*,*) 'At land point number', i
           WRITE(*,*) 'And patch numbers:  ', landpt(i)%cstart, landpt(i)%cend
@@ -1920,8 +1920,8 @@ CONTAINS
     ! Ensure soil moisture values are reasonable (possible restart precision
     ! issue):
     DO i = 1, ms
-       WHERE (ssnow%wb(:, i) > real(soil%ssat,r_2)) ! Can only happen due to i/o issues
-          ssnow%wb(:, i) = 0.9999_r_2 * real(soil%ssat,r_2)
+       WHERE (ssnow%wb(:, i) > real(soil%ssat,r2)) ! Can only happen due to i/o issues
+          ssnow%wb(:, i) = 0.9999_r2 * real(soil%ssat,r2)
        END WHERE
     END DO
 
@@ -1991,7 +1991,7 @@ SUBROUTINE report_parameters(logn, soil, veg, bgc, rough, &
                      '------'
       DO g = 1, landpt(e)%nap
          WRITE(logn, '(A7, I2, A3, F6.2, A11, I3, 1X, A30)') ' patch ', &
-               g,':  ', patch(landpt(e)%cstart + g - 1)%frac * 100.0_r_2, &
+               g,':  ', patch(landpt(e)%cstart + g - 1)%frac * 100.0_r2, &
                '% veg type ', veg%iveg(landpt(e)%cstart + g - 1), &
                TRIM(veg_desc(veg%iveg(landpt(e)%cstart + g - 1)))
          WRITE(logn,'(18X, A11, I3, 1X, A45)') '  soil type', &

--- a/offline/cable_plume_mip.F90
+++ b/offline/cable_plume_mip.F90
@@ -1124,7 +1124,7 @@ END SUBROUTINE GET_PLUME_Ndep
     !
     !==============================================================================
 
-    USE cable_def_types_mod,   ONLY: MET_TYPE, r_2
+    USE cable_def_types_mod,   ONLY: MET_TYPE, r2
     USE cable_IO_vars_module,  ONLY: LANDPT, latitude
     USE cable_common_module,   ONLY: DOYSOD2YMDHMS
     USE cable_weathergenerator,ONLY: WEATHER_GENERATOR_TYPE, WGEN_INIT, &
@@ -1244,9 +1244,9 @@ END SUBROUTINE GET_PLUME_Ndep
        met%precip(is:ie)    = real(WG%Precip(i))  ! +  WG%Snow(i)
        met%precip_sn(is:ie) = real(min(WG%Snow(i), WG%Precip(i)))
        met%fld(is:ie)       = PLUME%MET(lwdn)%VAL(i) * real(WG%PhiLD(i)) / PLUME%AVG_LWDN(i)
-       met%fsd(is:ie,1)     = real(WG%PhiSD(i) * 0.5_r_2)
-       met%fsd(is:ie,2)     = real(WG%PhiSD(i) * 0.5_r_2)
-       met%tk(is:ie)        = real(WG%Temp(i) + 273.15_r_2)
+       met%fsd(is:ie,1)     = real(WG%PhiSD(i) * 0.5_r2)
+       met%fsd(is:ie,2)     = real(WG%PhiSD(i) * 0.5_r2)
+       met%tk(is:ie)        = real(WG%Temp(i) + 273.15_r2)
        met%ua(is:ie)        = real(WG%Wind(i))
        met%coszen(is:ie)    = real(WG%coszen(i))
        ! compute qv

--- a/offline/cable_read.F90
+++ b/offline/cable_read.F90
@@ -33,7 +33,7 @@
 MODULE cable_read_module
 
    USE cable_abort_module
-   USE cable_def_types_mod,  ONLY: ms, ncp, r_1, r_2, mland, mp, ncs, nrb, msn, mf
+   USE cable_def_types_mod,  ONLY: ms, ncp, r1, r2, mland, mp, ncs, nrb, msn, mf
    USE cable_IO_vars_module, ONLY: landpt, exists, land_x, land_y, metGrid
    USE netcdf
 #ifdef __MPI__
@@ -183,7 +183,7 @@ CONTAINS
     INTEGER, INTENT(IN) :: ncid ! netcdf file ID
     INTEGER, INTENT(IN) :: npatch ! # of veg patches in parameter's file
     INTEGER, INTENT(IN), OPTIONAL :: INpatch
-    REAL(KIND=r_1), DIMENSION(:), INTENT(INOUT) :: var_r ! returned parameter values
+    REAL(KIND=r1), DIMENSION(:), INTENT(INOUT) :: var_r ! returned parameter values
     LOGICAL, INTENT(IN), OPTIONAL :: from_restart ! reading from restart file?
     LOGICAL, INTENT(INOUT) :: completeSet ! has every parameter been loaded?
     CHARACTER(LEN=*), INTENT(IN) :: parname ! name of parameter
@@ -193,10 +193,10 @@ CONTAINS
     INTEGER :: parID ! parameter's netcdf ID
     INTEGER :: pardims ! # dimensions of parameter
     INTEGER :: i ! do loop counter
-    REAL(KIND=r_1), DIMENSION(1) :: data1r ! temporary for ncdf read in
-    REAL(KIND=r_1), DIMENSION(1, 1) :: data2r ! temporary for ncdf read in
-    REAL(KIND=r_1), DIMENSION(:, :), POINTER :: tmp2r => null() ! temporary for ncdf read in
-    REAL(KIND=r_1), DIMENSION(:, :, :), POINTER :: tmp3r => null() ! temporary for ncdf read in
+    REAL(KIND=r1), DIMENSION(1) :: data1r ! temporary for ncdf read in
+    REAL(KIND=r1), DIMENSION(1, 1) :: data2r ! temporary for ncdf read in
+    REAL(KIND=r1), DIMENSION(:, :), POINTER :: tmp2r => null() ! temporary for ncdf read in
+    REAL(KIND=r1), DIMENSION(:, :, :), POINTER :: tmp3r => null() ! temporary for ncdf read in
 
     ! Check if parameter exists:
     ok = NF90_INQ_VARID(ncid, parname, parID)
@@ -325,7 +325,7 @@ CONTAINS
     ! Subroutine for loading a double precision real-valued parameter
     INTEGER, INTENT(IN) :: ncid ! netcdf file ID
     INTEGER, INTENT(IN) :: npatch ! # of veg patches in parameter's file
-    REAL(r_2), DIMENSION(:), INTENT(INOUT) :: var_rd ! returned parameter values
+    REAL(r2), DIMENSION(:), INTENT(INOUT) :: var_rd ! returned parameter values
     LOGICAL, INTENT(IN), OPTIONAL :: from_restart ! reading from restart file?
     LOGICAL, INTENT(INOUT) :: completeSet ! has every parameter been loaded?
     CHARACTER(LEN=*), INTENT(IN) :: parname ! name of parameter
@@ -336,10 +336,10 @@ CONTAINS
     INTEGER :: parID ! parameter's netcdf ID
     INTEGER :: pardims ! # dimensions of parameter
     INTEGER :: i ! do loop counter
-    REAL(r_1), DIMENSION(1) :: data1r ! temporary for ncdf read in
-    REAL(r_1), DIMENSION(1, 1) :: data2r ! temporary for ncdf read in
-    REAL(r_1), DIMENSION(:, :), POINTER :: tmp2r => null() ! temporary for ncdf read in
-    REAL(r_1), DIMENSION(:, :, :), POINTER :: tmp3r => null() ! temporary for ncdf read in
+    REAL(r1), DIMENSION(1) :: data1r ! temporary for ncdf read in
+    REAL(r1), DIMENSION(1, 1) :: data2r ! temporary for ncdf read in
+    REAL(r1), DIMENSION(:, :), POINTER :: tmp2r => null() ! temporary for ncdf read in
+    REAL(r1), DIMENSION(:, :, :), POINTER :: tmp3r => null() ! temporary for ncdf read in
 
     ! Check if parameter exists:
     ok = NF90_INQ_VARID(ncid, parname, parID)
@@ -381,7 +381,7 @@ CONTAINS
                            //TRIM(filename)//' (SUBROUTINE readpar_rd)')
                       ! Give single value to all patches if no patch specific
                       ! info:
-                      var_rd(landpt(i)%cstart:landpt(i)%cend) = real(data1r(1), r_2)
+                      var_rd(landpt(i)%cstart:landpt(i)%cend) = real(data1r(1), r2)
                    END DO
                 END IF
              ELSE IF (pardims == 2) THEN ! i.e. parameter has a patch dimension
@@ -398,7 +398,7 @@ CONTAINS
                            CALL nc_abort(ok, 'Error reading '//parname//' in file ' &
                            //TRIM(filename)//' (SUBROUTINE readpar_rd)')
                       ! Set values for this par for the # patches that exist
-                      var_rd(landpt(i)%cstart:(landpt(i)%cstart + npatch - 1)) = REAL(tmp2r(1, :), r_2)
+                      var_rd(landpt(i)%cstart:(landpt(i)%cstart + npatch - 1)) = REAL(tmp2r(1, :), r2)
                    END DO
                    DEALLOCATE(tmp2r)
                 endif
@@ -423,7 +423,7 @@ CONTAINS
                            CALL nc_abort(ok, 'Error reading '//parname//' in file ' &
                            //TRIM(filename)//' (SUBROUTINE readpar_rd)')
                       ! Set all patches to have the same value for this par:
-                      var_rd(landpt(i)%cstart:landpt(i)%cend) = REAL(data2r(1, 1), r_2)
+                      var_rd(landpt(i)%cstart:landpt(i)%cend) = REAL(data2r(1, 1), r2)
                    END DO
                 ELSE IF (pardims == 3) THEN ! i.e. parameter has a patch dimension
                    ALLOCATE(tmp3r(1, 1, npatch))
@@ -435,7 +435,7 @@ CONTAINS
                            CALL nc_abort(ok, 'Error reading '//parname//' in file ' &
                            //TRIM(filename)//' (SUBROUTINE readpar_rd)')
                       ! Set values for this par for the # patches that exist
-                      var_rd(landpt(i)%cstart:(landpt(i)%cstart + npatch - 1)) = REAL(tmp3r(1, 1, :), r_2)
+                      var_rd(landpt(i)%cstart:(landpt(i)%cstart + npatch - 1)) = REAL(tmp3r(1, 1, :), r2)
                    END DO
                    DEALLOCATE(tmp3r)
                 ELSE
@@ -456,7 +456,7 @@ CONTAINS
                  IF (ok /= NF90_NOERR) &
                       CALL nc_abort(ok, 'Error reading '//parname//' in file ' &
                       //TRIM(filename)//' (SUBROUTINE readpar_rd)')
-                 var_rd(i) = REAL(data1r(1), r_2)
+                 var_rd(i) = REAL(data1r(1), r2)
               END DO
            endif
         ELSE IF (dimswitch(1:2) == 'msn') THEN ! ie par has only soil dimension, no spatial
@@ -469,7 +469,7 @@ CONTAINS
                  IF (ok /= NF90_NOERR) &
                       CALL nc_abort(ok, 'Error reading '//parname//' in file ' &
                       //TRIM(filename)//' (SUBROUTINE readpar_rd)')
-                 var_rd(i) = REAL(data1r(1), r_2)
+                 var_rd(i) = REAL(data1r(1), r2)
               END DO
            endif
         ELSE IF (dimswitch(1:2) == 'mf') THEN ! ie par has only soil dimension, no spatial
@@ -482,7 +482,7 @@ CONTAINS
                  IF (ok /= NF90_NOERR) &
                       CALL nc_abort(ok, 'Error reading '//parname//' in file ' &
                       //TRIM(filename)//' (SUBROUTINE readpar_rd)')
-                 var_rd(i) = REAL(data1r(1), r_2)
+                 var_rd(i) = REAL(data1r(1), r2)
               END DO
            endif
        ELSE IF (dimswitch(1:3) == 'ncp') THEN ! ie par has only ncp dimension e.g. ratecp
@@ -495,7 +495,7 @@ CONTAINS
                 IF(ok /= NF90_NOERR) &
                      CALL nc_abort(ok, 'Error reading '//parname//' in file ' &
                      //TRIM(filename)//' (SUBROUTINE readpar_rd)')
-                var_rd(i) = REAL(data1r(1), r_2)
+                var_rd(i) = REAL(data1r(1), r2)
              END DO
           endif
        ELSE IF (dimswitch(1:3) == 'ncs') THEN ! ie par has only ncs dimension e.g. ratecs
@@ -508,7 +508,7 @@ CONTAINS
                 IF(ok /= NF90_NOERR) &
                      CALL nc_abort(ok,'Error reading '//parname//' in file ' &
                      //TRIM(filename)//' (SUBROUTINE readpar_rd)')
-                var_rd(i) = REAL(data1r(1), r_2)
+                var_rd(i) = REAL(data1r(1), r2)
              END DO
           endif
        ELSE
@@ -528,7 +528,7 @@ CONTAINS
     INTEGER, INTENT(IN) :: ncid ! netcdf file ID
     INTEGER, INTENT(IN) :: npatch ! number of veg patches in file
     INTEGER, INTENT(IN), OPTIONAL :: INpatch
-    REAL(KIND=r_1), DIMENSION(:,:), INTENT(INOUT) :: var_r2 ! returned parameter values
+    REAL(KIND=r1), DIMENSION(:,:), INTENT(INOUT) :: var_r2 ! returned parameter values
     LOGICAL, INTENT(IN), OPTIONAL :: from_restart ! reading from restart file?
     LOGICAL, INTENT(INOUT) :: completeSet ! has every parameter been loaded?
     CHARACTER(LEN=*), INTENT(IN) :: filename ! file containing parameter values
@@ -540,11 +540,11 @@ CONTAINS
     INTEGER :: pardims ! # dimensions of parameter
     INTEGER :: dimctr ! size of non-spatial (2nd) dimension of parameter
     INTEGER :: i, j ! do loop counter
-    REAL(KIND=r_1), DIMENSION(:, :), POINTER       :: tmp2r => null() ! temporary for ncdf
+    REAL(KIND=r1), DIMENSION(:, :), POINTER       :: tmp2r => null() ! temporary for ncdf
                                                           ! read in
-    REAL(KIND=r_1), DIMENSION(:, :, :), POINTER    :: tmp3r => null() ! temporary for ncdf
+    REAL(KIND=r1), DIMENSION(:, :, :), POINTER    :: tmp3r => null() ! temporary for ncdf
                                                           ! read in
-    REAL(KIND=r_1), DIMENSION(:, :, :, :), POINTER :: tmp4r => null() ! temporary for ncdf read in
+    REAL(KIND=r1), DIMENSION(:, :, :, :), POINTER :: tmp4r => null() ! temporary for ncdf read in
     REAL :: tmpjh
 
     ! Check if parameter exists:
@@ -697,7 +697,7 @@ CONTAINS
     INTEGER, INTENT(IN) :: ncid ! netcdf file ID
     INTEGER, INTENT(IN) :: npatch ! # of veg patches in parameter's file
     INTEGER, INTENT(IN), OPTIONAL :: INpatch
-    REAL(r_2), DIMENSION(:, :), INTENT(INOUT) :: var_r2d ! returned parameter
+    REAL(r2), DIMENSION(:, :), INTENT(INOUT) :: var_r2d ! returned parameter
                                                          ! value
     LOGICAL, INTENT(IN), OPTIONAL :: from_restart ! reading from restart file?
     LOGICAL, INTENT(INOUT) :: completeSet ! has every parameter been loaded?
@@ -709,11 +709,11 @@ CONTAINS
     INTEGER :: pardims ! # dimensions of parameter
     INTEGER :: dimctr ! size of non-spatial (2nd) dimension of parameter
     INTEGER :: i,j ! do loop counter
-    REAL(r_1), DIMENSION(:, :), POINTER       :: tmp2r => null()  ! temporary for ncdf
+    REAL(r1), DIMENSION(:, :), POINTER       :: tmp2r => null()  ! temporary for ncdf
                                                       ! read in
-    REAL(r_1), DIMENSION(:, :, :), POINTER    :: tmp3r => null()  ! temporary for ncdf
+    REAL(r1), DIMENSION(:, :, :), POINTER    :: tmp3r => null()  ! temporary for ncdf
                                                       ! read in
-    REAL(r_1), DIMENSION(:, :, :, :), POINTER :: tmp4r => null()  ! temporary for ncdf
+    REAL(r1), DIMENSION(:, :, :, :), POINTER :: tmp4r => null()  ! temporary for ncdf
                                                       ! read in
 
     ! Check if parameter exists:
@@ -779,7 +779,7 @@ CONTAINS
                           CALL nc_abort(ok, 'Error reading '//parname//' in met data file ' &
                           //TRIM(filename)//' (SUBROUTINE readpar_r2d)')
                      DO j = 1, dimctr
-                        var_r2d(landpt(i)%cstart:landpt(i)%cend, j) = REAL(tmp2r(1,j), r_2)
+                        var_r2d(landpt(i)%cstart:landpt(i)%cend, j) = REAL(tmp2r(1,j), r2)
                      END DO
                   END DO
                   DEALLOCATE(tmp2r)
@@ -801,7 +801,7 @@ CONTAINS
                    DO j=1, dimctr
                       ! Set values for this par for the # patches that exist
                       var_r2d(landpt(i)%cstart:(landpt(i)%cstart + npatch - 1),j) &
-                           = REAL(tmp3r(1,:,j), r_2)
+                           = REAL(tmp3r(1,:,j), r2)
                    END DO
                 END DO
                 DEALLOCATE(tmp3r)
@@ -830,7 +830,7 @@ CONTAINS
                    ! Set all patches to have the same value for this par:
                    DO j=1, dimctr
                       var_r2d(landpt(i)%cstart:landpt(i)%cend, j) = &
-                           REAL(tmp3r(1, 1, j), r_2)
+                           REAL(tmp3r(1, 1, j), r2)
                    END DO
                 END DO
                 DEALLOCATE(tmp3r)
@@ -846,7 +846,7 @@ CONTAINS
                    DO j=1, dimctr
                       ! Set values for this par for the # patches that exist
                       var_r2d(landpt(i)%cstart:(landpt(i)%cstart + npatch - 1), j) = &
-                           REAL(tmp4r(1, 1, :, j), r_2)
+                           REAL(tmp4r(1, 1, :, j), r2)
                    END DO
                 END DO
                 DEALLOCATE(tmp4r)
@@ -934,12 +934,12 @@ CONTAINS
     IMPLICIT NONE
     INTEGER,     INTENT(IN)  :: INpatch
     INTEGER,     INTENT(IN)  :: nap(INpatch)
-    REAL(r_2),        INTENT(IN)  :: in_rd(INpatch)
-    REAL(r_2),        INTENT(OUT) :: out_rd(mp)
+    REAL(r2),        INTENT(IN)  :: in_rd(INpatch)
+    REAL(r2),        INTENT(OUT) :: out_rd(mp)
     CHARACTER(LEN=*), INTENT(IN)  :: parname ! name of parameter
 
     ! local variables
-    REAL(r_2)    :: ave_rd
+    REAL(r2)    :: ave_rd
     INTEGER :: ii, jj, npt
 
     npt = 0
@@ -1004,12 +1004,12 @@ CONTAINS
     INTEGER,     INTENT(IN)  :: INpatch
     INTEGER,     INTENT(IN)  :: dim2
     INTEGER,     INTENT(IN)  :: nap(INpatch)
-    REAL(r_2),        INTENT(IN)  :: in_r2d (INpatch,dim2)
-    REAL(r_2),        INTENT(OUT) :: out_r2d(mp,dim2)
+    REAL(r2),        INTENT(IN)  :: in_r2d (INpatch,dim2)
+    REAL(r2),        INTENT(OUT) :: out_r2d(mp,dim2)
     CHARACTER(LEN=*), INTENT(IN)  :: parname ! name of parameter
 
     ! local variables
-    REAL(r_2)    :: ave_r2d(dim2)
+    REAL(r2)    :: ave_r2d(dim2)
     INTEGER :: ii, jj, npt
 
     npt = 0

--- a/offline/cable_weathergenerator.F90
+++ b/offline/cable_weathergenerator.F90
@@ -1,29 +1,28 @@
 MODULE CABLE_WEATHERGENERATOR
   
   USE CABLE_COMMON_MODULE, ONLY: cable_user
-  USE cable_def_types_mod, only: r_2
+  USE cable_def_types_mod, only: r2
   
   IMPLICIT NONE
 
   ! Parameters
-  INTEGER, PARAMETER,PRIVATE :: sp = r_2 ! this is double precision
-  REAL(sp),PARAMETER,PRIVATE :: &
-       Pi         = 3.14159265_sp , &            ! Pi
-       PiBy2      = 1.57079632_sp , &            ! Pi/2
-       SecDay     = 86400.0_sp    , &            ! Seconds/day
-       SolarConst = 1370._sp*SecDay/1e6_sp, &    ! Solar constant [MJ/m2/day]
-       epsilon    = 0.736_sp        , &
-       SBoltz     = 5.67e-8_sp  ! Stefan-Boltzmann constant [W/m2/K4]
+  REAL(r2),PARAMETER,PRIVATE :: &
+       Pi         = 3.14159265_r2 , &            ! Pi
+       PiBy2      = 1.57079632_r2 , &            ! Pi/2
+       SecDay     = 86400.0_r2    , &            ! Seconds/day
+       SolarConst = 1370._r2*SecDay/1e6_r2, &    ! Solar constant [MJ/m2/day]
+       epsilon    = 0.736_r2        , &
+       SBoltz     = 5.67e-8_r2  ! Stefan-Boltzmann constant [W/m2/K4]
   ! Global variables
   TYPE WEATHER_GENERATOR_TYPE
      ! general
      INTEGER :: np
      INTEGER :: ndtime   ! number of subdiurnal steps in 24 hr
      REAL    :: delT     ! subdiurnal timestep (in s)
-     REAL(sp),DIMENSION(:),ALLOCATABLE :: LatDeg
+     REAL(r2),DIMENSION(:),ALLOCATABLE :: LatDeg
 
      ! Daily input to subdiurnal met calculations
-     REAL(sp),DIMENSION(:),ALLOCATABLE :: &
+     REAL(r2),DIMENSION(:),ALLOCATABLE :: &
           WindDay        ,&
           TempMinDay     ,&    ! Daily minimum air temp [degC]
           TempMaxDay     ,&    ! Daily maximum air temp [degC]
@@ -41,8 +40,8 @@ MODULE CABLE_WEATHERGENERATOR
           VapPmb0900Next    ! 0900(next day) water vapour pressure [mb]
 
      ! Daily constants
-     REAL(sp) :: DecRad                                   ! Declination in radians
-     REAL(sp),DIMENSION(:),ALLOCATABLE :: &
+     REAL(r2) :: DecRad                                   ! Declination in radians
+     REAL(r2),DIMENSION(:),ALLOCATABLE :: &
           WindDark           ,&  ! Wind [m/s] during night hrs
           WindLite           ,&  ! Wind [m/s] during daylight hrs
           SolarNorm          ,&  ! (daily solar)/(solar const): geometry
@@ -61,7 +60,7 @@ MODULE CABLE_WEATHERGENERATOR
 
      !   Solar and Temperature Params
      !   Hourly Met outgoing
-     REAL(sp),DIMENSION(:),ALLOCATABLE :: &
+     REAL(r2),DIMENSION(:),ALLOCATABLE :: &
           PhiSd           ,&  ! downward solar irradiance [W/m2]
           PhiLd           ,&  ! down longwave irradiance  [W/m2]
           Precip          ,&  ! precip [mm/h]
@@ -145,45 +144,45 @@ subroutine wgen_zero(wg)
 
   type(weather_generator_type), intent(inout) :: wg
 
-  wg%LatDeg            = 0.0_sp
-  wg%WindDay           = 0.0_sp
-  wg%TempMinDay        = 0.0_sp
-  wg%TempMaxDay        = 0.0_sp
-  wg%TempMinDayNext    = 0.0_sp
-  wg%TempMaxDayPrev    = 0.0_sp
-  wg%SolarMJDay        = 0.0_sp
-  wg%PrecipDay         = 0.0_sp
-  wg%SnowDay           = 0.0_sp
-  wg%PmbDay            = 0.0_sp
-  wg%VapPmbDay         = 0.0_sp
-  wg%VapPmb0900        = 0.0_sp
-  wg%VapPmb1500        = 0.0_sp
-  wg%VapPmb1500Prev    = 0.0_sp
-  wg%VapPmb0900Next    = 0.0_sp
-  wg%WindDark          = 0.0_sp
-  wg%WindLite          = 0.0_sp
-  wg%SolarNorm         = 0.0_sp
-  wg%LatRad            = 0.0_sp
-  wg%DayLength         = 0.0_sp
-  wg%TimeSunsetPrev    = 0.0_sp
-  wg%TimeSunrise       = 0.0_sp
-  wg%TimeMaxTemp       = 0.0_sp
-  wg%TimeSunset        = 0.0_sp
-  wg%TempSunsetPrev    = 0.0_sp
-  wg%TempSunset        = 0.0_sp
-  wg%TempNightRate     = 0.0_sp
-  wg%TempNightRatePrev = 0.0_sp
-  wg%TempRangeDay      = 0.0_sp
-  Wg%TempRangeAft      = 0.0_sp
-  wg%PhiSd             = 0.0_sp
-  wg%PhiLd             = 0.0_sp
-  wg%Precip            = 0.0_sp
-  wg%Snow              = 0.0_sp
-  wg%Wind              = 0.0_sp
-  wg%Temp              = 0.0_sp
-  wg%VapPmb            = 0.0_sp
-  wg%Pmb               = 0.0_sp
-  wg%coszen            = 0.0_sp
+  wg%LatDeg            = 0.0_r2
+  wg%WindDay           = 0.0_r2
+  wg%TempMinDay        = 0.0_r2
+  wg%TempMaxDay        = 0.0_r2
+  wg%TempMinDayNext    = 0.0_r2
+  wg%TempMaxDayPrev    = 0.0_r2
+  wg%SolarMJDay        = 0.0_r2
+  wg%PrecipDay         = 0.0_r2
+  wg%SnowDay           = 0.0_r2
+  wg%PmbDay            = 0.0_r2
+  wg%VapPmbDay         = 0.0_r2
+  wg%VapPmb0900        = 0.0_r2
+  wg%VapPmb1500        = 0.0_r2
+  wg%VapPmb1500Prev    = 0.0_r2
+  wg%VapPmb0900Next    = 0.0_r2
+  wg%WindDark          = 0.0_r2
+  wg%WindLite          = 0.0_r2
+  wg%SolarNorm         = 0.0_r2
+  wg%LatRad            = 0.0_r2
+  wg%DayLength         = 0.0_r2
+  wg%TimeSunsetPrev    = 0.0_r2
+  wg%TimeSunrise       = 0.0_r2
+  wg%TimeMaxTemp       = 0.0_r2
+  wg%TimeSunset        = 0.0_r2
+  wg%TempSunsetPrev    = 0.0_r2
+  wg%TempSunset        = 0.0_r2
+  wg%TempNightRate     = 0.0_r2
+  wg%TempNightRatePrev = 0.0_r2
+  wg%TempRangeDay      = 0.0_r2
+  Wg%TempRangeAft      = 0.0_r2
+  wg%PhiSd             = 0.0_r2
+  wg%PhiLd             = 0.0_r2
+  wg%Precip            = 0.0_r2
+  wg%Snow              = 0.0_r2
+  wg%Wind              = 0.0_r2
+  wg%Temp              = 0.0_r2
+  wg%VapPmb            = 0.0_r2
+  wg%Pmb               = 0.0_r2
+  wg%coszen            = 0.0_r2
   
 end subroutine wgen_zero
 
@@ -204,38 +203,38 @@ SUBROUTINE WGEN_DAILY_CONSTANTS( WG, np, YearDay )
   INTEGER, INTENT(IN) :: np, YearDay
 
   ! Local variables
-  REAL(sp) :: YearRad
-  REAL(sp),DIMENSION(np) :: LatDeg1
-  REAL(sp),DIMENSION(np) :: TanTan
-  REAL(sp),DIMENSION(np) :: HDLRad
-  REAL(sp),DIMENSION(np) :: TimeSunriseNext
-  REAL(sp) :: RatioWindLiteDark
+  REAL(r2) :: YearRad
+  REAL(r2),DIMENSION(np) :: LatDeg1
+  REAL(r2),DIMENSION(np) :: TanTan
+  REAL(r2),DIMENSION(np) :: HDLRad
+  REAL(r2),DIMENSION(np) :: TimeSunriseNext
+  REAL(r2) :: RatioWindLiteDark
 
 ! -------------------------
 ! Downward solar irradiance
 ! -------------------------
-LatDeg1    = SIGN(MIN(ABS(WG%LatDeg),89.9_sp), WG%LatDeg)   ! avoid singularity at pole
-WG%LatRad  = LatDeg1*Pi/180.0_sp                      ! latitude in radians
-YearRad    = 2.0_sp*Pi*(YearDay-1)/365.0_sp              ! day of year in radians
+LatDeg1    = SIGN(MIN(ABS(WG%LatDeg),89.9_r2), WG%LatDeg)   ! avoid singularity at pole
+WG%LatRad  = LatDeg1*Pi/180.0_r2                      ! latitude in radians
+YearRad    = 2.0_r2*Pi*(YearDay-1)/365.0_r2              ! day of year in radians
 !YearRadPrev = 2.0*Pi*(YearDay-2)/365.0          ! previous day of year in radians
                                                 ! (Ok for YD - 2 = -1)
 
 ! DecRad = Declination in radians (+23.5 deg on 22 June, -23.5 deg on 22 Dec):
-WG%DecRad = 0.006918_sp - 0.399912_sp*COS(YearRad) + 0.070257_sp*SIN(YearRad)     &
-         - 0.006758_sp*COS(2.0_sp*YearRad) + 0.000907_sp*SIN(2.0_sp*YearRad)      &
-         - 0.002697_sp*COS(3.0_sp*YearRad) + 0.001480_sp*SIN(3.0_sp*YearRad)
+WG%DecRad = 0.006918_r2 - 0.399912_r2*COS(YearRad) + 0.070257_r2*SIN(YearRad)     &
+         - 0.006758_r2*COS(2.0_r2*YearRad) + 0.000907_r2*SIN(2.0_r2*YearRad)      &
+         - 0.002697_r2*COS(3.0_r2*YearRad) + 0.001480_r2*SIN(3.0_r2*YearRad)
                                         ! Paltridge and Platt eq [3.7]
 
 ! Daylength: HDLRad = Half Day Length in radians (dawn:noon = noon:dusk):
 TanTan = -TAN(WG%LatRad)*TAN(WG%DecRad)
-WHERE (TanTan .LE. -1.0_sp)
+WHERE (TanTan .LE. -1.0_r2)
   HDLRad = Pi                           ! polar summer: sun never sets
-ELSEWHERE (TanTan .GE. 1.0_sp)
-  HDLRad = 0.0_sp                          ! polar winter: sun never rises
+ELSEWHERE (TanTan .GE. 1.0_r2)
+  HDLRad = 0.0_r2                          ! polar winter: sun never rises
 ELSEWHERE
   HDLRad = ACOS(TanTan)                 ! Paltridge and Platt eq [3.21]
 END WHERE                                  ! (HDLRad = their capital PI)
-WG%DayLength = 24.0_sp*2.0_sp*HDLRad / (2.0_sp*Pi)  ! Daylength (dawn:dusk) in hours
+WG%DayLength = 24.0_r2*2.0_r2*HDLRad / (2.0_r2*Pi)  ! Daylength (dawn:dusk) in hours
 
 ! Daily solar irradiance without atmosphere, normalised by solar constant,
 ! with both energy fluxes in MJ/m2/day, calculated from solar geometry:
@@ -247,11 +246,11 @@ WG%SolarNorm =  &                          ! Paltridge and Platt eq [3.22]
 ! Wind
 ! ----
 
-RatioWindLiteDark = 3.0_sp                 ! (daytime wind) / (nighttime wind)
+RatioWindLiteDark = 3.0_r2                 ! (daytime wind) / (nighttime wind)
 WG%WindDark  = WG%WindDay / &
-     ( (24.0_sp-WG%DayLength)/24.0_sp + RatioWindLiteDark*WG%DayLength/24.0_sp )
+     ( (24.0_r2-WG%DayLength)/24.0_r2 + RatioWindLiteDark*WG%DayLength/24.0_r2 )
 WG%WindLite  = WG%WindDay / &
-     ( (1.0_sp/RatioWindLiteDark)*(24.0_sp-WG%DayLength)/24.0_sp + WG%DayLength/24.0_sp )
+     ( (1.0_r2/RatioWindLiteDark)*(24.0_r2-WG%DayLength)/24.0_r2 + WG%DayLength/24.0_r2 )
 
 ! -----------
 ! Temperature
@@ -271,28 +270,28 @@ WG%WindLite  = WG%WindDay / &
 !!$   write(72, "( 1000e16.6)") TAN(WG%DecRad)
 !!$   write(73, "( 1000e16.6)") TAN(WG%LatRad)
 !!$ write(74, "( 1000e16.6)")  WG%DayLength 
-WHERE ( WG%DayLength .LT. 0.01_sp )
+WHERE ( WG%DayLength .LT. 0.01_r2 )
    ! Polar night
-   WG%TimeSunrise     = 9._sp              ! Hn
-   WG%TimeSunset      = 16._sp                            ! Ho
-   WG%TimeMaxTemp     = 13._sp                                    ! Hx
-ELSEWHERE ( WG%DayLength .GT. 23.0_sp )
+   WG%TimeSunrise     = 9._r2              ! Hn
+   WG%TimeSunset      = 16._r2                            ! Ho
+   WG%TimeMaxTemp     = 13._r2                                    ! Hx
+ELSEWHERE ( WG%DayLength .GT. 23.0_r2 )
    ! Polar day
-   WG%TimeSunrise     = 1._sp              ! Hn
-   WG%TimeSunset      = 23._sp                            ! Ho
-   WG%TimeMaxTemp     = 13._sp                                    ! Hx
+   WG%TimeSunrise     = 1._r2              ! Hn
+   WG%TimeSunset      = 23._r2                            ! Ho
+   WG%TimeMaxTemp     = 13._r2                                    ! Hx
 ELSEWHERE
    
-   WG%TimeSunrise     = (ACOS(min(TAN(WG%LatRad)*TAN(WG%DecRad),0.9999_sp)))*12._sp/Pi              ! Hn
+   WG%TimeSunrise     = (ACOS(min(TAN(WG%LatRad)*TAN(WG%DecRad),0.9999_r2)))*12._r2/Pi              ! Hn
    WG%TimeSunset      = WG%TimeSunrise + WG%DayLength                             ! Ho
-   WG%TimeMaxTemp     = WG%TimeSunset - MIN(4._sp,( WG%DayLength * 0.4_sp)) ! Hx
+   WG%TimeMaxTemp     = WG%TimeSunset - MIN(4._r2,( WG%DayLength * 0.4_r2)) ! Hx
 END WHERE
-WG%TimeSunsetPrev  = WG%TimeSunset - 24._sp                                 ! * Ho-24h (a negative hour)
-TimeSunriseNext    = WG%TimeSunrise + 24._sp                               ! Hp
+WG%TimeSunsetPrev  = WG%TimeSunset - 24._r2                                 ! * Ho-24h (a negative hour)
+TimeSunriseNext    = WG%TimeSunrise + 24._r2                               ! Hp
 WG%TempSunset      = WG%TempMaxDay - &
-     (0.39_sp * (WG%TempMaxDay - WG%TempMinDayNext))               ! To
+     (0.39_r2 * (WG%TempMaxDay - WG%TempMinDayNext))               ! To
 WG%TempSunsetPrev  = WG%TempMaxDayPrev - &
-     (0.39_sp * (WG%TempMaxDayPrev - WG%TempMinDay))           ! * To-24h
+     (0.39_r2 * (WG%TempMaxDayPrev - WG%TempMinDay))           ! * To-24h
 WG%TempRangeDay    = WG%TempMaxDay - WG%TempMinDay                            ! alpha = Tx-Tn
 WG%TempRangeAft    = WG%TempMaxDay - WG%TempSunset                            ! R = Tx-To
 WG%TempNightRate   = (WG%TempMinDayNext - WG%TempSunset)/ &
@@ -346,36 +345,36 @@ SUBROUTINE WGEN_SUBDIURNAL_MET(WG, np, itime)
   INTEGER, INTENT(IN) :: np, itime
 
   ! Local variables
-  REAL(sp) :: TimeNoon, adjust_fac(np)
-  REAL(sp) :: TimeRad
-  REAL(sp) :: rntime    ! Real version of ntime
-  REAL(sp) :: ritime    ! Real version of current time
-  REAL(sp),DIMENSION(np):: PhiLd_Swinbank     ! down longwave irradiance  [W/m2]
+  REAL(r2) :: TimeNoon, adjust_fac(np)
+  REAL(r2) :: TimeRad
+  REAL(r2) :: rntime    ! Real version of ntime
+  REAL(r2) :: ritime    ! Real version of current time
+  REAL(r2),DIMENSION(np):: PhiLd_Swinbank     ! down longwave irradiance  [W/m2]
 #ifdef __MPI__
   integer :: ierr
 #endif
 
   !-------------------------------------------------------------------------------
 
-  ritime = REAL(itime)     * WG%delT/3600._sp  ! Convert the current time to real
-  rntime = REAL(WG%ndtime) * WG%delT/3600._sp  ! Convert ntime to real
+  ritime = REAL(itime)     * WG%delT/3600._r2  ! Convert the current time to real
+  rntime = REAL(WG%ndtime) * WG%delT/3600._r2  ! Convert ntime to real
 
   ! Instantaneous downward hemispheric solar irradiance PhiSd
-  TimeNoon = ritime/rntime - 0.5_sp   ! Time in day frac (-0.5 to 0.5, zero at noon)
-  TimeRad  = 2.0_sp*Pi*TimeNoon       ! Time in day frac (-Pi to Pi, zero at noon)
+  TimeNoon = ritime/rntime - 0.5_r2   ! Time in day frac (-0.5 to 0.5, zero at noon)
+  TimeRad  = 2.0_r2*Pi*TimeNoon       ! Time in day frac (-Pi to Pi, zero at noon)
   WHERE (ritime >= WG%TimeSunrise .AND. ritime <= WG%TimeSunset&
-       .AND.WG%SolarNorm.gt.1.e-3_sp  ) ! Sun is up
+       .AND.WG%SolarNorm.gt.1.e-3_r2  ) ! Sun is up
      WG%PhiSd = MAX((WG%SolarMJDay/WG%SolarNorm)  &   ! PhiSd [MJ/m2/day]
           * ( SIN(WG%DecRad)*SIN(WG%LatRad) + COS(WG%DecRad)*COS(WG%LatRad) &
-          * COS(TimeRad) ), 0.0_sp)  ! fix to avoid negative PhiSD vh 13/05/08
+          * COS(TimeRad) ), 0.0_r2)  ! fix to avoid negative PhiSD vh 13/05/08
      ! Paltridge and Platt eq [3.4]
      WG%coszen = ( SIN(WG%DecRad)*SIN(WG%LatRad) + COS(WG%DecRad)*COS(WG%LatRad)*COS(TimeRad) )
   ELSEWHERE ! sun is down
-     WG%PhiSd  = 0.0_sp
-     WG%coszen = 0.0_sp
+     WG%PhiSd  = 0.0_r2
+     WG%coszen = 0.0_r2
   END WHERE
 
-  WG%PhiSd    = WG%PhiSd*1.e6_sp/SecDay       ! Convert PhiSd: [MJ/m2/day] to [W/m2]
+  WG%PhiSd    = WG%PhiSd*1.e6_r2/SecDay       ! Convert PhiSd: [MJ/m2/day] to [W/m2]
   ! -------------
   ! Precipitation
   ! -------------
@@ -384,7 +383,7 @@ SUBROUTINE WGEN_SUBDIURNAL_MET(WG, np, itime)
   !Precip = (PrecipDay*1000.*9./24. + PrecipDayNext*1000.*15./24.)/rntime
   !Precip = (PrecipDay*1000.*9./24. + PrecipDayNext*1000.*15./24.)/24.  ! hourly precip [mm/h]
 
-  IF ( ABS(ritime-REAL(INT(ritime))) .GT. 1.e-7_sp) THEN
+  IF ( ABS(ritime-REAL(INT(ritime))) .GT. 1.e-7_r2) THEN
      WRITE(*,*) "Only works for integer hourly timestep! tstep = ", ritime
      write(*,*) "cable_weathergenerator.F90!"
 #ifdef __MPI__
@@ -395,20 +394,20 @@ SUBROUTINE WGEN_SUBDIURNAL_MET(WG, np, itime)
   ENDIF
 
   IF ((WG%ndtime .eq. 24) .OR. (WG%ndtime .eq. 8)) then
-     IF ((ritime >= 15._sp .AND. ritime < 16._sp).OR.(ritime >= 18._sp .AND. ritime < 19._sp)) THEN
-        WG%Precip = WG%PrecipDay *1000._sp/2._sp
-        WG%Snow   = WG%SnowDay*1000._sp/2._sp
+     IF ((ritime >= 15._r2 .AND. ritime < 16._r2).OR.(ritime >= 18._r2 .AND. ritime < 19._r2)) THEN
+        WG%Precip = WG%PrecipDay *1000._r2/2._r2
+        WG%Snow   = WG%SnowDay*1000._r2/2._r2
      ELSE
-        WG%Precip = 0._sp
-        WG%Snow   = 0._sp
+        WG%Precip = 0._r2
+        WG%Snow   = 0._r2
      ENDIF
   elseif (WG%ndtime .eq. 12) then
-     IF ((ritime >= 16._sp .AND. ritime < 17._sp).OR.(ritime >= 18._sp .AND. ritime < 19._sp)) THEN
-        WG%Precip = WG%PrecipDay *1000._sp/2._sp
-        WG%Snow   = WG%SnowDay*1000._sp/2._sp
+     IF ((ritime >= 16._r2 .AND. ritime < 17._r2).OR.(ritime >= 18._r2 .AND. ritime < 19._r2)) THEN
+        WG%Precip = WG%PrecipDay *1000._r2/2._r2
+        WG%Snow   = WG%SnowDay*1000._r2/2._r2
      ELSE
-        WG%Precip = 0._sp
-        WG%Snow   = 0._sp
+        WG%Precip = 0._r2
+        WG%Snow   = 0._r2
      ENDIF
      
   endif
@@ -440,7 +439,7 @@ SUBROUTINE WGEN_SUBDIURNAL_MET(WG, np, itime)
   ELSEWHERE (ritime > WG%TimeMaxTemp .AND. ritime <= WG%TimeSunset)
      ! Time of maximum temperature to sunset
      WG%Temp = WG%TempSunset + &
-          WG%TempRangeAft * SIN(PiBy2 + ((ritime-WG%TimeMaxTemp)/4._sp*PiBy2))
+          WG%TempRangeAft * SIN(PiBy2 + ((ritime-WG%TimeMaxTemp)/4._r2*PiBy2))
   ELSEWHERE (ritime > WG%TimeSunset )
      ! Sunset to midnight
      WG%Temp = WG%TempSunset + WG%TempNightRate * SQRT(ritime - WG%TimeSunset)
@@ -454,15 +453,15 @@ SUBROUTINE WGEN_SUBDIURNAL_MET(WG, np, itime)
 
   IF (TRIM(cable_user%MetType).EQ.'bios') THEN
      
-     IF (ritime <= 9._sp) THEN
+     IF (ritime <= 9._r2) THEN
         ! before 9am
-        WG%VapPmb = WG%VapPmb1500Prev + (WG%VapPmb0900 - WG%VapPmb1500Prev) * (9._sp + ritime)/18._sp
-     ELSEIF (ritime > 9_sp .AND. ritime <= 15._sp) THEN
+        WG%VapPmb = WG%VapPmb1500Prev + (WG%VapPmb0900 - WG%VapPmb1500Prev) * (9._r2 + ritime)/18._r2
+     ELSEIF (ritime > 9_r2 .AND. ritime <= 15._r2) THEN
         ! between 9am and 15:00
-        WG%VapPmb = WG%VapPmb0900 + (WG%VapPmb1500 - WG%VapPmb0900) * (ritime - 9._sp)/(15._sp-9._sp)
-     ELSEIF (ritime > 15._sp) THEN
+        WG%VapPmb = WG%VapPmb0900 + (WG%VapPmb1500 - WG%VapPmb0900) * (ritime - 9._r2)/(15._r2-9._r2)
+     ELSEIF (ritime > 15._r2) THEN
         ! after 15:00
-        WG%VapPmb  = WG%VapPmb1500 + (WG%VapPmb0900Next - WG%VapPmb1500) * (ritime - 15._sp)/18._sp
+        WG%VapPmb  = WG%VapPmb1500 + (WG%VapPmb0900Next - WG%VapPmb1500) * (ritime - 15._r2)/18._r2
      END IF
    
   ELSE
@@ -476,27 +475,27 @@ SUBROUTINE WGEN_SUBDIURNAL_MET(WG, np, itime)
   ! Downward longwave irradiance
   ! ----------------------------
 
-  PhiLd_Swinbank = 335.97_sp * (((WG%Temp + 273.16_sp) / 293.0_sp)**6)   ! [W/m2] (Swinbank 1963)
+  PhiLd_Swinbank = 335.97_r2 * (((WG%Temp + 273.16_r2) / 293.0_r2)**6)   ! [W/m2] (Swinbank 1963)
 
   ! -------------------------------
   ! Alternate longwave formulation
   ! ----------------------------
 
-  WG%PhiLd = epsilon * SBoltz * (WG%Temp + 273.16_sp)**4       ! [W/m2] (Brutsaert)
+  WG%PhiLd = epsilon * SBoltz * (WG%Temp + 273.16_r2)**4       ! [W/m2] (Brutsaert)
 
-  WHERE (WG%PhiSd.GT.50.0_sp)
-     adjust_fac = ((1.17_sp)**(WG%SolarNorm))/1.17_sp
+  WHERE (WG%PhiSd.GT.50.0_r2)
+     adjust_fac = ((1.17_r2)**(WG%SolarNorm))/1.17_r2
   ELSEWHERE
-     adjust_fac = 0.9_sp
+     adjust_fac = 0.9_r2
   ENDWHERE
 
-  WG%PhiLd = WG%PhiLd /adjust_fac * (1.0_sp + WG%PhiSd/8000._sp)       ! adjustment (formulation from Gab Abramowitz)
+  WG%PhiLd = WG%PhiLd /adjust_fac * (1.0_r2 + WG%PhiSd/8000._r2)       ! adjustment (formulation from Gab Abramowitz)
 
-  WHERE ((WG%PhiLd.GT.500.0_sp).OR.(WG%PhiLd.LT.100.0_sp))
+  WHERE ((WG%PhiLd.GT.500.0_r2).OR.(WG%PhiLd.LT.100.0_r2))
      WG%PhiLd = PhiLd_Swinbank
   ENDWHERE
 
-  IF (ANY((WG%PhiLd.GT.750.0_sp).OR.(WG%PhiLd.LT.100.0_sp))) THEN
+  IF (ANY((WG%PhiLd.GT.750.0_r2).OR.(WG%PhiLd.LT.100.0_r2))) THEN
      !write(*,*) 'PhiLD out of range'
   ENDIF
 

--- a/offline/cable_write.F90
+++ b/offline/cable_write.F90
@@ -292,12 +292,12 @@ CONTAINS
       (ok, 'Error defining '//vname//' variable attributes in output file. '// &
                                                       '(INTERFACE define_ovar)')
     ! Define missing/fill values:
-    ok = NF90_PUT_ATT(ncid, varID, '_FillValue', REAL(ncmissingr, r_1))
+    ok = NF90_PUT_ATT(ncid, varID, '_FillValue', REAL(ncmissingr, r1))
     IF (ok /= NF90_NOERR) CALL nc_abort                                        &
       (ok, 'Error defining '//vname//' variable attributes in output file. '// &
                                                       '(INTERFACE define_ovar)')
     ! Define missing/fill values:
-    ok = NF90_PUT_ATT(ncid, varID, 'missing_value', REAL(ncmissingr, r_1))
+    ok = NF90_PUT_ATT(ncid, varID, 'missing_value', REAL(ncmissingr, r1))
     IF (ok /= NF90_NOERR) CALL nc_abort                                        &
       (ok, 'Error defining '//vname//' variable attributes in output file. '// &
                                                       '(INTERFACE define_ovar)')
@@ -527,12 +527,12 @@ CONTAINS
       (ok, 'Error defining '//vname//' variable attributes in output file. '// &
                                        '(SUBROUTINE define_output_variable_r2)')
     ! Define missing/fill values:
-    ok = NF90_PUT_ATT(ncid, varID, '_FillValue', REAL(ncmissingr, r_1))
+    ok = NF90_PUT_ATT(ncid, varID, '_FillValue', REAL(ncmissingr, r1))
     IF (ok /= NF90_NOERR) CALL nc_abort                                        &
        (ok,'Error defining '//vname//' variable attributes in output file. '// &
                                                       '(INTERFACE define_ovar)')
     ! Define missing/fill values:
-    ok = NF90_PUT_ATT(ncid, varID, 'missing_value', REAL(ncmissingr, r_1))
+    ok = NF90_PUT_ATT(ncid, varID, 'missing_value', REAL(ncmissingr, r1))
     IF (ok /= NF90_NOERR) CALL nc_abort                                        &
       (ok, 'Error defining '//vname//' variable attributes in output file. '// &
                                                       '(INTERFACE define_ovar)')
@@ -711,20 +711,20 @@ CONTAINS
             'Error defining '//pname//' variable attributes in '// &
             'output file. (INTERFACE define_ovar)')
     else if (dimswitch(1:2) == 'r2') then
-       ok = nf90_put_att(ncid, parID, '_FillValue', real(ncmissingr, r_2))
+       ok = nf90_put_att(ncid, parID, '_FillValue', real(ncmissingr, r2))
        if (ok /= nf90_noerr) call nc_abort(ok, &
             'Error defining '//pname//' variable attributes in '// &
             'output file. (INTERFACE define_ovar)')
-       ok = nf90_put_att(ncid, parid, 'missing_value', real(ncmissingr, r_2))
+       ok = nf90_put_att(ncid, parid, 'missing_value', real(ncmissingr, r2))
        if (ok /= nf90_noerr) call nc_abort(ok, &
             'Error defining '//pname//' variable attributes in '// &
             'output file. (INTERFACE define_ovar)')
     else
-       ok = nf90_put_att(ncid, parID, '_FillValue', real(ncmissingr, r_1))
+       ok = nf90_put_att(ncid, parID, '_FillValue', real(ncmissingr, r1))
        if (ok /= nf90_noerr) call nc_abort(ok, &
             'Error defining '//pname//' variable attributes in '// &
             'output file. (INTERFACE define_ovar)')
-       ok = nf90_put_att(ncid, parid, 'missing_value', real(ncmissingr, r_1))
+       ok = nf90_put_att(ncid, parid, 'missing_value', real(ncmissingr, r1))
        if (ok /= nf90_noerr) call nc_abort(ok, &
             'Error defining '//pname//' variable attributes in '// &
             'output file. (INTERFACE define_ovar)')
@@ -933,20 +933,20 @@ CONTAINS
           (ok, 'Error defining '//pname//' variable attributes in '//          &
                                          'output file. (INTERFACE define_ovar)')
     ELSE IF(dimswitch(1:2) == 'r2') THEN
-       ok = NF90_PUT_ATT(ncid, parID, '_FillValue', REAL(ncmissingr, r_2))
+       ok = NF90_PUT_ATT(ncid, parID, '_FillValue', REAL(ncmissingr, r2))
        IF (ok /= NF90_NOERR) CALL nc_abort                                     &
           (ok, 'Error defining '//pname//' variable attributes in '//          &
                                          'output file. (INTERFACE define_ovar)')
-       ok = NF90_PUT_ATT(ncid, parID, 'missing_value', REAL(ncmissingr, r_2))
+       ok = NF90_PUT_ATT(ncid, parID, 'missing_value', REAL(ncmissingr, r2))
        IF (ok /= NF90_NOERR) CALL nc_abort                                     &
           (ok, 'Error defining '//pname//' variable attributes in '//          &
                                          'output file. (INTERFACE define_ovar)')
     ELSE
-       ok = NF90_PUT_ATT(ncid, parID, '_FillValue', REAL(ncmissingr, r_1))
+       ok = NF90_PUT_ATT(ncid, parID, '_FillValue', REAL(ncmissingr, r1))
        IF (ok /= NF90_NOERR) CALL nc_abort                                     &
             (ok, 'Error defining '//pname//' variable attributes in '//        &
                                          'output file. (INTERFACE define_ovar)')
-       ok = NF90_PUT_ATT(ncid, parID, 'missing_value', REAL(ncmissingr, r_1))
+       ok = NF90_PUT_ATT(ncid, parID, 'missing_value', REAL(ncmissingr, r1))
        IF (ok /= NF90_NOERR) CALL nc_abort                                     &
           (ok, 'Error defining '//pname//' variable attributes in '//          &
                                          'output file. (INTERFACE define_ovar)')
@@ -962,7 +962,7 @@ CONTAINS
     INTEGER, INTENT(IN) :: ktau ! current time step #
     INTEGER, INTENT(IN) :: ncid ! netcdf file ID
     INTEGER, INTENT(IN) :: varID ! variable's netcdf ID
-    REAL(KIND=r_1), DIMENSION(:), INTENT(IN) :: var_r1 ! variable values
+    REAL(KIND=r1), DIMENSION(:), INTENT(IN) :: var_r1 ! variable values
     REAL, DIMENSION(2), INTENT(IN) :: vrange ! max and min for variable ! error checking
     LOGICAL, INTENT(IN) :: writepatch ! write patch-specific info for this var?
     CHARACTER(LEN=*), INTENT(IN) :: vname ! name of variable
@@ -1002,7 +1002,7 @@ CONTAINS
              WHERE(mask /= 1) otmp4xypt(:, :, j, 1) = ncmissingr ! not land
           END DO
           ! write data to file
-          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp4xypt(:, :, :, 1), r_1),       &
+          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp4xypt(:, :, :, 1), r1),       &
                             start = (/1, 1, 1, ktau/),                         &
                             count = (/xdimsize, ydimsize, max_vegpatches, 1/))
        ELSE ! only grid point values, no patch-specific info
@@ -1014,7 +1014,7 @@ CONTAINS
              ! patches):
              otmp4xyzt(land_x(i), land_y(i), 1, 1) =                           &
                                                   SUM(var_r1(landpt(i)%cstart: &
-                  landpt(i)%cend) * real(patch(landpt(i)%cstart:landpt(i)%cend)%frac, r_1))
+                  landpt(i)%cend) * real(patch(landpt(i)%cstart:landpt(i)%cend)%frac, r1))
             IF(check%ranges) THEN  ! Check ranges:
               IF((otmp4xyzt(land_x(i), land_y(i), 1, 1) < vrange(1)) .OR.      &
                  (otmp4xyzt(land_x(i), land_y(i), 1, 1) > vrange(2)))          &
@@ -1025,7 +1025,7 @@ CONTAINS
           END DO
           ! Fill non-land points with dummy value:
           WHERE(mask /= 1) otmp4xyzt(:, :, 1, 1) = ncmissingr ! not land
-          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp4xyzt, r_1),                   &
+          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp4xyzt, r1),                   &
                             start = (/1, 1, 1, ktau/),                         &
                       count = (/xdimsize, ydimsize, 1, 1/)) ! write data to file
         ELSE ! normal x-y-t mask grid
@@ -1033,7 +1033,7 @@ CONTAINS
             ! Write to temporary variable (area weighted average across all
             ! patches):
             otmp3xyt(land_x(i), land_y(i), 1) = SUM(var_r1(landpt(i)%cstart:   &
-                  landpt(i)%cend) * real(patch(landpt(i)%cstart:landpt(i)%cend)%frac, r_1))
+                  landpt(i)%cend) * real(patch(landpt(i)%cstart:landpt(i)%cend)%frac, r1))
             IF(check%ranges) THEN  ! Check ranges:
               IF((otmp3xyt(land_x(i), land_y(i), 1) < vrange(1)) .OR.          &
                  (otmp3xyt(land_x(i), land_y(i), 1) > vrange(2)))              &
@@ -1044,7 +1044,7 @@ CONTAINS
           END DO
           ! Fill non-land points with dummy value:
           WHERE(mask /= 1) otmp3xyt(:, :, 1) = ncmissingr ! not land
-          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp3xyt, r_1),                    &
+          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp3xyt, r1),                    &
                           start = (/1,1,ktau/),                                &
                          count = (/xdimsize, ydimsize, 1/)) ! write data to file
         END IF
@@ -1070,14 +1070,14 @@ CONTAINS
           END IF
         END DO
         ! write data to file
-        ok = NF90_PUT_VAR(ncid, varID, REAL(otmp3lpt(:, :, 1), r_1),             &
+        ok = NF90_PUT_VAR(ncid, varID, REAL(otmp3lpt(:, :, 1), r1),             &
                    start = (/1, 1, ktau/), count = (/mland, max_vegpatches, 1/))
       ELSE ! only grid point values, no patch-specific info
         DO i = 1, mland ! over all land grid points
           ! Write to temporary variable (area weighted average across all
           ! patches):
           otmp2lt(i, 1) = SUM(var_r1(landpt(i)%cstart:                         &
-                  landpt(i)%cend) * real(patch(landpt(i)%cstart:landpt(i)%cend)%frac, r_1))
+                  landpt(i)%cend) * real(patch(landpt(i)%cstart:landpt(i)%cend)%frac, r1))
           IF(check%ranges) THEN  ! Check ranges:
             IF((otmp2lt(i, 1) < vrange(1)) .OR.                                &
                  (otmp2lt(i, 1) > vrange(2)))                                  &
@@ -1085,7 +1085,7 @@ CONTAINS
                  ktau, met, otmp2lt(i, 1), vrange, i)
           END IF
         END DO
-        ok = NF90_PUT_VAR(ncid, varID, REAL(otmp2lt, r_1),                       &
+        ok = NF90_PUT_VAR(ncid, varID, REAL(otmp2lt, r1),                       &
                  start = (/1, ktau/), count = (/mland, 1/)) ! write data to file
       END IF
     ELSE
@@ -1106,7 +1106,7 @@ CONTAINS
     INTEGER, INTENT(IN) :: ktau ! current time step #
     INTEGER, INTENT(IN) :: ncid ! netcdf file ID
     INTEGER, INTENT(IN) :: varID ! variable's netcdf ID
-    REAL(KIND=r_1), DIMENSION(:, :), INTENT(IN) :: var_r2 ! variable values
+    REAL(KIND=r1), DIMENSION(:, :), INTENT(IN) :: var_r2 ! variable values
     REAL, DIMENSION(2), INTENT(IN) :: vrange ! max and min for variable
                                                   ! error checking
     LOGICAL, INTENT(IN) :: writepatch ! write patch-specific info for this var?
@@ -1116,7 +1116,7 @@ CONTAINS
 
     INTEGER :: i, j, k ! do loop counter
     integer :: n2 ! 2nd dimension of input var
-    real(kind=r_1) :: rout
+    real(kind=r1) :: rout
     real, dimension(:,:,:),     allocatable :: otmp3
     real, dimension(:,:,:,:),   allocatable :: otmp4
     real, dimension(:,:,:,:,:), allocatable :: otmp5
@@ -1159,7 +1159,7 @@ CONTAINS
             END DO
           END DO
           ! Write data to file:
-          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp5xypst(:, :, :, :,1), r_1),    &
+          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp5xypst(:, :, :, :,1), r1),    &
                             start = (/1, 1, 1, 1, ktau/),                      &
                           count = (/xdimsize, ydimsize, max_vegpatches, ms, 1/))
         ELSE IF(dimswitch == 'snow') THEN ! other dim is snow
@@ -1190,7 +1190,7 @@ CONTAINS
                 END DO
           END DO
           ! Write data to file:
-          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp5xypsnt(:, :, :, :, 1), r_1),  &
+          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp5xypsnt(:, :, :, :, 1), r1),  &
                             start = (/1, 1, 1, 1, ktau/),                      &
                          count = (/xdimsize, ydimsize, max_vegpatches, msn, 1/))
         ELSE IF(dimswitch=='radiation') THEN ! other dim is radiation bands
@@ -1222,7 +1222,7 @@ CONTAINS
                 END DO
           END DO
           ! Write data to file:
-          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp5xyprt(:, :, :, :, 1), r_1),   &
+          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp5xyprt(:, :, :, :, 1), r1),   &
                             start = (/1, 1, 1, 1, ktau/),                      &
                          count = (/xdimsize, ydimsize, max_vegpatches, nrb, 1/))
 
@@ -1257,7 +1257,7 @@ CONTAINS
                 END DO
           END DO
           ! Write data to file:
-          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp5xyppct(:, :, :, :, 1), r_1),  &
+          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp5xyppct(:, :, :, :, 1), r1),  &
                             start = (/1, 1, 1, 1, ktau/),                      &
                          count = (/xdimsize, ydimsize, max_vegpatches, ncp, 1/))
         ELSE IF(dimswitch == 'soilcarbon') THEN ! other dim is soil carbon pools
@@ -1289,7 +1289,7 @@ CONTAINS
             END DO
           END DO
           ! Write data to file:
-          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp5xypsct(:, :, :, :, 1), r_1),  &
+          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp5xypsct(:, :, :, :, 1), r1),  &
                             start = (/1, 1, 1, 1, ktau/),                      &
                          count = (/xdimsize, ydimsize, max_vegpatches, ncs, 1/))
        else if (dimswitch == 'generic') then ! dimensions are determined from var_r2
@@ -1318,7 +1318,7 @@ CONTAINS
           
           ! write data to file
           ok = NF90_PUT_VAR(ncid, varid, &
-               real(otmp5(:, :, :, :, 1), r_1), &
+               real(otmp5(:, :, :, :, 1), r1), &
                start = (/1, 1, 1, 1, ktau/), &
                count = (/xdimsize, ydimsize, max_vegpatches, n2, 1/))
           
@@ -1338,7 +1338,7 @@ CONTAINS
             DO j = 1, ms
                otmp4xyst(land_x(i), land_y(i), j, 1) = SUM(                    &
                                  var_r2(landpt(i)%cstart:landpt(i)%cend, j) *  &
-                                    real(patch(landpt(i)%cstart:landpt(i)%cend)%frac, r_1))
+                                    real(patch(landpt(i)%cstart:landpt(i)%cend)%frac, r1))
             END DO
             IF(check%ranges) THEN  ! Check ranges:
               DO j = 1, ms
@@ -1354,7 +1354,7 @@ CONTAINS
           DO j = 1, ms
             WHERE(mask /= 1) otmp4xyst(:, :, j, 1) = ncmissingr ! not land
           END DO
-          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp4xyst, r_1),                   &
+          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp4xyst, r1),                   &
                             start = (/1, 1, 1, ktau/),                         &
                      count = (/xdimsize, ydimsize, ms, 1/)) ! write data to file
         ELSE IF(dimswitch == 'snow') THEN ! other dim is snow
@@ -1364,7 +1364,7 @@ CONTAINS
             DO j = 1, msn
                otmp4xysnt(land_x(i), land_y(i), j, 1) = SUM(                   &
                                  var_r2(landpt(i)%cstart:landpt(i)%cend, j) *  &
-                                    real(patch(landpt(i)%cstart:landpt(i)%cend)%frac, r_1))
+                                    real(patch(landpt(i)%cstart:landpt(i)%cend)%frac, r1))
             END DO
             IF(check%ranges) THEN  ! Check ranges:
               DO j = 1, msn
@@ -1380,7 +1380,7 @@ CONTAINS
           DO j = 1, msn
             WHERE(mask /= 1) otmp4xysnt(:, :, j, 1) = ncmissingr ! not land
           END DO
-          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp4xysnt, r_1),                  &
+          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp4xysnt, r1),                  &
                             start = (/1, 1, 1, ktau/),                         &
                     count = (/xdimsize, ydimsize, msn, 1/)) ! write data to file
         ELSE IF(dimswitch == 'radiation') THEN ! other dim is radiation bands
@@ -1390,7 +1390,7 @@ CONTAINS
             DO j = 1, nrb
                otmp4xyrt(land_x(i), land_y(i), j, 1) = SUM(                    &
                                   var_r2(landpt(i)%cstart:landpt(i)%cend, j) * &
-                                    real(patch(landpt(i)%cstart:landpt(i)%cend)%frac, r_1))
+                                    real(patch(landpt(i)%cstart:landpt(i)%cend)%frac, r1))
             END DO
             IF(check%ranges) THEN  ! Check ranges:
               DO j = 1, nrb
@@ -1406,7 +1406,7 @@ CONTAINS
           DO j = 1, nrb
             WHERE(mask /= 1) otmp4xyrt(:, :, j, 1) = ncmissingr ! not land
           END DO
-          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp4xyrt, r_1),                   &
+          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp4xyrt, r1),                   &
                             start = (/1, 1, 1, ktau/),                         &
                     count = (/xdimsize, ydimsize, nrb, 1/)) ! write data to file
         ELSE IF(dimswitch == 'plantcarbon') THEN ! other dim is plant carbon
@@ -1416,7 +1416,7 @@ CONTAINS
             DO j = 1, ncp
                otmp4xypct(land_x(i), land_y(i), j, 1) = SUM(                   &
                                   var_r2(landpt(i)%cstart:landpt(i)%cend, j) * &
-                                    real(patch(landpt(i)%cstart:landpt(i)%cend)%frac, r_1))
+                                    real(patch(landpt(i)%cstart:landpt(i)%cend)%frac, r1))
             END DO
             IF(check%ranges) THEN  ! Check ranges:
               DO j = 1, ncp
@@ -1432,7 +1432,7 @@ CONTAINS
           DO j = 1, ncp
             WHERE(mask /= 1) otmp4xypct(:, :, j, 1) = ncmissingr ! not land
           END DO
-          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp4xypct, r_1),                  &
+          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp4xypct, r1),                  &
                             start = (/1, 1, 1, ktau/),                         &
                     count = (/xdimsize, ydimsize, ncp, 1/)) ! write data to file
         ELSE IF(dimswitch == 'soilcarbon') THEN ! other dim is soil carbon pools
@@ -1441,7 +1441,7 @@ CONTAINS
             DO j = 1, ncs
                otmp4xysct(land_x(i), land_y(i), j, 1) = SUM(                   &
                                   var_r2(landpt(i)%cstart:landpt(i)%cend, j) * &
-                                    real(patch(landpt(i)%cstart:landpt(i)%cend)%frac, r_1))
+                                    real(patch(landpt(i)%cstart:landpt(i)%cend)%frac, r1))
             END DO
             IF(check%ranges) THEN  ! Check ranges:
               DO j = 1, ncs
@@ -1457,7 +1457,7 @@ CONTAINS
           DO j = 1, ncs
             WHERE(mask /= 1) otmp4xysct(:, :, j, 1) = ncmissingr ! not land
           END DO
-          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp4xysct, r_1),                  &
+          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp4xysct, r1),                  &
                             start = (/1, 1, 1, ktau/),                         &
                     count = (/xdimsize, ydimsize, ncs, 1/)) ! write data to file
        else if (dimswitch == 'generic') then ! dimensions are determined from var_r2
@@ -1470,7 +1470,7 @@ CONTAINS
              ! Write active patches to temporary variable (sum over patches & weight by fraction)
              do j=1, n2
                 otmp4(land_x(i), land_y(i), j, 1) = sum( var_r2(landpt(i)%cstart:landpt(i)%cend, j) * &
-                     real(patch(landpt(i)%cstart:landpt(i)%cend)%frac, r_1) )
+                     real(patch(landpt(i)%cstart:landpt(i)%cend)%frac, r1) )
              end do             
 
              ! Check ranges
@@ -1489,7 +1489,7 @@ CONTAINS
           
           ! write data to file
           ok = NF90_PUT_VAR(ncid, varid, &
-               real(otmp4(:, :, :, 1), r_1), &
+               real(otmp4(:, :, :, 1), r1), &
                start = (/1, 1, 1, ktau/), &
                count = (/xdimsize, ydimsize, n2, 1/))
 
@@ -1528,7 +1528,7 @@ CONTAINS
             END IF
           END DO
           ! Write data to file:
-          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp4lpst(:, :, :, 1), r_1),       &
+          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp4lpst(:, :, :, 1), r1),       &
                             start = (/1, 1, 1, ktau/),                         &
                             count = (/mland, max_vegpatches, ms, 1/))
         ELSE IF(dimswitch == 'snow') THEN ! other dim is snow
@@ -1551,7 +1551,7 @@ CONTAINS
             END IF
           END DO
           ! write data to file
-          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp4lpsnt(:, :, :, 1), r_1),      &
+          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp4lpsnt(:, :, :, 1), r1),      &
                             start = (/1, 1, 1, ktau/),                         &
                             count = (/mland, max_vegpatches, msn, 1/))
         ELSE IF(dimswitch == 'radiation') THEN ! other dim is radiation bands
@@ -1575,7 +1575,7 @@ CONTAINS
             END IF
           END DO
           ! write data to file
-          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp4lprt(:, :, :, 1), r_1),       &
+          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp4lprt(:, :, :, 1), r1),       &
                             start = (/1, 1, 1, ktau/),                         &
                             count = (/mland, max_vegpatches, nrb, 1/))
 !write(*,*) 'var', var_r2(landpt(1)%cstart:landpt(1)%cend,:)
@@ -1601,7 +1601,7 @@ CONTAINS
             END IF
           END DO
           ! write data to file
-          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp4lppct(:, :, :, 1), r_1),      &
+          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp4lppct(:, :, :, 1), r1),      &
                             start = (/1, 1, 1, ktau/),                         &
                             count = (/mland, max_vegpatches, ncp, 1/))
         ELSE IF(dimswitch == 'soilcarbon') THEN ! other dim is soil carbon pools
@@ -1624,7 +1624,7 @@ CONTAINS
             END IF
           END DO
           ! write data to file
-          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp4lpsct(:, :, :, 1), r_1),      &
+          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp4lpsct(:, :, :, 1), r1),      &
                             start = (/1, 1, 1, ktau/),                         &
                             count = (/mland, max_vegpatches, ncs, 1/))
        else if (dimswitch == 'generic') then ! dimensions are determined from var_r2
@@ -1653,7 +1653,7 @@ CONTAINS
           
           ! write data to file
           ok = NF90_PUT_VAR(ncid, varid, &
-               real(otmp4(:, :, :, 1), r_1), &
+               real(otmp4(:, :, :, 1), r1), &
                start = (/1, 1, 1, ktau/), &
                count = (/mland, max_vegpatches, n2, 1/))
           
@@ -1673,7 +1673,7 @@ CONTAINS
             DO j = 1, ms
                otmp3lst(i, j, 1) = SUM(                                        &
                                   var_r2(landpt(i)%cstart:landpt(i)%cend, j) * &
-                                    real(patch(landpt(i)%cstart:landpt(i)%cend)%frac, r_1))
+                                    real(patch(landpt(i)%cstart:landpt(i)%cend)%frac, r1))
             END DO
             IF(check%ranges) THEN  ! Check ranges:
               DO j = 1, ms
@@ -1684,7 +1684,7 @@ CONTAINS
               END DO
             END IF
           END DO
-          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp3lst, r_1),                    &
+          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp3lst, r1),                    &
                             start = (/1, 1, ktau/),                            &
                             count = (/mland, ms, 1/)) ! write data to file
         ELSE IF(dimswitch == 'snow') THEN ! other dim is snow
@@ -1694,7 +1694,7 @@ CONTAINS
             DO j = 1, msn
                otmp3lsnt(i, j, 1) = SUM(                                       &
                                   var_r2(landpt(i)%cstart:landpt(i)%cend, j) * &
-                                    real(patch(landpt(i)%cstart:landpt(i)%cend)%frac, r_1))
+                                    real(patch(landpt(i)%cstart:landpt(i)%cend)%frac, r1))
             END DO
             IF(check%ranges) THEN  ! Check ranges:
               DO j = 1, msn
@@ -1705,7 +1705,7 @@ CONTAINS
               END DO
             END IF
           END DO
-          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp3lsnt, r_1),                   &
+          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp3lsnt, r1),                   &
                             start = (/1, 1, ktau/),                            &
                             count = (/mland, msn, 1/)) ! write data to file
         ELSE IF(dimswitch == 'radiation') THEN ! other dim is radiation bands
@@ -1714,7 +1714,7 @@ CONTAINS
             DO j = 1, nrb
                otmp3lrt(i, j, 1) = SUM(                                        &
                                   var_r2(landpt(i)%cstart:landpt(i)%cend, j) * &
-                                    real(patch(landpt(i)%cstart:landpt(i)%cend)%frac, r_1))
+                                    real(patch(landpt(i)%cstart:landpt(i)%cend)%frac, r1))
             END DO
             IF(check%ranges) THEN  ! Check ranges:
               DO j = 1, nrb
@@ -1725,7 +1725,7 @@ CONTAINS
               END DO
             END IF
           END DO
-          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp3lrt, r_1),                    &
+          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp3lrt, r1),                    &
                             start = (/1, 1, ktau/),                            &
                             count = (/mland, nrb, 1/)) ! write data to file
         ELSE IF(dimswitch == 'plantcarbon') THEN ! other dim is plant carbon
@@ -1735,7 +1735,7 @@ CONTAINS
             DO j = 1, ncp
                otmp3lpct(i, j, 1) = SUM(                                       &
                                   var_r2(landpt(i)%cstart:landpt(i)%cend, j) * &
-                                    real(patch(landpt(i)%cstart:landpt(i)%cend)%frac, r_1))
+                                    real(patch(landpt(i)%cstart:landpt(i)%cend)%frac, r1))
             END DO
             IF(check%ranges) THEN  ! Check ranges:
               DO j = 1, ncp
@@ -1746,7 +1746,7 @@ CONTAINS
               END DO
             END IF
           END DO
-          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp3lpct, r_1),                   &
+          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp3lpct, r1),                   &
                             start = (/1, 1, ktau/),                            &
                             count = (/mland, ncp, 1/)) ! write data to file
         ELSE IF(dimswitch == 'soilcarbon') THEN ! other dim is soil carbon pools
@@ -1755,7 +1755,7 @@ CONTAINS
             DO j = 1, ncs
                otmp3lsct(i, j, 1) = SUM(                                       &
                                   var_r2(landpt(i)%cstart:landpt(i)%cend, j) * &
-                                    real(patch(landpt(i)%cstart:landpt(i)%cend)%frac, r_1))
+                                    real(patch(landpt(i)%cstart:landpt(i)%cend)%frac, r1))
             END DO
             IF(check%ranges) THEN  ! Check ranges:
               DO j = 1, ncs
@@ -1766,7 +1766,7 @@ CONTAINS
               END DO
             END IF
           END DO
-          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp3lsct, r_1),                   &
+          ok = NF90_PUT_VAR(ncid, varID, REAL(otmp3lsct, r1),                   &
                             start = (/1, 1, ktau/),                            &
                             count = (/mland, ncs, 1/)) ! write data to file
        else if (dimswitch == 'generic') then ! dimensions are determined from var_r2
@@ -1779,7 +1779,7 @@ CONTAINS
              ! Write active patches to temporary variable (sum over patches & weight by fraction)
              do j=1, n2
                 otmp3(i, j, 1) = sum(var_r2(landpt(i)%cstart:landpt(i)%cend, j) * &
-                     real(patch(landpt(i)%cstart:landpt(i)%cend)%frac, r_1))
+                     real(patch(landpt(i)%cstart:landpt(i)%cend)%frac, r1))
              end do             
 
              ! Check ranges
@@ -1798,7 +1798,7 @@ CONTAINS
           
           ! write data to file
           ok = NF90_PUT_VAR(ncid, varid, &
-               real(otmp3(:, :, 1), r_1), &
+               real(otmp3(:, :, 1), r1), &
                start = (/1, 1, ktau/), &
                count = (/mland, n2, 1/))
 
@@ -1827,7 +1827,7 @@ CONTAINS
     INTEGER,                    INTENT(IN) :: ncid       ! netcdf file ID
     INTEGER,                    INTENT(IN) :: parID      ! variable's netcdf ID
     CHARACTER(LEN=*),           INTENT(IN) :: pname      ! name of variable
-    REAL(KIND=r_1), DIMENSION(:), INTENT(IN) :: par_r1     ! variable values
+    REAL(KIND=r1), DIMENSION(:), INTENT(IN) :: par_r1     ! variable values
     REAL,         DIMENSION(2), INTENT(IN) :: prange     ! max and min for variable error checking
     LOGICAL,                    INTENT(IN) :: writepatch ! write patch-specific info for this var?
     CHARACTER(LEN=*),           INTENT(IN) :: dimswitch  ! indicates dimesnion of parameter
@@ -1875,7 +1875,7 @@ CONTAINS
              DO j = 1, max_vegpatches
                 WHERE(mask /= 1) otmp3xyp(:, :, j) = ncmissingr ! not land
              END DO
-             ok = NF90_PUT_VAR(ncid, parID, REAL(otmp3xyp(:, :, :), r_1),        &
+             ok = NF90_PUT_VAR(ncid, parID, REAL(otmp3xyp(:, :, :), r1),        &
                                start = (/1, 1, 1/),                            &
                                count = (/xdimsize, ydimsize, max_vegpatches/))
           ELSE IF(dimswitch(1:1) == 'i') THEN
@@ -1907,7 +1907,7 @@ CONTAINS
           IF(dimswitch(1:1) == 'r') THEN
              ! Fill non-land points with dummy value:
              WHERE(mask /= 1) otmp2xy(:, :) = ncmissingr ! not land
-             ok = NF90_PUT_VAR(ncid, parID, REAL(otmp2xy, r_1),                  &
+             ok = NF90_PUT_VAR(ncid, parID, REAL(otmp2xy, r1),                  &
                                start = (/1, 1/),                               &
                             count = (/xdimsize, ydimsize/)) ! write data to file
           ELSE IF(dimswitch(1:1) == 'i') THEN
@@ -1952,7 +1952,7 @@ CONTAINS
           END DO
           ! Write data to file
           IF(dimswitch(1:1) == 'r') THEN
-             ok = NF90_PUT_VAR(ncid, parID, REAL(otmp2lp(:, :), r_1),            &
+             ok = NF90_PUT_VAR(ncid, parID, REAL(otmp2lp(:, :), r1),            &
                             start = (/1, 1/), count = (/mland, max_vegpatches/))
           ELSE IF(dimswitch(1:1) == 'i') THEN
              ok = NF90_PUT_VAR(ncid, parID, INT(otmp2lp(:, :)),                &
@@ -1964,7 +1964,7 @@ CONTAINS
           IF(PRESENT(restart)) THEN ! If writing restart data:
              ! Write output:
              IF(dimswitch(1:1) == 'r') THEN
-                ok = NF90_PUT_VAR(ncid, parID, REAL(par_r1, r_1),                &
+                ok = NF90_PUT_VAR(ncid, parID, REAL(par_r1, r1),                &
                              start = (/1/), count = (/mp/)) ! write data to file
              ELSE IF(dimswitch(1:1) == 'i') THEN
                 ok = NF90_PUT_VAR(ncid, parID, INT(par_r1),                    &
@@ -1987,7 +1987,7 @@ CONTAINS
              END DO
              ! Write output:
              IF(dimswitch(1:1) == 'r') THEN
-                ok = NF90_PUT_VAR(ncid, parID, REAL(otmp1l, r_1),                &
+                ok = NF90_PUT_VAR(ncid, parID, REAL(otmp1l, r1),                &
                           start = (/1/), count = (/mland/)) ! write data to file
              ELSE IF(dimswitch(1:1) == 'i') THEN
                 ok = NF90_PUT_VAR(ncid, parID, INT(otmp1l),                    &
@@ -2011,7 +2011,7 @@ CONTAINS
     ! Subroutine for writing a double precision 1D parameter (time invariant)
     INTEGER, INTENT(IN) :: ncid ! netcdf file ID
     INTEGER, INTENT(IN) :: parID ! variable's netcdf ID
-    REAL(r_2), DIMENSION(:), INTENT(IN) :: par_r1d ! variable values
+    REAL(r2), DIMENSION(:), INTENT(IN) :: par_r1d ! variable values
     REAL, DIMENSION(2), INTENT(IN) :: prange ! max and min for variable
                                                   ! error checking
     LOGICAL, INTENT(IN) :: writepatch ! write patch-specific info for this var?
@@ -2020,7 +2020,7 @@ CONTAINS
     CHARACTER(LEN=*), INTENT(IN) :: dimswitch ! indicates dimesnion of parameter
 
     INTEGER :: i, j ! do loop counter
-    REAL(r_2), POINTER, DIMENSION(:, :) :: tmpout => null()
+    REAL(r2), POINTER, DIMENSION(:, :) :: tmpout => null()
 
     IF(PRESENT(restart)) THEN ! If writing to a a restart file
        ! Write parameter data:
@@ -2037,7 +2037,7 @@ CONTAINS
           ! Then write data for inactive patches as dummy value:
           IF(landpt(i)%nap < max_vegpatches)                                   &
                tmpout(i, (landpt(i)%nap + 1):max_vegpatches) =                 &
-                                                           REAL(ncmissingr, r_2)
+                                                           REAL(ncmissingr, r2)
           IF(check%ranges) THEN  ! Check ranges over active patches:
              DO j = 1, landpt(i)%nap
                 IF((tmpout(i, j) < prange(1)) .OR.                             &
@@ -2051,7 +2051,7 @@ CONTAINS
              END DO
           END IF
        END DO
-       ok = NF90_PUT_VAR(ncid, parID, REAL(tmpout(:, :), r_2), start = (/1, 1/), &
+       ok = NF90_PUT_VAR(ncid, parID, REAL(tmpout(:, :), r2), start = (/1, 1/), &
                          count = (/mland, max_vegpatches/)) ! write data to file
        DEALLOCATE(tmpout)
        ! Check writing was successful:
@@ -2066,7 +2066,7 @@ CONTAINS
     ! Subroutine for writing a real valued 2D parameter (time invariant)
     INTEGER, INTENT(IN) :: ncid ! netcdf file ID
     INTEGER, INTENT(IN) :: parID ! variable's netcdf ID
-    REAL(KIND=r_1), DIMENSION(:, :), INTENT(IN) :: par_r2 ! variable values
+    REAL(KIND=r1), DIMENSION(:, :), INTENT(IN) :: par_r2 ! variable values
     REAL, DIMENSION(2), INTENT(IN) :: prange ! max and min for variable
                                                   ! error checking
     LOGICAL, INTENT(IN) :: writepatch ! write patch-specific info for this var?
@@ -2115,7 +2115,7 @@ CONTAINS
             END DO
           END DO
           ! write data to file
-          ok = NF90_PUT_VAR(ncid, parID, REAL(otmp4xyps(:, :, :, :), r_1),       &
+          ok = NF90_PUT_VAR(ncid, parID, REAL(otmp4xyps(:, :, :, :), r1),       &
                             start = (/1, 1, 1, 1/),                            &
                             count = (/xdimsize, ydimsize, max_vegpatches, ms/))
         ELSE IF(dimswitch == 'plantcarbon') THEN ! i.e. spatial and plant carbon
@@ -2148,7 +2148,7 @@ CONTAINS
             END DO
           END DO
           ! write data to file
-          ok = NF90_PUT_VAR(ncid, parID, REAL(otmp4xyppc(:, :, :, :), r_1),      &
+          ok = NF90_PUT_VAR(ncid, parID, REAL(otmp4xyppc(:, :, :, :), r1),      &
                             start = (/1, 1, 1, 1/),                            &
                             count = (/xdimsize, ydimsize, max_vegpatches, ncp/))
         ELSE IF(dimswitch == 'soilcarbon') THEN ! i.e. spatial and soil carbon
@@ -2181,7 +2181,7 @@ CONTAINS
             END DO
           END DO
           ! write data to file:
-          ok = NF90_PUT_VAR(ncid, parID, REAL(otmp4xypsc(:, :, :, :), r_1),      &
+          ok = NF90_PUT_VAR(ncid, parID, REAL(otmp4xypsc(:, :, :, :), r1),      &
                             start = (/1, 1, 1, 1/),                            &
                             count = (/xdimsize, ydimsize, max_vegpatches, ncs/))
         ELSE IF(dimswitch == 'radiation') THEN ! i.e. spatial and soil carbon
@@ -2214,7 +2214,7 @@ CONTAINS
             END DO
           END DO
           ! write data to file:
-          ok = NF90_PUT_VAR(ncid, parID, REAL(otmp4xypr(:, :, :, :), r_1),       &
+          ok = NF90_PUT_VAR(ncid, parID, REAL(otmp4xypr(:, :, :, :), r1),       &
                             start = (/1, 1, 1, 1/),                            &
                             count = (/xdimsize, ydimsize, max_vegpatches, nrb/))
         ELSE
@@ -2243,7 +2243,7 @@ CONTAINS
           DO j = 1, ms
             WHERE(mask /= 1) otmp3xys(:, :, j) = ncmissingr ! not land
           END DO
-          ok = NF90_PUT_VAR(ncid, parID, REAL(otmp3xys, r_1),                    &
+          ok = NF90_PUT_VAR(ncid, parID, REAL(otmp3xys, r1),                    &
                             start = (/1, 1, 1/),                               &
                         count = (/xdimsize, ydimsize, ms/)) ! write data to file
         ELSE IF(dimswitch == 'plantcarbon') THEN ! i.e. spatial and plant carbon
@@ -2265,7 +2265,7 @@ CONTAINS
           DO j = 1, ncp
             WHERE(mask /= 1) otmp3xypc(:, :, j) = ncmissingr ! not land
           END DO
-          ok = NF90_PUT_VAR(ncid, parID, REAL(otmp3xypc, r_1),                   &
+          ok = NF90_PUT_VAR(ncid, parID, REAL(otmp3xypc, r1),                   &
                             start = (/1, 1, 1/),                               &
                        count = (/xdimsize, ydimsize, ncp/)) ! write data to file
         ELSE IF(dimswitch == 'soilcarbon') THEN ! i.e. spatial and soil carbon
@@ -2287,7 +2287,7 @@ CONTAINS
           DO j = 1, ncs
             WHERE(mask /= 1) otmp3xysc(:, :, j) = ncmissingr ! not land
           END DO
-          ok = NF90_PUT_VAR(ncid, parID, REAL(otmp3xysc, r_1),                   &
+          ok = NF90_PUT_VAR(ncid, parID, REAL(otmp3xysc, r1),                   &
                             start = (/1, 1, 1/),                               &
                        count = (/xdimsize, ydimsize, ncs/)) ! write data to file
         ELSE IF(dimswitch == 'radiation') THEN ! i.e. spatial and soil carbon
@@ -2309,7 +2309,7 @@ CONTAINS
           DO j = 1, nrb
             WHERE(mask /= 1) otmp3xyr(:, :, j) = ncmissingr ! not land
           END DO
-          ok = NF90_PUT_VAR(ncid, parID, REAL(otmp3xyr, r_1),                    &
+          ok = NF90_PUT_VAR(ncid, parID, REAL(otmp3xyr, r1),                    &
                             start = (/1, 1, 1/),                               &
                        count = (/xdimsize, ydimsize, nrb/)) ! write data to file
         ELSE IF(dimswitch == 'surftype') THEN ! i.e. surface fraction
@@ -2331,7 +2331,7 @@ CONTAINS
           DO j = 1, 4
             WHERE(mask /= 1) otmp3xysf(:, :, j) = ncmissingr ! not land
           END DO
-          ok = NF90_PUT_VAR(ncid, parID, REAL(otmp3xysf, r_1),                   &
+          ok = NF90_PUT_VAR(ncid, parID, REAL(otmp3xysf, r1),                   &
                             start = (/1, 1, 1/),                               &
                          count = (/xdimsize, ydimsize, 4/)) ! write data to file
         ELSE
@@ -2369,7 +2369,7 @@ CONTAINS
             END IF
           END DO
           ! write data to file
-          ok = NF90_PUT_VAR(ncid, parID, REAL(otmp3lps(:, :, :), r_1),           &
+          ok = NF90_PUT_VAR(ncid, parID, REAL(otmp3lps(:, :, :), r1),           &
                      start = (/1, 1, 1/), count = (/mland, max_vegpatches, ms/))
         ELSE IF(dimswitch == 'plantcarbon') THEN ! i.e. spatial and plant carbon
           DO i = 1, mland ! over all land grid points
@@ -2393,7 +2393,7 @@ CONTAINS
             END IF
           END DO
           ! write data to file
-          ok = NF90_PUT_VAR(ncid, parID, REAL(otmp3lppc(:, :, :), r_1),          &
+          ok = NF90_PUT_VAR(ncid, parID, REAL(otmp3lppc(:, :, :), r1),          &
                     start = (/1, 1, 1/), count = (/mland, max_vegpatches, ncp/))
         ELSE IF(dimswitch == 'soilcarbon') THEN ! i.e. spatial and soil carbon
           DO i = 1, mland ! over all land grid points
@@ -2417,7 +2417,7 @@ CONTAINS
             END IF
           END DO
           ! write data to file
-          ok = NF90_PUT_VAR(ncid, parID, REAL(otmp3lpsc(:, :, :), r_1),          &
+          ok = NF90_PUT_VAR(ncid, parID, REAL(otmp3lpsc(:, :, :), r1),          &
                     start = (/1, 1, 1/), count = (/mland, max_vegpatches, ncs/))
         ELSE IF(dimswitch == 'radiation') THEN ! i.e. spatial and radiation
                                                ! bands
@@ -2442,7 +2442,7 @@ CONTAINS
             END IF
           END DO
           ! write data to file
-          ok = NF90_PUT_VAR(ncid, parID, REAL(otmp3lpr(:, :, :), r_1),           &
+          ok = NF90_PUT_VAR(ncid, parID, REAL(otmp3lpr(:, :, :), r1),           &
                     start = (/1, 1, 1/), count = (/mland, max_vegpatches, nrb/))
         ELSE IF(dimswitch == 'snow') THEN ! i.e. spatial and radiation bands
           DO i = 1, mland ! over all land grid points
@@ -2466,7 +2466,7 @@ CONTAINS
             END IF
           END DO
           ! write data to file
-          ok = NF90_PUT_VAR(ncid, parID, REAL(otmp3lpsn(:, :, :), r_1),          &
+          ok = NF90_PUT_VAR(ncid, parID, REAL(otmp3lpsn(:, :, :), r1),          &
                     start = (/1, 1, 1/), count = (/mland, max_vegpatches, msn/))
         ELSE
           CALL cable_abort('Parameter '//pname//                                     &
@@ -2478,7 +2478,7 @@ CONTAINS
          IF(dimswitch=='soil') THEN ! i.e. spatial and soil
             IF(PRESENT(restart)) THEN
                ! Write data to restart file
-               ok=NF90_PUT_VAR(ncid,parID,REAL(par_r2, r_1), &
+               ok=NF90_PUT_VAR(ncid,parID,REAL(par_r2, r1), &
                     start=(/1,1/),count=(/mp,ms/))
             ELSE
                DO i = 1, mland ! over all land grid points
@@ -2495,13 +2495,13 @@ CONTAINS
                      END IF
                   END IF
                END DO
-               ok=NF90_PUT_VAR(ncid,parID,REAL(otmp2ls, r_1), &
+               ok=NF90_PUT_VAR(ncid,parID,REAL(otmp2ls, r1), &
                     start=(/1,1/),count=(/mland,ms/)) ! write data to file
             END IF
         ELSE IF(dimswitch == 'plantcarbon') THEN ! i.e. spatial and plant carbon
            IF(PRESENT(restart)) THEN
               ! Write data to restart file
-              ok = NF90_PUT_VAR(ncid, parID, REAL(par_r2, r_1),                  &
+              ok = NF90_PUT_VAR(ncid, parID, REAL(par_r2, r1),                  &
                                 start = (/1, 1/), count = (/mp, ncp/))
            ELSE
               DO i = 1, mland ! over all land grid points
@@ -2518,13 +2518,13 @@ CONTAINS
                     END IF
                  END IF
               END DO
-              ok = NF90_PUT_VAR(ncid, parID, REAL(otmp2lpc, r_1),                &
+              ok = NF90_PUT_VAR(ncid, parID, REAL(otmp2lpc, r1),                &
                   start = (/1, 1/), count = (/mland, ncp/)) ! write data to file
            END IF
         ELSE IF(dimswitch == 'soilcarbon') THEN ! i.e. spatial and soil carbon
            IF(PRESENT(restart)) THEN
               ! Write data to restart file
-              ok = NF90_PUT_VAR(ncid, parID, REAL(par_r2, r_1),                  &
+              ok = NF90_PUT_VAR(ncid, parID, REAL(par_r2, r1),                  &
                    start = (/1, 1/), count = (/mp, ncs/))
            ELSE
               DO i = 1, mland ! over all land grid points
@@ -2541,14 +2541,14 @@ CONTAINS
                     END IF
                  END IF
               END DO
-              ok = NF90_PUT_VAR(ncid, parID, REAL(otmp2lsc, r_1),                &
+              ok = NF90_PUT_VAR(ncid, parID, REAL(otmp2lsc, r1),                &
                     start = (/1, 1/), count=(/mland, ncs/)) ! write data to file
            END IF
         ELSE IF(dimswitch == 'radiation') THEN ! i.e. spatial and radiation
                                                ! bands
            IF(PRESENT(restart)) THEN
               ! Write data to restart file
-              ok = NF90_PUT_VAR(ncid, parID, REAL(par_r2, r_1),                  &
+              ok = NF90_PUT_VAR(ncid, parID, REAL(par_r2, r1),                  &
                                 start = (/1, 1/), count = (/mp, nrb/))
            ELSE ! writing to output file
               DO i = 1, mland ! over all land grid points
@@ -2565,13 +2565,13 @@ CONTAINS
                     END IF
                  END IF
               END DO
-              ok = NF90_PUT_VAR(ncid, parID, REAL(otmp2lr, r_1),                 &
+              ok = NF90_PUT_VAR(ncid, parID, REAL(otmp2lr, r1),                 &
                   start = (/1, 1/), count = (/mland, nrb/)) ! write data to file
            END IF
         ELSE IF(dimswitch == 'snow') THEN ! i.e. spatial and radiation bands
            IF(PRESENT(restart)) THEN
               ! Write data to restart file
-              ok = NF90_PUT_VAR(ncid, parID, REAL(par_r2, r_1),                  &
+              ok = NF90_PUT_VAR(ncid, parID, REAL(par_r2, r1),                  &
                                 start = (/1, 1/), count = (/mp, msn/))
            ELSE ! writing to output file
               DO i = 1, mland ! over all land grid points
@@ -2588,7 +2588,7 @@ CONTAINS
                     END IF
                  END IF
               END DO
-              ok = NF90_PUT_VAR(ncid, parID, REAL(otmp2lsn, r_1),                &
+              ok = NF90_PUT_VAR(ncid, parID, REAL(otmp2lsn, r1),                &
                   start = (/1, 1/), count = (/mland, msn/)) ! write data to file
            END IF
         ELSE IF(dimswitch == 'surftype') THEN
@@ -2606,7 +2606,7 @@ CONTAINS
               END IF
             END IF
           END DO
-          ok = NF90_PUT_VAR(ncid, parID, REAL(otmp2lsf, r_1),                    &
+          ok = NF90_PUT_VAR(ncid, parID, REAL(otmp2lsf, r1),                    &
                     start = (/1, 1/), count = (/mland, 4/)) ! write data to file
         ELSE
           CALL cable_abort('Parameter '//pname//                                     &
@@ -2630,7 +2630,7 @@ CONTAINS
     ! ONLY USED FOR RESTART FILE.
     INTEGER, INTENT(IN) :: ncid ! netcdf file ID
     INTEGER, INTENT(IN) :: parID ! variable's netcdf ID
-    REAL(r_2), DIMENSION(:, :), INTENT(IN) :: par_r2d ! variable values
+    REAL(r2), DIMENSION(:, :), INTENT(IN) :: par_r2d ! variable values
     REAL, DIMENSION(2), INTENT(IN) :: prange ! max and min for variable
                                                   ! error checking
     LOGICAL, INTENT(IN) :: writepatch ! write patch-specific info for this var?
@@ -2639,7 +2639,7 @@ CONTAINS
     CHARACTER(LEN=*), INTENT(IN) :: dimswitch ! indicates dimesnion of parameter
 
     INTEGER :: i,j ! do loop counter
-    REAL(r_2),POINTER,DIMENSION(:,:,:) :: tmpout => null()
+    REAL(r2),POINTER,DIMENSION(:,:,:) :: tmpout => null()
 
     ! Check the nature of the parameter's second dimension:
     if (present(restart)) then
@@ -2656,11 +2656,11 @@ CONTAINS
              ! Then write data for inactive patches as dummy value:
              IF(landpt(i)%nap < max_vegpatches)                                &
                   tmpout(i, (landpt(i)%nap + 1):max_vegpatches, :) =           &
-                                                           REAL(ncmissingr, r_2)
+                                                           REAL(ncmissingr, r2)
              IF (check%ranges) THEN  ! Check ranges over active patches:
                 DO j = 1, landpt(i)%nap
-                   IF (ANY(tmpout(i, j, :) < real(prange(1),r_2)) .OR.         &
-                        ANY(tmpout(i, j, :) > real(prange(2),r_2)))  THEN
+                   IF (ANY(tmpout(i, j, :) < real(prange(1),r2)) .OR.         &
+                        ANY(tmpout(i, j, :) > real(prange(2),r2)))  THEN
                       WRITE(*, *) 'Parameter '//pname//                        &
                                   ' is set at a value out of specified ranges!'
                       WRITE(*, *) 'Land point # ',i, 'patch #', j
@@ -2670,7 +2670,7 @@ CONTAINS
                 END DO
              END IF
           END DO
-          ok = NF90_PUT_VAR(ncid, parID, REAL(tmpout(:, :, :), r_2),           &
+          ok = NF90_PUT_VAR(ncid, parID, REAL(tmpout(:, :, :), r2),           &
                             start = (/1, 1, 1/),                               &
                             count = (/mland, max_vegpatches, ms/)) ! write data to file
           DEALLOCATE(tmpout)

--- a/offline/old/cable_mpicommon.F90
+++ b/offline/old/cable_mpicommon.F90
@@ -198,7 +198,7 @@ contains
 
     integer,   dimension(2) :: itmp
     real,      dimension(2) :: r1tmp
-    real(r_2), dimension(2) :: r2tmp
+    real(r2), dimension(2) :: r2tmp
     logical,   dimension(2) :: ltmp
 
     integer(KIND=MPI_ADDRESS_KIND), dimension(2) :: a
@@ -437,12 +437,12 @@ contains
 #else
     use mpi
 #endif
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
     ! variable to add from offset *off* with length *cnt*
-    real(r_2), dimension(:), intent(in) :: var
+    real(r2), dimension(:), intent(in) :: var
     integer,                 intent(in) :: off
     integer,                 intent(in) :: cnt
     ! MPI adress
@@ -570,12 +570,12 @@ contains
 #else
     use mpi
 #endif
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
     ! variable to add from offset *off* with length *cnt*
-    real(r_2), dimension(:,:), intent(in) :: var
+    real(r2), dimension(:,:), intent(in) :: var
     integer,                   intent(in) :: off
     integer,                   intent(in) :: cnt
     ! MPI adress
@@ -703,12 +703,12 @@ contains
 #else
     use mpi
 #endif
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
     ! variable to add from offset *off* with length *cnt*
-    real(r_2), dimension(:,:,:), intent(in) :: var
+    real(r2), dimension(:,:,:), intent(in) :: var
     integer,                     intent(in) :: off
     integer,                     intent(in) :: cnt
     ! MPI adress
@@ -849,12 +849,12 @@ contains
 #else
     use mpi
 #endif
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
     ! variable to add from offset *off* with length *cnt*
-    real(r_2), dimension(:), intent(in) :: var
+    real(r2), dimension(:), intent(in) :: var
     integer,                 intent(in) :: off
     integer,                 intent(in) :: cnt
     ! length of 1st dim of original array
@@ -1007,12 +1007,12 @@ contains
 #else
     use mpi
 #endif
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
     ! variable to add from offset *off* with length *cnt*
-    real(r_2), dimension(:,:), intent(in) :: var
+    real(r2), dimension(:,:), intent(in) :: var
     integer,                   intent(in) :: off
     integer,                   intent(in) :: cnt
     ! length of 1st dim of original array
@@ -1168,12 +1168,12 @@ contains
 #else
     use mpi
 #endif
-    use cable_def_types_mod, only: r_2
+    use cable_def_types_mod, only: r2
 
     implicit none
 
     ! variable to add from offset *off* with length *cnt*
-    real(r_2), dimension(:,:,:), intent(in) :: var
+    real(r2), dimension(:,:,:), intent(in) :: var
     integer,                     intent(in) :: off
     integer,                     intent(in) :: cnt
     ! length of 1st dim of original array

--- a/offline/old/cable_mpimaster.F90
+++ b/offline/old/cable_mpimaster.F90
@@ -309,8 +309,8 @@ contains
     type(c13o2_flux)  :: c13o2flux
     type(c13o2_pool)  :: c13o2pools, sum_c13o2pools
     type(c13o2_luc)   :: c13o2luc
-    real(r_2), dimension(:,:), allocatable :: casasave
-    real(r_2), dimension(:,:), allocatable :: lucsave
+    real(r2), dimension(:,:), allocatable :: casasave
+    real(r2), dimension(:,:), allocatable :: lucsave
     ! I/O
     logical :: first_casa_write
     integer :: c13o2_outfile_id
@@ -363,7 +363,7 @@ contains
          Ftrunk_sumbal  = ".trunk_sumbal", &
          Fnew_sumbal    = "new_sumbal"
 
-    real(r_2), save :: &
+    real(r2), save :: &
          trunk_sumbal = 0.0, & !
          new_sumbal   = 0.0, &
          new_sumfpn   = 0.0, &
@@ -575,7 +575,7 @@ contains
           read(iunit, fmt=*, iostat=ios) iyear, c13o2_delta_atm(floor(iyear))
        end do
        close(iunit)
-       c13o2_delta_atm = c13o2_delta_atm / 1000._r_2
+       c13o2_delta_atm = c13o2_delta_atm / 1000._r2
     end if
 
     ! Tell the workers if we're leaping
@@ -727,7 +727,7 @@ contains
                 end if
              end if
 
-             canopy%fes_cor = 0.0_r_2
+             canopy%fes_cor = 0.0_r2
              canopy%fhs_cor = 0.0
              met%ofsd       = 0.1 ! not used
 
@@ -750,8 +750,8 @@ contains
 
              !MC - do we need that? casamet also set only if icycle>0
              ! if (trim(cable_user%MetType) .eq. 'cru') then
-             !    casamet%glai = 1.0_r_2 ! initialise glai for use in cable_roughness
-             !    where (veg%iveg(:) .ge. 14) casamet%glai = 0.0_r_2
+             !    casamet%glai = 1.0_r2 ! initialise glai for use in cable_roughness
+             !    where (veg%iveg(:) .ge. 14) casamet%glai = 0.0_r2
              ! end if
              if ((trim(cable_user%MetType) == 'cru') .and. (icycle > 0)) then
                 if (all(real(casamet%glai(:)) == 0.)) then
@@ -994,8 +994,8 @@ contains
                      c13o2_atm_syear, c13o2_atm_eyear
                 call MPI_Abort(comm, 14, ierr)
              end if
-             c13o2flux%ca = (c13o2_delta_atm(CurYear) + 1.0_r_2) * &
-                  real(imet%ca, r_2) ! * vpdbc13 / vpdbc13
+             c13o2flux%ca = (c13o2_delta_atm(CurYear) + 1.0_r2) * &
+                  real(imet%ca, r2) ! * vpdbc13 / vpdbc13
              ! broadcast
              do rank=1, wnp
                 off = wland(rank)%patch0
@@ -1120,7 +1120,7 @@ contains
                 ! 13C
                 if (cable_user%c13o2) then
                    ! already checked that CurYear is in input file
-                   c13o2flux%ca = (c13o2_delta_atm(CurYear) + 1.0_r_2) * real(imet%ca,r_2)
+                   c13o2flux%ca = (c13o2_delta_atm(CurYear) + 1.0_r2) * real(imet%ca,r2)
                    do rank=1, wnp
                       off = wland(rank)%patch0
                       cnt = wland(rank)%npatch
@@ -3128,15 +3128,15 @@ SUBROUTINE master_outtypes(comm,met,canopy,ssnow,rad,bal,air,soil,veg)
      CALL MPI_Type_commit (mat_t(midx, rank), ierr)
 
      ! canopy 2D
-     !     ! REAL(r_1)
+     !     ! REAL(r1)
      !     CALL MPI_Get_address (canopy%rwater(off,1), maddr(midx), ierr) ! 1
      !     CALL MPI_Type_create_hvector (ms, r1len, r1stride, MPI_BYTE, &
      ! &                        mat_t(midx, rank), ierr)
      !     CALL MPI_Type_commit (mat_t(midx, rank), ierr)
      !     midx = midx + 1
-     ! REAL(r_2)
-     ! MPI: gol124: backport to r1134 changes r_2 to r_1
-     ! MPI: gol124: in newest CABLE-cnp it's r_2 again
+     ! REAL(r2)
+     ! MPI: gol124: backport to r1134 changes r2 to r1
+     ! MPI: gol124: in newest CABLE-cnp it's r2 again
      midx = midx + 1
      CALL MPI_Get_address (canopy%evapfbl(off,1), maddr(midx), ierr) ! 2
      ! MPI: gol124: changed to r1 when Bernard ported to CABLE_r491
@@ -3214,86 +3214,86 @@ SUBROUTINE master_outtypes(comm,met,canopy,ssnow,rad,bal,air,soil,veg)
      CALL MPI_Type_commit(mat_t(midx, rank), ierr)
 
      midx = midx + 1
-     ! REAL(r_1)
+     ! REAL(r1)
      CALL MPI_Get_address (ssnow%albsoilsn(off,1), maddr(midx), ierr) ! 3
      CALL MPI_Type_create_hvector (nrb, r1len, r1stride, MPI_BYTE, &
  &                        mat_t(midx, rank), ierr)
      CALL MPI_Type_commit (mat_t(midx, rank), ierr)
      midx = midx + 1
-     ! REAL(r_2)
+     ! REAL(r2)
      CALL MPI_Get_address (ssnow%gammzz(off,1), maddr(midx), ierr) ! 4
      CALL MPI_Type_create_hvector (ms, r2len, r2stride, MPI_BYTE, &
  &                        mat_t(midx, rank), ierr)
      CALL MPI_Type_commit (mat_t(midx, rank), ierr)
      midx = midx + 1
-     ! REAL(r_1)
+     ! REAL(r1)
      CALL MPI_Get_address (ssnow%sconds(off,1), maddr(midx), ierr) ! 5
      CALL MPI_Type_create_hvector (msn, r1len, r1stride, MPI_BYTE, &
  &                        mat_t(midx, rank), ierr)
      CALL MPI_Type_commit (mat_t(midx, rank), ierr)
      midx = midx + 1
-     ! REAL(r_1)
+     ! REAL(r1)
      CALL MPI_Get_address (ssnow%sdepth(off,1), maddr(midx), ierr) ! 6
      CALL MPI_Type_create_hvector (msn, r1len, r1stride, MPI_BYTE, &
  &                        mat_t(midx, rank), ierr)
      CALL MPI_Type_commit (mat_t(midx, rank), ierr)
      midx = midx + 1
-     ! REAL(r_1)
+     ! REAL(r1)
      CALL MPI_Get_address (ssnow%smass(off,1), maddr(midx), ierr) ! 7
      CALL MPI_Type_create_hvector (msn, r1len, r1stride, MPI_BYTE, &
  &                        mat_t(midx, rank), ierr)
      CALL MPI_Type_commit (mat_t(midx, rank), ierr)
      ! MPI: r1134 does not know about this field, comment out
      !midx = midx + 1
-     ! REAL(r_1)
+     ! REAL(r1)
      !CALL MPI_Get_address (ssnow%dtmlt(off,1), maddr(midx), ierr) ! 8
      !CALL MPI_Type_create_hvector (msn, r1len, r1stride, MPI_BYTE, &
      ! &                        mat_t(midx, rank), ierr)
      !CALL MPI_Type_commit (mat_t(midx, rank), ierr)
      midx = midx + 1
-     ! REAL(r_1)
+     ! REAL(r1)
      CALL MPI_Get_address (ssnow%ssdn(off,1), maddr(midx), ierr) ! 9
      CALL MPI_Type_create_hvector (msn, r1len, r1stride, MPI_BYTE, &
  &                        mat_t(midx, rank), ierr)
      CALL MPI_Type_commit (mat_t(midx, rank), ierr)
      midx = midx + 1
-     ! REAL(r_1)
+     ! REAL(r1)
      CALL MPI_Get_address (ssnow%tgg(off,1), maddr(midx), ierr) ! 10
      CALL MPI_Type_create_hvector (ms, r1len, r1stride, MPI_BYTE, &
  &                        mat_t(midx, rank), ierr)
      CALL MPI_Type_commit (mat_t(midx, rank), ierr)
      midx = midx + 1
-     ! REAL(r_1)
+     ! REAL(r1)
      CALL MPI_Get_address (ssnow%tggsn(off,1), maddr(midx), ierr) ! 11
      CALL MPI_Type_create_hvector (msn, r1len, r1stride, MPI_BYTE, &
  &                        mat_t(midx, rank), ierr)
      CALL MPI_Type_commit (mat_t(midx, rank), ierr)
      midx = midx + 1
-     ! REAL(r_2)
+     ! REAL(r2)
      CALL MPI_Get_address (ssnow%wb(off,1), maddr(midx), ierr) ! 12
      CALL MPI_Type_create_hvector (ms, r2len, r2stride, MPI_BYTE, &
  &                        mat_t(midx, rank), ierr)
      CALL MPI_Type_commit (mat_t(midx, rank), ierr)
      midx = midx + 1
-     ! REAL(r_1)
+     ! REAL(r1)
      CALL MPI_Get_address (ssnow%evapfbl(off,1), maddr(midx), ierr) ! 12
      CALL MPI_Type_create_hvector (ms, r1len, r1stride, MPI_BYTE, &
  &                        mat_t(midx, rank), ierr)
      CALL MPI_Type_commit (mat_t(midx, rank), ierr)
      midx = midx + 1
-     ! REAL(r_1)
+     ! REAL(r1)
      CALL MPI_Get_address (ssnow%wbfice(off,1), maddr(midx), ierr) ! 13
      CALL MPI_Type_create_hvector (ms, r2len, r2stride, MPI_BYTE, &
  &                        mat_t(midx, rank), ierr)
      CALL MPI_Type_commit (mat_t(midx, rank), ierr)
      midx = midx + 1
-     ! REAL(r_2)
+     ! REAL(r2)
      CALL MPI_Get_address (ssnow%wbice(off,1), maddr(midx), ierr) ! 14
      CALL MPI_Type_create_hvector (ms, r2len, r2stride, MPI_BYTE, &
  &                        mat_t(midx, rank), ierr)
      CALL MPI_Type_commit (mat_t(midx, rank), ierr)
      midx = midx + 1
-     ! REAL(r_2)
+     ! REAL(r2)
      CALL MPI_Get_address (ssnow%wblf(off,1), maddr(midx), ierr) ! 15
      CALL MPI_Type_create_hvector (ms, r2len, r2stride, MPI_BYTE, &
  &                        mat_t(midx, rank), ierr)
@@ -3339,67 +3339,67 @@ SUBROUTINE master_outtypes(comm,met,canopy,ssnow,rad,bal,air,soil,veg)
      CALL MPI_Type_commit (mat_t(midx, rank), ierr)
 
      midx = midx + 1
-     ! REAL(r_1)
+     ! REAL(r1)
      CALL MPI_Get_address (rad%albedo(off,1), maddr(midx), ierr) ! 16
      CALL MPI_Type_create_hvector (nrb, r1len, r1stride, MPI_BYTE, &
  &                        mat_t(midx, rank), ierr)
      CALL MPI_Type_commit (mat_t(midx, rank), ierr)
      midx = midx + 1
-     ! REAL(r_1)
+     ! REAL(r1)
      CALL MPI_Get_address (rad%fvlai(off,1), maddr(midx), ierr) ! 17
      CALL MPI_Type_create_hvector (mf, r1len, r1stride, MPI_BYTE, &
  &                        mat_t(midx, rank), ierr)
      CALL MPI_Type_commit (mat_t(midx, rank), ierr)
      midx = midx + 1
-     ! REAL(r_2)
+     ! REAL(r2)
      CALL MPI_Get_address (rad%gradis(off,1), maddr(midx), ierr) ! 18
      CALL MPI_Type_create_hvector (mf, r1len, r1stride, MPI_BYTE, &
  &                        mat_t(midx, rank), ierr)
      CALL MPI_Type_commit (mat_t(midx, rank), ierr)
      midx = midx + 1
-     ! REAL(r_1)
+     ! REAL(r1)
      CALL MPI_Get_address (rad%rhocdf(off,1), maddr(midx), ierr) ! 19
      CALL MPI_Type_create_hvector (nrb, r1len, r1stride, MPI_BYTE, &
  &                        mat_t(midx, rank), ierr)
      CALL MPI_Type_commit (mat_t(midx, rank), ierr)
      midx = midx + 1
-     ! REAL(r_1)
+     ! REAL(r1)
      CALL MPI_Get_address (rad%rniso(off,1), maddr(midx), ierr) ! 20
      CALL MPI_Type_create_hvector (mf, r1len, r1stride, MPI_BYTE, &
  &                        mat_t(midx, rank), ierr)
      CALL MPI_Type_commit (mat_t(midx, rank), ierr)
      midx = midx + 1
-     ! REAL(r_1)
+     ! REAL(r1)
      CALL MPI_Get_address (rad%scalex(off,1), maddr(midx), ierr) ! 21
      CALL MPI_Type_create_hvector (mf, r1len, r1stride, MPI_BYTE, &
  &                        mat_t(midx, rank), ierr)
      CALL MPI_Type_commit (mat_t(midx, rank), ierr)
      midx = midx + 1
-     ! REAL(r_1)
+     ! REAL(r1)
      CALL MPI_Get_address (rad%reffdf(off,1), maddr(midx), ierr) ! 22
      CALL MPI_Type_create_hvector (nrb, r1len, r1stride, MPI_BYTE, &
  &                        mat_t(midx, rank), ierr)
      CALL MPI_Type_commit (mat_t(midx, rank), ierr)
      midx = midx + 1
-     ! REAL(r_1)
+     ! REAL(r1)
      CALL MPI_Get_address (rad%reffbm(off,1), maddr(midx), ierr) ! 23
      CALL MPI_Type_create_hvector (nrb, r1len, r1stride, MPI_BYTE, &
  &                        mat_t(midx, rank), ierr)
      CALL MPI_Type_commit (mat_t(midx, rank), ierr)
      midx = midx + 1
-     ! REAL(r_1)
+     ! REAL(r1)
      CALL MPI_Get_address (rad%extkbm(off,1), maddr(midx), ierr) ! 24
      CALL MPI_Type_create_hvector (nrb, r1len, r1stride, MPI_BYTE, &
  &                        mat_t(midx, rank), ierr)
      CALL MPI_Type_commit (mat_t(midx, rank), ierr)
      midx = midx + 1
-     ! REAL(r_1)
+     ! REAL(r1)
      CALL MPI_Get_address (rad%extkdm(off,1), maddr(midx), ierr) ! 25
      CALL MPI_Type_create_hvector (nrb, r1len, r1stride, MPI_BYTE, &
  &                        mat_t(midx, rank), ierr)
      CALL MPI_Type_commit (mat_t(midx, rank), ierr)
      midx = midx + 1
-     ! REAL(r_1)
+     ! REAL(r1)
      CALL MPI_Get_address (rad%cexpkbm(off,1), maddr(midx), ierr) ! 26
      ! Maciej: cexpkbm is mp*swb
      !     CALL MPI_Type_create_hvector (nrb, r1len, r1stride, MPI_BYTE, &
@@ -3408,7 +3408,7 @@ SUBROUTINE master_outtypes(comm,met,canopy,ssnow,rad,bal,air,soil,veg)
  &                        mat_t(midx, rank), ierr)
      CALL MPI_Type_commit (mat_t(midx, rank), ierr)
      midx = midx + 1
-     ! REAL(r_1)
+     ! REAL(r1)
      CALL MPI_Get_address (rad%cexpkdm(off,1), maddr(midx), ierr) ! 27
      ! Maciej: cexpkdm is mp*swb
      !     CALL MPI_Type_create_hvector (nrb, r1len, r1stride, MPI_BYTE, &
@@ -3418,7 +3418,7 @@ SUBROUTINE master_outtypes(comm,met,canopy,ssnow,rad,bal,air,soil,veg)
      CALL MPI_Type_commit (mat_t(midx, rank), ierr)
 
      midx = midx + 1
-     ! REAL(r_1)
+     ! REAL(r1)
      CALL MPI_Get_address (rad%rhocbm(off,1), maddr(midx), ierr) ! 27
      ! Maciej: rhocbm is mp*nrb
      !     CALL MPI_Type_create_hvector (swb, r1len, r1stride, MPI_BYTE, &
@@ -3431,7 +3431,7 @@ SUBROUTINE master_outtypes(comm,met,canopy,ssnow,rad,bal,air,soil,veg)
 
      ! soil 2D
      midx = midx + 1
-     ! REAL(r_1)
+     ! REAL(r1)
      CALL MPI_Get_address (soil%albsoil(off,1), maddr(midx), ierr) ! 28
      CALL MPI_Type_create_hvector (nrb, r1len, r1stride, MPI_BYTE, &
  &                        mat_t(midx, rank), ierr)
@@ -3439,21 +3439,21 @@ SUBROUTINE master_outtypes(comm,met,canopy,ssnow,rad,bal,air,soil,veg)
 
      ! veg 2D
      midx = midx + 1
-     ! REAL(r_1)
+     ! REAL(r1)
      CALL MPI_Get_address (veg%refl(off,1), maddr(midx), ierr) ! 29
      CALL MPI_Type_create_hvector (2, r1len, r1stride, MPI_BYTE, &
  &                        mat_t(midx, rank), ierr)
      CALL MPI_Type_commit (mat_t(midx, rank), ierr)
 
      midx = midx + 1
-     ! REAL(r_1)
+     ! REAL(r1)
      CALL MPI_Get_address (veg%taul(off,1), maddr(midx), ierr) ! 29
      CALL MPI_Type_create_hvector (2, r1len, r1stride, MPI_BYTE, &
  &                        mat_t(midx, rank), ierr)
      CALL MPI_Type_commit (mat_t(midx, rank), ierr)
 
      midx = midx + 1
-     ! REAL(r_1)
+     ! REAL(r1)
      CALL MPI_Get_address (veg%froot(off,1), maddr(midx), ierr) ! 29
      CALL MPI_Type_create_hvector (ms, r1len, r1stride, MPI_BYTE, &
  &                        mat_t(midx, rank), ierr)
@@ -6566,7 +6566,7 @@ SUBROUTINE LUCdriver(casabiome, casapool, casaflux, POP, LUC_EXPT, POPLUC, veg, 
      ! 13C
      c13o2pools)
 
-  USE cable_def_types_mod , ONLY: r_2, veg_parameter_type, mland
+  USE cable_def_types_mod , ONLY: r2, veg_parameter_type, mland
   USE cable_carbon_module
   USE cable_common_module,  ONLY: cable_user, CurYear
   USE cable_IO_vars_module, ONLY: landpt
@@ -6603,28 +6603,28 @@ SUBROUTINE LUCdriver(casabiome, casapool, casaflux, POP, LUC_EXPT, POPLUC, veg, 
   LUC_EXPT%CTSTEP = yyyy -  LUC_EXPT%FirstYear + 1
   CALL READ_LUH2(LUC_EXPT)
   DO k=1,mland
-     POPLUC%ptos(k)   = real(LUC_EXPT%INPUT(ptos)%VAL(k), r_2)
-     POPLUC%ptog(k)   = real(LUC_EXPT%INPUT(ptog)%VAL(k), r_2)
-     POPLUC%stog(k)   = real(LUC_EXPT%INPUT(stog)%VAL(k), r_2)
-     POPLUC%gtop(k)   = 0.0_r_2
-     POPLUC%gtos(k)   = real(LUC_EXPT%INPUT(gtos)%VAL(k),   r_2)
-     POPLUC%pharv(k)  = real(LUC_EXPT%INPUT(pharv)%VAL(k),  r_2)
-     POPLUC%smharv(k) = real(LUC_EXPT%INPUT(smharv)%VAL(k), r_2)
-     POPLUC%syharv(k) = real(LUC_EXPT%INPUT(syharv)%VAL(k), r_2)
+     POPLUC%ptos(k)   = real(LUC_EXPT%INPUT(ptos)%VAL(k), r2)
+     POPLUC%ptog(k)   = real(LUC_EXPT%INPUT(ptog)%VAL(k), r2)
+     POPLUC%stog(k)   = real(LUC_EXPT%INPUT(stog)%VAL(k), r2)
+     POPLUC%gtop(k)   = 0.0_r2
+     POPLUC%gtos(k)   = real(LUC_EXPT%INPUT(gtos)%VAL(k),   r2)
+     POPLUC%pharv(k)  = real(LUC_EXPT%INPUT(pharv)%VAL(k),  r2)
+     POPLUC%smharv(k) = real(LUC_EXPT%INPUT(smharv)%VAL(k), r2)
+     POPLUC%syharv(k) = real(LUC_EXPT%INPUT(syharv)%VAL(k), r2)
 
      ! MC - not in serial code
-     ! POPLUC%ptoc(k) = real(LUC_EXPT%INPUT(ptoc)%VAL(k), r_2)
-     ! POPLUC%ptoq(k) = real(LUC_EXPT%INPUT(ptoq)%VAL(k), r_2)
-     ! POPLUC%stoc(k) = real(LUC_EXPT%INPUT(stoc)%VAL(k), r_2)
-     ! POPLUC%stoq(k) = real(LUC_EXPT%INPUT(stoq)%VAL(k), r_2)
-     ! POPLUC%ctos(k) = real(LUC_EXPT%INPUT(ctos)%VAL(k), r_2)
-     ! POPLUC%qtos(k) = real(LUC_EXPT%INPUT(qtos)%VAL(k), r_2)
+     ! POPLUC%ptoc(k) = real(LUC_EXPT%INPUT(ptoc)%VAL(k), r2)
+     ! POPLUC%ptoq(k) = real(LUC_EXPT%INPUT(ptoq)%VAL(k), r2)
+     ! POPLUC%stoc(k) = real(LUC_EXPT%INPUT(stoc)%VAL(k), r2)
+     ! POPLUC%stoq(k) = real(LUC_EXPT%INPUT(stoq)%VAL(k), r2)
+     ! POPLUC%ctos(k) = real(LUC_EXPT%INPUT(ctos)%VAL(k), r2)
+     ! POPLUC%qtos(k) = real(LUC_EXPT%INPUT(qtos)%VAL(k), r2)
 
      POPLUC%thisyear = yyyy
   END DO
   ! zero secondary forest tiles in POP where secondary forest area is zero
   DO k=1,mland
-     if ( eq(POPLUC%frac_primf(k)-POPLUC%frac_forest(k), 0.0_r_2) &
+     if ( eq(POPLUC%frac_primf(k)-POPLUC%frac_forest(k), 0.0_r2) &
           .and. (.not. LUC_EXPT%prim_only(k)) ) then
         j = landpt(k)%cstart+1
         do l=1,size(POP%Iwood)
@@ -6634,24 +6634,24 @@ SUBROUTINE LUCdriver(casabiome, casapool, casaflux, POP, LUC_EXPT, POPLUC, veg, 
            end if
         end do
 
-        casapool%cplant(j,leaf) = 0.01_r_2
+        casapool%cplant(j,leaf) = 0.01_r2
         casapool%nplant(j,leaf)= casabiome%ratioNCplantmin(veg%iveg(j),leaf)* casapool%cplant(j,leaf)
         casapool%pplant(j,leaf)= casabiome%ratioPCplantmin(veg%iveg(j),leaf)* casapool%cplant(j,leaf)
 
-        casapool%cplant(j,froot) = 0.01_r_2
+        casapool%cplant(j,froot) = 0.01_r2
         casapool%nplant(j,froot)= casabiome%ratioNCplantmin(veg%iveg(j),froot)* casapool%cplant(j,froot)
         casapool%pplant(j,froot)= casabiome%ratioPCplantmin(veg%iveg(j),froot)* casapool%cplant(j,froot)
 
-        casapool%cplant(j,wood) = 0.01_r_2
+        casapool%cplant(j,wood) = 0.01_r2
         casapool%nplant(j,wood)= casabiome%ratioNCplantmin(veg%iveg(j),wood)* casapool%cplant(j,wood)
         casapool%pplant(j,wood)= casabiome%ratioPCplantmin(veg%iveg(j),wood)* casapool%cplant(j,wood)
-        casaflux%frac_sapwood(j) = 1.0_r_2
+        casaflux%frac_sapwood(j) = 1.0_r2
 
         ! 13C
         if (cable_user%c13o2) then
-           c13o2pools%cplant(j,leaf)  = 0.01_r_2 ! * vpdbc13 / vpdbc13 ! Divide by 13C
-           c13o2pools%cplant(j,wood)  = 0.01_r_2 ! * vpdbc13 / vpdbc13 ! so that about same numerical precision as 12C
-           c13o2pools%cplant(j,froot) = 0.01_r_2 ! * vpdbc13 / vpdbc13 !
+           c13o2pools%cplant(j,leaf)  = 0.01_r2 ! * vpdbc13 / vpdbc13 ! Divide by 13C
+           c13o2pools%cplant(j,wood)  = 0.01_r2 ! * vpdbc13 / vpdbc13 ! so that about same numerical precision as 12C
+           c13o2pools%cplant(j,froot) = 0.01_r2 ! * vpdbc13 / vpdbc13 !
         end if
 
      end if

--- a/offline/old/cable_mpiworker.F90
+++ b/offline/old/cable_mpiworker.F90
@@ -224,7 +224,7 @@ contains
     ! BLAZE variables
     type(TYPE_BLAZE)     :: BLAZE
     type(TYPE_SIMFIRE)   :: SIMFIRE
-    ! REAL(r_2), DIMENSION(:), ALLOCATABLE :: POP_TO, POP_CWD, POP_STR
+    ! REAL(r2), DIMENSION(:), ALLOCATABLE :: POP_TO, POP_CWD, POP_STR
 
     ! 13C
     type(c13o2_flux) :: c13o2flux
@@ -233,8 +233,8 @@ contains
     ! I/O
     ! discrimination
     ! integer :: ileaf
-    real(r_2), dimension(:,:), allocatable :: gpp
-    real(r_2), dimension(:),   allocatable :: Ra
+    real(r2), dimension(:,:), allocatable :: gpp
+    real(r2), dimension(:),   allocatable :: Ra
 
     ! declare vars for switches (default .FALSE.) etc declared thru namelist
     logical, save :: &
@@ -537,7 +537,7 @@ contains
                 call worker_restart_type(comm, canopy, air, veg, ssnow)
              end if
 
-             canopy%fes_cor = 0.0_r_2
+             canopy%fes_cor = 0.0_r2
              canopy%fhs_cor = 0.
              met%ofsd       = 0.1 ! not used
              !MC diff to serial code - pdep not set
@@ -545,8 +545,8 @@ contains
              met%pdep = 0.0
              !MC - do we need that? casamet also set only if icycle>0
              ! if (trim(cable_user%MetType) .eq. 'cru') then
-             !    casamet%glai = 1.0_r_2
-             !    where (veg%iveg(:) .ge. 14) casamet%glai = 0.0_r_2
+             !    casamet%glai = 1.0_r2
+             !    where (veg%iveg(:) .ge. 14) casamet%glai = 0.0_r2
              ! end if
              if ((trim(cable_user%MetType) == 'cru') .and. (icycle > 0)) then
                 if (all(real(casamet%glai(:)) == 0.)) then
@@ -687,12 +687,12 @@ contains
              ! 13C
              if (cable_user%c13o2) then
                 gpp  = canopy%An + canopy%Rd
-                Ra   = isoratio(c13o2flux%ca, real(met%ca,r_2), 1.0_r_2)
+                Ra   = isoratio(c13o2flux%ca, real(met%ca,r2), 1.0_r2)
                 !MCTest
                 c13o2flux%An       = canopy%An
-                ! c13o2flux%An       = 1.005_r_2 * canopy%An !  * vpdbc13 / vpdbc13 ! Test 5 permil
-                c13o2flux%Disc     = 0.0_r_2
-                c13o2flux%Vstarch  = c13o2flux%Vstarch + 1.0e-6_r_2
+                ! c13o2flux%An       = 1.005_r2 * canopy%An !  * vpdbc13 / vpdbc13 ! Test 5 permil
+                c13o2flux%Disc     = 0.0_r2
+                c13o2flux%Vstarch  = c13o2flux%Vstarch + 1.0e-6_r2
                 c13o2flux%Rstarch  = c13o2flux%Rstarch
                 c13o2flux%Rsucrose = c13o2flux%Rsucrose
                 c13o2flux%Rphoto   = c13o2flux%Rphoto
@@ -701,13 +701,13 @@ contains
                 !       call c13o2_discrimination_simple( &
                 !            ! -- Input
                 !            ! isc3
-                !            real(dels,r_2), canopy%isc3, &
+                !            real(dels,r2), canopy%isc3, &
                 !            ! GPP and Leaf respiration
                 !            gpp(:,ileaf), canopy%Rd(:,ileaf), &
                 !            ! Ambient and stomatal CO2 concentration
-                !            real(met%ca,r_2), canopy%ci(:,ileaf), &
+                !            real(met%ca,r2), canopy%ci(:,ileaf), &
                 !            ! leaf temperature
-                !            real(canopy%tlf,r_2), &
+                !            real(canopy%tlf,r2), &
                 !            ! Ambient isotope ratio
                 !            Ra, &
                 !            ! -- Inout
@@ -721,16 +721,16 @@ contains
                 !    else
                 !       call c13o2_discrimination( &
                 !            ! -- Input
-                !            real(dels,r_2), canopy%isc3, &
+                !            real(dels,r2), canopy%isc3, &
                 !            ! Photosynthesis variables
                 !            ! Vcmax<< because of temperature dependence of Vcmax
                 !            canopy%vcmax(:,ileaf), gpp(:,ileaf), canopy%Rd(:,ileaf), canopy%gammastar(:,ileaf), &
                 !            ! CO2 concentrations
-                !            real(met%ca,r_2), canopy%ci(:,ileaf), &
+                !            real(met%ca,r2), canopy%ci(:,ileaf), &
                 !            ! Conductances
                 !            canopy%gac(:,ileaf), canopy%gbc(:,ileaf), canopy%gsc(:,ileaf), &
                 !            ! leaf temperature
-                !            real(canopy%tlf,r_2), &
+                !            real(canopy%tlf,r2), &
                 !            ! Ambient isotope ratio
                 !            Ra, &
                 !            ! -- Inout
@@ -872,11 +872,11 @@ contains
 
           if ((icycle > 0) .and. (.not. casaonly)) then
              ! re-initalise annual flux sums
-             casabal%FCgppyear = 0.0_r_2
-             casabal%FCrpyear  = 0.0_r_2
-             casabal%FCnppyear = 0.0_r_2
-             casabal%FCrsyear  = 0.0_r_2
-             casabal%FCneeyear = 0.0_r_2
+             casabal%FCgppyear = 0.0_r2
+             casabal%FCrpyear  = 0.0_r2
+             casabal%FCnppyear = 0.0_r2
+             casabal%FCrsyear  = 0.0_r2
+             casabal%FCneeyear = 0.0_r2
           end if
 
        end do YEARLOOP
@@ -4287,22 +4287,22 @@ SUBROUTINE worker_spincasacnp(dels, kstart, kend, mloop, &
   integer,                   intent(in)  :: icomm, ocomm
 
   ! local variables
-  real(r_2), dimension(:), allocatable, save  :: avg_cleaf2met, avg_cleaf2str, avg_croot2met, avg_croot2str, avg_cwood2cwd
-  real(r_2), dimension(:), allocatable, save  :: avg_nleaf2met, avg_nleaf2str, avg_nroot2met, avg_nroot2str, avg_nwood2cwd
-  real(r_2), dimension(:), allocatable, save  :: avg_pleaf2met, avg_pleaf2str, avg_proot2met, avg_proot2str, avg_pwood2cwd
-  real(r_2), dimension(:), allocatable, save  :: avg_cgpp,      avg_cnpp,      avg_nuptake,   avg_puptake
-  real(r_2), dimension(:), allocatable, save  :: avg_nsoilmin,  avg_psoillab,  avg_psoilsorb, avg_psoilocc
+  real(r2), dimension(:), allocatable, save  :: avg_cleaf2met, avg_cleaf2str, avg_croot2met, avg_croot2str, avg_cwood2cwd
+  real(r2), dimension(:), allocatable, save  :: avg_nleaf2met, avg_nleaf2str, avg_nroot2met, avg_nroot2str, avg_nwood2cwd
+  real(r2), dimension(:), allocatable, save  :: avg_pleaf2met, avg_pleaf2str, avg_proot2met, avg_proot2str, avg_pwood2cwd
+  real(r2), dimension(:), allocatable, save  :: avg_cgpp,      avg_cnpp,      avg_nuptake,   avg_puptake
+  real(r2), dimension(:), allocatable, save  :: avg_nsoilmin,  avg_psoillab,  avg_psoilsorb, avg_psoilocc
   ! chris 12/oct/2012 for spin up casa
-  real(r_2), dimension(:), allocatable, save  :: avg_ratioNCsoilmic,  avg_ratioNCsoilslow,  avg_ratioNCsoilpass
-  real(r_2), dimension(:), allocatable, save  :: avg_xnplimit,  avg_xkNlimiting,avg_xklitter, avg_xksoil
+  real(r2), dimension(:), allocatable, save  :: avg_ratioNCsoilmic,  avg_ratioNCsoilslow,  avg_ratioNCsoilpass
+  real(r2), dimension(:), allocatable, save  :: avg_xnplimit,  avg_xkNlimiting,avg_xklitter, avg_xksoil
 
   ! local variables
   integer                  :: myearspin, nyear, nloop1, loy
   integer                  :: ktau,ktauday,nday,idoy,ktauy,nloop
-  real(r_2), dimension(mp) :: cleaf2met, cleaf2str, croot2met, croot2str, cwood2cwd
-  real(r_2), dimension(mp) :: nleaf2met, nleaf2str, nroot2met, nroot2str, nwood2cwd
-  real(r_2), dimension(mp) :: pleaf2met, pleaf2str, proot2met, proot2str, pwood2cwd
-  real(r_2), dimension(mp) :: xnplimit,  xknlimiting, xklitter, xksoil,xkleaf, xkleafcold, xkleafdry
+  real(r2), dimension(mp) :: cleaf2met, cleaf2str, croot2met, croot2str, cwood2cwd
+  real(r2), dimension(mp) :: nleaf2met, nleaf2str, nroot2met, nroot2str, nwood2cwd
+  real(r2), dimension(mp) :: pleaf2met, pleaf2str, proot2met, proot2str, pwood2cwd
+  real(r2), dimension(mp) :: xnplimit,  xknlimiting, xklitter, xksoil,xkleaf, xkleafcold, xkleafdry
 
   ! more variables to store the spinup pool size over the last 10 loops. Added by Yp Wang 30 Nov 2012
   integer, allocatable :: iw(:) ! array of indices corresponding to woody (shrub or forest) tiles
@@ -4316,8 +4316,8 @@ SUBROUTINE worker_spincasacnp(dels, kstart, kend, mloop, &
   type(type_simfire) :: simfire
 
   ! 13C
-  real(r_2), dimension(:,:), allocatable :: casasave
-  real(r_2), dimension(:), allocatable :: avg_c13leaf2met, avg_c13leaf2str, avg_c13root2met, &
+  real(r2), dimension(:,:), allocatable :: casasave
+  real(r2), dimension(:), allocatable :: avg_c13leaf2met, avg_c13leaf2str, avg_c13root2met, &
        avg_c13root2str, avg_c13wood2cwd
 
   if (.not.allocated(iw)) allocate(iw(POP%np))
@@ -4444,7 +4444,7 @@ SUBROUTINE worker_spincasacnp(dels, kstart, kend, mloop, &
            end if  ! end of year
         else
            casaflux%stemnpp = 0.0_dp
-           casaflux%potstemnpp = 0.0_r_2
+           casaflux%potstemnpp = 0.0_r2
         end if ! CALL_POP
 
         !CLN CALL BLAZE_DRIVER(...)
@@ -4616,7 +4616,7 @@ SUBROUTINE worker_spincasacnp(dels, kstart, kend, mloop, &
               end if  ! end of year
            else
               casaflux%stemnpp = 0.0_dp
-              casaflux%potstemnpp = 0.0_r_2
+              casaflux%potstemnpp = 0.0_r2
            end if ! CALL_POP
            write(wlogn,*) 'idoy ', idoy
 
@@ -4686,10 +4686,10 @@ SUBROUTINE worker_CASAONLY_LUC(dels, kstart, kend, veg, soil, casabiome, casapoo
   ! local variables
   integer           :: myearspin, nyear
   integer           :: ktau, ktauday, nday, idoy
-  real(r_2), dimension(mp) :: cleaf2met, cleaf2str, croot2met, croot2str, cwood2cwd
-  real(r_2), dimension(mp) :: nleaf2met, nleaf2str, nroot2met, nroot2str, nwood2cwd
-  real(r_2), dimension(mp) :: pleaf2met, pleaf2str, proot2met, proot2str, pwood2cwd
-  real(r_2), dimension(mp) :: xnplimit,  xkNlimiting, xklitter, xksoil,xkleaf, xkleafcold, xkleafdry
+  real(r2), dimension(mp) :: cleaf2met, cleaf2str, croot2met, croot2str, cwood2cwd
+  real(r2), dimension(mp) :: nleaf2met, nleaf2str, nroot2met, nroot2str, nwood2cwd
+  real(r2), dimension(mp) :: pleaf2met, pleaf2str, proot2met, proot2str, pwood2cwd
+  real(r2), dimension(mp) :: xnplimit,  xkNlimiting, xklitter, xksoil,xkleaf, xkleafcold, xkleafdry
 
   ! more variables to store the spinup pool size over the last 10 loops. Added by Yp Wang 30 Nov 2012
   real(dp) :: StemNPP(mp,2)


### PR DESCRIPTION
# CABLE

## Description

The numrical kinds used in cable were renamed and unified as much as possible. Changed `r_2` to `r2`, `r_1` to `r1`, `i_d` to `i4`. It was also tried to remove the kind `sp` and `dp` as much as possible. However, the latter kinds are still used in POP, the reading of BIOS files and my numerical utilities in `mo_utils.f90`. `dp` and `sp` in the latter point to `r1` and `r2` in the latter, though.
The kinds between POP and CABLE were synchronised. Only the definition of `sp` in BIOS is different to CABLE (it is also defined differently in POP but not used in the code).

As an example: a double precision numerical constant is now `1.0_r2` instead of `1.0_r_2` or `1.0_dp`. 

Fixes #(513)

## Type of change

Please delete options that are not relevant.

- [X] Refactoring

## Checklist

- [X] The new content is accessible and located in the appropriate section
- [X] I have checked my code/text and corrected any misspellings

## Testing

- [X] Are the changes bitwise-compatible with the main branch?
Local tests were run, not benchcab. I used `cdo diff` on all restart and output files. However, Only one science configuration was tested.