### PR TITLE
src/offline/cable_output.F90: Fix meth fill value

### DIFF
--- a/src/offline/cable_output.F90
+++ b/src/offline/cable_output.F90
@@ -1459,12 +1459,12 @@ CONTAINS
       CALL check_and_write(opid%iveg,    &
            'iveg', REAL(veg%iveg, 4), ranges%iveg, patchout%iveg, out_settings)
     END IF
+
+    out_settings%dimswitch = "real"
     IF (output%meth) THEN
       CALL check_and_write(opid%meth,    &
            'meth', REAL(veg%meth, 4), ranges%meth, patchout%meth, out_settings)
     END IF
-
-    out_settings%dimswitch = "real"
     IF (output%canst1) THEN
       CALL check_and_write(opid%canst1, 'canst1', REAL(veg%canst1, 4), &
            ranges%canst1, patchout%canst1, out_settings)


### PR DESCRIPTION
This change fixes the `meth` variable to use the fill value for `real` variables instead of that of integer variables.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix

## Checklist

- [x] The new content is accessible and located in the appropriate section
- [x] I have checked that links are valid and point to the intended content
- [x] I have checked my code/text and corrected any misspellings

## Testing

- [x] Are the changes bitwise-compatible with the main branch? If working on an optional feature, are the results bitwise-compatible when this feature is off? If yes, copy benchcab output showing successful completion of the bitwise compatibility tests or equivalent results below this line.

```
2026-02-25 11:39:20,813 - INFO - benchcab.benchcab.py:380 - Running comparison tasks...
2026-02-25 11:39:20,839 - INFO - benchcab.benchcab.py:381 - tasks: 168 (models: 2, sites: 42, science configurations: 4)
2026-02-25 11:42:08,176 - INFO - benchcab.benchcab.py:391 - 0 failed, 168 passed
```

Site simulations show no differences as there are no fill values present in the data. For spatial simulations where fill values are present, there are differences in outputs. Running the following:
```
nccmp -d runs/spatial/tasks/crujra_access_R*_S0/archive/output000/cable_out.nc
nccmp -d runs/spatial/tasks/crujra_access_R*_S1/archive/output000/cable_out.nc
nccmp -d runs/spatial/tasks/crujra_access_R*_S2/archive/output000/cable_out.nc
nccmp -d runs/spatial/tasks/crujra_access_R*_S3/archive/output000/cable_out.nc
```

Outputs:

```
DIFFER : VARIABLE : meth : POSITION : [0,0] : VALUES : -1e+07 <> -1e+33
DIFFER : VARIABLE : meth : POSITION : [0,0] : VALUES : -1e+07 <> -1e+33
DIFFER : VARIABLE : meth : POSITION : [0,0] : VALUES : -1e+07 <> -1e+33
DIFFER : VARIABLE : meth : POSITION : [0,0] : VALUES : -1e+07 <> -1e+33
```

Results are bitwise reproducible if we ignore the meth variable:

```
nccmp -d -x meth runs/spatial/tasks/crujra_access_R*_S0/archive/output000/cable_out.nc
nccmp -d -x meth runs/spatial/tasks/crujra_access_R*_S1/archive/output000/cable_out.nc
nccmp -d -x meth runs/spatial/tasks/crujra_access_R*_S2/archive/output000/cable_out.nc
nccmp -d -x meth runs/spatial/tasks/crujra_access_R*_S3/archive/output000/cable_out.nc
```

<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--690.org.readthedocs.build/en/690/

<!-- readthedocs-preview cable end -->