### PR TITLE
src/offline/cable_output.F90: Define GW variables only when `cable_user%GW_MODEL` is enabled

### DIFF
--- a/src/offline/cable_output.F90
+++ b/src/offline/cable_output.F90
@@ -882,27 +882,28 @@ CONTAINS
     END IF
 
     !MD groundwater related variables
-    IF(output%WatTable) THEN
-       CALL define_ovar(ncid_out, ovid%WatTable, 'WatTable', 'm',      &
-            'Water Table Depth', patchout%WatTable,     &
-            'dummy', xID, yID, zID, landID, patchID, tID)
-       ALLOCATE(out%WatTable(mp))
-       out%WatTable = 0.0 ! initialise
-    END IF
-    IF(output%GWMoist) THEN
-       CALL define_ovar(ncid_out, ovid%GWMoist, 'GWMoist', 'mm3/mm3',      &
-            'Aquifer mositure content', patchout%GWMoist,     &
-            'dummy', xID, yID, zID, landID, patchID, tID)
-       ALLOCATE(out%GWMoist(mp))
-       out%GWMoist = 0.0 ! initialise
-    END IF
-
-    IF(output%SatFrac) THEN
-       CALL define_ovar(ncid_out, ovid%SatFrac, 'SatFrac', 'unitless',      &
-            'Saturated Fraction of Gridcell', patchout%SatFrac,     &
-            'dummy', xID, yID, zID, landID, patchID, tID)
-       ALLOCATE(out%SatFrac(mp))
-       out%SatFrac = 0.0 ! initialise
+    IF (cable_user%GW_MODEL) THEN
+      IF(output%WatTable) THEN
+        CALL define_ovar(ncid_out, ovid%WatTable, 'WatTable', 'm',      &
+              'Water Table Depth', patchout%WatTable,     &
+              'dummy', xID, yID, zID, landID, patchID, tID)
+        ALLOCATE(out%WatTable(mp))
+        out%WatTable = 0.0 ! initialise
+      END IF
+      IF(output%GWMoist) THEN
+        CALL define_ovar(ncid_out, ovid%GWMoist, 'GWMoist', 'mm3/mm3',      &
+              'Aquifer mositure content', patchout%GWMoist,     &
+              'dummy', xID, yID, zID, landID, patchID, tID)
+        ALLOCATE(out%GWMoist(mp))
+        out%GWMoist = 0.0 ! initialise
+      END IF
+      IF(output%SatFrac) THEN
+        CALL define_ovar(ncid_out, ovid%SatFrac, 'SatFrac', 'unitless',      &
+              'Saturated Fraction of Gridcell', patchout%SatFrac,     &
+              'dummy', xID, yID, zID, landID, patchID, tID)
+        ALLOCATE(out%SatFrac(mp))
+        out%SatFrac = 0.0 ! initialise
+      END IF
     END IF
 
     IF(output%Qrecharge) THEN


### PR DESCRIPTION
This change defines the ground water specific variables `WatTable`, `GWMoist` and `SatFrac` when `cable_user%GW_MODEL` is enabled, rather defining them always by default.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix

## Checklist

- [x] The new content is accessible and located in the appropriate section
- [x] I have checked that links are valid and point to the intended content
- [x] I have checked my code/text and corrected any misspellings

## Testing

- [x] Are the changes non bitwise-compatible with the main branch because of a bug fix or a feature being newly implemented or improved? If yes, add the link to the modelevaluation.org analysis versus the main branch or equivalent results below this line.

Changes are non bitwise compatible as variables `WatTable`, `GWMoist` and `SatFrac` are no longer defined by default. Ignoring these variables in the comparison restores bitwise compatibility.

<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--691.org.readthedocs.build/en/691/

<!-- readthedocs-preview cable end -->