### PR TITLE
Add carbon molar mass physical constant

### DIFF
--- a/documentation/docs/user_guide/constants/physical_constants.md
+++ b/documentation/docs/user_guide/constants/physical_constants.md
@@ -20,4 +20,4 @@
 |  cswat                | 4.218E3     	   | \( J \cdot kg^{-1} \cdot K^{-1} \)		      	 |   Specific heat for water at \( 0^{\circ}C \)       |
 |  density_liq          | 1000.0      	   | \( kg \cdot m^{-3} \) 			      	 |   Density of liquid water                           |
 |  density_ice          | 921.0       	   | \( kg \cdot m^{-3} \) 			      	 |   Density of ice                                    |                
-        
+|  c_molar_mass         | 1.201E-5         | \( \mu g / mol \)                       |   Molar mass of carbon                              |

--- a/src/params/cable_phys_constants_mod.F90
+++ b/src/params/cable_phys_constants_mod.F90
@@ -42,6 +42,7 @@ REAL, PARAMETER :: csice = 2.100e3        ! specific heat for ice (J/kg/K)
 REAL, PARAMETER :: cswat = 4.218e3        ! specific heat for water at 0°C (J/kg/K)
 REAL, PARAMETER :: density_liq = 1000.0   ! density of liquid water
 REAL, PARAMETER :: density_ice = 921.0    ! density of ice                              
+REAL, PARAMETER :: c_molar_mass = 1.201e-5 ! molar mass of carbon (ug/mol)
 
 ! Teten coefficients
 REAL, PARAMETER :: tetena = 6.106         ! Magnus Tetans (Murray 1967)


### PR DESCRIPTION
This change replaces the magic number `1.201e-5` with a carbon molar mass constant (units: $\mu g / mol$) in the cable output module.

## Type of change

Please delete options that are not relevant.

- [X] New or updated documentation

## Checklist

- [x] The new content is accessible and located in the appropriate section
- [x] I have checked that links are valid and point to the intended content
- [x] I have checked my code/text and corrected any misspellings

## Testing

- [x] Are the changes bitwise-compatible with the main branch? If working on an optional feature, are the results bitwise-compatible when this feature is off? If yes, copy benchcab output showing successful completion of the bitwise compatibility tests or equivalent results below this line.

```
2026-02-23 17:04:18,445 - INFO - benchcab.benchcab.py:380 - Running comparison tasks...
2026-02-23 17:04:18,472 - INFO - benchcab.benchcab.py:381 - tasks: 168 (models: 2, sites: 42, science configurations: 4)
2026-02-23 17:07:09,718 - INFO - benchcab.benchcab.py:391 - 0 failed, 168 passed
```

<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--687.org.readthedocs.build/en/687/

<!-- readthedocs-preview cable end -->