### PR TITLE
Change library name to access-esm1.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,7 @@ if(CABLE_LIBRARY)
         src/util/masks_cbl.F90
     )
 
-    if(CABLE_LIBRARY_TARGET STREQUAL "ESM1.6")
+    if(CABLE_LIBRARY_TARGET STREQUAL "access-esm1.6")
         list(APPEND SOURCES
             src/coupled/esm/cable_iovars.F90
             src/coupled/esm/cable_surface_types.F90


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

Update name specification of library to "access-esm1.6" as per [this spack-packages PR](https://github.com/ACCESS-NRI/spack-packages/pull/340), for consistency with other models.


<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--646.org.readthedocs.build/en/646/

<!-- readthedocs-preview cable end -->