### PR TITLE
Remove duplicate namelist variables

### DIFF
--- a/src/offline/cable_driver_common.F90
+++ b/src/offline/cable_driver_common.F90
@@ -13,6 +13,10 @@ MODULE cable_driver_common_mod
     snmin,                        &
     cable_user,                   &
     gw_params,                    &
+    l_casacnp,                    &
+    l_landuse,                    &
+    l_laiFeedbk,                  &
+    l_vcmaxFeedbk,                &
     cable_runtime
   USE cable_IO_vars_module, ONLY : &
     soilparmnew,                   &
@@ -55,10 +59,6 @@ MODULE cable_driver_common_mod
   LOGICAL, SAVE, PUBLIC :: spinup        = .FALSE. ! model spinup to soil state equilibrium?
   LOGICAL, SAVE, PUBLIC :: spincasa      = .FALSE. ! TRUE: CASA-CNP Will spin mloop times, FALSE: no spin up
   LOGICAL, SAVE, PUBLIC :: CASAONLY      = .FALSE. ! ONLY Run CASA-CNP
-  LOGICAL, SAVE, PUBLIC :: l_casacnp     = .FALSE. ! using CASA-CNP with CABLE
-  LOGICAL, SAVE, PUBLIC :: l_landuse     = .FALSE. ! using CASA-CNP with CABLE
-  LOGICAL, SAVE, PUBLIC :: l_laiFeedbk   = .FALSE. ! using prognostic LAI
-  LOGICAL, SAVE, PUBLIC :: l_vcmaxFeedbk = .FALSE. ! using prognostic Vcmax
 
   REAL, SAVE, PUBLIC :: delsoilM ! allowed variation in soil moisture for spin up
   REAL, SAVE, PUBLIC :: delsoilT ! allowed variation in soil temperature for spin up

--- a/src/offline/cable_mpimaster.F90
+++ b/src/offline/cable_mpimaster.F90
@@ -80,7 +80,6 @@ MODULE cable_mpimaster
     spinup,                           &
     spincasa,                         &
     CASAONLY,                         &
-    l_landuse,                        &
     delsoilM,                         &
     delsoilT,                         &
     delgwM,                           &
@@ -179,6 +178,7 @@ CONTAINS
     USE cable_common_module,  ONLY: ktau_gl, kend_gl, knode_gl, cable_user,     &
          cable_runtime, fileName,            &
          CurYear,    &
+         l_landuse, &
          IS_LEAPYEAR, calcsoilalbedo,                &
          kwidth_gl
     USE casa_ncdf_module, ONLY: is_casa_time

--- a/src/offline/cable_mpiworker.F90
+++ b/src/offline/cable_mpiworker.F90
@@ -70,13 +70,11 @@ MODULE cable_mpiworker
     spinup,                           &
     spincasa,                         &
     CASAONLY,                         &
-    l_laiFeedbk,                      &
-    l_vcmaxFeedbk,                    &
     delsoilM,                         &
     delsoilT,                         &
     LALLOC
   USE cable_mpicommon
-  USE cable_common_module,  ONLY: cable_user
+  USE cable_common_module,  ONLY: cable_user, l_laiFeedbk, l_vcmaxFeedbk
   USE casa_inout_module
   USE casa_cable
   USE bgcdriver_mod, ONLY : bgcdriver

--- a/src/offline/cable_serial.F90
+++ b/src/offline/cable_serial.F90
@@ -66,10 +66,6 @@ MODULE cable_serial
     spinup,                           &
     spincasa,                         &
     CASAONLY,                         &
-    l_casacnp,                        &
-    l_landuse,                        &
-    l_laiFeedbk,                      &
-    l_vcmaxFeedbk,                    &
     delsoilM,                         &
     delsoilT,                         &
     delgwM,                           &
@@ -89,6 +85,9 @@ MODULE cable_serial
        filename, myhome,            &
        CurYear,    &
        IS_LEAPYEAR, &
+       l_landuse, &
+       l_laiFeedbk, &
+       l_vcmaxFeedbk, &
        kwidth_gl
 
 ! physical constants

--- a/src/util/cable_common.F90
+++ b/src/util/cable_common.F90
@@ -46,10 +46,12 @@ USE cable_runtime_opts_mod ,ONLY : snmin
   LOGICAL :: calcsoilalbedo = .FALSE.
   !---Lestevens Sept2012
   !---CASACNP switches and cycle index
-  LOGICAL, SAVE :: l_casacnp,l_laiFeedbk,l_vcmaxFeedbk
-   LOGICAL :: l_luc = .FALSE.
-   LOGICAL :: l_thinforest = .FALSE.
-   LOGICAL :: l_landuse = .FALSE.
+  LOGICAL :: l_casacnp = .FALSE.
+  LOGICAL :: l_laiFeedbk = .FALSE.
+  LOGICAL :: l_vcmaxFeedbk = .FALSE.
+  LOGICAL :: l_luc = .FALSE.
+  LOGICAL :: l_thinforest = .FALSE.
+  LOGICAL :: l_landuse = .FALSE.
 
   !---CABLE runtime switches def in this type
   TYPE kbl_internal_switches


### PR DESCRIPTION
This change removes duplicate module variables for namelist options `l_casacnp`, `l_landuse`, `l_laiFeedbk`, and `l_vcmaxFeedbk`. 

Cherry-picked from https://github.com/CABLE-LSM/CABLE/pull/655

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## Checklist

- [x] The new content is accessible and located in the appropriate section
- [x] I have checked that links are valid and point to the intended content
- [x] I have checked my code/text and corrected any misspellings

## Testing

- [x] Are the changes bitwise-compatible with the main branch? If working on an optional feature, are the results bitwise-compatible when this feature is off? If yes, copy benchcab output showing successful completion of the bitwise compatibility tests or equivalent results below this line.

```
2026-02-24 11:49:25,946 - INFO - benchcab.benchcab.py:380 - Running comparison tasks...
2026-02-24 11:49:25,982 - INFO - benchcab.benchcab.py:381 - tasks: 168 (models: 2, sites: 42, science configurations: 4)
2026-02-24 11:52:24,750 - INFO - benchcab.benchcab.py:391 - 0 failed, 168 passed
```

Spatial runs are also bitwise compatible:

```
nccmp -d runs/spatial/tasks/crujra_access_R*_S0/archive/output000/cable_out.nc
nccmp -d runs/spatial/tasks/crujra_access_R*_S1/archive/output000/cable_out.nc
nccmp -d runs/spatial/tasks/crujra_access_R*_S2/archive/output000/cable_out.nc
nccmp -d runs/spatial/tasks/crujra_access_R*_S3/archive/output000/cable_out.nc
```

<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--692.org.readthedocs.build/en/692/

<!-- readthedocs-preview cable end -->