### PR TITLE
Use mpi_f08 in `cable_mpi.F90`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,6 +252,7 @@ else()
         src/offline/cable_initialise.F90
         src/offline/cable_input.F90
         src/offline/cable_metutils.F90
+        src/offline/cable_mpi_stub_types.F90
         src/offline/cable_mpi.F90
         src/offline/cable_namelist_input.F90
         src/offline/cable_output.F90

--- a/src/offline/cable_mpi.F90
+++ b/src/offline/cable_mpi.F90
@@ -5,7 +5,9 @@
 MODULE cable_mpi_mod
   !! Module for handling some common MPI operations and MPI groups
 #ifdef __MPI__
-  USE mpi
+  USE mpi_f08
+#else
+  USE cable_mpi_stub_types_mod
 #endif
   USE iso_fortran_env, ONLY : error_unit
   IMPLICIT NONE
@@ -17,15 +19,15 @@ MODULE cable_mpi_mod
     mpi_mod_end, &
     mpi_check_error
 
-  INTEGER, PARAMETER :: MPI_COMM_UNDEFINED = -1
+  TYPE(MPI_Comm), PARAMETER :: MPI_COMM_UNDEFINED = MPI_COMM_NULL
 
-  INTEGER :: default_comm ! Default communicator to use when creating groups
+  TYPE(MPI_Comm) :: default_comm ! Default communicator to use when creating groups
 
   TYPE mpi_grp_t
     !* Class to handle MPI groups.
     ! This class stores information about the group and
     ! the current proccess.
-    INTEGER :: comm = MPI_COMM_UNDEFINED  !! Communicator
+    TYPE(MPI_Comm) :: comm = MPI_COMM_UNDEFINED  !! Communicator
     INTEGER :: rank = -1   !! Rank of the current process
     INTEGER :: size = -1   !! Size of the communicator
   CONTAINS
@@ -79,7 +81,7 @@ CONTAINS
     !
     ! Note that when the undefined communicator is used, the group size is 1 and
     ! the rank to 0, such that the code can work in serial mode.
-    INTEGER, INTENT(IN), OPTIONAL :: comm !! MPI communicator
+    TYPE(MPI_Comm), INTENT(IN), OPTIONAL :: comm !! MPI communicator
     TYPE(mpi_grp_t) :: mpi_grp
 
     INTEGER :: ierr

