### PR TITLE
`build-ci v3`: Update Infra For `spack v1`

### DIFF
--- a/.github/build-ci/compilers/spack.yaml
+++ b/.github/build-ci/compilers/spack.yaml
@@ -1,0 +1,7 @@
+spack:
+  specs:
+  - gcc@13.2.0 %gcc@8.5.0
+  - intel-oneapi-compilers-classic@2021.10.0
+  view: false
+  concretizer:
+    unify: false

--- a/.github/build-ci/manifests/gcc.spack.yaml.j2
+++ b/.github/build-ci/manifests/gcc.spack.yaml.j2
@@ -2,9 +2,12 @@ spack:
   specs:
   - cable@git.{{ ref }}
   packages:
+    gcc:
+      require:
+      - '@13.2.0'
     all:
       require:
-      - '%gcc@13.2.0'
+      - '%access_gcc'
       - target=x86_64
   concretizer:
     unify: false

--- a/.github/build-ci/manifests/gcc.spack.yaml.j2
+++ b/.github/build-ci/manifests/gcc.spack.yaml.j2
@@ -7,7 +7,7 @@ spack:
       - '@13.2.0'
     all:
       require:
-      - '%access_gcc'
+      - '%access_gcc'  # https://github.com/ACCESS-NRI/spack-config/blob/main/v1.1/toolchains.yaml
       - target=x86_64
   concretizer:
     unify: false

--- a/.github/build-ci/manifests/intel.spack.yaml.j2
+++ b/.github/build-ci/manifests/intel.spack.yaml.j2
@@ -2,6 +2,9 @@ spack:
   specs:
   - cable@git.{{ ref }}
   packages:
+    python:
+      require:
+        - '@3.11.14'
     intel-oneapi-compilers-classic:
       require:
       - '@2021.10.0'

--- a/.github/build-ci/manifests/intel.spack.yaml.j2
+++ b/.github/build-ci/manifests/intel.spack.yaml.j2
@@ -2,9 +2,12 @@ spack:
   specs:
   - cable@git.{{ ref }}
   packages:
+    intel-oneapi-compilers-classic:
+      require:
+      - '@2021.10.0'
     all:
       require:
-      - '%intel@2021.10.0'
+      - '%access_intel'
       - target=x86_64
   concretizer:
     unify: false

--- a/.github/build-ci/manifests/intel.spack.yaml.j2
+++ b/.github/build-ci/manifests/intel.spack.yaml.j2
@@ -10,7 +10,7 @@ spack:
       - '@2021.10.0'
     all:
       require:
-      - '%access_intel'
+      - '%access_intel'  # https://github.com/ACCESS-NRI/spack-config/blob/main/v1.1/toolchains.yaml
       - target=x86_64
   concretizer:
     unify: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,15 +12,17 @@ jobs:
         spack-manifest-path:
           - .github/build-ci/manifests/gcc.spack.yaml.j2
           - .github/build-ci/manifests/intel.spack.yaml.j2
-    uses: access-nri/build-ci/.github/workflows/ci-github-hosted.yml@v3
+    uses: access-nri/build-ci/.github/workflows/ci.yml@v3
     with:
       spack-manifest-path: ${{ matrix.spack-manifest-path }}
       # spack-config-ref: main
-      # builtin-spack-packages-ref: main
+      # builtin-spack-packages-ref: develop
       # access-spack-packages-ref: api-v2
-      # spack-ref: releases/v1.0
+      # spack-ref: releases/v1.1
       allow-ssh-into-spack-install: false
-      container-image-version: :rocky-v1.0-2025.11.001  # https://github.com/ACCESS-NRI/build-ci/pkgs/container/build-ci-upstream/572613242?tag=rocky-v1.0-2025.11.001
       spack-oci-buildcache-url: oci://ghcr.io/CABLE-LSM/build-ci-buildcache  # https://github.com/CABLE-LSM/CABLE/pkgs/container/build-ci-buildcache
