### PR TITLE
Merge phenvariable module into casavariable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ if(CABLE_LIBRARY)
         src/science/casa-cnp/casa_feedback.F90
         src/science/casa-cnp/casa_inout.F90
         src/science/casa-cnp/casa_param.F90
-        src/science/casa-cnp/casa_phenology.F90
+        #src/science/casa-cnp/casa_phenology.F90
         src/science/casa-cnp/casa_readbiome.F90
         src/science/casa-cnp/casa_rplant.F90
         src/science/casa-cnp/casa_sumcflux.F90
@@ -186,7 +186,7 @@ else()
         src/science/casa-cnp/casa_feedback.F90
         src/science/casa-cnp/casa_inout.F90
         src/science/casa-cnp/casa_param.F90
-        src/science/casa-cnp/casa_phenology.F90
+        #src/science/casa-cnp/casa_phenology.F90
         src/science/casa-cnp/casa_readbiome.F90
         src/science/casa-cnp/casa_rplant.F90
         src/science/casa-cnp/casa_sumcflux.F90

--- a/src/offline/CASAONLY_LUC.F90
+++ b/src/offline/CASAONLY_LUC.F90
@@ -11,7 +11,6 @@ SUBROUTINE CASAONLY_LUC( dels,kstart,kend,veg,soil,casabiome,casapool, &
   USE casadimension
   USE casaparm
   USE casavariable
-  USE phenvariable
   USE POP_Types,  ONLY: POP_TYPE
   USE POPMODULE,            ONLY: POPStep, POP_init_single
   USE TypeDef,              ONLY: i4b, dp

--- a/src/offline/cable_input.F90
+++ b/src/offline/cable_input.F90
@@ -26,7 +26,6 @@
 !               netcdf
 !               casadimension
 !               casavariable
-!               phenvariable
 !               cable_param_module
 !               cable_checks_module
 !               cable_radiation_module
@@ -42,7 +41,6 @@ MODULE cable_input_module
   USE casadimension,     ONLY: icycle
   USE casavariable
   USE casaparm, ONLY: forest, shrub
-  USE phenvariable
   ! vh_js !
   USE POP_Types,               ONLY: POP_TYPE
   USE POPLUC_Types,               ONLY: POPLUC_TYPE

--- a/src/offline/cable_mpimaster.F90
+++ b/src/offline/cable_mpimaster.F90
@@ -7405,6 +7405,7 @@ CONTAINS
 
     USE mpi
 
+    use casadimension, only: mphase
     USE casavariable, ONLY: casa_met, casa_flux, phen_variable
     USE cable_def_types_mod, ONLY: climate_type
     IMPLICIT NONE

--- a/src/offline/cable_mpimaster.F90
+++ b/src/offline/cable_mpimaster.F90
@@ -31,7 +31,6 @@
 !                 cable_cbm_module
 !                 casadimension
 !                 casavariable
-!                 phenvariable
 !                 casa_cable
 !                 casa_inout_module
 !
@@ -199,8 +198,7 @@ CONTAINS
     ! modules related to CASA-CNP
     USE casadimension,        ONLY: icycle,mplant,mlitter,msoil,mwood
     USE casavariable,         ONLY: casafile, casa_biome, casa_pool, casa_flux,  &
-         casa_met, casa_balance, zero_sum_casa, update_sum_casa
-    USE phenvariable,         ONLY: phen_variable
+         casa_met, casa_balance, zero_sum_casa, update_sum_casa, phen_variable
     USE casa_cable
     USE casa_inout_module
 
@@ -3272,7 +3270,6 @@ CONTAINS
     USE cable_def_types_mod
 
     USE casavariable
-    USE phenvariable
 
     IMPLICIT NONE
 
@@ -6065,7 +6062,6 @@ CONTAINS
     USE cable_def_types_mod
     USE casadimension
     USE casavariable
-    USE phenvariable
 
     IMPLICIT NONE
 
@@ -7409,9 +7405,8 @@ CONTAINS
 
     USE mpi
 
-    USE casavariable, ONLY: casa_met, casa_flux
+    USE casavariable, ONLY: casa_met, casa_flux, phen_variable
     USE cable_def_types_mod, ONLY: climate_type
-    USE phenvariable
     IMPLICIT NONE
 
     INTEGER,INTENT(IN) :: comm
@@ -8049,7 +8044,6 @@ CONTAINS
     USE casadimension
     USE casaparm
     USE casavariable
-    USE phenvariable
     USE POP_Types,  ONLY: POP_TYPE
     USE POPMODULE,            ONLY: POPStep
     USE TypeDef,              ONLY: i4b, dp
@@ -8203,7 +8197,6 @@ CONTAINS
     USE casadimension
     USE casaparm
     USE casavariable
-    USE phenvariable
     USE POP_Types,  ONLY: POP_TYPE
     USE POPMODULE,            ONLY: POPStep, POP_init_single
     USE TypeDef,              ONLY: i4b, dp

--- a/src/offline/cable_mpiworker.F90
+++ b/src/offline/cable_mpiworker.F90
@@ -32,7 +32,6 @@
 !                 cable_cbm_module
 !                 casadimension
 !                 casavariable
-!                 phenvariable
 !                 casa_cable
 !                 casa_inout_module
 !
@@ -149,8 +148,7 @@ CONTAINS
     ! modules related to CASA-CNP
     USE casadimension,        ONLY: icycle
     USE casavariable,         ONLY: casafile, casa_biome, casa_pool, casa_flux,  &
-         casa_met, casa_balance
-    USE phenvariable,         ONLY: phen_variable
+         casa_met, casa_balance, phen_variable
 
     !CLN added
     ! modules related to POP
@@ -2401,7 +2399,6 @@ CONTAINS
     USE cable_def_types_mod
 
     USE casavariable
-    USE phenvariable
 
     IMPLICIT NONE
 
@@ -5560,7 +5557,6 @@ CONTAINS
     USE casavariable
     !  gol124: commented out because casa_poolout in this version
     !  is no longer writing phen%phase
-    USE phenvariable
 
     IMPLICIT NONE
 
@@ -6541,9 +6537,8 @@ CONTAINS
 
     USE mpi
 
-    USE casavariable, ONLY: casa_met, casa_flux, mplant
+    USE casavariable, ONLY: casa_met, casa_flux, mplant, phen_variable
     USE cable_def_types_mod, ONLY: climate_type
-    USE phenvariable
 
     IMPLICIT NONE
 
@@ -6948,7 +6943,6 @@ CONTAINS
     USE casadimension
     USE casaparm
     USE casavariable
-    USE phenvariable
     USE POP_Types,  ONLY: POP_TYPE
     USE POPMODULE,            ONLY: POPStep
     USE TypeDef,              ONLY: i4b, dp
@@ -7303,7 +7297,6 @@ CONTAINS
     USE casadimension
     USE casaparm
     USE casavariable
-    USE phenvariable
     USE POP_Types,  ONLY: POP_TYPE
     USE POPMODULE,            ONLY: POPStep
     USE TypeDef,              ONLY: i4b, dp

--- a/src/offline/cable_mpiworker.F90
+++ b/src/offline/cable_mpiworker.F90
@@ -6537,7 +6537,8 @@ CONTAINS
 
     USE mpi
 
-    USE casavariable, ONLY: casa_met, casa_flux, mplant, phen_variable
+    use casadimension, only: mphase, mplant
+    USE casavariable, ONLY: casa_met, casa_flux, phen_variable
     USE cable_def_types_mod, ONLY: climate_type
 
     IMPLICIT NONE

--- a/src/offline/cable_parameters.F90
+++ b/src/offline/cable_parameters.F90
@@ -35,7 +35,6 @@
 !                casadimension
 !                casaparm
 !                cable_IO_vars_module
-!                phenvariable
 !                physical_constants
 !                netcdf
 
@@ -56,7 +55,6 @@ MODULE cable_param_module
   USE cable_def_types_mod
   USE casadimension, ONLY: icycle
   USE casavariable
-  USE phenvariable
   USE cable_abort_module
   USE cable_IO_vars_module
   USE cable_common_module, ONLY: cable_user, gw_params

--- a/src/offline/cable_serial.F90
+++ b/src/offline/cable_serial.F90
@@ -119,9 +119,7 @@ USE cable_phys_constants_mod, ONLY : CSBOLTZ => SBOLTZ
   ! modules related to CASA-CNP
   USE casadimension,        ONLY: icycle
   USE casavariable,         ONLY: casafile, casa_biome, casa_pool, casa_flux,  &
-                                !mpidiff
-       casa_met, casa_balance, zero_sum_casa, update_sum_casa
-  USE phenvariable,         ONLY: phen_variable
+       casa_met, casa_balance, zero_sum_casa, update_sum_casa, phen_variable
 
   ! vh_js !
   ! modules related to POP

--- a/src/offline/casa_cable.F90
+++ b/src/offline/casa_cable.F90
@@ -34,7 +34,6 @@ SUBROUTINE POPdriver(casaflux,casabal,veg, POP)
   USE casadimension
   USE casaparm
   USE casavariable
-  USE phenvariable
   USE cable_common_module,  ONLY: CurYear, CABLE_USER
   USE TypeDef,              ONLY: i4b, dp
   USE POPMODULE,            ONLY: POPStep
@@ -92,7 +91,6 @@ SUBROUTINE read_casa_dump(  ncfile, casamet, casaflux,phen, climate, ncall, kend
       USE cable_def_types_mod,   ONLY : r_2,ms,mp, climate_type
       USE casadimension,         ONLY : mplant,mdyear
       USE casavariable,          ONLY : casa_met, casa_flux
-      USE phenvariable
       USE cable_common_module,  ONLY:  CABLE_USER
       USE casa_ncdf_module,     ONLY : get_var_ncr2, &
                                         get_var_ncr3, stderr_nc
@@ -261,9 +259,8 @@ SUBROUTINE write_casa_dump( ncfile, casamet, casaflux, phen, climate, n_call, ke
   USE casa_ncdf_module,     ONLY : def_dims, def_vars, def_var_atts, &
        put_var_ncr1, put_var_ncr2,       &
        put_var_ncr3, stderr_nc
-  USE casavariable,          ONLY : CASA_MET, CASA_FLUX
+  USE casavariable,          ONLY : CASA_MET, CASA_FLUX, phen_variable
   USE casadimension,         ONLY : mplant
-  USE phenvariable
   USE cable_common_module,  ONLY:  CABLE_USER
 
   IMPLICIT NONE
@@ -640,7 +637,6 @@ END SUBROUTINE sumcflux
   USE casadimension
   USE casaparm
   USE casavariable
-  USE phenvariable
   IMPLICIT NONE
   INTEGER, INTENT(IN)    :: kend
   TYPE (veg_parameter_type),    INTENT(INOUT) :: veg  ! vegetation parameters

--- a/src/offline/casa_cable.F90
+++ b/src/offline/casa_cable.F90
@@ -90,7 +90,7 @@ SUBROUTINE read_casa_dump(  ncfile, casamet, casaflux,phen, climate, ncall, kend
       USE netcdf
       USE cable_def_types_mod,   ONLY : r_2,ms,mp, climate_type
       USE casadimension,         ONLY : mplant,mdyear
-      USE casavariable,          ONLY : casa_met, casa_flux
+      USE casavariable,          ONLY : casa_met, casa_flux, phen_variable
       USE cable_common_module,  ONLY:  CABLE_USER
       USE casa_ncdf_module,     ONLY : get_var_ncr2, &
                                         get_var_ncr3, stderr_nc

--- a/src/offline/spincasacnp.F90
+++ b/src/offline/spincasacnp.F90
@@ -10,7 +10,6 @@ SUBROUTINE spincasacnp( dels,kstart,kend,mloop,veg,soil,casabiome,casapool, &
   USE casa_cable !jhan:also put this in mod
   USE casa_inout_module
   USE casavariable
-  USE phenvariable
   USE POP_Types,  ONLY: POP_TYPE
   USE POPMODULE,            ONLY: POPStep
   USE TypeDef,              ONLY: i4b, dp

--- a/src/science/casa-cnp/bgcdriver.F90
+++ b/src/science/casa-cnp/bgcdriver.F90
@@ -14,7 +14,6 @@ SUBROUTINE bgcdriver(ktau,kstart,kend,dels,met,ssnow,canopy,veg,soil, &
    USE casadimension
    USE casaparm
    USE casavariable
-   USE phenvariable
    USE cable_common_module,  ONLY: CurYear, CABLE_USER
    USE TypeDef,              ONLY: i4b, dp
 #  ifndef UM_CBL

--- a/src/science/casa-cnp/casa_cnp.F90
+++ b/src/science/casa-cnp/casa_cnp.F90
@@ -54,7 +54,6 @@ MODULE casa_cnp_module
   USE casadimension
   USE casaparm
   USE casavariable
-  USE phenvariable
   USE cable_common_module, ONLY: cable_user,l_landuse ! Custom soil respiration: Ticket #42
   USE landuse_constant
   IMPLICIT NONE

--- a/src/science/casa-cnp/casa_inout.F90
+++ b/src/science/casa-cnp/casa_inout.F90
@@ -44,7 +44,6 @@ CONTAINS
     USE casadimension
     USE casaparm
     USE casavariable
-    USE phenvariable
     IMPLICIT NONE
     !  INTEGER,              INTENT(IN)    :: mvt
     TYPE (veg_parameter_type), INTENT(IN)    :: veg  ! vegetation parameters
@@ -131,7 +130,6 @@ CONTAINS
     USE casadimension
     USE casaparm
     USE casavariable
-    USE phenvariable
     ! for first time reading file *_1220.csv  (BP may2010)
     USE cable_def_types_mod
     USE cable_io_vars_module, ONLY: landpt, patch
@@ -447,7 +445,6 @@ USE casa_offline_inout_module, ONLY : READ_CASA_RESTART_NC
     USE casadimension
     USE casaparm
     USE casavariable
-    USE phenvariable
     USE cable_common_module, ONLY: cable_user
     IMPLICIT NONE
     INTEGER,               INTENT(IN)    :: ktau
@@ -608,7 +605,6 @@ USE casa_offline_inout_module, ONLY : READ_CASA_RESTART_NC
     USE casadimension
     USE casaparm
     USE casavariable
-    USE phenvariable
     !  USE casaDeclare
     IMPLICIT NONE
     TYPE (veg_parameter_type),  INTENT(INOUT) :: veg  ! vegetation parameters

--- a/src/science/casa-cnp/casa_readbiome.F90
+++ b/src/science/casa-cnp/casa_readbiome.F90
@@ -41,7 +41,6 @@ USE casavariable, ONLY :  casa_pool
 USE casavariable, ONLY :  casa_flux
 USE casavariable, ONLY :  casa_met
    
-    USE phenvariable
     !! vh_js !!
     USE cable_common_module, ONLY: cable_user
     IMPLICIT NONE

--- a/src/science/casa-cnp/casa_readbiome.F90
+++ b/src/science/casa-cnp/casa_readbiome.F90
@@ -35,12 +35,8 @@ CONTAINS
     USE cable_def_types_mod
     USE casadimension
     USE casaparm
-USE casavariable, ONLY : casafile
-USE casavariable, ONLY :  casa_biome
-USE casavariable, ONLY :  casa_pool
-USE casavariable, ONLY :  casa_flux
-USE casavariable, ONLY :  casa_met
-   
+    USE casavariable, ONLY : casafile, casa_biome, casa_pool, casa_flux,&
+                             casa_met, phen_variable
     !! vh_js !!
     USE cable_common_module, ONLY: cable_user
     IMPLICIT NONE

--- a/src/science/casa-cnp/casa_rplant.F90
+++ b/src/science/casa-cnp/casa_rplant.F90
@@ -42,7 +42,6 @@ MODULE casa_rplant_module
   USE casadimension
   USE casaparm
   USE casavariable
-  USE phenvariable
   USE cable_common_module, ONLY: cable_user,l_landuse ! Custom soil respiration: Ticket #42
 #ifndef UM_CBL
   USE landuse_constant

--- a/src/science/casa-cnp/casa_variable.F90
+++ b/src/science/casa-cnp/casa_variable.F90
@@ -264,13 +264,19 @@ MODULE casavariable
      REAL(r_2), DIMENSION(:),POINTER   :: clabilelast
   END TYPE casa_balance
 
-  ! The following declarations are removed and have to be passed using
-  ! parameter list for each subroutine (BP apr2010)
-  !  TYPE (casa_biome)              :: casabiome
-  !  TYPE (casa_pool)               :: casapool
-  !  TYPE (casa_flux)               :: casaflux
-  !  TYPE (casa_met)                :: casamet
-  !  TYPE (casa_balance)            :: casabal
+  TYPE phen_variable
+     INTEGER,   DIMENSION(:),  POINTER :: phase
+     REAL(r_2), DIMENSION(:),  POINTER :: TKshed
+     INTEGER,   DIMENSION(:,:),POINTER :: doyphase
+     REAL, DIMENSION(:),  POINTER :: phen   ! fraction of max LAI
+     REAL, DIMENSION(:),  POINTER :: aphen  ! annual leaf on sum
+     INTEGER,   DIMENSION(:,:),POINTER :: phasespin
+     INTEGER,   DIMENSION(:,:),POINTER :: doyphasespin_1
+     INTEGER,   DIMENSION(:,:),POINTER :: doyphasespin_2
+     INTEGER,   DIMENSION(:,:),POINTER :: doyphasespin_3
+     INTEGER,   DIMENSION(:,:),POINTER :: doyphasespin_4
+
+  END TYPE phen_variable
 
   ! Added filename type for casaCNP (BP apr2010)
   TYPE casafiles_type
@@ -605,6 +611,27 @@ CONTAINS
          casabal%clabilelast(arraysize),         &
          SOURCE=0.0_r_2)
   END SUBROUTINE alloc_casavariable
+
+  SUBROUTINE alloc_phenvariable(phen,arraysize)
+    !* Allocate phen derived type instance.
+    ! Allocated arrays are initialised to zero.
+
+    TYPE(phen_variable), INTENT(INOUT) :: phen
+    INTEGER,             INTENT(IN   ) :: arraysize
+
+    ALLOCATE(phen%Tkshed(mvtype), source=0.0_r_2)
+    ALLOCATE(phen%phen(arraysize), phen%aphen(arraysize), source=0.0)
+    ALLOCATE(                                &
+      phen%phase(arraysize),                 &
+      phen%doyphase(arraysize,mphase),       &
+      phen%phasespin(arraysize,mdyear),      &
+      phen%doyphasespin_1(arraysize,mdyear), &
+      phen%doyphasespin_2(arraysize,mdyear), &
+      phen%doyphasespin_3(arraysize,mdyear), &
+      phen%doyphasespin_4(arraysize,mdyear), &
+      source=0                               &
+    )
+  END SUBROUTINE alloc_phenvariable
 
   SUBROUTINE alloc_sum_casavariable(  sum_casapool, sum_casaflux &
        ,arraysize)

--- a/src/science/landuse/landuse3.F90
+++ b/src/science/landuse/landuse3.F90
@@ -741,8 +741,8 @@ END MODULE landuse_variable
                                   soil_parameter_type, soil_snow_type, veg_parameter_type, &
                                   balances_type, canopy_type, bgc_pool_type, radiation_type
   USE casadimension,        ONLY: icycle,mplant,mlitter,msoil,mwood,mso
-  USE casavariable,         ONLY: casa_pool,casa_balance,casa_met,casa_biome,casa_flux
-  USE phenvariable,         ONLY: phen_variable
+  USE casavariable,         ONLY: casa_pool,casa_balance,casa_met,casa_biome,casa_flux,&
+                                  phen_variable
   USE landuse_variable
   IMPLICIT NONE
   TYPE (soil_snow_type)          :: ssnow   ! soil and snow variables

--- a/src/shared/cable_phenology.F90
+++ b/src/shared/cable_phenology.F90
@@ -42,7 +42,6 @@ CONTAINS
     USE casadimension
     USE casaparm
     USE casavariable
-    USE phenvariable
 !data
 USE cable_surface_types_mod, ONLY: evergreen_needleleaf, deciduous_needleleaf
 USE cable_surface_types_mod, ONLY: evergreen_broadleaf, deciduous_broadleaf    

--- a/src/shared/casa_offline_inout.F90
+++ b/src/shared/casa_offline_inout.F90
@@ -262,7 +262,6 @@ CONTAINS
   SUBROUTINE READ_CASA_RESTART_NC (  casamet, casapool, casaflux,phen )
 
     USE CASAVARIABLE
-    USE phenvariable
     USE CABLE_COMMON_MODULE
     USE casa_ncdf_module, ONLY: HANDLE_ERR
     USE CABLE_DEF_TYPES_MOD, ONLY: MET_TYPE, r_2, mp

--- a/src/shared/casa_offline_inout.F90
+++ b/src/shared/casa_offline_inout.F90
@@ -34,18 +34,19 @@
 MODULE casa_offline_inout_module
 
 USE casavariable, ONLY : casafile
+use casadimension, only: r_2
 
 CONTAINS
 
 #ifndef UM_BUILD
   SUBROUTINE WRITE_CASA_RESTART_NC ( casamet, casapool, casaflux, phen, CASAONLY )
 
-    USE casavariable, ONLY : casa_met, casa_pool, casa_flux, icycle, mplant, mlitter, msoil
+    USE casavariable, ONLY : casa_met, casa_pool, casa_flux, phen_variable,&
+                             icycle, mplant, mlitter, msoil
     USE cable_common_module
   USE casa_ncdf_module, ONLY: HANDLE_ERR
    
     USE cable_def_types_mod, ONLY: met_type, mp
-    USE phenvariable
     USE netcdf
 
     IMPLICIT NONE


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

Merges the `src/science/casa-cnp/casa_phenology.F90` file into `src/science/casa-cnp/casa_variable.F90`. That file already defines the rest of the CASA derived types- there's no reason for it not to define this as well. Also makes the merging with AM3 easier, as it's version of `casa_variable.F90` and the offline version will have a unified purpose.

Fixes #674 

## Type of change

- [x] Code clean up

## Testing

- [x] Are the changes bitwise-compatible with the main branch? If working on an optional feature, are the results bitwise-compatible when this feature is off? If yes, copy benchcab output showing successful completion of the bitwise compatibility tests or equivalent results below this line.

- [ ] Are the changes non bitwise-compatible with the main branch because of a bug fix or a feature being newly implemented or improved? If yes, add the link to the modelevaluation.org analysis versus the main branch or equivalent results below this line.

Please add a reviewer when ready for review.


<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--676.org.readthedocs.build/en/676/

<!-- readthedocs-preview cable end -->