--- a/src/offline/cable_mpi_stub_types.F90
+++ b/src/offline/cable_mpi_stub_types.F90
@@ -1,0 +1,213 @@
+MODULE cable_mpi_stub_types_mod
+  !* Stubs for MPI datatypes when compiling without MPI
+  !
+  ! Adapted from https://github.com/open-mpi/ompi/blob/v3.0.0/ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-types.F90
+  IMPLICIT NONE
+
+  TYPE, BIND(c) :: MPI_Status
+    INTEGER :: MPI_SOURCE
+    INTEGER :: MPI_TAG
+    INTEGER :: MPI_ERROR
+  END TYPE MPI_Status
+
+  TYPE, bind(c) :: MPI_Comm
+    INTEGER :: MPI_VAL
+  END TYPE MPI_Comm
+
+  TYPE, bind(c) :: MPI_Datatype
+    INTEGER :: MPI_VAL
+  END TYPE MPI_Datatype
+
+  TYPE, bind(c) :: MPI_Errhandler
+    INTEGER :: MPI_VAL
+  END TYPE MPI_Errhandler
+
+  TYPE, bind(c) :: MPI_File
+    INTEGER :: MPI_VAL
+  END TYPE MPI_File
+
+  TYPE, bind(c) :: MPI_Group
+    INTEGER :: MPI_VAL
+  END TYPE MPI_Group
+
+  TYPE, bind(c) :: MPI_Info
+    INTEGER :: MPI_VAL
+  END TYPE MPI_Info
+
+  TYPE, bind(c) :: MPI_Message
+    INTEGER :: MPI_VAL
+  END TYPE MPI_Message
+
+  TYPE, bind(c) :: MPI_Op
+    INTEGER :: MPI_VAL
+  END TYPE MPI_Op
+
+  TYPE, bind(c) :: MPI_Request
+    INTEGER :: MPI_VAL
+  END TYPE MPI_Request
+
+  TYPE, bind(c) :: MPI_Session
+    INTEGER :: MPI_VAL
+  END TYPE MPI_Session
+
+  TYPE, bind(c) :: MPI_Win
+    INTEGER :: MPI_VAL
+  END TYPE MPI_Win
+
+  TYPE(MPI_Comm), PARAMETER       :: MPI_COMM_NULL       = MPI_Comm(0)
+  TYPE(MPI_Datatype), PARAMETER   :: MPI_DATATYPE_NULL   = MPI_Datatype(0)
+  TYPE(MPI_Errhandler), PARAMETER :: MPI_ERRHANDLER_NULL = MPI_Errhandler(0)
+  TYPE(MPI_File), PARAMETER       :: MPI_FILE_NULL       = MPI_File(0)
+  TYPE(MPI_Group),  PARAMETER     :: MPI_GROUP_NULL      = MPI_Group(0)
+  TYPE(MPI_Info), PARAMETER       :: MPI_INFO_NULL       = MPI_Info(0)
+  TYPE(MPI_Message), PARAMETER    :: MPI_MESSAGE_NULL    = MPI_Message(0)
+  TYPE(MPI_Op), PARAMETER         :: MPI_OP_NULL         = MPI_Op(0)
+  TYPE(MPI_Request), PARAMETER    :: MPI_REQUEST_NULL    = MPI_Request(0)
+  TYPE(MPI_Win), PARAMETER        :: MPI_WIN_NULL        = MPI_Win(0)
+
+  TYPE(MPI_Datatype), PARAMETER :: MPI_INTEGER           = MPI_Datatype(0)
+  TYPE(MPI_Datatype), PARAMETER :: MPI_INTEGER8          = MPI_Datatype(0)
+  TYPE(MPI_Datatype), PARAMETER :: MPI_DOUBLE_PRECISION  = MPI_Datatype(0)
+  TYPE(MPI_Datatype), PARAMETER :: MPI_DOUBLE_COMPLEX    = MPI_Datatype(0)
+  TYPE(MPI_Datatype), PARAMETER :: MPI_2DOUBLE_PRECISION = MPI_Datatype(0)
+  TYPE(MPI_Datatype), PARAMETER :: MPI_CHARACTER         = MPI_Datatype(0)
+  TYPE(MPI_Datatype), PARAMETER :: MPI_LOGICAL           = MPI_Datatype(0)
+
+  TYPE(MPI_Op), PARAMETER :: MPI_SUM      = MPI_Op(0)
+  TYPE(MPI_Op), PARAMETER :: MPI_MINLOC   = MPI_Op(0)
+  TYPE(MPI_Op), PARAMETER :: MPI_MAXLOC   = MPI_Op(0)
+  TYPE(MPI_Op), PARAMETER :: MPI_LOR      = MPI_Op(0)
+  TYPE(MPI_Op), PARAMETER :: MPI_LAND     = MPI_Op(0)
+  TYPE(MPI_Op), PARAMETER :: MPI_MAX      = MPI_Op(0)
+  TYPE(MPI_Op), PARAMETER :: MPI_MIN      = MPI_Op(0)
+  TYPE(MPI_Op), PARAMETER :: MPI_IN_PLACE = MPI_Op(0)
+
+  INTERFACE OPERATOR (.EQ.)
+    MODULE PROCEDURE oct_mpi_comm_op_eq
+    MODULE PROCEDURE oct_mpi_datatype_op_eq
+    MODULE PROCEDURE oct_mpi_errhandler_op_eq
+    MODULE PROCEDURE oct_mpi_file_op_eq
+    MODULE PROCEDURE oct_mpi_group_op_eq
+    MODULE PROCEDURE oct_mpi_info_op_eq
+    MODULE PROCEDURE oct_mpi_message_op_eq
+    MODULE PROCEDURE oct_mpi_op_op_eq
+    MODULE PROCEDURE oct_mpi_request_op_eq
+    MODULE PROCEDURE oct_mpi_win_op_eq
+  END INTERFACE OPERATOR (.EQ.)
+
+  INTERFACE OPERATOR (.NE.)
+    MODULE PROCEDURE oct_mpi_comm_op_ne
+    MODULE PROCEDURE oct_mpi_datatype_op_ne
+    MODULE PROCEDURE oct_mpi_errhandler_op_ne
+    MODULE PROCEDURE oct_mpi_file_op_ne
+    MODULE PROCEDURE oct_mpi_group_op_ne
+    MODULE PROCEDURE oct_mpi_info_op_ne
+    MODULE PROCEDURE oct_mpi_message_op_ne
+    MODULE PROCEDURE oct_mpi_op_op_ne
+    MODULE PROCEDURE oct_mpi_request_op_ne
+    MODULE PROCEDURE oct_mpi_win_op_ne
+  END INTERFACE OPERATOR (.NE.)
+
+CONTAINS
+
+  LOGICAL FUNCTION oct_mpi_comm_op_eq(a, b)
+    TYPE(MPI_Comm), intent(in) :: a, b
+    oct_mpi_comm_op_eq = (a%MPI_VAL .EQ. b%MPI_VAL)
+  END FUNCTION oct_mpi_comm_op_eq
+
+  LOGICAL FUNCTION oct_mpi_datatype_op_eq(a, b)
+    TYPE(MPI_Datatype), intent(in) :: a, b
+    oct_mpi_datatype_op_eq = (a%MPI_VAL .EQ. b%MPI_VAL)
+  END FUNCTION oct_mpi_datatype_op_eq
+
+  LOGICAL FUNCTION oct_mpi_errhandler_op_eq(a, b)
+    TYPE(MPI_Errhandler), intent(in) :: a, b
+    oct_mpi_errhandler_op_eq = (a%MPI_VAL .EQ. b%MPI_VAL)
+  END FUNCTION oct_mpi_errhandler_op_eq
+
+  LOGICAL FUNCTION oct_mpi_file_op_eq(a, b)
+    TYPE(MPI_File), intent(in) :: a, b
+    oct_mpi_file_op_eq = (a%MPI_VAL .EQ. b%MPI_VAL)
+  END FUNCTION oct_mpi_file_op_eq
+
+  LOGICAL FUNCTION oct_mpi_group_op_eq(a, b)
+    TYPE(MPI_Group), intent(in) :: a, b
+    oct_mpi_group_op_eq = (a%MPI_VAL .EQ. b%MPI_VAL)
+  END FUNCTION oct_mpi_group_op_eq
+
+  LOGICAL FUNCTION oct_mpi_info_op_eq(a, b)
+    TYPE(MPI_Info), intent(in) :: a, b
+    oct_mpi_info_op_eq = (a%MPI_VAL .EQ. b%MPI_VAL)
+  END FUNCTION oct_mpi_info_op_eq
+
+  LOGICAL FUNCTION oct_mpi_message_op_eq(a, b)
+    TYPE(MPI_Message), intent(in) :: a, b
+    oct_mpi_message_op_eq = (a%MPI_VAL .EQ. b%MPI_VAL)
+  END FUNCTION oct_mpi_message_op_eq
+
+  LOGICAL FUNCTION oct_mpi_op_op_eq(a, b)
+    TYPE(MPI_Op), intent(in) :: a, b
+    oct_mpi_op_op_eq = (a%MPI_VAL .EQ. b%MPI_VAL)
+  END FUNCTION oct_mpi_op_op_eq
+
+  LOGICAL FUNCTION oct_mpi_request_op_eq(a, b)
+    TYPE(MPI_Request), intent(in) :: a, b
+    oct_mpi_request_op_eq = (a%MPI_VAL .EQ. b%MPI_VAL)
+  END FUNCTION oct_mpi_request_op_eq
+
+  LOGICAL FUNCTION oct_mpi_win_op_eq(a, b)
+    TYPE(MPI_Win), intent(in) :: a, b
+    oct_mpi_win_op_eq = (a%MPI_VAL .EQ. b%MPI_VAL)
+  END FUNCTION oct_mpi_win_op_eq
+
+  LOGICAL FUNCTION oct_mpi_comm_op_ne(a, b)
+    TYPE(MPI_Comm), intent(in) :: a, b
+    oct_mpi_comm_op_ne = (a%MPI_VAL .NE. b%MPI_VAL)
+  END FUNCTION oct_mpi_comm_op_ne
+
+  LOGICAL FUNCTION oct_mpi_datatype_op_ne(a, b)
+    TYPE(MPI_Datatype), intent(in) :: a, b
+    oct_mpi_datatype_op_ne = (a%MPI_VAL .NE. b%MPI_VAL)
+  END FUNCTION oct_mpi_datatype_op_ne
+
+  LOGICAL FUNCTION oct_mpi_errhandler_op_ne(a, b)
+    TYPE(MPI_Errhandler), intent(in) :: a, b
+    oct_mpi_errhandler_op_ne = (a%MPI_VAL .NE. b%MPI_VAL)
+  END FUNCTION oct_mpi_errhandler_op_ne
+
+  LOGICAL FUNCTION oct_mpi_file_op_ne(a, b)
+    TYPE(MPI_File), intent(in) :: a, b
+    oct_mpi_file_op_ne = (a%MPI_VAL .NE. b%MPI_VAL)
+  END FUNCTION oct_mpi_file_op_ne
+
+  LOGICAL FUNCTION oct_mpi_group_op_ne(a, b)
+    TYPE(MPI_Group), intent(in) :: a, b
+    oct_mpi_group_op_ne = (a%MPI_VAL .NE. b%MPI_VAL)
+  END FUNCTION oct_mpi_group_op_ne
+
+  LOGICAL FUNCTION oct_mpi_info_op_ne(a, b)
+    TYPE(MPI_Info), intent(in) :: a, b
+    oct_mpi_info_op_ne = (a%MPI_VAL .NE. b%MPI_VAL)
+  END FUNCTION oct_mpi_info_op_ne
+
+  LOGICAL FUNCTION oct_mpi_message_op_ne(a, b)
+    TYPE(MPI_Message), intent(in) :: a, b
+    oct_mpi_message_op_ne = (a%MPI_VAL .NE. b%MPI_VAL)
+  END FUNCTION oct_mpi_message_op_ne
+
+  LOGICAL FUNCTION oct_mpi_op_op_ne(a, b)
+    TYPE(MPI_Op), intent(in) :: a, b
+    oct_mpi_op_op_ne = (a%MPI_VAL .NE. b%MPI_VAL)
+  END FUNCTION oct_mpi_op_op_ne
+
+  LOGICAL FUNCTION oct_mpi_request_op_ne(a, b)
+    TYPE(MPI_Request), intent(in) :: a, b
+    oct_mpi_request_op_ne  = (a%MPI_VAL .NE. b%MPI_VAL)
+  END FUNCTION oct_mpi_request_op_ne
+
+  LOGICAL FUNCTION oct_mpi_win_op_ne(a, b)
+    TYPE(MPI_Win), intent(in) :: a, b
+    oct_mpi_win_op_ne = (a%MPI_VAL .NE. b%MPI_VAL)
+  END FUNCTION oct_mpi_win_op_ne
+
+END MODULE

