### PR TITLE
fix-whitespace-error-in-CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,7 @@ if(CABLE_LIBRARY)
         src/util/masks_cbl.F90
     )
 
-if(CABLE_LIBRARY_TARGET STREQUAL "ESM1.6")
+    if(CABLE_LIBRARY_TARGET STREQUAL "ESM1.6")
         list(APPEND SOURCES
             src/coupled/esm/cable_iovars.F90
             src/coupled/esm/cable_surface_types.F90


### PR DESCRIPTION
Trivial change- the `if` clause in CMakeLists was not intended when it should've been, making the control flow easy to misinterpret. No functional change.


<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--625.org.readthedocs.build/en/625/

<!-- readthedocs-preview cable end -->