### PR TITLE
Fix snowmelt declaration that should be illegal

### DIFF
--- a/src/science/soilsnow/cbl_snowMelt.F90
+++ b/src/science/soilsnow/cbl_snowMelt.F90
@@ -27,7 +27,7 @@ IMPLICIT NONE
 
     REAL, DIMENSION(mp,0:3) :: smelt1
 
-    ALLOCATE(ssnow(SIZE(ssnow%smelt)))
+    ALLOCATE(snowmlt(SIZE(ssnow%smelt)))
     snowmlt= 0.0
     smelt1 = 0.0
 

--- a/src/science/soilsnow/cbl_snowMelt.F90
+++ b/src/science/soilsnow/cbl_snowMelt.F90
@@ -13,7 +13,7 @@ IMPLICIT NONE
 
     REAL, INTENT(IN) :: dels   ! integration time step (s)
 
-    REAL, DIMENSION(:), INTENT(OUT) :: snowmlt ! snow melt
+    REAL, DIMENSION(:), ALLOCATABLE, INTENT(OUT) :: snowmlt ! snow melt
 
     TYPE(soil_parameter_type), INTENT(INOUT) :: soil
     TYPE(soil_snow_type), INTENT(INOUT)   :: ssnow  ! soil+snow variables

--- a/src/science/soilsnow/cbl_snowMelt.F90
+++ b/src/science/soilsnow/cbl_snowMelt.F90
@@ -1,6 +1,7 @@
 MODULE snow_melting_mod
 
 USE cbl_ssnow_data_mod
+USE cable_common_module
 
 PUBLIC  snow_melting
 
@@ -8,12 +9,11 @@ CONTAINS
 
 SUBROUTINE snow_melting (dels, snowmlt, ssnow, soil )
 
-    USE cable_common_module
 IMPLICIT NONE
 
     REAL, INTENT(IN) :: dels   ! integration time step (s)
 
-    REAL, DIMENSION(mp), INTENT(OUT) :: snowmlt ! snow melt
+    REAL, DIMENSION(:), INTENT(OUT) :: snowmlt ! snow melt
 
     TYPE(soil_parameter_type), INTENT(INOUT) :: soil
     TYPE(soil_snow_type), INTENT(INOUT)   :: ssnow  ! soil+snow variables
@@ -27,6 +27,7 @@ IMPLICIT NONE
 
     REAL, DIMENSION(mp,0:3) :: smelt1
 
+    ALLOCATE(ssnow(SIZE(ssnow%smelt)))
     snowmlt= 0.0
     smelt1 = 0.0
 

--- a/src/science/soilsnow/cbl_thermal.F90
+++ b/src/science/soilsnow/cbl_thermal.F90
@@ -28,12 +28,10 @@ IMPLICIT NONE
     TYPE(veg_parameter_type), INTENT(INOUT)  :: veg
     TYPE(met_type), INTENT(INOUT)            :: met ! all met forcing
     TYPE (balances_type), INTENT(INOUT)      :: bal
-    REAL, DIMENSION(mp)                      :: snowmlt !track snow melt 
+    REAL, DIMENSION(:), ALLOCATABLE                      :: snowmlt !track snow melt 
 !    REAL, DIMENSION(:),  INTENT(INOUT)       :: snowmlt  ! replaced by rk4417 - phase2
     INTEGER             :: k,i
 
-    snowmlt = 0.0  ! inserted by rk4417 - phase2
-    
     CALL snowcheck (dels, ssnow, soil, met )
 
     CALL snowdensity (dels, ssnow, soil)


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

The declaration of the `ssnow` dummy variable in `snow_melting` seems like it *should* be illegal, as it's using a non-parameter value to declare an explicit array shape. The sequence around this call is also somewhat non-sensical, as the dummy variable is `INTENT(OUT)`, so any information set prior to this call is meaningless.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## Checklist

- [x] The new content is accessible and located in the appropriate section
- [x] I have checked that links are valid and point to the intended content
- [x] I have checked my code/text and corrected any misspellings

## Testing

- [ ] Are the changes bitwise-compatible with the main branch? If working on an optional feature, are the results bitwise-compatible when this feature is off? If yes, copy benchcab output showing successful completion of the bitwise compatibility tests or equivalent results below this line.

- [ ] Are the changes non bitwise-compatible with the main branch because of a bug fix or a feature being newly implemented or improved? If yes, add the link to the modelevaluation.org analysis versus the main branch or equivalent results below this line.



<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--695.org.readthedocs.build/en/695/

<!-- readthedocs-preview cable end -->