+      # container-image-version: :rocky  # https://github.com/ACCESS-NRI/build-ci/pkgs/container/build-ci-upstream/572613242?tag=rocky
+      # Since CABLE-LSM can't access ACCESS-NRI's self-hosted runners, we use a GitHub-hosted version
+      run-self-hosted: false
     permissions:
       packages: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,15 @@ jobs:
         spack-manifest-path:
           - .github/build-ci/manifests/gcc.spack.yaml.j2
           - .github/build-ci/manifests/intel.spack.yaml.j2
-    uses: access-nri/build-ci/.github/workflows/ci-github-hosted.yml@v2
+    uses: access-nri/build-ci/.github/workflows/ci-github-hosted.yml@v3
     with:
       spack-manifest-path: ${{ matrix.spack-manifest-path }}
-      spack-config-ref: 2025.11.000  # Before build-ci@v2-breaking change to spack-config, don't go any further forward!
-      spack-packages-ref: api-v2  # This branch contains the package defs compatible with spack >=1.0. May be incorporated into the main branch
-      spack-ref: releases/v1.0
+      # spack-config-ref: main
+      # builtin-spack-packages-ref: main
+      # access-spack-packages-ref: api-v2
+      # spack-ref: releases/v1.0
       allow-ssh-into-spack-install: false
-      container-image-version: :rocky-v1.0-2025.09.000  # https://github.com/ACCESS-NRI/build-ci/pkgs/container/build-ci-upstream/501398004?tag=rocky-v1.0-2025.09.000
+      container-image-version: :rocky-v1.0-2025.11.001  # https://github.com/ACCESS-NRI/build-ci/pkgs/container/build-ci-upstream/572613242?tag=rocky-v1.0-2025.11.001
       spack-oci-buildcache-url: oci://ghcr.io/CABLE-LSM/build-ci-buildcache  # https://github.com/CABLE-LSM/CABLE/pkgs/container/build-ci-buildcache
     permissions:
       packages: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,10 @@ jobs:
           - .github/build-ci/manifests/intel.spack.yaml.j2
     uses: access-nri/build-ci/.github/workflows/ci.yml@v3
     with:
+      # For defaults for args not specified here (eg. spack/packages/config refs), see https://github.com/ACCESS-NRI/build-ci/blob/v3/.github/workflows/README.md
       spack-manifest-path: ${{ matrix.spack-manifest-path }}
-      # spack-config-ref: main
-      # builtin-spack-packages-ref: develop
-      # access-spack-packages-ref: api-v2
-      # spack-ref: releases/v1.1
       allow-ssh-into-spack-install: false
       spack-oci-buildcache-url: oci://ghcr.io/CABLE-LSM/build-ci-buildcache  # https://github.com/CABLE-LSM/CABLE/pkgs/container/build-ci-buildcache
-      # container-image-version: :rocky  # https://github.com/ACCESS-NRI/build-ci/pkgs/container/build-ci-upstream/572613242?tag=rocky
       # Since CABLE-LSM can't access ACCESS-NRI's self-hosted runners, we use a GitHub-hosted version
       run-self-hosted: false
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         spack-manifest-path:
           - .github/build-ci/manifests/gcc.spack.yaml.j2
           - .github/build-ci/manifests/intel.spack.yaml.j2
