### PR TITLE
Fix NN search

### DIFF
--- a/src/offline/cable_parameters.F90
+++ b/src/offline/cable_parameters.F90
@@ -957,7 +957,13 @@ CONTAINS
     ! and longitude(:) has already been converted to -180 to 180 for CABLE.
     landpt(:)%ilon = -999
     landpt(:)%ilat = -999
+
+    ! This search is not a nearest neighbour in the true sense, due to the latitude dependence on
+    ! arc length. It is only a nearest neighbour in the latitute/longitude coordinate space.
     DO kk = 1, mland
+       ! This is the maximum distance in degrees^2 for a gridinfo point to be considered valid for
+       ! the nearest neighbour search. If no valid neighbours are found within this 12 degree radius,
+       ! consider the search failed and crash out.
        distance = 144.0 ! initialise, units are degrees^2
        DO jj = 1, nlat
           DO ii = 1, nlon
@@ -1028,7 +1034,13 @@ CONTAINS
     landpt(:)%ilon = -999
     landpt(:)%ilat = -999
     ncount = 0
+
+    ! This search is not a nearest neighbour in the true sense, due to the latitude dependence on
+    ! arc length. It is only a nearest neighbour in the latitute/longitude coordinate space.
     DO kk = 1, mland
+       ! This is the maximum distance in degrees^2 for a gridinfo point to be considered valid for
+       ! the nearest neighbour search. If no valid neighbours are found within this 12 degree radius,
+       ! consider the search failed and crash out.
        distance = 144.0 ! initialise, units are degrees^2
        DO jj = 1, nlat
           DO ii = 1, nlon


### PR DESCRIPTION
# CABLE

## Description

The nearest neighbour searches in `src/offline/cable_parameters.F90` were wrong around the antimeridian- did not account for the wrap around at -180/180. The use of SQRT in computing the distance was also unnecessary, assuming you also set your upper bound for the distance appropriately. There are two instances of this search, [here](https://github.com/CABLE-LSM/CABLE/blob/a78e3a46c88dad3f098d6c082d11af3841621543/src/offline/cable_parameters.F90#L961-L984) and [here](https://github.com/CABLE-LSM/CABLE/blob/a78e3a46c88dad3f098d6c082d11af3841621543/src/offline/cable_parameters.F90#L1029-L1095). The first instance sets a maximum distance in degrees to be 5300 (?!), while the second 300. Neither of these make sense as maximum distances. `CABLE_POP_TRENDY` sets a maximum of distance of 12 degrees before the search fails, which seems more reasonable (although happy to adjust this value).

Fixes #643 

## Type of change

- [x] Bug fix

## Checklist

- [x] The new content is accessible and located in the appropriate section
- [x] I have checked that links are valid and point to the intended content
- [x] I have checked my code/text and corrected any misspellings

## Testing

- [x] Are the changes bitwise-compatible with the main branch? If working on an optional feature, are the results bitwise-compatible when this feature is off? If yes, copy benchcab output showing successful completion of the bitwise compatibility tests or equivalent results below this line.

```
2025-11-17 10:19:57,695 - INFO - benchcab.benchcab.py:391 - 0 failed, 168 passed
```

<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--644.org.readthedocs.build/en/644/

<!-- readthedocs-preview cable end -->