### PR TITLE
Replace aust_temperate and aust_tropical

### DIFF
--- a/src/coupled/esm/LAI_canopy_height_cbl.F90
+++ b/src/coupled/esm/LAI_canopy_height_cbl.F90
@@ -78,8 +78,8 @@ SUBROUTINE Limit_HGT_LAI( HGT_pft_temp, LAI_pft_cbl, HGT_pft_cbl, mp, land_pts,&
 !     2. canopy height for other vegetation is limited to be greater than 0.1m
 
 USE cable_surface_types_mod, ONLY: shrub_cable, evergreen_broadleaf,           &
-                                   deciduous_broadleaf, aust_temperate,        &       
-                                   aust_tropical        
+                                   deciduous_broadleaf, aust_mesic,        &       
+                                   aust_xeric        
 
 IMPLICIT NONE
 
@@ -129,12 +129,12 @@ DO n=1,ntiles
         LAI_pft_temp(i,n) = MAX( 0.99*CLAI_thresh, LAI_pft(i,n) )
         HGT_pft_temp(i,n) = MAX( 1.0, HGT_pft(i,n) )
          
-      ELSE IF( n >= shrub_cable  .AND. n < aust_temperate ) THEN  ! shrubs/grass
+      ELSE IF( n >= shrub_cable  .AND. n < aust_mesic ) THEN  ! shrubs/grass
 
         LAI_pft_temp(i,n) = MAX( 0.99*CLAI_thresh, LAI_pft(i,n) )
         HGT_pft_temp(i,n) = MAX( 0.1, HGT_pft(i,n) ) 
 
-      ELSE IF( n == aust_temperate .OR. n == aust_tropical ) THEN  ! Aust. trees
+      ELSE IF( n == aust_mesic .OR. n == aust_xeric ) THEN  ! Aust. trees
 
         LAI_pft_temp(i,n) = MAX( CLAI_thresh, LAI_pft(i,n) ) 
         HGT_pft_temp(i,n) = MAX( 1.0, HGT_pft(i,n) ) 


### PR DESCRIPTION
# CABLE

## Description

Looks like one file was missed from the previous ESM1.6/CABLE merge, `src/coupled/esm/LAI_canopy_height_cbl.F90`. Replaced `aust_temperate` with `aust_mesic` and `aust_tropical` with `aust_xeric`.

Fixes #(638)

## Type of change

- [x] Bug fix

<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--639.org.readthedocs.build/en/639/

<!-- readthedocs-preview cable end -->