### PR TITLE
`build-ci`: Pin `spack-config-ref` to fix breaking `spack-config` change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
     uses: access-nri/build-ci/.github/workflows/ci-github-hosted.yml@v2
     with:
       spack-manifest-path: ${{ matrix.spack-manifest-path }}
+      spack-config-ref: 2025.11.000  # Before build-ci@v2-breaking change to spack-config, don't go any further forward!
       spack-packages-ref: api-v2  # This branch contains the package defs compatible with spack >=1.0. May be incorporated into the main branch
       spack-ref: releases/v1.0
       allow-ssh-into-spack-install: false


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

We are updating our `build-ci` infrastructure so it will be able to support `spack >= v1.0` more fully. There is an incoming change (see https://github.com/ACCESS-NRI/spack-config/pull/82) to `spack-config` to forward this goal, that will no longer work with `build-ci@v2`. There is a new version of `build-ci@v3` (see https://github.com/ACCESS-NRI/build-ci/pull/253) that will work with this new version of `spack-config`, but it is not yet ready for merging. 

This interim fix for `build-ci@v2` will work while `build-ci@v3` is being tested, so there is no downtime between versions, by pinning the version of `spack-config` to a tag before the breaking change. 

> [!NOTE]
> Open pull requests will need to be rebased to get this fix, or a similar pinning of `spack-config-ref` in the PR added

## Type of change

- [x] Bug fix


<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--653.org.readthedocs.build/en/653/

<!-- readthedocs-preview cable end -->