### PR TITLE
meaningful description of switch

### DIFF
--- a/src/science/gw_hydro/cable_gw_hydro.F90
+++ b/src/science/gw_hydro/cable_gw_hydro.F90
@@ -997,7 +997,7 @@ CONTAINS
     END IF
 
      !> 7. MMY???
-    IF( (.NOT.cable_user%cable_runtime_coupled ) .AND. (first_gw_hydro_call)) THEN
+    IF( (cable_user%soilsnow_init_spec ) .AND. (first_gw_hydro_call)) THEN
 
        IF (cable_runtime%um) canopy%dgdtg = 0.0 ! RML added um condition  
 
@@ -1081,7 +1081,7 @@ CONTAINS
                   soil%zse_vec(i,k) +   gammzz_snow(i,k)
           END DO
        END DO                          
-    ENDIF  ! if(.NOT.cable_runtime_coupled) and first_gw_hydro_call
+    ENDIF  ! IF( (cable_user%soilsnow_init_spec ) ) and first_gw_hydro_call
 
   !>  wbliq_old is used for hysteresis 
    ssnow%wbliq_old = ssnow%wbliq       

--- a/src/science/soilsnow/cbl_soilsnow_init_special.F90
+++ b/src/science/soilsnow/cbl_soilsnow_init_special.F90
@@ -32,7 +32,7 @@ REAL :: heat_cap_lower_limit(mp,ms)
 
 ktau = ktau +1
 
-IF( .NOT.cable_user%cable_runtime_coupled ) THEN
+IF( (cable_user%soilsnow_init_spec ) ) THEN
 
    IF( ktau_gl <= 1 ) THEN
       IF (cable_runtime%um) canopy%dgdtg = 0.0 ! RML added um condition
@@ -76,7 +76,7 @@ IF( .NOT.cable_user%cable_runtime_coupled ) THEN
            & + (ssnow%wb(:,1) - ssnow%wbice(:,1) ) * Ccswat * Cdensity_liq &
            & + ssnow%wbice(:,1) * Ccsice * Cdensity_ice, xx ) * soil%zse(1)
    END IF
-ENDIF  ! if(.NOT.cable_runtime_coupled)
+ENDIF  ! if(.NOT.soilsnow_init_spec )
 
 IF (ktau <= 1)       THEN
   xx=heat_cap_lower_limit(:,1)
@@ -131,7 +131,7 @@ END SUBROUTINE spec_init_soil_snow
           !H!ssnow%smass(j,3) = 0.0
           !H!ssnow%ssdn(j,:) = ssnow%ssdnn(j)
 
-          IF( .NOT.cable_user%CABLE_RUNTIME_COUPLED ) THEN
+          IF( (cable_user%soilsnow_init_spec ) ) THEN
              IF( soil%isoilm(j) == 9 .AND. ktau_gl <= 2 )                       &
                                 ! permanent ice: fixed hard-wired number in next version
                   ssnow%ssdnn(j) = 700.0
@@ -144,7 +144,7 @@ END SUBROUTINE spec_init_soil_snow
              !H!ssnow%tggsn(j,:) = MIN( CTFRZ, ssnow%tgg(j,1) )
              !H!ssnow%ssdn(j,2) = ssnow%ssdn(j,1)
              !H!ssnow%ssdn(j,3) = ssnow%ssdn(j,1)
-             IF( .NOT. cable_user%cable_runtime_coupled) THEN
+             IF( (cable_user%soilsnow_init_spec ) ) THEN
                 IF( soil%isoilm(j) == 9 .AND. ktau_gl <= 2 ) THEN
                    ! permanent ice: fix hard-wired number in next version
                    ssnow%ssdn(j,1)  = 450.0

--- a/src/science/soilsnow/cbl_soilsnow_main.F90
+++ b/src/science/soilsnow/cbl_soilsnow_main.F90
@@ -86,7 +86,7 @@ USE cable_phys_constants_mod,  ONLY: density_liq, density_ice
 
     ssnow%wbliq = ssnow%wb - ssnow%wbice
 
-  !%cable_runtime_coupled special initalizations in um_init NA for ESM1.5
+  ! soilsnow_init_spec, special initalizations in um_init NA for ESM1.5
 
    xx=soil%css * soil%rhosoil
    IF (ktau <= 1)                                                              &

--- a/src/util/cable_runtime_opts_mod.F90
+++ b/src/util/cable_runtime_opts_mod.F90
@@ -88,7 +88,7 @@ TYPE kbl_user_switches
        consistency_check     = .FALSE., & !
        casa_dump_read        = .FALSE., & !
        casa_dump_write       = .FALSE., & !
-       cable_runtime_coupled = .TRUE. , & !
+       soilsnow_init_spec    = .FALSE., & !
        LogWorker             = .TRUE. , & ! Write Output of each worker
                              ! L.Stevens - Test Switches
        l_new_roughness_soil  = .FALSE., & !


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

The history of this switch was that in ACCESS1.3, when we first introduced 17 tiles, and tiled soils, manipulation of fields files was way harder than what it is now. Plus, we didn't have a similar field to use as a base. We began with files of constant temperature, moisture etc. Progressively made amendments. In one iteration (lasting months perhaps), we clobbered values on snow fields in particular by calling a special initialization routine. This was more or less the first time was coupled (to the UM) - hence the naming of the flag as runtime_coupled. As time went on we occasionally used it in other scenarios. The meaning of the flag and its declaration initialization got mixed up until eventually it was determined that while the flag was TRUE, the conditions should be IF .NOT. . It is all very convoluted evolution to basically set a switch that triggers a special (albeit basic) initialization of soilnow fields in the instance where the initializations through a restart (etc) cannot be trusted.

It make way more sense to rename the switch, declare it as FALSE, and update the conditionals rather than than have this crazy double negative situation.

Fixes #536 

## Type of change

CLARIFICATION

## Checklist

- [x] The new content is accessible and located in the appropriate section
- [x] I have checked my code/text and corrected any misspellings

## Testing

- [x] Are the changes bitwise-compatible with the main branch? If working on an optional feature, are the results bitwise-compatible when this feature is off? If yes, copy benchcab output showing successful completion of the bitwise compatibility tests or equivalent results below this line.

<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--634.org.readthedocs.build/en/634/

<!-- readthedocs-preview cable end -->