--- a/src/offline/cable_offline_driver.F90
+++ b/src/offline/cable_offline_driver.F90
@@ -62,9 +62,9 @@ PROGRAM cable_offline_driver
     CALL serialdrv(NRRRR, dels, koffset, kend, GSWP_MID, PLUME, CRU, site)
   ELSE
     IF (mpi_grp%rank == 0) THEN
-      CALL mpidrv_master(mpi_grp%comm, dels, koffset, kend, PLUME, CRU)
+      CALL mpidrv_master(mpi_grp%comm%mpi_val, dels, koffset, kend, PLUME, CRU)
     ELSE
-      CALL mpidrv_worker(mpi_grp%comm)
+      CALL mpidrv_worker(mpi_grp%comm%mpi_val)
     END IF
   END IF
 


### PR DESCRIPTION
In our mock CABLE prototype, @micaeljtoliveira, @Whyborn and I made the change to use the Fortran 2008 MPI types and procedures via the `mpi_f08` module. The new interfaces provide type safety by distinguishing various MPI types, instead of using integer for all types, as is done in the old interfaces.

This feature has been available already for a few years:
- OpenMPI >= 1.7 [2013]
  https://github.com/open-mpi/ompi/blob/v1.7.0/NEWS#L65
- MPICH >= 3.1.1 [2014]
  https://github.com/pmodels/mpich/blob/v3.1.1/CHANGES#L10-L11
