### PR TITLE
Fix Area variable

### DIFF
--- a/src/offline/cable_iovars.F90
+++ b/src/offline/cable_iovars.F90
@@ -155,7 +155,7 @@ MODULE cable_IO_vars_module
      INTEGER :: bch,latitude,clay,css,rhosoil,hyds,rs20,sand,sfc,silt,        &
           ssat,sucs,swilt,froot,zse,canst1,dleaf,meth,za_tq,za_uv,             &
           ejmax,frac4,hc,lai,rp20,rpcoef,shelrb, vbeta, xalbnir,               &
-          vcmax,xfang,ratecp,ratecs,refsbare,isoil,iveg,albsoil,               &
+          vcmax,xfang,ratecp,ratecs,area,refsbare,isoil,iveg,albsoil,          &
           taul,refl,tauw,refw,wai,vegcf,extkn,tminvj,tmaxvj,                   &
           veg_class,soil_class,mvtype,mstype,patchfrac,                        &
           WatSat,GWWatSat,SoilMatPotSat,GWSoilMatPotSat,                       &

--- a/src/offline/cable_mpimaster.F90
+++ b/src/offline/cable_mpimaster.F90
@@ -440,7 +440,7 @@ CONTAINS
               ENDIF
             ENDIF
             CALL nullify_write() ! nullify pointers
-            CALL open_output_file( dels, soil, veg, bgc, rough, met)
+            CALL open_output_file( dels, soil, veg, bgc, rough, met, casamet)
           ENDIF
 
           ssnow%otss_0 = ssnow%tgg(:,1)
@@ -865,13 +865,10 @@ CONTAINS
               SELECT CASE (TRIM(cable_user%MetType))
               CASE ('plum', 'cru', 'gswp', 'gswp3', 'prin')
                 CALL write_output( dels, ktau_tot, met, canopy, casaflux, casapool, &
-                     casamet,ssnow,         &
-                     rad, bal, air, soil, veg, CSBOLTZ,     &
-                     CEMLEAF, CEMSOIL )
+                     ssnow, rad, bal, air, soil, veg, CSBOLTZ, CEMLEAF, CEMSOIL )
               CASE DEFAULT
                 CALL write_output( dels, ktau, met, canopy, casaflux, casapool, &
-                     casamet, ssnow,   &
-                     rad, bal, air, soil, veg, CSBOLTZ, CEMLEAF, CEMSOIL )
+                     ssnow, rad, bal, air, soil, veg, CSBOLTZ, CEMLEAF, CEMSOIL )
 
               END SELECT
             END IF
@@ -1067,10 +1064,10 @@ CONTAINS
           IF ( (.NOT. CASAONLY) .AND. spinConv ) THEN
             SELECT CASE (TRIM(cable_user%MetType))
             CASE ('plum', 'cru', 'gswp', 'gswp3')
-              CALL write_output( dels, ktau_tot, met, canopy, casaflux, casapool, casamet, &
+              CALL write_output( dels, ktau_tot, met, canopy, casaflux, casapool, &
                    ssnow, rad, bal, air, soil, veg, CSBOLTZ, CEMLEAF, CEMSOIL )
             CASE DEFAULT
-              CALL write_output( dels, ktau, met, canopy, casaflux, casapool, casamet, &
+              CALL write_output( dels, ktau, met, canopy, casaflux, casapool, &
                    ssnow, rad, bal, air, soil, veg, CSBOLTZ, CEMLEAF, CEMSOIL )
 
             END SELECT

--- a/src/offline/cable_serial.F90
+++ b/src/offline/cable_serial.F90
@@ -416,7 +416,7 @@ SUBROUTINE serialdrv(NRRRR, dels, koffset, kend, GSWP_MID, PLUME, CRU, site)
               ENDIF
             ENDIF
             CALL nullify_write() ! nullify pointers
-            CALL open_output_file( dels, soil, veg, bgc, rough, met)
+            CALL open_output_file( dels, soil, veg, bgc, rough, met, casamet)
           ENDIF
 
           ssnow%otss_0 = ssnow%tgg(:,1)
@@ -710,10 +710,10 @@ SUBROUTINE serialdrv(NRRRR, dels, koffset, kend, GSWP_MID, PLUME, CRU, site)
             !mpidiff
             SELECT CASE (TRIM(cable_user%MetType))
             CASE ('plum', 'cru', 'bios', 'gswp', 'gswp3', 'site')
-              CALL write_output( dels, ktau_tot, met, canopy, casaflux, casapool, casamet, &
+              CALL write_output( dels, ktau_tot, met, canopy, casaflux, casapool, &
                    ssnow, rad, bal, air, soil, veg, CSBOLTZ, CEMLEAF, CEMSOIL )
             CASE DEFAULT
-              CALL write_output( dels, ktau, met, canopy, casaflux, casapool, casamet, &
+              CALL write_output( dels, ktau, met, canopy, casaflux, casapool, &
                    ssnow, rad, bal, air, soil, veg, CSBOLTZ, CEMLEAF, CEMSOIL )
             END SELECT
           ENDIF


### PR DESCRIPTION
This change writes the Area variable (`casamet%areacell`) as a parameter instead of a time-varying variable, as `casamet%areacell` is only ever set on initialisation in `load_parameters`. The Area variable is also only written when CASA is enabled, however it is always defined in the output file. This change additionally fixes the definition of the Area variable such that it is only defined when CASA is enabled.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix

## Checklist

- [X] The new content is accessible and located in the appropriate section
- [X] I have checked that links are valid and point to the intended content
- [X] I have checked my code/text and corrected any misspellings

## Testing

- [x] Are the changes non bitwise-compatible with the main branch because of a bug fix or a feature being newly implemented or improved? If yes, add the link to the modelevaluation.org analysis versus the main branch or equivalent results below this line.

Benchcab comparison tests fail as the Area variable is no longer being defined as CASA-CNP is disabled. Ignoring the Area when running `nccmp` restores bitwise compatibility.

<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--689.org.readthedocs.build/en/689/

<!-- readthedocs-preview cable end -->