### PR TITLE
rm esm15 dependence

### DIFF
--- a/src/science/casa-cnp/biogeochem_casa.F90
+++ b/src/science/casa-cnp/biogeochem_casa.F90
@@ -10,7 +10,7 @@ CONTAINS
        nleaf2met,nleaf2str,nroot2met,nroot2str,nwood2cwd,         &
        pleaf2met,pleaf2str,proot2met,proot2str,pwood2cwd)
 USE cable_def_types_mod
-USE cable_common_module, ONLY : cable_runtime, cable_user
+USE cable_common_module, ONLY : cable_user
 USE casadimension
 USE casa_cnp_module
 USE casa_inout_module, ONLY : casa_cnpflux
@@ -52,8 +52,8 @@ xKNlimiting = 1.0
 ! zero annual sums
 IF (idoy==1) CALL casa_cnpflux(casaflux,casapool,casabal,.TRUE.)
 
-IF (cable_user%PHENOLOGY_SWITCH.EQ.'MODIS' .OR. cable_runtime%esm15 ) THEN
-       CALL phenology(idoy,veg,phen)
+IF (cable_user%PHENOLOGY_SWITCH.EQ.'MODIS' ) THEN
+  CALL phenology(idoy,veg,phen)
 ENDIF
 CALL avgsoil(veg,soil,casamet)
 


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

[See UM7 issue/PR](https://github.com/ACCESS-NRI/UM7/pull/173)

To eradicate what was intended to be a temporary switch for testing, cable_runtime%esm15 we remove this solitary instance and maintain activation the call to phenology in esm1.6 by adding cable_user%phenology_switch='MODIS' to the cable.nml used in that app. As such this is no longer required in the code. Discussed in above link are remaining instances of this code where it cannot (as yet) be removed. This will be further investigated in AM3 development, 


Fixes #636

## Type of change

## Checklist

- [NA] The new content is accessible and located in the appropriate section
- [NA] I have checked that links are valid and point to the intended content
- [NA] I have checked my code/text and corrected any misspellings

## Testing

- [NA] Are the changes bitwise-compatible with the main branch? If working on an optional feature, are the results bitwise-compatible when this feature is off? If yes, copy benchcab output showing successful completion of the bitwise compatibility tests or equivalent results below this line.



<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--637.org.readthedocs.build/en/637/

<!-- readthedocs-preview cable end -->