- Intel MPI >= 5.1 (needs Intel Fortran Compiler >= 16.0, part of Intel Parallel Studio XE 2016) [2015]
  https://www.intel.com/content/dam/develop/external/us/en/documents/intelmpi-5-1-update3-build223-releasenotes-linux.pdf 

This change brings across these changes to CABLE main. The new interface will be required for the new MPI implementation (#358).

## Type of change

Please delete options that are not relevant.

- [x] New feature

## Checklist

- [x] The new content is accessible and located in the appropriate section
- [x] I have checked that links are valid and point to the intended content
- [x] I have checked my code/text and corrected any misspellings

## Testing

- [x] Are the changes bitwise-compatible with the main branch? If working on an optional feature, are the results bitwise-compatible when this feature is off? If yes, copy benchcab output showing successful completion of the bitwise compatibility tests or equivalent results below this line.
```
2025-10-03 12:21:47,177 - INFO - benchcab.benchcab.py:379 - Running comparison tasks...
2025-10-03 12:21:47,204 - INFO - benchcab.benchcab.py:380 - tasks: 168 (models: 2, sites: 42, science configurations: 4)
2025-10-03 12:24:39,211 - INFO - benchcab.benchcab.py:390 - 0 failed, 168 passed
```

<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--616.org.readthedocs.build/en/616/

<!-- readthedocs-preview cable end -->