### PR TITLE
Update Markdown Link Check CI

### DIFF
--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -1,12 +1,13 @@
 name: Check Markdown links
 
-on: push
+on:
+  pull_request:
+    branches:
+      - main
 
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
-      with:
-        config-file: '.github/workflows/mlc_config.json'
+    - uses: actions/checkout@v4
+    - uses: tcort/github-action-markdown-link-check@v1


### PR DESCRIPTION
This change fixes the link checker CI for the documentation. It looks like https://github.com/gaurav-nelson/github-action-markdown-link-check is deprecated. This change replaces this with the currently maintained fork: https://github.com/tcort/github-action-markdown-link-check.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## Checklist

- [x] The new content is accessible and located in the appropriate section
- [x] I have checked that links are valid and point to the intended content
- [x] I have checked my code/text and corrected any misspellings

## Testing

- [x] Are the changes bitwise-compatible with the main branch? If working on an optional feature, are the results bitwise-compatible when this feature is off? If yes, copy benchcab output showing successful completion of the bitwise compatibility tests or equivalent results below this line.

<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--617.org.readthedocs.build/en/617/

<!-- readthedocs-preview cable end -->