-    uses: access-nri/build-ci/.github/workflows/ci.yml@268-github-hosted-pull-fix
+    uses: access-nri/build-ci/.github/workflows/ci.yml@v3
     with:
       # For defaults for args not specified here (eg. spack/packages/config refs), see https://github.com/ACCESS-NRI/build-ci/blob/v3/.github/workflows/README.md
       spack-manifest-path: ${{ matrix.spack-manifest-path }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,14 @@ jobs:
         spack-manifest-path:
           - .github/build-ci/manifests/gcc.spack.yaml.j2
           - .github/build-ci/manifests/intel.spack.yaml.j2
-    uses: access-nri/build-ci/.github/workflows/ci.yml@v3
+    uses: access-nri/build-ci/.github/workflows/ci.yml@268-github-hosted-pull-fix
     with:
       # For defaults for args not specified here (eg. spack/packages/config refs), see https://github.com/ACCESS-NRI/build-ci/blob/v3/.github/workflows/README.md
       spack-manifest-path: ${{ matrix.spack-manifest-path }}
+      # We need to install the compilers manually here because the upstream image is too large to run on GitHub-hosted runners
+      spack-compiler-manifest-path: .github/build-ci/compilers/spack.yaml
       allow-ssh-into-spack-install: false
-      spack-oci-buildcache-url: oci://ghcr.io/CABLE-LSM/build-ci-buildcache  # https://github.com/CABLE-LSM/CABLE/pkgs/container/build-ci-buildcache
+      spack-oci-buildcache-url: oci://ghcr.io/CABLE-LSM/build-ci-buildcache  # https://github.com/orgs/CABLE-LSM/packages/container/package/build-ci-buildcache
       # Since CABLE-LSM can't access ACCESS-NRI's self-hosted runners, we use a GitHub-hosted version
       run-self-hosted: false
     permissions:


### PR DESCRIPTION
References issue ACCESS-NRI/build-ci#231 and PR ACCESS-NRI/build-ci#253
References project https://github.com/orgs/ACCESS-NRI/projects/37

> [!IMPORTANT]
> This PR is a major update to the infrastructure. See below for the prerequisites for this repository to be able to merge this PR.

> [!IMPORTANT]
> This major version change marks the end of major infrastructure updates for CI using `spack < 1.0`. They will still get bug fixes and non-breaking features if required.
> If you want to deploy to instances of `spack < 1.0`, you must use `build-ci v2`.
> If you want to deploy to instances of `spack >= 1.0`, you must use `build-ci v3`.

## Background

We are looking to transition `build-ci` to `v3`! This is due to a migration to `spack v1.X`, from `v0.X`, which offers many bug fixes, features, and optimisations.

One of these changes is the splitting of spacks core codebase from the builtin spack-packages repository, which means that we have another lever to tweak for our builds: the version of `spack`, `spack-config`, our `spack-packages` and the (new!) builtin `spack-packages`.

Since we want to leave open the possibility of forking the builtin `spack-packages`, we have also decided to rename `ACCESS-NRI/spack-packages` to `ACCESS-NRI/access-spack-packages`. See ACCESS-NRI/access-spack-packages#295 for more info.

Therefore this is a major version update, as there are the following changes to the inputs (and analogous changes to the workflow outputs):

* Deleted the optional `spack-packages-ref` input, which defaulted to `main` (in future, `api-v1`).
* Added the optional `access-spack-packages-ref` input, which defaults to the `api-v2` branch.
* Added the optional `builtin-spack-packages-ref` input, which defaults to the `main` branch.

This means that:

* If you want to use `container-image-version: :rocky-0.22-*`, or `spack-ref` < `releases/1.0`, you must stay on `v2` due to the input changes.
* If you want to use `container-image-version: :rocky-1.*-*`, or `spack-ref` >= `releases/1.0`, you must migrate to `v3` due to the input changes.

It is possible to test across these versions of `spack` if required, via a mix of workflow versions. Ask @CodeGat if you need this functionality.

## Features

The main new features include:

* **Proper Spack v1 Support**: Users now can tweak both the builtin `spack-packages` repository, as well as our own `access-spack-packages` repository. All of the bugfixes, features and optimisations added since `0.22` are available to us for future inclusion into `build-ci`.
* **GitHub Hosted via `ci.yml`**: A special extra feature for `CABLE-LSM`! We can now combine the self- and GitHub-hosted versions of the workflow into one file, so now one just needs to do `inputs.run-self-hosted:false`!

## Prerequisites for Merging

- [x] Update `build-ci` entrypoints to `v3` (this PR!)
- [x] Determine if a specific `builtin-spack-packages-ref` is required
- [x] Determine if the added `access-spack-packages-ref` is appropriate
- [x] Validate if maintainers want to move to `spack v1` over `spack v0.22`


<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--654.org.readthedocs.build/en/654/

<!-- readthedocs-preview cable end -->