### PR TITLE
Add Parallel I/O Infrastructure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,8 @@ pkg_check_modules(NETCDF REQUIRED IMPORTED_TARGET "netcdf-fortran")
 if(CABLE_TESTS)
     if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel" AND CMAKE_Fortran_COMPILER_VERSION VERSION_LESS "2024.0")
         message(WARNING "Intel Fortran 2024.0 or higher is recommended for building tests.")
-    elseif(CMAKE_Fortran_COMPILER_ID MATCHES "GNU" AND CMAKE_Fortran_COMPILER_VERSION VERSION_LESS "13.2")
-        message(WARNING "GNU Fortran 13.2 or higher is recommended for building tests.")
+    elseif(CMAKE_Fortran_COMPILER_ID MATCHES "GNU" AND CMAKE_Fortran_COMPILER_VERSION VERSION_LESS "14.1")
+        message(WARNING "GNU Fortran 14.1 or higher is recommended for building tests.")
     endif()
     enable_testing()
     option(FORTUNO_WITH_MPI "Fortuno: whether to build the MPI interface" ${CABLE_MPI})
@@ -352,8 +352,10 @@ else()
     if (CABLE_TESTS)
         add_executable(
             cable-tests
+            tests/fixtures/cable_netcdf_fixtures.F90
+            tests/utils/file_utils.F90
             tests/testapp.F90
-            tests/test_example.F90
+            tests/test_cable_netcdf.F90
         )
         if(CABLE_MPI)
             target_sources(cable-tests PRIVATE tests/utils/fortuno_interface_mpi.F90)
@@ -361,14 +363,20 @@ else()
             target_sources(cable-tests PRIVATE tests/utils/fortuno_interface_serial.F90)
         endif()
         target_link_libraries(cable-tests PRIVATE cable_common ${fortuno_libs})
+        if(NOT TARGET PIO::PIO_Fortran)
+            target_compile_definitions(cable-tests PRIVATE SKIP_PIO_TESTS)
+        endif()
         if(CABLE_MPI)
-            add_test(
-                NAME cable-tests
-                COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 1 $<TARGET_FILE:cable-tests>
+            add_test(NAME cable-tests-serial
+                COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 1 $<TARGET_FILE:cable-tests> ~parallel
             )
-            set_tests_properties(cable-tests PROPERTIES PROCESSORS 1)
+            set_tests_properties(cable-tests-serial PROPERTIES PROCESSORS 1)
+            add_test(NAME cable-tests-parallel
+                COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4 $<TARGET_FILE:cable-tests> parallel
+            )
+            set_tests_properties(cable-tests-parallel PROPERTIES PROCESSORS 4)
         else()
-            add_test(NAME cable-tests COMMAND $<TARGET_FILE:cable-tests>)
+            add_test(NAME cable-tests-serial COMMAND $<TARGET_FILE:cable-tests> ~parallel)
         endif()
     endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,10 @@ option(CABLE_TESTS "Build CABLE tests" OFF)
 # third party libs
 if(CABLE_MPI)
     find_package(MPI REQUIRED COMPONENTS Fortran)
+    find_package(PIO COMPONENTS Fortran QUIET)
+    if(TARGET PIO::PIO_Fortran)
+        message(STATUS "Found PIO_Fortran: ${PIO_DIR}")
+    endif()
 endif()
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(NETCDF REQUIRED IMPORTED_TARGET "netcdf-fortran")
@@ -302,6 +306,11 @@ else()
         src/offline/spincasacnp.F90
         src/util/cable_climate_type_mod.F90
         src/util/masks_cbl.F90
+        src/util/cable_array_utils.F90
+        src/util/netcdf/cable_netcdf.F90
+        src/util/netcdf/cable_netcdf_init.F90
+        src/util/netcdf/cable_netcdf_stub_types.F90
+        src/util/netcdf/nf90/cable_netcdf_nf90.F90
     )
 
     target_link_libraries(cable_common PRIVATE PkgConfig::NETCDF)
@@ -309,6 +318,13 @@ else()
     if(CABLE_MPI)
     target_compile_definitions(cable_common PRIVATE __MPI__)
     target_link_libraries(cable_common PRIVATE MPI::MPI_Fortran)
+    endif()
+
+    if(TARGET PIO::PIO_Fortran)
+        target_link_libraries(cable_common PRIVATE PIO::PIO_Fortran)
+        target_sources(cable_common PRIVATE src/util/netcdf/pio/cable_netcdf_pio.F90)
+    else()
+        target_sources(cable_common PRIVATE src/util/netcdf/pio/cable_netcdf_pio_stub.F90)
     endif()
 
     if(CABLE_MPI)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,6 +307,7 @@ else()
         src/util/cable_climate_type_mod.F90
         src/util/masks_cbl.F90
         src/util/cable_array_utils.F90
+        src/util/netcdf/cable_netcdf_decomp_util.F90
         src/util/netcdf/cable_netcdf.F90
         src/util/netcdf/cable_netcdf_init.F90
         src/util/netcdf/cable_netcdf_stub_types.F90

--- a/build.bash
+++ b/build.bash
@@ -116,7 +116,7 @@ if hostname -f | grep gadi.nci.org.au > /dev/null; then
             [[ -n ${mpi} ]] && module add intel-mpi/2019.5.281
             ;;
         gnu)
-            module add gcc/13.2.0
+            module add gcc/14.1.0
             compiler_lib_install_dir=GNU
             [[ -n ${mpi} ]] && module add openmpi/4.1.4
             ;;

--- a/documentation/docs/user_guide/inputs/cable_nml.md
+++ b/documentation/docs/user_guide/inputs/cable_nml.md
@@ -134,6 +134,10 @@ The cable.nml file includes some settings that are common across all CABLE appli
 | cable_user%l_limit_labile        | logical            | .TRUE. .FALSE.                                             | .FALSE.                          | Limit labile in spinup.                                                                                 |
 | cable_user%NtilesThruMetFile     | logical            | .TRUE. .FALSE.                                             | .FALSE.                          | Specify Ntiles through met file.                                                                        |
 | cable_user%l_ice_consistency     | logical            | .TRUE. .FALSE.                                             | .FALSE.                          | If true, ensures consistency between soil and vegetation tiles with permanent ice. All tiles with permanent ice for soil will have ice for vegetation and vice-versa. All the parameters for these new ice tiles are updated to the ice parameters.                       |
+| pio_settings%io_tasks            | integer            | any integer greater than 0                                 | 1                                | Number of PIO I/O tasks used to perform distributed I/O operations.                                     |
+| pio_settings%base                | integer            | any integer greater than 0                                 | 1                                | The starting MPI rank index (1-based) used to assign the subset of I/O ranks from compute ranks.        |
+| pio_settings%stride              | integer            | any integer greater than 0                                 | 1                                | The stride used to assign the subset of I/O ranks from compute ranks.                                   |
+| pio_settings%rearr               | character(len=16)  | 'box' 'subset'                                             | 'box'                            | PIO rearranger to use.                                                                                  |
 
 
 <!-- markdown-link-check-disable-line --> [Walker]: https://doi.org/10.1002/ece3.1173

--- a/src/offline/cable_driver_common.F90
+++ b/src/offline/cable_driver_common.F90
@@ -17,6 +17,7 @@ MODULE cable_driver_common_mod
     l_landuse,                    &
     l_laiFeedbk,                  &
     l_vcmaxFeedbk,                &
+    pio_settings,                 &
     cable_runtime
   USE cable_IO_vars_module, ONLY : &
     soilparmnew,                   &
@@ -98,7 +99,8 @@ MODULE cable_driver_common_mod
     satuParam,      &
     snmin,          &
     cable_user,     & ! additional USER switches
-    gw_params
+    gw_params,      &
+    pio_settings
 
   PUBLIC :: cable_driver_init
   PUBLIC :: cable_driver_init_gswp

--- a/src/offline/cable_mpi.F90
+++ b/src/offline/cable_mpi.F90
@@ -38,6 +38,7 @@ MODULE cable_mpi_mod
   INTERFACE mpi_grp_t
     !* Overload the default construct for mpi_grp_t
     PROCEDURE mpi_grp_constructor
+    PROCEDURE mpi_grp_constructor_legacy
   END INTERFACE mpi_grp_t
 
 CONTAINS
@@ -119,6 +120,13 @@ CONTAINS
     END IF
 
   END FUNCTION mpi_grp_constructor
+
+  FUNCTION mpi_grp_constructor_legacy(comm) RESULT(mpi_grp)
+    !* Contructor for mpi_grp_t using the legacy communicator type.
+    INTEGER, INTENT(IN) :: comm !! MPI communicator
+    TYPE(mpi_grp_t) :: mpi_grp
+    mpi_grp = mpi_grp_constructor(MPI_Comm(comm))
+  END FUNCTION mpi_grp_constructor_legacy
 
   SUBROUTINE mpi_grp_abort(this, error_code)
     !* Class method to abort execution of an MPI group.

--- a/src/offline/cable_mpi.F90
+++ b/src/offline/cable_mpi.F90
@@ -34,6 +34,7 @@ MODULE cable_mpi_mod
   CONTAINS
     PROCEDURE :: abort => mpi_grp_abort !! Send abort signal to processes in this group
     PROCEDURE :: split => mpi_grp_split !! Split this group into sub-groups
+    PROCEDURE :: comm_defined => mpi_grp_comm_defined !! Check if communicator is defined
   END TYPE mpi_grp_t
 
   INTERFACE mpi_grp_t
@@ -168,6 +169,12 @@ CONTAINS
     END IF
 
   END SUBROUTINE mpi_grp_split
+
+  LOGICAL FUNCTION mpi_grp_comm_defined(this)
+    !* Class method to check if the communicator is defined.
+    CLASS(mpi_grp_t), INTENT(IN) :: this
+    mpi_grp_comm_defined = this%comm /= MPI_COMM_UNDEFINED
+  END FUNCTION mpi_grp_comm_defined
 
   SUBROUTINE mpi_check_error(ierr)
     !* Check if an MPI return code signaled an error. If so, print the

--- a/src/offline/cable_mpi.F90
+++ b/src/offline/cable_mpi.F90
@@ -33,6 +33,7 @@ MODULE cable_mpi_mod
     INTEGER :: size = -1   !! Size of the communicator
   CONTAINS
     PROCEDURE :: abort => mpi_grp_abort !! Send abort signal to processes in this group
+    PROCEDURE :: split => mpi_grp_split !! Split this group into sub-groups
   END TYPE mpi_grp_t
 
   INTERFACE mpi_grp_t
@@ -146,6 +147,27 @@ CONTAINS
 #endif
 
   END SUBROUTINE mpi_grp_abort
+
+  SUBROUTINE mpi_grp_split(this, color, key, new_grp)
+    !* Class method to split an MPI group.
+    CLASS(mpi_grp_t), INTENT(IN) :: this
+    INTEGER, INTENT(IN) :: color, key
+    TYPE(mpi_grp_t), INTENT(OUT) :: new_grp
+
+    TYPE(MPI_Comm) :: new_comm
+    INTEGER :: ierr
+
+    IF (this%comm /= MPI_COMM_UNDEFINED) THEN
+#ifdef __MPI__
+      CALL MPI_Comm_split(this%comm, color, key, new_comm, ierr)
+#endif
+      call mpi_check_error(ierr)
+      new_grp = mpi_grp_t(new_comm)
+    ELSE
+      new_grp = mpi_grp_t()
+    END IF
+
+  END SUBROUTINE mpi_grp_split
 
   SUBROUTINE mpi_check_error(ierr)
     !* Check if an MPI return code signaled an error. If so, print the

--- a/src/util/cable_array_utils.F90
+++ b/src/util/cable_array_utils.F90
@@ -1,0 +1,41 @@
+! CSIRO Open Source Software License Agreement (variation of the BSD / MIT License)
+! Copyright (c) 2015, Commonwealth Scientific and Industrial Research Organisation
+! (CSIRO) ABN 41 687 119 230.
+
+module cable_array_utils_mod
+  !! Utility procedures for working with arrays.
+  implicit none
+  private
+
+  public array_offset
+  public array_index
+
+contains
+
+  !> Calculate the memory offset corresponding to a given index in a multi-dimensional array.
+  function array_offset(index, shape) result(offset)
+    integer, intent(in) :: index(:) !! The multi-dimensional index for which to calculate the offset.
+    integer, intent(in) :: shape(:) !! The shape of the multi-dimensional array.
+    integer :: offset !! The calculated memory offset corresponding to the given index.
+    integer :: i, scale
+    offset = 1; scale = 1
+    do i = 1, size(index)
+      offset = offset + (index(i) - 1) * scale
+      scale = scale * shape(i)
+    end do
+  end function
+
+  !> Calculate the index corresponding to a given memory offset in a multi-dimensional array.
+  subroutine array_index(offset_in, shape, index)
+    integer, intent(in) :: offset_in !! The memory offset for which to calculate the multi-dimensional index.
+    integer, intent(in) :: shape(:) !! The shape of the multi-dimensional array.
+    integer, intent(inout) :: index(:) !! The calculated multi-dimensional index corresponding to the given offset.
+    integer :: i, offset
+    offset = offset_in
+    do i = 1, size(shape)
+      index(i) = mod(offset - 1, shape(i)) + 1
+      offset = (offset - 1) / shape(i) + 1
+    end do
+  end subroutine
+
+end module cable_array_utils_mod

--- a/src/util/cable_common.F90
+++ b/src/util/cable_common.F90
@@ -194,6 +194,15 @@ USE cable_runtime_opts_mod ,ONLY : snmin
 
   TYPE(gw_parameters_type), SAVE :: gw_params
 
+  TYPE pio_settings_type
+    INTEGER :: io_tasks = 1
+    INTEGER :: stride = 1
+    INTEGER :: base = 1
+    CHARACTER(16) :: rearr = "box"
+  END TYPE pio_settings_type
+
+  TYPE(pio_settings_type) :: pio_settings
+
 ! psi_c and psi_o below inserted by rk4417 - phase2 
   REAL, DIMENSION(17),SAVE :: psi_c = (/-2550000.0,-2550000.0,-2550000.0, &  
                                   -2240000.0,-4280000.0,-2750000.0,-2750000.0,&

--- a/src/util/netcdf/cable_netcdf.F90
+++ b/src/util/netcdf/cable_netcdf.F90
@@ -1,0 +1,1155 @@
+! CSIRO Open Source Software License Agreement (variation of the BSD / MIT License)
+! Copyright (c) 2015, Commonwealth Scientific and Industrial Research Organisation
+! (CSIRO) ABN 41 687 119 230.
+
+module cable_netcdf_mod
+  !* Interface for netCDF file handling in CABLE.
+  !
+  ! This module defines abstract types and interfaces for working with netCDF
+  ! files using different underlying libraries (e.g., NetCDF Fortran, ParallelIO).
+  ! Concrete implementations should extend the abstract types and implement the
+  ! deferred procedures.
+
+  use iso_fortran_env, only: CABLE_NETCDF_INT32_KIND => int32
+  use iso_fortran_env, only: CABLE_NETCDF_REAL32_KIND => real32
+  use iso_fortran_env, only: CABLE_NETCDF_REAL64_KIND => real64
+
+  use cable_mpi_mod, only: mpi_grp_t
+
+  use cable_error_handler_mod, only: cable_abort
+
+  implicit none
+
+  private
+
+  public :: &
+    cable_netcdf_decomp_t, &
+    cable_netcdf_file_t, &
+    cable_netcdf_io_t
+
+  public :: &
+    cable_netcdf_mod_init, &
+    cable_netcdf_mod_end, &
+    cable_netcdf_create_file, &
+    cable_netcdf_open_file, &
+    cable_netcdf_create_decomp
+
+  public :: &
+    CABLE_NETCDF_INT32_KIND, &
+    CABLE_NETCDF_REAL32_KIND, &
+    CABLE_NETCDF_REAL64_KIND, &
+    CABLE_NETCDF_INT, &
+    CABLE_NETCDF_FLOAT, &
+    CABLE_NETCDF_DOUBLE, &
+    CABLE_NETCDF_UNLIMITED, &
+    CABLE_NETCDF_IOTYPE_NETCDF, &
+    CABLE_NETCDF_IOTYPE_CLASSIC, &
+    CABLE_NETCDF_IOTYPE_NETCDF4C, &
+    CABLE_NETCDF_IOTYPE_NETCDF4P, &
+    CABLE_NETCDF_MODE_CLOBBER, &
+    CABLE_NETCDF_MODE_NOCLOBBER, &
+    CABLE_NETCDF_MODE_WRITE, &
+    CABLE_NETCDF_MODE_NOWRITE
+
+  !> Data type constants for netCDF variables and attributes.
+  enum, bind(c)
+    enumerator :: CABLE_NETCDF_INT
+      !! Data type constant for 32-bit integer variables and attributes in netCDF files.
+    enumerator :: CABLE_NETCDF_FLOAT
+      !! Data type constant for 32-bit real variables and attributes in netCDF files.
+    enumerator :: CABLE_NETCDF_DOUBLE
+      !! Data type constant for 64-bit real variables and attributes in netCDF files.
+  end enum
+
+  !> I/O type options for opening and creating files.
+  !! Follows the I/O type options defined in ParallelIO:
+  !! <https://github.com/NCAR/ParallelIO/blob/pio2_6_8/src/flib/pio_types.F90#L102-L106>
+  enum, bind(c)
+    enumerator :: CABLE_NETCDF_IOTYPE_NETCDF
+      !! Serial read/write of NetCDF files.
+    enumerator :: CABLE_NETCDF_IOTYPE_CLASSIC
+      !! Parallel read/write of pNetCDF files.
+    enumerator :: CABLE_NETCDF_IOTYPE_NETCDF4C
+      !! NetCDF4 (HDF5 format) file opened for compression (serial write access only).
+    enumerator :: CABLE_NETCDF_IOTYPE_NETCDF4P
+      !! NetCDF4 (HDF5 format) file opened in parallel.
+  end enum
+
+  !> File mode options for opening and creating files
+  enum, bind(c)
+    enumerator :: CABLE_NETCDF_MODE_CLOBBER
+      !! Overwrite existing file.
+    enumerator :: CABLE_NETCDF_MODE_NOCLOBBER
+      !! Do not overwrite existing file.
+    enumerator :: CABLE_NETCDF_MODE_WRITE
+      !! Open file for writing.
+    enumerator :: CABLE_NETCDF_MODE_NOWRITE
+      !! Open file for reading only.
+  end enum
+
+  integer, parameter :: CABLE_NETCDF_UNLIMITED = -1
+    !! Constant to represent an unlimited dimension length in netCDF files.
+
+  type, abstract :: cable_netcdf_decomp_t
+    !* Abstract type for describing netCDF decomposition information.
+    ! This type describes the mapping from the local in-memory layout of an array
+    ! on the current process to the global layout of a netCDF variable on disk
+    ! following the degree of freedom decomposition described in Denis et al.
+    ! (2011)
+    ! [[10.1177/1094342011428143](https://www.doi.org/10.1177/1094342011428143)].
+  end type
+
+  type, abstract :: cable_netcdf_file_t
+    !* Abstract type for netCDF file handling.
+    ! This type defines the interface for operations on netCDF files, such as
+    ! defining dimensions and variables, writing and reading data, and managing
+    ! attributes.
+  contains
+    procedure(cable_netcdf_file_close), deferred :: close
+    procedure(cable_netcdf_file_end_def), deferred :: end_def
+    procedure(cable_netcdf_file_redef), deferred :: redef
+    procedure(cable_netcdf_file_sync), deferred :: sync
+    procedure(cable_netcdf_file_def_dims), deferred :: def_dims
+    procedure(cable_netcdf_file_def_var), deferred :: def_var
+    procedure(cable_netcdf_file_put_att_global_string), deferred :: put_att_global_string
+    procedure(cable_netcdf_file_put_att_global_int32), deferred :: put_att_global_int32
+    procedure(cable_netcdf_file_put_att_global_real32), deferred :: put_att_global_real32
+    procedure(cable_netcdf_file_put_att_global_real64), deferred :: put_att_global_real64
+    procedure(cable_netcdf_file_put_att_var_string), deferred :: put_att_var_string
+    procedure(cable_netcdf_file_put_att_var_int32), deferred :: put_att_var_int32
+    procedure(cable_netcdf_file_put_att_var_real32), deferred :: put_att_var_real32
+    procedure(cable_netcdf_file_put_att_var_real64), deferred :: put_att_var_real64
+    generic :: put_att => &
+      put_att_global_string, put_att_global_int32, put_att_global_real32, put_att_global_real64, &
+      put_att_var_string, put_att_var_int32, put_att_var_real32, put_att_var_real64
+    procedure(cable_netcdf_file_get_att_global_string), deferred :: get_att_global_string
+    procedure(cable_netcdf_file_get_att_global_int32), deferred :: get_att_global_int32
+    procedure(cable_netcdf_file_get_att_global_real32), deferred :: get_att_global_real32
+    procedure(cable_netcdf_file_get_att_global_real64), deferred :: get_att_global_real64
+    procedure(cable_netcdf_file_get_att_var_string), deferred :: get_att_var_string
+    procedure(cable_netcdf_file_get_att_var_int32), deferred :: get_att_var_int32
+    procedure(cable_netcdf_file_get_att_var_real32), deferred :: get_att_var_real32
+    procedure(cable_netcdf_file_get_att_var_real64), deferred :: get_att_var_real64
+    generic :: get_att => &
+      get_att_global_string, get_att_global_int32, get_att_global_real32, get_att_global_real64, &
+      get_att_var_string, get_att_var_int32, get_att_var_real32, get_att_var_real64
+    procedure(cable_netcdf_file_inq_dim_len), deferred :: inq_dim_len
+    procedure(cable_netcdf_file_inq_var_ndims), deferred :: inq_var_ndims
+    procedure(cable_netcdf_file_put_var_int32_0d), deferred :: put_var_int32_0d
+    procedure(cable_netcdf_file_put_var_int32_1d), deferred :: put_var_int32_1d
+    procedure(cable_netcdf_file_put_var_int32_2d), deferred :: put_var_int32_2d
+    procedure(cable_netcdf_file_put_var_int32_3d), deferred :: put_var_int32_3d
+    procedure(cable_netcdf_file_put_var_real32_0d), deferred :: put_var_real32_0d
+    procedure(cable_netcdf_file_put_var_real32_1d), deferred :: put_var_real32_1d
+    procedure(cable_netcdf_file_put_var_real32_2d), deferred :: put_var_real32_2d
+    procedure(cable_netcdf_file_put_var_real32_3d), deferred :: put_var_real32_3d
+    procedure(cable_netcdf_file_put_var_real64_0d), deferred :: put_var_real64_0d
+    procedure(cable_netcdf_file_put_var_real64_1d), deferred :: put_var_real64_1d
+    procedure(cable_netcdf_file_put_var_real64_2d), deferred :: put_var_real64_2d
+    procedure(cable_netcdf_file_put_var_real64_3d), deferred :: put_var_real64_3d
+    generic :: put_var => &
+      put_var_int32_0d, put_var_int32_1d, put_var_int32_2d, put_var_int32_3d, &
+      put_var_real32_0d, put_var_real32_1d, put_var_real32_2d, put_var_real32_3d, &
+      put_var_real64_0d, put_var_real64_1d, put_var_real64_2d, put_var_real64_3d
+    procedure(cable_netcdf_file_write_darray_int32_1d), deferred :: write_darray_int32_1d
+    procedure(cable_netcdf_file_write_darray_int32_2d), deferred :: write_darray_int32_2d
+    procedure(cable_netcdf_file_write_darray_int32_3d), deferred :: write_darray_int32_3d
+    procedure(cable_netcdf_file_write_darray_real32_1d), deferred :: write_darray_real32_1d
+    procedure(cable_netcdf_file_write_darray_real32_2d), deferred :: write_darray_real32_2d
+    procedure(cable_netcdf_file_write_darray_real32_3d), deferred :: write_darray_real32_3d
+    procedure(cable_netcdf_file_write_darray_real64_1d), deferred :: write_darray_real64_1d
+    procedure(cable_netcdf_file_write_darray_real64_2d), deferred :: write_darray_real64_2d
+    procedure(cable_netcdf_file_write_darray_real64_3d), deferred :: write_darray_real64_3d
+    generic :: write_darray => &
+      write_darray_int32_1d, write_darray_int32_2d, write_darray_int32_3d, &
+      write_darray_real32_1d, write_darray_real32_2d, write_darray_real32_3d, &
+      write_darray_real64_1d, write_darray_real64_2d, write_darray_real64_3d
+    procedure(cable_netcdf_file_get_var_int32_0d), deferred :: get_var_int32_0d
+    procedure(cable_netcdf_file_get_var_int32_1d), deferred :: get_var_int32_1d
+    procedure(cable_netcdf_file_get_var_int32_2d), deferred :: get_var_int32_2d
+    procedure(cable_netcdf_file_get_var_int32_3d), deferred :: get_var_int32_3d
+    procedure(cable_netcdf_file_get_var_real32_0d), deferred :: get_var_real32_0d
+    procedure(cable_netcdf_file_get_var_real32_1d), deferred :: get_var_real32_1d
+    procedure(cable_netcdf_file_get_var_real32_2d), deferred :: get_var_real32_2d
+    procedure(cable_netcdf_file_get_var_real32_3d), deferred :: get_var_real32_3d
+    procedure(cable_netcdf_file_get_var_real64_0d), deferred :: get_var_real64_0d
+    procedure(cable_netcdf_file_get_var_real64_1d), deferred :: get_var_real64_1d
+    procedure(cable_netcdf_file_get_var_real64_2d), deferred :: get_var_real64_2d
+    procedure(cable_netcdf_file_get_var_real64_3d), deferred :: get_var_real64_3d
+    generic :: get_var => &
+      get_var_int32_0d, get_var_int32_1d, get_var_int32_2d, get_var_int32_3d, &
+      get_var_real32_0d, get_var_real32_1d, get_var_real32_2d, get_var_real32_3d, &
+      get_var_real64_0d, get_var_real64_1d, get_var_real64_2d, get_var_real64_3d
+    procedure(cable_netcdf_file_read_darray_int32_1d), deferred :: read_darray_int32_1d
+    procedure(cable_netcdf_file_read_darray_int32_2d), deferred :: read_darray_int32_2d
+    procedure(cable_netcdf_file_read_darray_int32_3d), deferred :: read_darray_int32_3d
+    procedure(cable_netcdf_file_read_darray_real32_1d), deferred :: read_darray_real32_1d
+    procedure(cable_netcdf_file_read_darray_real32_2d), deferred :: read_darray_real32_2d
+    procedure(cable_netcdf_file_read_darray_real32_3d), deferred :: read_darray_real32_3d
+    procedure(cable_netcdf_file_read_darray_real64_1d), deferred :: read_darray_real64_1d
+    procedure(cable_netcdf_file_read_darray_real64_2d), deferred :: read_darray_real64_2d
+    procedure(cable_netcdf_file_read_darray_real64_3d), deferred :: read_darray_real64_3d
+    generic :: read_darray => &
+      read_darray_int32_1d, read_darray_int32_2d, read_darray_int32_3d, &
+      read_darray_real32_1d, read_darray_real32_2d, read_darray_real32_3d, &
+      read_darray_real64_1d, read_darray_real64_2d, read_darray_real64_3d
+  end type
+
+  abstract interface
+    !> Close the netCDF file and release any associated resources.
+    subroutine cable_netcdf_file_close(this)
+      import cable_netcdf_file_t
+      class(cable_netcdf_file_t), intent(inout) :: this
+    end subroutine
+    !> End the definition mode of the netCDF file, allowing data to be written.
+    subroutine cable_netcdf_file_end_def(this)
+      import cable_netcdf_file_t
+      class(cable_netcdf_file_t), intent(inout) :: this
+    end subroutine
+    !> Re-enter definition mode for the netCDF file, allowing dimensions and
+    !! variables to be defined.
+    subroutine cable_netcdf_file_redef(this)
+      import cable_netcdf_file_t
+      class(cable_netcdf_file_t), intent(inout) :: this
+    end subroutine
+    !> Synchronize the netCDF file, ensuring that all data is written to disk
+    !! and visible to other processes.
+    subroutine cable_netcdf_file_sync(this)
+      import cable_netcdf_file_t
+      class(cable_netcdf_file_t), intent(inout) :: this
+    end subroutine
+    !> Define dimensions in the netCDF file.
+    subroutine cable_netcdf_file_def_dims(this, dim_names, dim_lens)
+      import cable_netcdf_file_t
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: dim_names(:)
+        !! Array of dimension names to define.
+      integer, intent(in) :: dim_lens(:)
+        !* Array of dimension lengths corresponding to dim_names. Use
+        ! `CABLE_NETCDF_UNLIMITED` for unlimited dimensions.
+    end subroutine
+    !> Define a variable in the netCDF file with the specified name, dimensions, and type.
+    subroutine cable_netcdf_file_def_var(this, var_name, type, dim_names)
+      import cable_netcdf_file_t
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to define.
+      integer, intent(in) :: type
+        !* Data type of the variable, using the `CABLE_NETCDF_*` constants (e.g.,
+        ! `CABLE_NETCDF_INT`, `CABLE_NETCDF_REAL32`).
+      character(len=*), intent(in), optional :: dim_names(:)
+        !* Array of dimension names for the variable. If not provided, the
+        ! variable will be defined as a scalar.
+    end subroutine
+    !> Define a global attribute with a string value in the netCDF file.
+    subroutine cable_netcdf_file_put_att_global_string(this, att_name, att_value)
+      import cable_netcdf_file_t
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: att_name
+        !! Name of the global attribute to define.
+      character(len=*), intent(in) :: att_value
+        !! Value of the global attribute to define.
+    end subroutine
+    !> Define a global attribute with an 32-bit integer value in the netCDF file.
+    subroutine cable_netcdf_file_put_att_global_int32(this, att_name, att_value)
+      import cable_netcdf_file_t, CABLE_NETCDF_INT32_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: att_name
+        !! Name of the global attribute to define.
+      integer(kind=CABLE_NETCDF_INT32_KIND), intent(in) :: att_value
+        !! Value of the global attribute to define.
+    end subroutine
+    !> Define a global attribute with a 32-bit real value in the netCDF file.
+    subroutine cable_netcdf_file_put_att_global_real32(this, att_name, att_value)
+      import cable_netcdf_file_t, CABLE_NETCDF_REAL32_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: att_name
+        !! Name of the global attribute to define.
+      real(kind=CABLE_NETCDF_REAL32_KIND), intent(in) :: att_value
+        !! Value of the global attribute to define.
+    end subroutine
+    !> Define a global attribute with a 64-bit real value in the netCDF file.
+    subroutine cable_netcdf_file_put_att_global_real64(this, att_name, att_value)
+      import cable_netcdf_file_t, CABLE_NETCDF_REAL64_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: att_name
+        !! Name of the global attribute to define.
+      real(kind=CABLE_NETCDF_REAL64_KIND), intent(in) :: att_value
+        !! Value of the global attribute to define.
+    end subroutine
+    !> Define a variable attribute with a string value in the netCDF file.
+    subroutine cable_netcdf_file_put_att_var_string(this, var_name, att_name, att_value)
+      import cable_netcdf_file_t
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to define the attribute for.
+      character(len=*), intent(in) :: att_name
+        !! Name of the variable attribute to define.
+      character(len=*), intent(in) :: att_value
+        !! Value of the variable attribute to define.
+    end subroutine
+    !> Define a variable attribute with an 32-bit integer value in the netCDF file.
+    subroutine cable_netcdf_file_put_att_var_int32(this, var_name, att_name, att_value)
+      import cable_netcdf_file_t, CABLE_NETCDF_INT32_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to define the attribute for.
+      character(len=*), intent(in) :: att_name
+        !! Name of the variable attribute to define.
+      integer(kind=CABLE_NETCDF_INT32_KIND), intent(in) :: att_value
+        !! Value of the variable attribute to define.
+    end subroutine
+    !> Define a variable attribute with a 32-bit real value in the netCDF file.
+    subroutine cable_netcdf_file_put_att_var_real32(this, var_name, att_name, att_value)
+      import cable_netcdf_file_t, CABLE_NETCDF_REAL32_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to define the attribute for.
+      character(len=*), intent(in) :: att_name
+        !! Name of the variable attribute to define.
+      real(kind=CABLE_NETCDF_REAL32_KIND), intent(in) :: att_value
+        !! Value of the variable attribute to define.
+    end subroutine
+    !> Define a variable attribute with a 64-bit real value in the netCDF file.
+    subroutine cable_netcdf_file_put_att_var_real64(this, var_name, att_name, att_value)
+      import cable_netcdf_file_t, CABLE_NETCDF_REAL64_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to define the attribute for.
+      character(len=*), intent(in) :: att_name
+        !! Name of the variable attribute to define.
+      real(kind=CABLE_NETCDF_REAL64_KIND), intent(in) :: att_value
+        !! Value of the variable attribute to define.
+    end subroutine
+    !> Read a global attribute with a string value from the netCDF file.
+    subroutine cable_netcdf_file_get_att_global_string(this, att_name, att_value)
+      import cable_netcdf_file_t
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: att_name
+        !! Name of the global attribute to read.
+      character(len=*), intent(out) :: att_value
+        !! Value of the global attribute read.
+    end subroutine
+    !> Read a global attribute with an 32-bit integer value from the netCDF file.
+    subroutine cable_netcdf_file_get_att_global_int32(this, att_name, att_value)
+      import cable_netcdf_file_t, CABLE_NETCDF_INT32_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: att_name
+        !! Name of the global attribute to read.
+      integer(kind=CABLE_NETCDF_INT32_KIND), intent(out) :: att_value
+        !! Value of the global attribute read.
+    end subroutine
+    !> Read a global attribute with a 32-bit real value from the netCDF file.
+    subroutine cable_netcdf_file_get_att_global_real32(this, att_name, att_value)
+      import cable_netcdf_file_t, CABLE_NETCDF_REAL32_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: att_name
+        !! Name of the global attribute to read.
+      real(kind=CABLE_NETCDF_REAL32_KIND), intent(out) :: att_value
+        !! Value of the global attribute read.
+    end subroutine
+    !> Read a global attribute with a 64-bit real value from the netCDF file.
+    subroutine cable_netcdf_file_get_att_global_real64(this, att_name, att_value)
+      import cable_netcdf_file_t, CABLE_NETCDF_REAL64_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: att_name
+        !! Name of the global attribute to read.
+      real(kind=CABLE_NETCDF_REAL64_KIND), intent(out) :: att_value
+        !! Value of the global attribute read.
+    end subroutine
+    !> Read a variable attribute with a string value from the netCDF file.
+    subroutine cable_netcdf_file_get_att_var_string(this, var_name, att_name, att_value)
+      import cable_netcdf_file_t
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to read the attribute from.
+      character(len=*), intent(in) :: att_name
+        !! Name of the variable attribute to read.
+      character(len=*), intent(out) :: att_value
+        !! Value of the variable attribute read.
+    end subroutine
+    !> Read a variable attribute with an 32-bit integer value from the netCDF file.
+    subroutine cable_netcdf_file_get_att_var_int32(this, var_name, att_name, att_value)
+      import cable_netcdf_file_t, CABLE_NETCDF_INT32_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to read the attribute from.
+      character(len=*), intent(in) :: att_name
+        !! Name of the variable attribute to read.
+      integer(kind=CABLE_NETCDF_INT32_KIND), intent(out) :: att_value
+        !! Value of the variable attribute read.
+    end subroutine
+    !> Read a variable attribute with a 32-bit real value from the netCDF file.
+    subroutine cable_netcdf_file_get_att_var_real32(this, var_name, att_name, att_value)
+      import cable_netcdf_file_t, CABLE_NETCDF_REAL32_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to read the attribute from.
+      character(len=*), intent(in) :: att_name
+        !! Name of the variable attribute to read.
+      real(kind=CABLE_NETCDF_REAL32_KIND), intent(out) :: att_value
+        !! Value of the variable attribute read.
+    end subroutine
+    !> Read a variable attribute with a 64-bit real value from the netCDF file.
+    subroutine cable_netcdf_file_get_att_var_real64(this, var_name, att_name, att_value)
+      import cable_netcdf_file_t, CABLE_NETCDF_REAL64_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to read the attribute from.
+      character(len=*), intent(in) :: att_name
+        !! Name of the variable attribute to read.
+      real(kind=CABLE_NETCDF_REAL64_KIND), intent(out) :: att_value
+        !! Value of the variable attribute read.
+    end subroutine
+    !> Inquire the length of a dimension in the netCDF file by its name.
+    subroutine cable_netcdf_file_inq_dim_len(this, dim_name, dim_len)
+      import cable_netcdf_file_t
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: dim_name
+        !! Name of the dimension to inquire.
+      integer, intent(out) :: dim_len
+        !* Length of the dimension returned. For unlimited dimensions, the
+        ! number of records will be returned.
+    end subroutine
+    !> Inquire the number of dimensions of a variable in the netCDF file by its name.
+    subroutine cable_netcdf_file_inq_var_ndims(this, var_name, ndims)
+      import cable_netcdf_file_t
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to inquire.
+      integer, intent(out) :: ndims
+        !! Number of dimensions of the variable returned.
+    end subroutine
+    !> Write a 0-dimensional (scalar) 32-bit integer variable to the netCDF file.
+    subroutine cable_netcdf_file_put_var_int32_0d(this, var_name, values, start, count)
+      import cable_netcdf_file_t, CABLE_NETCDF_INT32_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to write to.
+      integer(kind=CABLE_NETCDF_INT32_KIND), intent(in) :: values
+        !! Value to write to the variable.
+      integer, intent(in), optional :: start(:)
+        !* Starting indices for writing the variable. If not provided, writing
+        ! will start at the beginning of the variable.
+      integer, intent(in), optional :: count(:)
+        !* Count of elements to write for each dimension. If not provided, the
+        ! entire variable will be written.
+    end subroutine
+    !> Write a 1-dimensional array of 32-bit integers to the netCDF file.
+    subroutine cable_netcdf_file_put_var_int32_1d(this, var_name, values, start, count)
+      import cable_netcdf_file_t, CABLE_NETCDF_INT32_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to write to.
+      integer(kind=CABLE_NETCDF_INT32_KIND), intent(in) :: values(:)
+        !! Array of values to write to the variable.
+      integer, intent(in), optional :: start(:)
+        !* Starting indices for writing the variable. If not provided, writing
+        ! will start at the beginning of the variable.
+      integer, intent(in), optional :: count(:)
+        !* Count of elements to write for each dimension. If not provided, the
+        ! entire variable will be written.
+    end subroutine
+    !> Write a 2-dimensional array of 32-bit integers to the netCDF file.
+    subroutine cable_netcdf_file_put_var_int32_2d(this, var_name, values, start, count)
+      import cable_netcdf_file_t, CABLE_NETCDF_INT32_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to write to.
+      integer(kind=CABLE_NETCDF_INT32_KIND), intent(in) :: values(:, :)
+        !! 2-dimensional array of values to write to the variable.
+      integer, intent(in), optional :: start(:)
+        !* Starting indices for writing the variable. If not provided, writing
+        ! will start at the beginning of the variable.
+      integer, intent(in), optional :: count(:)
+        !* Count of elements to write for each dimension. If not provided, the
+        ! entire variable will be written.
+    end subroutine
+    !> Write a 3-dimensional array of 32-bit integers to the netCDF file.
+    subroutine cable_netcdf_file_put_var_int32_3d(this, var_name, values, start, count)
+      import cable_netcdf_file_t, CABLE_NETCDF_INT32_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to write to.
+      integer(kind=CABLE_NETCDF_INT32_KIND), intent(in) :: values(:, :, :)
+        !! 3-dimensional array of values to write to the variable.
+      integer, intent(in), optional :: start(:)
+        !* Starting indices for writing the variable. If not provided, writing
+        ! will start at the beginning of the variable.
+      integer, intent(in), optional :: count(:)
+        !* Count of elements to write for each dimension. If not provided, the
+        ! entire variable will be written.
+    end subroutine
+    !> Write a 0-dimensional (scalar) 32-bit real variable to the netCDF file.
+    subroutine cable_netcdf_file_put_var_real32_0d(this, var_name, values, start, count)
+      import cable_netcdf_file_t, CABLE_NETCDF_REAL32_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to write to.
+      real(kind=CABLE_NETCDF_REAL32_KIND), intent(in) :: values
+        !! Scalar value to write to the variable.
+      integer, intent(in), optional :: start(:)
+        !* Starting indices for writing the variable. If not provided, writing
+        ! will start at the beginning of the variable.
+      integer, intent(in), optional :: count(:)
+        !* Count of elements to write for each dimension. If not provided, the
+        ! entire variable will be written.
+    end subroutine
+    !> Write a 1-dimensional array of 32-bit real values to the netCDF file.
+    subroutine cable_netcdf_file_put_var_real32_1d(this, var_name, values, start, count)
+      import cable_netcdf_file_t, CABLE_NETCDF_REAL32_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to write to.
+      real(kind=CABLE_NETCDF_REAL32_KIND), intent(in) :: values(:)
+        !! 1-dimensional array of values to write to the variable.
+      integer, intent(in), optional :: start(:)
+        !* Starting indices for writing the variable. If not provided, writing
+        ! will start at the beginning of the variable.
+      integer, intent(in), optional :: count(:)
+        !* Count of elements to write for each dimension. If not provided, the
+        ! entire variable will be written.
+    end subroutine
+    !> Write a 2-dimensional array of 32-bit real values to the netCDF file.
+    subroutine cable_netcdf_file_put_var_real32_2d(this, var_name, values, start, count)
+      import cable_netcdf_file_t, CABLE_NETCDF_REAL32_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to write to.
+      real(kind=CABLE_NETCDF_REAL32_KIND), intent(in) :: values(:, :)
+        !! 2-dimensional array of values to write to the variable.
+      integer, intent(in), optional :: start(:)
+        !* Starting indices for writing the variable. If not provided, writing
+        ! will start at the beginning of the variable.
+      integer, intent(in), optional :: count(:)
+        !* Count of elements to write for each dimension. If not provided, the
+        ! entire variable will be written.
+    end subroutine
+    !> Write a 3-dimensional array of 32-bit real values to the netCDF file.
+    subroutine cable_netcdf_file_put_var_real32_3d(this, var_name, values, start, count)
+      import cable_netcdf_file_t, CABLE_NETCDF_REAL32_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to write to.
+      real(kind=CABLE_NETCDF_REAL32_KIND), intent(in) :: values(:, :, :)
+        !! 3-dimensional array of values to write to the variable.
+      integer, intent(in), optional :: start(:)
+        !* Starting indices for writing the variable. If not provided, writing
+        ! will start at the beginning of the variable.
+      integer, intent(in), optional :: count(:)
+        !* Count of elements to write for each dimension. If not provided, the
+        ! entire variable will be written.
+    end subroutine
+    !> Write a 0-dimensional (scalar) 64-bit real variable to the netCDF file.
+    subroutine cable_netcdf_file_put_var_real64_0d(this, var_name, values, start, count)
+      import cable_netcdf_file_t, CABLE_NETCDF_REAL64_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to write to.
+      real(kind=CABLE_NETCDF_REAL64_KIND), intent(in) :: values
+        !! The scalar value to write.
+      integer, intent(in), optional :: start(:)
+        !* Starting indices for writing the variable. If not provided, writing
+        ! will start at the beginning of the variable.
+      integer, intent(in), optional :: count(:)
+        !* Count of elements to write for each dimension. If not provided, the
+        ! entire variable will be written.
+    end subroutine
+    !> Write a 1-dimensional array of 64-bit real values to the netCDF file.
+    subroutine cable_netcdf_file_put_var_real64_1d(this, var_name, values, start, count)
+      import cable_netcdf_file_t, CABLE_NETCDF_REAL64_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to write to.
+      real(kind=CABLE_NETCDF_REAL64_KIND), intent(in) :: values(:)
+        !! 1-dimensional array of values to write to the variable.
+      integer, intent(in), optional :: start(:)
+        !* Starting indices for writing the variable. If not provided, writing
+        ! will start at the beginning of the variable.
+      integer, intent(in), optional :: count(:)
+        !* Count of elements to write for each dimension. If not provided, the
+        ! entire variable will be written.
+    end subroutine
+    !> Write a 2-dimensional array of 64-bit real values to the netCDF file.
+    subroutine cable_netcdf_file_put_var_real64_2d(this, var_name, values, start, count)
+      import cable_netcdf_file_t, CABLE_NETCDF_REAL64_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to write to.
+      real(kind=CABLE_NETCDF_REAL64_KIND), intent(in) :: values(:, :)
+        !! 2-dimensional array of values to write to the variable.
+      integer, intent(in), optional :: start(:)
+        !* Starting indices for writing the variable. If not provided, writing
+        ! will start at the beginning of the variable.
+      integer, intent(in), optional :: count(:)
+        !* Count of elements to write for each dimension. If not provided, the
+        ! entire variable will be written.
+    end subroutine
+    !> Write a 3-dimensional array of 64-bit real values to the netCDF file.
+    subroutine cable_netcdf_file_put_var_real64_3d(this, var_name, values, start, count)
+      import cable_netcdf_file_t, CABLE_NETCDF_REAL64_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to write to.
+      real(kind=CABLE_NETCDF_REAL64_KIND), intent(in) :: values(:, :, :)
+        !! 3-dimensional array of values to write to the variable.
+      integer, intent(in), optional :: start(:)
+        !* Starting indices for writing the variable. If not provided, writing
+        ! will start at the beginning of the variable.
+      integer, intent(in), optional :: count(:)
+        !* Count of elements to write for each dimension. If not provided, the
+        ! entire variable will be written.
+    end subroutine
+    !> Write a 1-dimensional array of 32-bit integers to the netCDF file using decomposition information for parallel I/O.
+    subroutine cable_netcdf_file_write_darray_int32_1d(this, var_name, values, decomp, fill_value, frame)
+      import cable_netcdf_file_t, cable_netcdf_decomp_t, CABLE_NETCDF_INT32_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to write to.
+      integer(kind=CABLE_NETCDF_INT32_KIND), intent(in) :: values(:)
+        !! 1-dimensional array of values to write to the variable.
+      class(cable_netcdf_decomp_t), intent(inout) :: decomp
+        !! Decomposition information for parallel I/O.
+      integer(kind=CABLE_NETCDF_INT32_KIND), intent(in), optional :: fill_value
+        !! Fill value to use for any missing data. If not provided, the default fill value for the variable's type will be used.
+      integer, intent(in), optional :: frame
+        !! Optional frame index for record variables. If provided, the data will be written to the specified frame along the unlimited dimension.
+    end subroutine
+    !> Write a 2-dimensional array of 32-bit integers to the netCDF file using decomposition information for parallel I/O.
+    subroutine cable_netcdf_file_write_darray_int32_2d(this, var_name, values, decomp, fill_value, frame)
+      import cable_netcdf_file_t, cable_netcdf_decomp_t, CABLE_NETCDF_INT32_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to write to.
+      integer(kind=CABLE_NETCDF_INT32_KIND), intent(in) :: values(:, :)
+        !! 2-dimensional array of values to write to the variable.
+      class(cable_netcdf_decomp_t), intent(inout) :: decomp
+        !! Decomposition information for parallel I/O.
+      integer(kind=CABLE_NETCDF_INT32_KIND), intent(in), optional :: fill_value
+        !! Fill value to use for any missing data. If not provided, the default fill value for the variable's type will be used.
+      integer, intent(in), optional :: frame
+        !! Optional frame index for record variables. If provided, the data will be written to the specified frame along the unlimited dimension.
+    end subroutine
+    !> Write a 3-dimensional array of 32-bit integers to the netCDF file using decomposition information for parallel I/O.
+    subroutine cable_netcdf_file_write_darray_int32_3d(this, var_name, values, decomp, fill_value, frame)
+      import cable_netcdf_file_t, cable_netcdf_decomp_t, CABLE_NETCDF_INT32_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to write to.
+      integer(kind=CABLE_NETCDF_INT32_KIND), intent(in) :: values(:, :, :)
+        !! 3-dimensional array of values to write to the variable.
+      class(cable_netcdf_decomp_t), intent(inout) :: decomp
+        !! Decomposition information for parallel I/O.
+      integer(kind=CABLE_NETCDF_INT32_KIND), intent(in), optional :: fill_value
+        !! Fill value to use for any missing data. If not provided, the default fill value for the variable's type will be used.
+      integer, intent(in), optional :: frame
+        !! Optional frame index for record variables. If provided, the data will be written to the specified frame along the unlimited dimension.
+    end subroutine
+    !> Write a 1-dimensional array of 32-bit real values to the netCDF file using decomposition information for parallel I/O.
+    subroutine cable_netcdf_file_write_darray_real32_1d(this, var_name, values, decomp, fill_value, frame)
+      import cable_netcdf_file_t, cable_netcdf_decomp_t, CABLE_NETCDF_REAL32_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to write to.
+      real(kind=CABLE_NETCDF_REAL32_KIND), intent(in) :: values(:)
+        !! 1-dimensional array of values to write to the variable.
+      class(cable_netcdf_decomp_t), intent(inout) :: decomp
+        !! Decomposition information for parallel I/O.
+      real(kind=CABLE_NETCDF_REAL32_KIND), intent(in), optional :: fill_value
+        !! Fill value to use for any missing data. If not provided, the default fill value for the variable's type will be used.
+      integer, intent(in), optional :: frame
+        !! Optional frame index for record variables. If provided, the data will be written to the specified frame along the unlimited dimension.
+    end subroutine
+    !> Write a 2-dimensional array of 32-bit real values to the netCDF file using decomposition information for parallel I/O.
+    subroutine cable_netcdf_file_write_darray_real32_2d(this, var_name, values, decomp, fill_value, frame)
+      import cable_netcdf_file_t, cable_netcdf_decomp_t, CABLE_NETCDF_REAL32_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to write to.
+      real(kind=CABLE_NETCDF_REAL32_KIND), intent(in) :: values(:, :)
+        !! 2-dimensional array of values to write to the variable.
+      class(cable_netcdf_decomp_t), intent(inout) :: decomp
+        !! Decomposition information for parallel I/O.
+      real(kind=CABLE_NETCDF_REAL32_KIND), intent(in), optional :: fill_value
+        !! Fill value to use for any missing data. If not provided, the default fill value for the variable's type will be used.
+      integer, intent(in), optional :: frame
+        !! Optional frame index for record variables. If provided, the data will be written to the specified frame along the unlimited dimension.
+    end subroutine
+    !> Write a 3-dimensional array of 32-bit real values to the netCDF file using decomposition information for parallel I/O.
+    subroutine cable_netcdf_file_write_darray_real32_3d(this, var_name, values, decomp, fill_value, frame)
+      import cable_netcdf_file_t, cable_netcdf_decomp_t, CABLE_NETCDF_REAL32_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to write to.
+      real(kind=CABLE_NETCDF_REAL32_KIND), intent(in) :: values(:, :, :)
+        !! 3-dimensional array of values to write to the variable.
+      class(cable_netcdf_decomp_t), intent(inout) :: decomp
+        !! Decomposition information for parallel I/O.
+      real(kind=CABLE_NETCDF_REAL32_KIND), intent(in), optional :: fill_value
+        !! Fill value to use for any missing data. If not provided, the default fill value for the variable's type will be used.
+      integer, intent(in), optional :: frame
+        !! Optional frame index for record variables. If provided, the data will be written to the specified frame along the unlimited dimension.
+    end subroutine
+    !> Write a 2-dimensional array of 32-bit real values to the netCDF file using decomposition information for parallel I/O.
+    subroutine cable_netcdf_file_write_darray_real64_1d(this, var_name, values, decomp, fill_value, frame)
+      import cable_netcdf_file_t, cable_netcdf_decomp_t, CABLE_NETCDF_REAL64_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to write to.
+      real(kind=CABLE_NETCDF_REAL64_KIND), intent(in) :: values(:)
+        !! 1-dimensional array of values to write to the variable.
+      class(cable_netcdf_decomp_t), intent(inout) :: decomp
+        !! Decomposition information for parallel I/O.
+      real(kind=CABLE_NETCDF_REAL64_KIND), intent(in), optional :: fill_value
+        !! Fill value to use for any missing data. If not provided, the default fill value for the variable's type will be used.
+      integer, intent(in), optional :: frame
+        !! Optional frame index for record variables. If provided, the data will be written to the specified frame along the unlimited dimension.
+    end subroutine
+    !> Write a 2-dimensional array of 32-bit real values to the netCDF file using decomposition information for parallel I/O.
+    subroutine cable_netcdf_file_write_darray_real64_2d(this, var_name, values, decomp, fill_value, frame)
+      import cable_netcdf_file_t, cable_netcdf_decomp_t, CABLE_NETCDF_REAL64_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to write to.
+      real(kind=CABLE_NETCDF_REAL64_KIND), intent(in) :: values(:, :)
+        !! 2-dimensional array of values to write to the variable.
+      class(cable_netcdf_decomp_t), intent(inout) :: decomp
+        !! Decomposition information for parallel I/O.
+      real(kind=CABLE_NETCDF_REAL64_KIND), intent(in), optional :: fill_value
+        !! Fill value to use for any missing data. If not provided, the default fill value for the variable's type will be used.
+      integer, intent(in), optional :: frame
+        !! Optional frame index for record variables. If provided, the data will be written to the specified frame along the unlimited dimension.
+    end subroutine
+    !> Write a 3-dimensional array of 32-bit real values to the netCDF file using decomposition information for parallel I/O.
+    subroutine cable_netcdf_file_write_darray_real64_3d(this, var_name, values, decomp, fill_value, frame)
+      import cable_netcdf_file_t, cable_netcdf_decomp_t, CABLE_NETCDF_REAL64_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to write to.
+      real(kind=CABLE_NETCDF_REAL64_KIND), intent(in) :: values(:, :, :)
+        !! 3-dimensional array of values to write to the variable.
+      class(cable_netcdf_decomp_t), intent(inout) :: decomp
+        !! Decomposition information for parallel I/O.
+      real(kind=CABLE_NETCDF_REAL64_KIND), intent(in), optional :: fill_value
+        !! Fill value to use for any missing data. If not provided, the default fill value for the variable's type will be used.
+      integer, intent(in), optional :: frame
+        !! Optional frame index for record variables. If provided, the data will be written to the specified frame along the unlimited dimension.
+    end subroutine
+    !> Read a 0-dimensional (scalar) 32-bit integer variable from the netCDF file.
+    subroutine cable_netcdf_file_get_var_int32_0d(this, var_name, values, start, count)
+      import cable_netcdf_file_t, CABLE_NETCDF_INT32_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to read from.
+      integer(kind=CABLE_NETCDF_INT32_KIND), intent(out) :: values
+        !! The scalar value read from the variable.
+      integer, intent(in), optional :: start(:)
+        !! Starting indices for reading the variable. If not provided, reading will start at the beginning of the variable.
+      integer, intent(in), optional :: count(:)
+        !! Count of elements to read for each dimension. If not provided, the entire variable will be read.
+    end subroutine
+    !> Read a 1-dimensional array of 32-bit integers from the netCDF file.
+    subroutine cable_netcdf_file_get_var_int32_1d(this, var_name, values, start, count)
+      import cable_netcdf_file_t, CABLE_NETCDF_INT32_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to read from.
+      integer(kind=CABLE_NETCDF_INT32_KIND), intent(out) :: values(:)
+        !! 1-dimensional array to store the values read from the variable.
+      integer, intent(in), optional :: start(:)
+        !! Starting indices for reading the variable. If not provided, reading will start at the beginning of the variable.
+      integer, intent(in), optional :: count(:)
+        !! Count of elements to read for each dimension. If not provided, the entire variable will
+    end subroutine
+    !> Read a 2-dimensional array of 32-bit integers from the netCDF file.
+    subroutine cable_netcdf_file_get_var_int32_2d(this, var_name, values, start, count)
+      import cable_netcdf_file_t, CABLE_NETCDF_INT32_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to read from.
+      integer(kind=CABLE_NETCDF_INT32_KIND), intent(out) :: values(:, :)
+        !! 2-dimensional array to store the values read from the variable.
+      integer, intent(in), optional :: start(:)
+        !! Starting indices for reading the variable. If not provided, reading will start at the beginning of the variable.
+      integer, intent(in), optional :: count(:)
+        !! Count of elements to read for each dimension. If not provided, the entire variable will be read.
+    end subroutine
+    !> Read a 3-dimensional array of 32-bit integers from the netCDF file.
+    subroutine cable_netcdf_file_get_var_int32_3d(this, var_name, values, start, count)
+      import cable_netcdf_file_t, CABLE_NETCDF_INT32_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to read from.
+      integer(kind=CABLE_NETCDF_INT32_KIND), intent(out) :: values(:, :, :)
+        !! 3-dimensional array to store the values read from the variable.
+      integer, intent(in), optional :: start(:)
+        !! Starting indices for reading the variable. If not provided, reading will start at the beginning of the variable.
+      integer, intent(in), optional :: count(:)
+        !! Count of elements to read for each dimension. If not provided, the entire variable will be read.
+    end subroutine
+    !> Read a 0-dimensional (scalar) 32-bit real variable from the netCDF file.
+    subroutine cable_netcdf_file_get_var_real32_0d(this, var_name, values, start, count)
+      import cable_netcdf_file_t, CABLE_NETCDF_REAL32_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to read from.
+      real(kind=CABLE_NETCDF_REAL32_KIND), intent(out) :: values
+        !! Scalar value to store the value read from the variable.
+      integer, intent(in), optional :: start(:)
+        !! Starting indices for reading the variable. If not provided, reading will start at the beginning of the variable.
+      integer, intent(in), optional :: count(:)
+        !! Count of elements to read for each dimension. If not provided, the entire variable will be read.
+    end subroutine
+    !> Read a 1-dimensional array of 32-bit real values from the netCDF file.
+    subroutine cable_netcdf_file_get_var_real32_1d(this, var_name, values, start, count)
+      import cable_netcdf_file_t, CABLE_NETCDF_REAL32_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to read from.
+      real(kind=CABLE_NETCDF_REAL32_KIND), intent(out) :: values(:)
+        !! 1-dimensional array to store the values read from the variable.
+      integer, intent(in), optional :: start(:)
+        !! Starting indices for reading the variable. If not provided, reading will start at the beginning of the variable.
+      integer, intent(in), optional :: count(:)
+        !! Count of elements to read for each dimension. If not provided, the entire variable will be read.
+    end subroutine
+    !> Read a 2-dimensional array of 32-bit real values from the netCDF file.
+    subroutine cable_netcdf_file_get_var_real32_2d(this, var_name, values, start, count)
+      import cable_netcdf_file_t, CABLE_NETCDF_REAL32_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to read from.
+      real(kind=CABLE_NETCDF_REAL32_KIND), intent(out) :: values(:, :)
+        !! 2-dimensional array to store the values read from the variable.
+      integer, intent(in), optional :: start(:)
+        !! Starting indices for reading the variable. If not provided, reading will start at the beginning of the variable.
+      integer, intent(in), optional :: count(:)
+        !! Count of elements to read for each dimension. If not provided, the entire variable will be read.
+    end subroutine
+    !> Read a 3-dimensional array of 32-bit real values from the netCDF file.
+    subroutine cable_netcdf_file_get_var_real32_3d(this, var_name, values, start, count)
+      import cable_netcdf_file_t, CABLE_NETCDF_REAL32_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to read from.
+      real(kind=CABLE_NETCDF_REAL32_KIND), intent(out) :: values(:, :, :)
+        !! 3-dimensional array to store the values read from the variable.
+      integer, intent(in), optional :: start(:)
+        !! Starting indices for reading the variable. If not provided, reading will start at the beginning of the variable.
+      integer, intent(in), optional :: count(:)
+        !! Count of elements to read for each dimension. If not provided, the entire variable will be read.
+    end subroutine
+    !> Read a 0-dimensional (scalar) 64-bit real variable from the netCDF file.
+    subroutine cable_netcdf_file_get_var_real64_0d(this, var_name, values, start, count)
+      import cable_netcdf_file_t, CABLE_NETCDF_REAL64_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to read from.
+      real(kind=CABLE_NETCDF_REAL64_KIND), intent(out) :: values
+        !! Scalar value to store the value read from the variable.
+      integer, intent(in), optional :: start(:)
+        !! Starting indices for reading the variable. If not provided, reading will start at the beginning of the variable.
+      integer, intent(in), optional :: count(:)
+        !! Count of elements to read for each dimension. If not provided, the entire variable will be read.
+    end subroutine
+    !> Read a 1-dimensional array of 64-bit real values from the netCDF file.
+    subroutine cable_netcdf_file_get_var_real64_1d(this, var_name, values, start, count)
+      import cable_netcdf_file_t, CABLE_NETCDF_REAL64_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to read from.
+      real(kind=CABLE_NETCDF_REAL64_KIND), intent(out) :: values(:)
+        !! 1-dimensional array to store the values read from the variable.
+      integer, intent(in), optional :: start(:)
+        !! Starting indices for reading the variable. If not provided, reading will start at the beginning of the variable.
+      integer, intent(in), optional :: count(:)
+        !! Count of elements to read for each dimension. If not provided, the entire variable will be read.
+    end subroutine
+    !> Read a 2-dimensional array of 64-bit real values from the netCDF file.
+    subroutine cable_netcdf_file_get_var_real64_2d(this, var_name, values, start, count)
+      import cable_netcdf_file_t, CABLE_NETCDF_REAL64_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to read from.
+      real(kind=CABLE_NETCDF_REAL64_KIND), intent(out) :: values(:, :)
+        !! 2-dimensional array to store the values read from the variable.
+      integer, intent(in), optional :: start(:)
+        !! Starting indices for reading the variable. If not provided, reading will start at the beginning of the variable.
+      integer, intent(in), optional :: count(:)
+        !! Count of elements to read for each dimension. If not provided, the entire variable will be read.
+    end subroutine
+    !> Read a 3-dimensional array of 64-bit real values from the netCDF file.
+    subroutine cable_netcdf_file_get_var_real64_3d(this, var_name, values, start, count)
+      import cable_netcdf_file_t, CABLE_NETCDF_REAL64_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to read from.
+      real(kind=CABLE_NETCDF_REAL64_KIND), intent(out) :: values(:, :, :)
+        !! 3-dimensional array to store the values read from the variable.
+      integer, intent(in), optional :: start(:)
+        !! Starting indices for reading the variable. If not provided, reading will start at the beginning of the variable.
+      integer, intent(in), optional :: count(:)
+        !! Count of elements to read for each dimension. If not provided, the entire variable will be read.
+    end subroutine
+    !> Read a 1-dimensional array of 32-bit integers from the netCDF file using decomposition information for parallel I/O.
+    subroutine cable_netcdf_file_read_darray_int32_1d(this, var_name, values, decomp, frame)
+      import cable_netcdf_file_t, cable_netcdf_decomp_t, CABLE_NETCDF_INT32_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to read from.
+      integer(kind=CABLE_NETCDF_INT32_KIND), intent(out) :: values(:)
+        !! 1-dimensional array to store the values read from the variable.
+      class(cable_netcdf_decomp_t), intent(inout) :: decomp
+        !! Decomposition information for parallel I/O.
+      integer, intent(in), optional :: frame
+        !! Optional frame index for record variables. If provided, the data will be read from the specified frame along the unlimited dimension.
+    end subroutine
+    !> Read a 2-dimensional array of 32-bit integers from the netCDF file using decomposition information for parallel I/O.
+    subroutine cable_netcdf_file_read_darray_int32_2d(this, var_name, values, decomp, frame)
+      import cable_netcdf_file_t, cable_netcdf_decomp_t, CABLE_NETCDF_INT32_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to read from.
+      integer(kind=CABLE_NETCDF_INT32_KIND), intent(out) :: values(:, :)
+        !! 2-dimensional array to store the values read from the variable.
+      class(cable_netcdf_decomp_t), intent(inout) :: decomp
+        !! Decomposition information for parallel I/O.
+      integer, intent(in), optional :: frame
+        !! Optional frame index for record variables. If provided, the data will be read from the specified frame along the unlimited dimension.
+    end subroutine
+    !> Read a 3-dimensional array of 32-bit integers from the netCDF file using decomposition information for parallel I/O.
+    subroutine cable_netcdf_file_read_darray_int32_3d(this, var_name, values, decomp, frame)
+      import cable_netcdf_file_t, cable_netcdf_decomp_t, CABLE_NETCDF_INT32_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to read from.
+      integer(kind=CABLE_NETCDF_INT32_KIND), intent(out) :: values(:, :, :)
+        !! 3-dimensional array to store the values read from the variable.
+      class(cable_netcdf_decomp_t), intent(inout) :: decomp
+        !! Decomposition information for parallel I/O.
+      integer, intent(in), optional :: frame
+        !! Optional frame index for record variables. If provided, the data will be read from the specified frame along the unlimited dimension.
+    end subroutine
+    !> Read a 1-dimensional array of 32-bit real values from the netCDF file using decomposition information for parallel I/O.
+    subroutine cable_netcdf_file_read_darray_real32_1d(this, var_name, values, decomp, frame)
+      import cable_netcdf_file_t, cable_netcdf_decomp_t, CABLE_NETCDF_REAL32_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to read from.
+      real(kind=CABLE_NETCDF_REAL32_KIND), intent(out) :: values(:)
+        !! 1-dimensional array to store the values read from the variable.
+      class(cable_netcdf_decomp_t), intent(inout) :: decomp
+        !! Decomposition information for parallel I/O.
+      integer, intent(in), optional :: frame
+        !! Optional frame index for record variables. If provided, the data will be read from the specified frame along the unlimited dimension.
+    end subroutine
+    !> Read a 2-dimensional array of 32-bit real values from the netCDF file using decomposition information for parallel I/O.
+    subroutine cable_netcdf_file_read_darray_real32_2d(this, var_name, values, decomp, frame)
+      import cable_netcdf_file_t, cable_netcdf_decomp_t, CABLE_NETCDF_REAL32_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to read from.
+      real(kind=CABLE_NETCDF_REAL32_KIND), intent(out) :: values(:, :)
+        !! 2-dimensional array to store the values read from the variable.
+      class(cable_netcdf_decomp_t), intent(inout) :: decomp
+        !! Decomposition information for parallel I/O.
+      integer, intent(in), optional :: frame
+        !! Optional frame index for record variables. If provided, the data will be read from the specified frame along the unlimited dimension.
+    end subroutine
+    !> Read a 3-dimensional array of 32-bit real values from the netCDF file using decomposition information for parallel I/O.
+    subroutine cable_netcdf_file_read_darray_real32_3d(this, var_name, values, decomp, frame)
+      import cable_netcdf_file_t, cable_netcdf_decomp_t, CABLE_NETCDF_REAL32_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to read from.
+      real(kind=CABLE_NETCDF_REAL32_KIND), intent(out) :: values(:, :, :)
+        !! 3-dimensional array to store the values read from the variable.
+      class(cable_netcdf_decomp_t), intent(inout) :: decomp
+        !! Decomposition information for parallel I/O.
+      integer, intent(in), optional :: frame
+        !! Optional frame index for record variables. If provided, the data will be read from the specified frame along the unlimited dimension.
+    end subroutine
+    !> Read a 1-dimensional array of 64-bit real values from the netCDF file using decomposition information for parallel I/O.
+    subroutine cable_netcdf_file_read_darray_real64_1d(this, var_name, values, decomp, frame)
+      import cable_netcdf_file_t, cable_netcdf_decomp_t, CABLE_NETCDF_REAL64_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to read from.
+      real(kind=CABLE_NETCDF_REAL64_KIND), intent(out) :: values(:)
+        !! 1-dimensional array to store the values read from the variable.
+      class(cable_netcdf_decomp_t), intent(inout) :: decomp
+        !! Decomposition information for parallel I/O.
+      integer, intent(in), optional :: frame
+        !! Optional frame index for record variables. If provided, the data will be read from the specified frame along the unlimited dimension.
+    end subroutine
+    !> Read a 2-dimensional array of 64-bit real values from the netCDF file using decomposition information for parallel I/O.
+    subroutine cable_netcdf_file_read_darray_real64_2d(this, var_name, values, decomp, frame)
+      import cable_netcdf_file_t, cable_netcdf_decomp_t, CABLE_NETCDF_REAL64_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to read from.
+      real(kind=CABLE_NETCDF_REAL64_KIND), intent(out) :: values(:, :)
+        !! 2-dimensional array to store the values read from the variable.
+      class(cable_netcdf_decomp_t), intent(inout) :: decomp
+        !! Decomposition information for parallel I/O.
+      integer, intent(in), optional :: frame
+        !! Optional frame index for record variables. If provided, the data will be read from the specified frame along the unlimited dimension.
+    end subroutine
+    !> Read a 3-dimensional array of 64-bit real values from the netCDF file using decomposition information for parallel I/O.
+    subroutine cable_netcdf_file_read_darray_real64_3d(this, var_name, values, decomp, frame)
+      import cable_netcdf_file_t, cable_netcdf_decomp_t, CABLE_NETCDF_REAL64_KIND
+      class(cable_netcdf_file_t), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+        !! Name of the variable to read from.
+      real(kind=CABLE_NETCDF_REAL64_KIND), intent(out) :: values(:, :, :)
+        !! 3-dimensional array to store the values read from the variable.
+      class(cable_netcdf_decomp_t), intent(inout) :: decomp
+        !! Decomposition information for parallel I/O.
+      integer, intent(in), optional :: frame
+        !! Optional frame index for record variables. If provided, the data will be read from the specified frame along the unlimited dimension.
+    end subroutine
+  end interface
+
+  type, abstract :: cable_netcdf_io_t
+    !* Abstract type defining the interface for netCDF I/O handlers.
+    ! This allows for different implementations (e.g. NetCDF, ParallelIO) to be
+    ! used interchangeably within the CABLE code
+  contains
+    procedure(cable_netcdf_io_init), deferred :: init
+    procedure(cable_netcdf_io_finalise), deferred :: finalise
+    procedure(cable_netcdf_io_create_file), deferred :: create_file
+    procedure(cable_netcdf_io_open_file), deferred :: open_file
+    procedure(cable_netcdf_io_create_decomp), deferred :: create_decomp
+  end type
+
+  abstract interface
+    !> Initialise the netcdf I/O handler.
+    !! This procedure is called during module initialisation and can be used to set
+    !! up any necessary state or resources for the I/O handler.
+    subroutine cable_netcdf_io_init(this)
+      import cable_netcdf_io_t
+      class(cable_netcdf_io_t), intent(inout) :: this
+    end subroutine
+    !> Finalise the netcdf I/O handler.
+    !! This procedure is called during module finalization and can be used to clean
+    !! up any resources allocated by the I/O handler.
+    subroutine cable_netcdf_io_finalise(this)
+      import cable_netcdf_io_t
+      class(cable_netcdf_io_t), intent(inout) :: this
+    end subroutine
+    !> Create a new netCDF file with the specified path and I/O type.
+    function cable_netcdf_io_create_file(this, path, iotype, mode) result(file)
+      import cable_netcdf_io_t, cable_netcdf_file_t
+      class(cable_netcdf_io_t), intent(inout) :: this
+      character(len=*), intent(in) :: path
+        !! Path to the netCDF file to create.
+      integer, intent(in) :: iotype
+        !! I/O type to use for the file using the `CABLE_NETCDF_IOTYPE_*` constants.
+      integer, intent(in), optional :: mode
+        !! Optional mode flags for file creation using the `CABLE_NETCDF_MODE_*` constants.
+      class(cable_netcdf_file_t), allocatable :: file
+    end function
+    !> Open an existing netCDF file with the specified path and I/O type.
+    function cable_netcdf_io_open_file(this, path, iotype, mode) result(file)
+      import cable_netcdf_io_t, cable_netcdf_file_t
+      class(cable_netcdf_io_t), intent(inout) :: this
+      character(len=*), intent(in) :: path
+        !! Path to the netCDF file to open.
+      integer, intent(in) :: iotype
+        !! I/O type to use for the file using the `CABLE_NETCDF_IOTYPE_*` constants.
+      integer, intent(in), optional :: mode
+        !! Optional mode flags for file opening using the `CABLE_NETCDF_MODE_*` constants.
+      class(cable_netcdf_file_t), allocatable :: file
+    end function
+    !> Create a new decomposition for parallel I/O.
+    !! This follows the degree of freedom approach for specifying I/O
+    !! decompositions as described in Denis et al. (2011)
+    !! [[10.1177/1094342011428143](https://www.doi.org/10.1177/1094342011428143)].
+    function cable_netcdf_io_create_decomp(this, compmap, dims, type) result(decomp)
+      import cable_netcdf_io_t, cable_netcdf_decomp_t
+      class(cable_netcdf_io_t), intent(inout) :: this
+      integer, intent(in) :: compmap(:)
+        !* An array of data offsets describing where each element of the
+        ! in-memory array is located in the netCDF variable data on disk.
+      integer, intent(in) :: dims(:)
+        !! An array of the global dimensions used to describe the shape of the data in the netCDF file
+      integer, intent(in) :: type
+        !! The data type of the in-memory array using the `CABLE_NETCDF_TYPE_*` constants.
+      class(cable_netcdf_decomp_t), allocatable :: decomp
+    end function
+  end interface
+
+  interface
+    module subroutine cable_netcdf_mod_init(mpi_grp)
+      !* Module initialisation procedure for cable_netcdf_mod.
+      ! This procedure should be called before any other procedures in this module.
+      type(mpi_grp_t), intent(in) :: mpi_grp
+        !* The MPI group for the set of processes that will be performing netCDF I/O operations.
+        ! All procedures in cable_netcdf_mod should be called collectively by all
+        ! processes in this group.
+    end subroutine
+  end interface
+
+  !> The internal I/O handler to use for all netCDF file operations.
+  class(cable_netcdf_io_t), allocatable, private :: cable_netcdf_io_handler
+
+contains
+
+  !> Module finalization procedure for the cable_netcdf_mod module.
+  subroutine cable_netcdf_mod_end()
+    if (.not. allocated(cable_netcdf_io_handler)) then
+      call cable_abort("cable_netcdf_io_handler is not allocated. Ensure cable_netcdf_mod_init has been called.", file=__FILE__, line=__LINE__)
+    end if
+    call cable_netcdf_io_handler%finalise()
+  end subroutine
+
+  !> Create a new netCDF file with the specified path and I/O type.
+  function cable_netcdf_create_file(path, iotype, mode) result(file)
+    character(len=*), intent(in) :: path
+      !! Path to the netCDF file to create.
+    integer, intent(in) :: iotype
+      !! I/O type to use for the file using the `CABLE_NETCDF_IOTYPE_*` constants.
+    integer, intent(in), optional :: mode
+      !! Optional mode flags for file creation using the `CABLE_NETCDF_MODE_*` constants.
+    class(cable_netcdf_file_t), allocatable :: file
+    if (.not. allocated(cable_netcdf_io_handler)) then
+      call cable_abort("cable_netcdf_io_handler is not allocated. Ensure cable_netcdf_mod_init has been called.", file=__FILE__, line=__LINE__)
+    end if
+    file = cable_netcdf_io_handler%create_file(path, iotype, mode)
+  end function
+
+  !> Open an existing netCDF file with the specified path and I/O type.
+  function cable_netcdf_open_file(path, iotype, mode) result(file)
+    character(len=*), intent(in) :: path
+      !! Path to the netCDF file to open.
+    integer, intent(in) :: iotype
+      !! I/O type to use for the file using the `CABLE_NETCDF_IOTYPE_*` constants.
+    integer, intent(in), optional :: mode
+      !! Optional mode flags for file opening using the `CABLE_NETCDF_MODE_*` constants.
+    class(cable_netcdf_file_t), allocatable :: file
+    if (.not. allocated(cable_netcdf_io_handler)) then
+      call cable_abort("cable_netcdf_io_handler is not allocated. Ensure cable_netcdf_mod_init has been called.", file=__FILE__, line=__LINE__)
+    end if
+    file = cable_netcdf_io_handler%open_file(path, iotype, mode)
+  end function
+
+  !> Create a new decomposition for parallel I/O.
+  !! This follows the degree of freedom approach for specifying I/O
+  !! decompositions as described in Denis et al. (2011)
+  !! [[10.1177/1094342011428143](https://www.doi.org/10.1177/1094342011428143)].
+  function cable_netcdf_create_decomp(compmap, dims, type) result(decomp)
+    integer, intent(in) :: compmap(:)
+      !* An array of data offsets describing where each element of the
+      ! in-memory array is located in the netCDF variable data on disk.
+    integer, intent(in) :: dims(:)
+      !! An array of the global dimensions used to describe the shape of the data in the netCDF file
+    integer, intent(in) :: type
+      !! The data type of the in-memory array using the `CABLE_NETCDF_TYPE_*` constants.
+    class(cable_netcdf_decomp_t), allocatable :: decomp
+    if (.not. allocated(cable_netcdf_io_handler)) then
+      call cable_abort("cable_netcdf_io_handler is not allocated. Ensure cable_netcdf_mod_init has been called.", file=__FILE__, line=__LINE__)
+    end if
+    decomp = cable_netcdf_io_handler%create_decomp(compmap, dims, type)
+  end function
+
+end module cable_netcdf_mod

--- a/src/util/netcdf/cable_netcdf_decomp_util.F90
+++ b/src/util/netcdf/cable_netcdf_decomp_util.F90
@@ -1,0 +1,368 @@
+! CSIRO Open Source Software License Agreement (variation of the BSD / MIT License)
+! Copyright (c) 2015, Commonwealth Scientific and Industrial Research Organisation
+! (CSIRO) ABN 41 687 119 230.
+
+module cable_netcdf_decomp_util_mod
+  !* Utilities for generating parallel I/O decompositions for grids used by CABLE.
+  !
+  ! Parallel I/O decompositions describe the mapping from the local in-memory
+  ! layout of an array on the current process to the global layout of a netCDF
+  ! variable on disk. For example, a common I/O decomposition in cable is the
+  ! mapping of a 1-dimensional array of size `mp` to a netCDF variable with
+  ! dimensions `(x, y, patch)` where `x` and `y` are the spatial coordinates of
+  ! the land point corresponding to the patch index, and `patch` is the relative
+  ! patch index on that land point. Please see the documentation of the individual
+  ! decomposition generating functions in this module for more details on the
+  ! specific mappings they generate.
+
+  use cable_netcdf_mod, only: cable_netcdf_decomp_t
+  use cable_netcdf_mod, only: cable_netcdf_create_decomp
+
+  use cable_array_utils_mod, only: array_index
+  use cable_array_utils_mod, only: array_offset
+
+  use cable_error_handler_mod, only: cable_abort
+
+  implicit none
+
+  private
+
+  public io_decomp_land_to_x_y
+  public io_decomp_patch_to_x_y_patch
+  public io_decomp_land_to_land
+  public io_decomp_patch_to_land_patch
+  public io_decomp_patch_to_patch
+
+  integer, parameter :: INDEX_NOT_FOUND = -1
+
+contains
+
+  integer function patch_land_index(cstart, nap, patch_index)
+    !* Returns the land index corresponding to the given patch index, using
+    ! `cstart` and `nap` to determine the mapping. If the patch index does not lie on
+    ! any land point, the function aborts.
+    integer, intent(in) :: cstart(:) !! The starting patch index for each land point.
+    integer, intent(in) :: nap(:) !! The number of active patches for each land point.
+    integer, intent(in) :: patch_index !! The patch index to map to a land index.
+    integer i
+    patch_land_index = INDEX_NOT_FOUND
+    do i = 1, size(cstart)
+      if (patch_index >= cstart(i) .and. patch_index <= cstart(i) + nap(i) - 1) then
+        patch_land_index = i
+        exit
+      end if
+    end do
+    if (patch_land_index == INDEX_NOT_FOUND) then
+      call cable_abort("Patch index does not lie on any land point.", file=__FILE__, line=__LINE__)
+    end if
+  end function
+
+  function io_decomp_land_to_x_y(land_x, land_y, mem_shape, var_shape, type, var_x_index, var_y_index, index_map) result(decomp)
+    !* Returns a parallel I/O decomposition mapping from a memory layout with a
+    ! 'land' dimension to a netCDF variable layout with 'x' and 'y' dimensions.
+    !
+    ! The ‘land’ dimension is assumed to be the first (i.e. fastest varying) index
+    ! in `mem_shape`.
+    integer, intent(in) :: land_x(:) !! An array mapping land indexes to x (longitude) indexes.
+    integer, intent(in) :: land_y(:) !! An array mapping land indexes to y (latitude) indexes.
+    integer, intent(in) :: mem_shape(:) !! The shape of the in-memory array.
+    integer, intent(in) :: var_shape(:) !! The shape of the netCDF variable.
+    integer, intent(in) :: type
+      !* The data type of the in-memory array for which the decomposition is being
+      ! created using `CABLE_NETCDF_TYPE_*` constants from `cable_netcdf_mod`.
+    integer, intent(in), optional :: var_x_index
+      !! The index of the 'x' dimension in `var_shape`. Defaults to 1 if not provided.
+    integer, intent(in), optional :: var_y_index
+      !! The index of the 'y' dimension in `var_shape`. Defaults to 2 if not provided.
+    integer, intent(in), optional :: index_map(:)
+      !* An optional mapping from the dimension indexes of `var_shape` to the
+      ! dimension indexes of `mem_shape`. If not provided, it is assumed that the
+      ! dimensions of `var_shape` map to the dimensions of `mem_shape` in order,
+      ! with `var_x_index` and `var_y_index` indexes mapped to the first index
+      ! of `mem_shape`.
+    class(cable_netcdf_decomp_t), allocatable :: decomp
+
+    integer, allocatable :: compmap(:)
+    integer, allocatable :: mem_index(:), var_index(:), index_map_local(:)
+    integer :: i, var_x_index_local, var_y_index_local, mem_offset
+
+    if (size(var_shape) < 2) call cable_abort("var_shape must have at least 2 dimensions.", __FILE__, __LINE__)
+
+    var_x_index_local = 1
+    if (present(var_x_index)) var_x_index_local = var_x_index
+    var_y_index_local = 2
+    if (present(var_y_index)) var_y_index_local = var_y_index
+    index_map_local = [1, (i, i = 1, size(var_shape) - 1)]
+    if (present(index_map)) index_map_local = index_map
+
+    allocate(mem_index, mold=mem_shape)
+    allocate(var_index, mold=var_shape)
+    allocate(compmap(product(mem_shape)))
+
+    do mem_offset = 1, size(compmap)
+      call array_index(mem_offset, mem_shape, mem_index)
+      do i = 1, size(var_shape)
+        if (i == var_x_index_local) then
+          var_index(i) = land_x(mem_index(index_map_local(i)))
+        else if (i == var_y_index_local) then
+          var_index(i) = land_y(mem_index(index_map_local(i)))
+        else
+          var_index(i) = mem_index(index_map_local(i))
+        end if
+      end do
+      compmap(mem_offset) = array_offset(var_index, var_shape)
+    end do
+
+    decomp = cable_netcdf_create_decomp(compmap, var_shape, type)
+
+  end function
+
+  function io_decomp_patch_to_x_y_patch(land_x, land_y, cstart, nap, mem_shape, var_shape, type, var_x_index, var_y_index, var_patch_index, index_map) result(decomp)
+    !* Returns a parallel I/O decomposition mapping from a memory layout with
+    ! a 'patch' dimension to a netCDF variable layout with 'x', 'y', and 'patch'
+    ! dimensions.
+    !
+    ! Note that the 'patch' dimension in the memory layout represents the index in
+    ! the 1-dimensional vector of patches, and in the netCDF variable layout, the
+    ! 'patch' dimension represents the index of the patch on a particular land
+    ! point.
+    !
+    ! The 'patch' dimension is assumed to be the first (i.e. fastest varying)
+    ! index in `mem_shape`.
+    integer, intent(in) :: land_x(:) !! An array mapping land indexes to x (longitude) indexes.
+    integer, intent(in) :: land_y(:) !! An array mapping land indexes to y (latitude) indexes.
+    integer, intent(in) :: cstart(:) !! The starting patch index for each land point.
+    integer, intent(in) :: nap(:) !! The number of active patches for each land point.
+    integer, intent(in) :: mem_shape(:) !! The shape of the in-memory array.
+    integer, intent(in) :: var_shape(:) !! The shape of the netCDF variable.
+    integer, intent(in) :: type
+      !* The data type of the in-memory array for which the decomposition is being
+      ! created using `CABLE_NETCDF_TYPE_*` constants from `cable_netcdf_mod`.
+    integer, intent(in), optional :: var_x_index
+      !! The index of the 'x' dimension in `var_shape`. Defaults to 1 if not provided.
+    integer, intent(in), optional :: var_y_index
+      !! The index of the 'y' dimension in `var_shape`. Defaults to 2 if not provided.
+    integer, intent(in), optional :: var_patch_index
+      !! The index of the 'patch' dimension in `var_shape`. Defaults to 3 if not provided.
+    integer, intent(in), optional :: index_map(:)
+      !* An optional mapping from the dimension indexes of `var_shape` to the
+      ! dimension indexes of `mem_shape`. If not provided, it is assumed that the
+      ! dimensions of `var_shape` map to the dimensions of `mem_shape` in order,
+      ! with `var_x_index`, `var_y_index` and `var_patch_index` being mapped to
+      ! the first index of `mem_shape`.
+    class(cable_netcdf_decomp_t), allocatable :: decomp
+
+    integer, allocatable :: compmap(:)
+    integer, allocatable :: mem_index(:), var_index(:), index_map_local(:)
+    integer :: i, mem_offset, var_x_index_local, var_y_index_local, var_patch_index_local
+
+    if (size(var_shape) < 3) call cable_abort("var_shape must have at least 3 dimensions.", __FILE__, __LINE__)
+
+    var_x_index_local = 1
+    if (present(var_x_index)) var_x_index_local = var_x_index
+    var_y_index_local = 2
+    if (present(var_y_index)) var_y_index_local = var_y_index
+    var_patch_index_local = 3
+    if (present(var_patch_index)) var_patch_index_local = var_patch_index
+    index_map_local = [1, 1, (i, i = 1, size(var_shape) - 2)]
+    if (present(index_map)) index_map_local = index_map
+
+    allocate(mem_index, mold=mem_shape)
+    allocate(var_index, mold=var_shape)
+    allocate(compmap(product(mem_shape)))
+
+    do mem_offset = 1, size(compmap)
+      call array_index(mem_offset, mem_shape, mem_index)
+      do i = 1, size(var_shape)
+        if (i == var_x_index_local) then
+          var_index(i) = land_x(patch_land_index(cstart, nap, mem_index(index_map_local(i))))
+        else if (i == var_y_index_local) then
+          var_index(i) = land_y(patch_land_index(cstart, nap, mem_index(index_map_local(i))))
+        else if (i == var_patch_index_local) then
+          var_index(i) = mem_index(index_map_local(i)) - cstart(patch_land_index(cstart, nap, mem_index(index_map_local(i)))) + 1
+        else
+          var_index(i) = mem_index(index_map_local(i))
+        end if
+      end do
+      compmap(mem_offset) = array_offset(var_index, var_shape)
+    end do
+
+    decomp = cable_netcdf_create_decomp(compmap, var_shape, type)
+
+  end function
+
+  function io_decomp_land_to_land(land_decomp_start, mem_shape, var_shape, type, var_land_index, index_map) result(decomp)
+    !* Returns a parallel I/O decomposition mapping from a memory layout with a
+    ! local 'land' dimension to a netCDF variable layout with a global 'land'
+    ! dimension.
+    !
+    ! The 'land' dimension is assumed to be the first (i.e. fastest varying)
+    ! index in `mem_shape`.
+    integer, intent(in) :: land_decomp_start
+      !! The starting index of the first local 'land' index along the global 'land' dimension.
+    integer, intent(in) :: mem_shape(:) !! The shape of the in-memory array.
+    integer, intent(in) :: var_shape(:) !! The shape of the netCDF variable.
+    integer, intent(in) :: type
+      !* The data type of the in-memory array for which the decomposition is being
+      ! created using `CABLE_NETCDF_TYPE_*` constants from `cable_netcdf_mod`.
+    integer, intent(in), optional :: var_land_index
+      !! The index of the 'land' dimension in `var_shape`. Defaults to 1 if not provided.
+    integer, intent(in), optional :: index_map(:)
+      !* An optional mapping from the dimension indexes of `var_shape` to the
+      ! dimension indexes of `mem_shape`. If not provided, it is assumed that the
+      ! dimensions of `var_shape` map to the dimensions of `mem_shape` in order.
+    class(cable_netcdf_decomp_t), allocatable :: decomp
+
+    integer, allocatable :: compmap(:)
+    integer, allocatable :: mem_index(:), var_index(:), index_map_local(:)
+    integer :: i, mem_offset, var_land_index_local
+
+    if (size(var_shape) < 1) call cable_abort("var_shape must have at least 1 dimension.", __FILE__, __LINE__)
+
+    var_land_index_local = 1
+    if (present(var_land_index)) var_land_index_local = var_land_index
+    index_map_local = [(i, i = 1, size(var_shape))]
+    if (present(index_map)) index_map_local = index_map
+
+    allocate(mem_index, mold=mem_shape)
+    allocate(var_index, mold=var_shape)
+    allocate(compmap(product(mem_shape)))
+
+    do mem_offset = 1, size(compmap)
+      call array_index(mem_offset, mem_shape, mem_index)
+      do i = 1, size(var_shape)
+        if (i == var_land_index_local) then
+          var_index(i) = land_decomp_start + mem_index(index_map_local(i)) - 1
+        else
+          var_index(i) = mem_index(index_map_local(i))
+        end if
+      end do
+      compmap(mem_offset) = array_offset(var_index, var_shape)
+    end do
+
+    decomp = cable_netcdf_create_decomp(compmap, var_shape, type)
+
+  end function
+
+  function io_decomp_patch_to_land_patch(land_decomp_start, cstart, nap, mem_shape, var_shape, type, var_land_index, var_patch_index, index_map) result(decomp)
+    !* Returns a parallel I/O decomposition mapping from a memory layout with a
+    ! 'patch' dimension to a netCDF variable layout with a 'land' and 'patch'
+    ! dimension.
+    !
+    ! Note that the 'patch' dimension in the memory layout represents the index in
+    ! the 1-dimensional vector of patches, and in the netCDF variable layout, the
+    ! 'patch' dimension represents the index of the patch on a particular land
+    ! point.
+    !
+    ! The 'patch' dimension is assumed to be the first (i.e. fastest varying)
+    ! index in `mem_shape`.
+    integer, intent(in) :: land_decomp_start
+      !! The starting index of the first local 'land' index along the global 'land' dimension.
+    integer, intent(in) :: cstart(:) !! The starting patch index for each land point.
+    integer, intent(in) :: nap(:) !! The number of active patches for each land point.
+    integer, intent(in) :: mem_shape(:) !! The shape of the in-memory array.
+    integer, intent(in) :: var_shape(:) !! The shape of the netCDF variable.
+    integer, intent(in) :: type
+      !* The data type of the in-memory array for which the decomposition is being
+      ! created using `CABLE_NETCDF_TYPE_*` constants from `cable_netcdf_mod`.
+    integer, intent(in), optional :: var_land_index
+      !! The index of the 'land' dimension in `var_shape`. Defaults to 1 if not provided.
+    integer, intent(in), optional :: var_patch_index
+      !! The index of the 'patch' dimension in `var_shape`. Defaults to 2 if not provided.
+    integer, intent(in), optional :: index_map(:)
+      !* An optional mapping from the dimension indexes of `var_shape` to the
+      ! dimension indexes of `mem_shape`. If not provided, it is assumed that the
+      ! dimensions of `var_shape` map to the dimensions of `mem_shape` in order,
+      ! with `var_land_index` and `var_patch_index` being mapped to the first
+      ! index of `mem_shape`.
+    class(cable_netcdf_decomp_t), allocatable :: decomp
+
+    integer, allocatable :: compmap(:)
+    integer, allocatable :: mem_index(:), var_index(:), index_map_local(:)
+    integer :: i, mem_offset, var_land_index_local, var_patch_index_local
+
+    if (size(var_shape) < 2) call cable_abort("var_shape must have at least 2 dimensions.", __FILE__, __LINE__)
+
+    var_land_index_local = 1
+    if (present(var_land_index)) var_land_index_local = var_land_index
+    var_patch_index_local = 2
+    if (present(var_patch_index)) var_patch_index_local = var_patch_index
+    index_map_local = [1, (i, i = 1, size(var_shape) - 1)]
+    if (present(index_map)) index_map_local = index_map
+
+    allocate(mem_index, mold=mem_shape)
+    allocate(var_index, mold=var_shape)
+    allocate(compmap(product(mem_shape)))
+
+    do mem_offset = 1, size(compmap)
+      call array_index(mem_offset, mem_shape, mem_index)
+      do i = 1, size(var_shape)
+        if (i == var_land_index_local) then
+          var_index(i) = land_decomp_start + patch_land_index(cstart, nap, mem_index(index_map_local(i))) - 1
+        else if (i == var_patch_index_local) then
+          var_index(i) = mem_index(index_map_local(i)) - cstart(patch_land_index(cstart, nap, mem_index(index_map_local(i)))) + 1
+        else
+          var_index(i) = mem_index(index_map_local(i))
+        end if
+      end do
+      compmap(mem_offset) = array_offset(var_index, var_shape)
+    end do
+
+    decomp = cable_netcdf_create_decomp(compmap, var_shape, type)
+
+  end function
+
+  function io_decomp_patch_to_patch(patch_decomp_start, mem_shape, var_shape, type, var_patch_index, index_map) result(decomp)
+    !* Returns a parallel I/O decomposition mapping from a memory layout with a
+    ! local 'patch' dimension to a netCDF variable layout with a global 'patch'
+    ! dimension.
+    !
+    ! The 'patch' dimension is assumed to be the first (i.e. fastest varying)
+    ! index in `mem_shape`.
+    integer, intent(in) :: patch_decomp_start
+      !! The starting index of the first local 'patch' index along the global 'patch' dimension.
+    integer, intent(in) :: mem_shape(:) !! The shape of the in-memory array.
+    integer, intent(in) :: var_shape(:) !! The shape of the netCDF variable.
+    integer, intent(in) :: type
+      !* The data type of the in-memory array for which the decomposition is being
+      ! created using `CABLE_NETCDF_TYPE_*` constants from `cable_netcdf_mod`.
+    integer, intent(in), optional :: var_patch_index
+      ! The index of the 'patch' dimension in `var_shape`. Defaults to 1 if not provided.
+    integer, intent(in), optional :: index_map(:)
+      !* An optional mapping from the dimension indexes of `var_shape` to the
+      ! dimension indexes of `mem_shape`. If not provided, it is assumed that the
+      ! dimensions of `var_shape` map to the dimensions of `mem_shape` in order.
+    class(cable_netcdf_decomp_t), allocatable :: decomp
+
+    integer, allocatable :: compmap(:)
+    integer, allocatable :: mem_index(:), var_index(:), index_map_local(:)
+    integer :: i, mem_offset, var_patch_index_local
+
+    if (size(var_shape) < 1) call cable_abort("var_shape must have at least 1 dimension.", __FILE__, __LINE__)
+
+    var_patch_index_local = 1
+    if (present(var_patch_index)) var_patch_index_local = var_patch_index
+    index_map_local = [(i, i = 1, size(var_shape))]
+    if (present(index_map)) index_map_local = index_map
+
+    allocate(mem_index, mold=mem_shape)
+    allocate(var_index, mold=var_shape)
+    allocate(compmap(product(mem_shape)))
+
+    do mem_offset = 1, size(compmap)
+      call array_index(mem_offset, mem_shape, mem_index)
+      do i = 1, size(var_shape)
+        if (i == var_patch_index_local) then
+          var_index(i) = patch_decomp_start + mem_index(index_map_local(i)) - 1
+        else
+          var_index(i) = mem_index(index_map_local(i))
+        end if
+      end do
+      compmap(mem_offset) = array_offset(var_index, var_shape)
+    end do
+
+    decomp = cable_netcdf_create_decomp(compmap, var_shape, type)
+
+  end function
+
+end module

--- a/src/util/netcdf/cable_netcdf_init.F90
+++ b/src/util/netcdf/cable_netcdf_init.F90
@@ -1,0 +1,30 @@
+! CSIRO Open Source Software License Agreement (variation of the BSD / MIT License)
+! Copyright (c) 2015, Commonwealth Scientific and Industrial Research Organisation
+! (CSIRO) ABN 41 687 119 230.
+
+submodule (cable_netcdf_mod) cable_netcdf_init_smod
+  !! Submodule for initialising the I/O handler in cable_netcdf_mod.
+
+  use cable_netcdf_nf90_mod
+  use cable_netcdf_pio_mod
+
+  implicit none
+
+contains
+
+  module subroutine cable_netcdf_mod_init(mpi_grp)
+    !* Module initialisation procedure for cable_netcdf_mod.
+    ! This procedure should be called before any other procedures in this module.
+    type(mpi_grp_t), intent(in) :: mpi_grp
+      !* The MPI group for the set of processes that will be performing netCDF I/O operations.
+      ! All procedures in cable_netcdf_mod should be called collectively by all
+      ! processes in this group.
+    if (mpi_grp%size > 1) then
+      cable_netcdf_io_handler = cable_netcdf_pio_io_t(mpi_grp)
+    else
+      cable_netcdf_io_handler = cable_netcdf_nf90_io_t()
+    end if
+    call cable_netcdf_io_handler%init()
+  end subroutine
+
+end submodule cable_netcdf_init_smod

--- a/src/util/netcdf/cable_netcdf_stub_types.F90
+++ b/src/util/netcdf/cable_netcdf_stub_types.F90
@@ -1,0 +1,625 @@
+! CSIRO Open Source Software License Agreement (variation of the BSD / MIT License)
+! Copyright (c) 2015, Commonwealth Scientific and Industrial Research Organisation
+! (CSIRO) ABN 41 687 119 230.
+
+module cable_netcdf_stub_types_mod
+  !! Stub implementation of the netCDF file handling interface in CABLE.
+
+  use cable_netcdf_mod
+  use cable_mpi_mod, only: mpi_grp_t
+  use iso_fortran_env, only: error_unit
+
+  implicit none
+
+  private
+  public :: &
+    cable_netcdf_stub_decomp_t, &
+    cable_netcdf_stub_file_t, &
+    cable_netcdf_stub_io_t
+
+  type, extends(cable_netcdf_decomp_t) :: cable_netcdf_stub_decomp_t
+  end type
+
+  type, extends(cable_netcdf_io_t) :: cable_netcdf_stub_io_t
+  contains
+    procedure :: init => cable_netcdf_stub_io_init
+    procedure :: finalise => cable_netcdf_stub_io_finalise
+    procedure :: create_file => cable_netcdf_stub_io_create_file
+    procedure :: open_file => cable_netcdf_stub_io_open_file
+    procedure :: create_decomp => cable_netcdf_stub_io_create_decomp
+  end type
+
+  type, extends(cable_netcdf_file_t) :: cable_netcdf_stub_file_t
+  contains
+    procedure :: close => cable_netcdf_stub_file_close
+    procedure :: end_def => cable_netcdf_stub_file_end_def
+    procedure :: redef => cable_netcdf_stub_file_redef
+    procedure :: sync => cable_netcdf_stub_file_sync
+    procedure :: def_dims => cable_netcdf_stub_file_def_dims
+    procedure :: def_var => cable_netcdf_stub_file_def_var
+    procedure :: put_att_global_string => cable_netcdf_stub_file_put_att_global_string
+    procedure :: put_att_global_int32 => cable_netcdf_stub_file_put_att_global_int32
+    procedure :: put_att_global_real32 => cable_netcdf_stub_file_put_att_global_real32
+    procedure :: put_att_global_real64 => cable_netcdf_stub_file_put_att_global_real64
+    procedure :: put_att_var_string => cable_netcdf_stub_file_put_att_var_string
+    procedure :: put_att_var_int32 => cable_netcdf_stub_file_put_att_var_int32
+    procedure :: put_att_var_real32 => cable_netcdf_stub_file_put_att_var_real32
+    procedure :: put_att_var_real64 => cable_netcdf_stub_file_put_att_var_real64
+    procedure :: get_att_global_string => cable_netcdf_stub_file_get_att_global_string
+    procedure :: get_att_global_int32 => cable_netcdf_stub_file_get_att_global_int32
+    procedure :: get_att_global_real32 => cable_netcdf_stub_file_get_att_global_real32
+    procedure :: get_att_global_real64 => cable_netcdf_stub_file_get_att_global_real64
+    procedure :: get_att_var_string => cable_netcdf_stub_file_get_att_var_string
+    procedure :: get_att_var_int32 => cable_netcdf_stub_file_get_att_var_int32
+    procedure :: get_att_var_real32 => cable_netcdf_stub_file_get_att_var_real32
+    procedure :: get_att_var_real64 => cable_netcdf_stub_file_get_att_var_real64
+    procedure :: inq_dim_len => cable_netcdf_stub_file_inq_dim_len
+    procedure :: inq_var_ndims => cable_netcdf_stub_file_inq_var_ndims
+    procedure :: put_var_int32_0d => cable_netcdf_stub_file_put_var_int32_0d
+    procedure :: put_var_int32_1d => cable_netcdf_stub_file_put_var_int32_1d
+    procedure :: put_var_int32_2d => cable_netcdf_stub_file_put_var_int32_2d
+    procedure :: put_var_int32_3d => cable_netcdf_stub_file_put_var_int32_3d
+    procedure :: put_var_real32_0d => cable_netcdf_stub_file_put_var_real32_0d
+    procedure :: put_var_real32_1d => cable_netcdf_stub_file_put_var_real32_1d
+    procedure :: put_var_real32_2d => cable_netcdf_stub_file_put_var_real32_2d
+    procedure :: put_var_real32_3d => cable_netcdf_stub_file_put_var_real32_3d
+    procedure :: put_var_real64_0d => cable_netcdf_stub_file_put_var_real64_0d
+    procedure :: put_var_real64_1d => cable_netcdf_stub_file_put_var_real64_1d
+    procedure :: put_var_real64_2d => cable_netcdf_stub_file_put_var_real64_2d
+    procedure :: put_var_real64_3d => cable_netcdf_stub_file_put_var_real64_3d
+    procedure :: write_darray_int32_1d => cable_netcdf_stub_file_write_darray_int32_1d
+    procedure :: write_darray_int32_2d => cable_netcdf_stub_file_write_darray_int32_2d
+    procedure :: write_darray_int32_3d => cable_netcdf_stub_file_write_darray_int32_3d
+    procedure :: write_darray_real32_1d => cable_netcdf_stub_file_write_darray_real32_1d
+    procedure :: write_darray_real32_2d => cable_netcdf_stub_file_write_darray_real32_2d
+    procedure :: write_darray_real32_3d => cable_netcdf_stub_file_write_darray_real32_3d
+    procedure :: write_darray_real64_1d => cable_netcdf_stub_file_write_darray_real64_1d
+    procedure :: write_darray_real64_2d => cable_netcdf_stub_file_write_darray_real64_2d
+    procedure :: write_darray_real64_3d => cable_netcdf_stub_file_write_darray_real64_3d
+    procedure :: get_var_int32_0d => cable_netcdf_stub_file_get_var_int32_0d
+    procedure :: get_var_int32_1d => cable_netcdf_stub_file_get_var_int32_1d
+    procedure :: get_var_int32_2d => cable_netcdf_stub_file_get_var_int32_2d
+    procedure :: get_var_int32_3d => cable_netcdf_stub_file_get_var_int32_3d
+    procedure :: get_var_real32_0d => cable_netcdf_stub_file_get_var_real32_0d
+    procedure :: get_var_real32_1d => cable_netcdf_stub_file_get_var_real32_1d
+    procedure :: get_var_real32_2d => cable_netcdf_stub_file_get_var_real32_2d
+    procedure :: get_var_real32_3d => cable_netcdf_stub_file_get_var_real32_3d
+    procedure :: get_var_real64_0d => cable_netcdf_stub_file_get_var_real64_0d
+    procedure :: get_var_real64_1d => cable_netcdf_stub_file_get_var_real64_1d
+    procedure :: get_var_real64_2d => cable_netcdf_stub_file_get_var_real64_2d
+    procedure :: get_var_real64_3d => cable_netcdf_stub_file_get_var_real64_3d
+    procedure :: read_darray_int32_1d => cable_netcdf_stub_file_read_darray_int32_1d
+    procedure :: read_darray_int32_2d => cable_netcdf_stub_file_read_darray_int32_2d
+    procedure :: read_darray_int32_3d => cable_netcdf_stub_file_read_darray_int32_3d
+    procedure :: read_darray_real32_1d => cable_netcdf_stub_file_read_darray_real32_1d
+    procedure :: read_darray_real32_2d => cable_netcdf_stub_file_read_darray_real32_2d
+    procedure :: read_darray_real32_3d => cable_netcdf_stub_file_read_darray_real32_3d
+    procedure :: read_darray_real64_1d => cable_netcdf_stub_file_read_darray_real64_1d
+    procedure :: read_darray_real64_2d => cable_netcdf_stub_file_read_darray_real64_2d
+    procedure :: read_darray_real64_3d => cable_netcdf_stub_file_read_darray_real64_3d
+  end type
+
+contains
+
+  subroutine cable_netcdf_stub_io_init(this)
+    class(cable_netcdf_stub_io_t), intent(inout) :: this
+  end subroutine
+
+  subroutine cable_netcdf_stub_io_finalise(this)
+    class(cable_netcdf_stub_io_t), intent(inout) :: this
+  end subroutine
+
+  function cable_netcdf_stub_io_create_file(this, path, iotype, mode) result(file)
+    class(cable_netcdf_stub_io_t), intent(inout) :: this
+    character(len=*), intent(in) :: path
+    integer, intent(in) :: iotype
+    integer, intent(in), optional :: mode
+    class(cable_netcdf_file_t), allocatable :: file
+    file = cable_netcdf_stub_file_t()
+  end function
+
+  function cable_netcdf_stub_io_open_file(this, path, iotype, mode) result(file)
+    class(cable_netcdf_stub_io_t), intent(inout) :: this
+    character(len=*), intent(in) :: path
+    integer, intent(in) :: iotype
+    integer, intent(in), optional :: mode
+    class(cable_netcdf_file_t), allocatable :: file
+    file = cable_netcdf_stub_file_t()
+  end function
+
+  function cable_netcdf_stub_io_create_decomp(this, compmap, dims, type) result(decomp)
+    class(cable_netcdf_stub_io_t), intent(inout) :: this
+    integer, intent(in) :: compmap(:), dims(:)
+    integer, intent(in) :: type
+    class(cable_netcdf_decomp_t), allocatable :: decomp
+    decomp = cable_netcdf_stub_decomp_t()
+  end function
+
+  subroutine cable_netcdf_stub_file_close(this)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_end_def(this)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_redef(this)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_sync(this)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_def_dims(this, dim_names, dim_lens)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: dim_names(:)
+    integer, intent(in) :: dim_lens(:)
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_def_var(this, var_name, type, dim_names)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer, intent(in) :: type
+    character(len=*), intent(in), optional :: dim_names(:)
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_put_att_global_string(this, att_name, att_value)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: att_name, att_value
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_put_att_global_int32(this, att_name, att_value)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: att_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(in) :: att_value
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_put_att_global_real32(this, att_name, att_value)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: att_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(in) :: att_value
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_put_att_global_real64(this, att_name, att_value)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: att_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(in) :: att_value
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_put_att_var_string(this, var_name, att_name, att_value)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name, att_name, att_value
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_put_att_var_int32(this, var_name, att_name, att_value)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name, att_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(in) :: att_value
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_put_att_var_real32(this, var_name, att_name, att_value)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name, att_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(in) :: att_value
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_put_att_var_real64(this, var_name, att_name, att_value)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name, att_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(in) :: att_value
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_get_att_global_string(this, att_name, att_value)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: att_name
+    character(len=*), intent(out) :: att_value
+    att_value = ""
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_get_att_global_int32(this, att_name, att_value)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: att_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(out) :: att_value
+    att_value = 0
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_get_att_global_real32(this, att_name, att_value)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: att_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(out) :: att_value
+    att_value = 0.0
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_get_att_global_real64(this, att_name, att_value)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: att_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(out) :: att_value
+    att_value = 0.0
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_get_att_var_string(this, var_name, att_name, att_value)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name, att_name
+    character(len=*), intent(out) :: att_value
+    att_value = ""
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_get_att_var_int32(this, var_name, att_name, att_value)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name, att_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(out) :: att_value
+    att_value = 0
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_get_att_var_real32(this, var_name, att_name, att_value)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name, att_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(out) :: att_value
+    att_value = 0.0
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_get_att_var_real64(this, var_name, att_name, att_value)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name, att_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(out) :: att_value
+    att_value = 0.0
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_inq_dim_len(this, dim_name, dim_len)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: dim_name
+    integer, intent(out) :: dim_len
+    dim_len = 0
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_inq_var_ndims(this, var_name, ndims)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer, intent(out) :: ndims
+    ndims = 0
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_put_var_int32_0d(this, var_name, values, start, count)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(in) :: values
+    integer, intent(in), optional :: start(:), count(:)
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_put_var_int32_1d(this, var_name, values, start, count)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(in) :: values(:)
+    integer, intent(in), optional :: start(:), count(:)
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_put_var_int32_2d(this, var_name, values, start, count)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(in) :: values(:, :)
+    integer, intent(in), optional :: start(:), count(:)
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_put_var_int32_3d(this, var_name, values, start, count)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(in) :: values(:, :, :)
+    integer, intent(in), optional :: start(:), count(:)
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_put_var_real32_0d(this, var_name, values, start, count)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(in) :: values
+    integer, intent(in), optional :: start(:), count(:)
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_put_var_real32_1d(this, var_name, values, start, count)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(in) :: values(:)
+    integer, intent(in), optional :: start(:), count(:)
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_put_var_real32_2d(this, var_name, values, start, count)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(in) :: values(:, :)
+    integer, intent(in), optional :: start(:), count(:)
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_put_var_real32_3d(this, var_name, values, start, count)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(in) :: values(:, :, :)
+    integer, intent(in), optional :: start(:), count(:)
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_put_var_real64_0d(this, var_name, values, start, count)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(in) :: values
+    integer, intent(in), optional :: start(:), count(:)
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_put_var_real64_1d(this, var_name, values, start, count)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(in) :: values(:)
+    integer, intent(in), optional :: start(:), count(:)
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_put_var_real64_2d(this, var_name, values, start, count)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(in) :: values(:, :)
+    integer, intent(in), optional :: start(:), count(:)
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_put_var_real64_3d(this, var_name, values, start, count)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(in) :: values(:, :, :)
+    integer, intent(in), optional :: start(:), count(:)
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_write_darray_int32_1d(this, var_name, values, decomp, fill_value, frame)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(in) :: values(:)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(in), optional :: fill_value
+    integer, intent(in), optional :: frame
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_write_darray_int32_2d(this, var_name, values, decomp, fill_value, frame)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(in) :: values(:, :)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(in), optional :: fill_value
+    integer, intent(in), optional :: frame
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_write_darray_int32_3d(this, var_name, values, decomp, fill_value, frame)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(in) :: values(:, :, :)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(in), optional :: fill_value
+    integer, intent(in), optional :: frame
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_write_darray_real32_1d(this, var_name, values, decomp, fill_value, frame)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(in) :: values(:)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(in), optional :: fill_value
+    integer, intent(in), optional :: frame
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_write_darray_real32_2d(this, var_name, values, decomp, fill_value, frame)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(in) :: values(:, :)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(in), optional :: fill_value
+    integer, intent(in), optional :: frame
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_write_darray_real32_3d(this, var_name, values, decomp, fill_value, frame)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(in) :: values(:, :, :)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(in), optional :: fill_value
+    integer, intent(in), optional :: frame
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_write_darray_real64_1d(this, var_name, values, decomp, fill_value, frame)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(in) :: values(:)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(in), optional :: fill_value
+    integer, intent(in), optional :: frame
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_write_darray_real64_2d(this, var_name, values, decomp, fill_value, frame)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(in) :: values(:, :)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(in), optional :: fill_value
+    integer, intent(in), optional :: frame
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_write_darray_real64_3d(this, var_name, values, decomp, fill_value, frame)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(in) :: values(:, :, :)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(in), optional :: fill_value
+    integer, intent(in), optional :: frame
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_get_var_int32_0d(this, var_name, values, start, count)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(out) :: values
+    integer, intent(in), optional :: start(:), count(:)
+    values = 0
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_get_var_int32_1d(this, var_name, values, start, count)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(out) :: values(:)
+    integer, intent(in), optional :: start(:), count(:)
+    values = 0
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_get_var_int32_2d(this, var_name, values, start, count)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(out) :: values(:, :)
+    integer, intent(in), optional :: start(:), count(:)
+    values = 0
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_get_var_int32_3d(this, var_name, values, start, count)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(out) :: values(:, :, :)
+    integer, intent(in), optional :: start(:), count(:)
+    values = 0
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_get_var_real32_0d(this, var_name, values, start, count)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(out) :: values
+    integer, intent(in), optional :: start(:), count(:)
+    values = 0.
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_get_var_real32_1d(this, var_name, values, start, count)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(out) :: values(:)
+    integer, intent(in), optional :: start(:), count(:)
+    values = 0.
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_get_var_real32_2d(this, var_name, values, start, count)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(out) :: values(:, :)
+    integer, intent(in), optional :: start(:), count(:)
+    values = 0.
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_get_var_real32_3d(this, var_name, values, start, count)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(out) :: values(:, :, :)
+    integer, intent(in), optional :: start(:), count(:)
+    values = 0.
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_get_var_real64_0d(this, var_name, values, start, count)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(out) :: values
+    integer, intent(in), optional :: start(:), count(:)
+    values = 0.
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_get_var_real64_1d(this, var_name, values, start, count)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(out) :: values(:)
+    integer, intent(in), optional :: start(:), count(:)
+    values = 0.
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_get_var_real64_2d(this, var_name, values, start, count)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(out) :: values(:, :)
+    integer, intent(in), optional :: start(:), count(:)
+    values = 0.
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_get_var_real64_3d(this, var_name, values, start, count)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(out) :: values(:, :, :)
+    integer, intent(in), optional :: start(:), count(:)
+    values = 0.
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_read_darray_int32_1d(this, var_name, values, decomp, frame)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(out) :: values(:)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    integer, intent(in), optional :: frame
+    values = 0.
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_read_darray_int32_2d(this, var_name, values, decomp, frame)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(out) :: values(:, :)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    integer, intent(in), optional :: frame
+    values = 0.
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_read_darray_int32_3d(this, var_name, values, decomp, frame)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(out) :: values(:, :, :)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    integer, intent(in), optional :: frame
+    values = 0.
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_read_darray_real32_1d(this, var_name, values, decomp, frame)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(out) :: values(:)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    integer, intent(in), optional :: frame
+    values = 0.
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_read_darray_real32_2d(this, var_name, values, decomp, frame)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(out) :: values(:, :)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    integer, intent(in), optional :: frame
+    values = 0.
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_read_darray_real32_3d(this, var_name, values, decomp, frame)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(out) :: values(:, :, :)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    integer, intent(in), optional :: frame
+    values = 0.
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_read_darray_real64_1d(this, var_name, values, decomp, frame)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(out) :: values(:)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    integer, intent(in), optional :: frame
+    values = 0.
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_read_darray_real64_2d(this, var_name, values, decomp, frame)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(out) :: values(:, :)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    integer, intent(in), optional :: frame
+    values = 0.
+  end subroutine
+
+  subroutine cable_netcdf_stub_file_read_darray_real64_3d(this, var_name, values, decomp, frame)
+    class(cable_netcdf_stub_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(out) :: values(:, :, :)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    integer, intent(in), optional :: frame
+    values = 0.
+  end subroutine
+
+end module cable_netcdf_stub_types_mod

--- a/src/util/netcdf/nf90/cable_netcdf_nf90.F90
+++ b/src/util/netcdf/nf90/cable_netcdf_nf90.F90
@@ -1,0 +1,1483 @@
+! CSIRO Open Source Software License Agreement (variation of the BSD / MIT License)
+! Copyright (c) 2015, Commonwealth Scientific and Industrial Research Organisation
+! (CSIRO) ABN 41 687 119 230.
+
+module cable_netcdf_nf90_mod
+  !* The NetCDF Fortran implementation of the netCDF file handling interface in CABLE.
+  !
+  ! For more information on NetCDF Fortran please refer to:
+  !
+  ! - <https://docs.unidata.ucar.edu/netcdf-fortran/current/>
+  ! - <https://github.com/Unidata/netcdf-fortran>
+  !
+  ! @note
+  ! This implementation does not support parallel I/O and can only be used when CABLE is running in serial.
+  ! @endnote
+
+  use cable_netcdf_mod
+
+  use cable_error_handler_mod, only: cable_abort
+  use cable_array_utils_mod, only: array_index
+
+  use netcdf, only: nf90_create
+  use netcdf, only: nf90_open
+  use netcdf, only: nf90_close
+  use netcdf, only: nf90_sync
+  use netcdf, only: nf90_strerror
+  use netcdf, only: nf90_def_dim
+  use netcdf, only: nf90_def_var
+  use netcdf, only: nf90_put_att
+  use netcdf, only: nf90_get_att
+  use netcdf, only: nf90_put_var
+  use netcdf, only: nf90_get_var
+  use netcdf, only: nf90_inq_dimid
+  use netcdf, only: nf90_inq_varid
+  use netcdf, only: nf90_inquire_dimension
+  use netcdf, only: nf90_inquire_variable
+  use netcdf, only: nf90_enddef
+  use netcdf, only: nf90_redef
+  use netcdf, only: NF90_NOERR
+  use netcdf, only: NF90_NETCDF4
+  use netcdf, only: NF90_CLASSIC_MODEL
+  use netcdf, only: NF90_CLOBBER
+  use netcdf, only: NF90_NOCLOBBER
+  use netcdf, only: NF90_WRITE
+  use netcdf, only: NF90_NOWRITE
+  use netcdf, only: NF90_UNLIMITED
+  use netcdf, only: NF90_INT
+  use netcdf, only: NF90_FLOAT
+  use netcdf, only: NF90_DOUBLE
+  use netcdf, only: NF90_FILL_INT
+  use netcdf, only: NF90_FILL_FLOAT
+  use netcdf, only: NF90_FILL_DOUBLE
+  use netcdf, only: NF90_MAX_VAR_DIMS
+  use netcdf, only: NF90_GLOBAL
+
+  implicit none
+
+  private
+
+  public :: cable_netcdf_nf90_io_t
+
+  type, extends(cable_netcdf_decomp_t) :: cable_netcdf_nf90_decomp_int32_t
+    !! A decomposition for 32-bit integer variables in the NetCDF Fortran implementation.
+    integer, allocatable :: dims(:)
+        !! An array of the global dimensions used to describe the shape of the data in the netCDF file
+    integer, allocatable :: compmap(:)
+        !* An array of data offsets describing where each element of the
+        ! in-memory array is located in the netCDF variable data on disk.
+    integer(kind=CABLE_NETCDF_INT32_KIND), allocatable, private :: values_filled(:)
+        !* A buffer for reading/writing data from the in-memory array to the
+        ! netCDF variable data on disk.
+  end type
+
+  type, extends(cable_netcdf_decomp_t) :: cable_netcdf_nf90_decomp_real32_t
+    !! A decomposition for 32-bit real variables in the NetCDF Fortran implementation.
+    integer, allocatable :: dims(:)
+        !! An array of the global dimensions used to describe the shape of the data in the netCDF file
+    integer, allocatable :: compmap(:)
+        !* An array of data offsets describing where each element of the
+        ! in-memory array is located in the netCDF variable data on disk.
+    real(kind=CABLE_NETCDF_REAL32_KIND), allocatable, private :: values_filled(:)
+        !* A buffer for reading/writing data from the in-memory array to the
+        ! netCDF variable data on disk.
+  end type
+
+  type, extends(cable_netcdf_decomp_t) :: cable_netcdf_nf90_decomp_real64_t
+    !! A decomposition for 64-bit real variables in the NetCDF Fortran implementation.
+    integer, allocatable :: dims(:)
+        !! An array of the global dimensions used to describe the shape of the data in the netCDF file
+    integer, allocatable :: compmap(:)
+        !* An array of data offsets describing where each element of the
+        ! in-memory array is located in the netCDF variable data on disk.
+    real(kind=CABLE_NETCDF_REAL64_KIND), allocatable, private :: values_filled(:)
+        !* A buffer for reading/writing data from the in-memory array to the
+        ! netCDF variable data on disk.
+  end type
+
+  type, extends(cable_netcdf_io_t) :: cable_netcdf_nf90_io_t
+    !! The NetCDF Fortran implementation of the netCDF I/O handler interface in CABLE.
+  contains
+    procedure :: init => cable_netcdf_nf90_io_init
+    procedure :: finalise => cable_netcdf_nf90_io_finalise
+    procedure :: create_file => cable_netcdf_nf90_io_create_file
+    procedure :: open_file => cable_netcdf_nf90_io_open_file
+    procedure :: create_decomp => cable_netcdf_nf90_io_create_decomp
+  end type
+
+  type, extends(cable_netcdf_file_t) :: cable_netcdf_nf90_file_t
+    !! The NetCDF Fortran implementation of the netCDF file handling interface in CABLE.
+    integer, private :: ncid
+  contains
+    procedure :: close => cable_netcdf_nf90_file_close
+    procedure :: end_def => cable_netcdf_nf90_file_end_def
+    procedure :: redef => cable_netcdf_nf90_file_redef
+    procedure :: sync => cable_netcdf_nf90_file_sync
+    procedure :: def_dims => cable_netcdf_nf90_file_def_dims
+    procedure :: def_var => cable_netcdf_nf90_file_def_var
+    procedure :: put_att_global_string => cable_netcdf_nf90_file_put_att_global_string
+    procedure :: put_att_global_int32 => cable_netcdf_nf90_file_put_att_global_int32
+    procedure :: put_att_global_real32 => cable_netcdf_nf90_file_put_att_global_real32
+    procedure :: put_att_global_real64 => cable_netcdf_nf90_file_put_att_global_real64
+    procedure :: put_att_var_string => cable_netcdf_nf90_file_put_att_var_string
+    procedure :: put_att_var_int32 => cable_netcdf_nf90_file_put_att_var_int32
+    procedure :: put_att_var_real32 => cable_netcdf_nf90_file_put_att_var_real32
+    procedure :: put_att_var_real64 => cable_netcdf_nf90_file_put_att_var_real64
+    procedure :: get_att_global_string => cable_netcdf_nf90_file_get_att_global_string
+    procedure :: get_att_global_int32 => cable_netcdf_nf90_file_get_att_global_int32
+    procedure :: get_att_global_real32 => cable_netcdf_nf90_file_get_att_global_real32
+    procedure :: get_att_global_real64 => cable_netcdf_nf90_file_get_att_global_real64
+    procedure :: get_att_var_string => cable_netcdf_nf90_file_get_att_var_string
+    procedure :: get_att_var_int32 => cable_netcdf_nf90_file_get_att_var_int32
+    procedure :: get_att_var_real32 => cable_netcdf_nf90_file_get_att_var_real32
+    procedure :: get_att_var_real64 => cable_netcdf_nf90_file_get_att_var_real64
+    procedure :: inq_dim_len => cable_netcdf_nf90_file_inq_dim_len
+    procedure :: inq_var_ndims => cable_netcdf_nf90_file_inq_var_ndims
+    procedure :: put_var_int32_0d => cable_netcdf_nf90_file_put_var_int32_0d
+    procedure :: put_var_int32_1d => cable_netcdf_nf90_file_put_var_int32_1d
+    procedure :: put_var_int32_2d => cable_netcdf_nf90_file_put_var_int32_2d
+    procedure :: put_var_int32_3d => cable_netcdf_nf90_file_put_var_int32_3d
+    procedure :: put_var_real32_0d => cable_netcdf_nf90_file_put_var_real32_0d
+    procedure :: put_var_real32_1d => cable_netcdf_nf90_file_put_var_real32_1d
+    procedure :: put_var_real32_2d => cable_netcdf_nf90_file_put_var_real32_2d
+    procedure :: put_var_real32_3d => cable_netcdf_nf90_file_put_var_real32_3d
+    procedure :: put_var_real64_0d => cable_netcdf_nf90_file_put_var_real64_0d
+    procedure :: put_var_real64_1d => cable_netcdf_nf90_file_put_var_real64_1d
+    procedure :: put_var_real64_2d => cable_netcdf_nf90_file_put_var_real64_2d
+    procedure :: put_var_real64_3d => cable_netcdf_nf90_file_put_var_real64_3d
+    procedure :: write_darray_int32_1d => cable_netcdf_nf90_file_write_darray_int32_1d
+    procedure :: write_darray_int32_2d => cable_netcdf_nf90_file_write_darray_int32_2d
+    procedure :: write_darray_int32_3d => cable_netcdf_nf90_file_write_darray_int32_3d
+    procedure :: write_darray_real32_1d => cable_netcdf_nf90_file_write_darray_real32_1d
+    procedure :: write_darray_real32_2d => cable_netcdf_nf90_file_write_darray_real32_2d
+    procedure :: write_darray_real32_3d => cable_netcdf_nf90_file_write_darray_real32_3d
+    procedure :: write_darray_real64_1d => cable_netcdf_nf90_file_write_darray_real64_1d
+    procedure :: write_darray_real64_2d => cable_netcdf_nf90_file_write_darray_real64_2d
+    procedure :: write_darray_real64_3d => cable_netcdf_nf90_file_write_darray_real64_3d
+    procedure :: get_var_int32_0d => cable_netcdf_nf90_file_get_var_int32_0d
+    procedure :: get_var_int32_1d => cable_netcdf_nf90_file_get_var_int32_1d
+    procedure :: get_var_int32_2d => cable_netcdf_nf90_file_get_var_int32_2d
+    procedure :: get_var_int32_3d => cable_netcdf_nf90_file_get_var_int32_3d
+    procedure :: get_var_real32_0d => cable_netcdf_nf90_file_get_var_real32_0d
+    procedure :: get_var_real32_1d => cable_netcdf_nf90_file_get_var_real32_1d
+    procedure :: get_var_real32_2d => cable_netcdf_nf90_file_get_var_real32_2d
+    procedure :: get_var_real32_3d => cable_netcdf_nf90_file_get_var_real32_3d
+    procedure :: get_var_real64_0d => cable_netcdf_nf90_file_get_var_real64_0d
+    procedure :: get_var_real64_1d => cable_netcdf_nf90_file_get_var_real64_1d
+    procedure :: get_var_real64_2d => cable_netcdf_nf90_file_get_var_real64_2d
+    procedure :: get_var_real64_3d => cable_netcdf_nf90_file_get_var_real64_3d
+    procedure :: read_darray_int32_1d => cable_netcdf_nf90_file_read_darray_int32_1d
+    procedure :: read_darray_int32_2d => cable_netcdf_nf90_file_read_darray_int32_2d
+    procedure :: read_darray_int32_3d => cable_netcdf_nf90_file_read_darray_int32_3d
+    procedure :: read_darray_real32_1d => cable_netcdf_nf90_file_read_darray_real32_1d
+    procedure :: read_darray_real32_2d => cable_netcdf_nf90_file_read_darray_real32_2d
+    procedure :: read_darray_real32_3d => cable_netcdf_nf90_file_read_darray_real32_3d
+    procedure :: read_darray_real64_1d => cable_netcdf_nf90_file_read_darray_real64_1d
+    procedure :: read_darray_real64_2d => cable_netcdf_nf90_file_read_darray_real64_2d
+    procedure :: read_darray_real64_3d => cable_netcdf_nf90_file_read_darray_real64_3d
+  end type
+
+contains
+
+  function type_nf90(type)
+    integer, intent(in) :: type
+    integer :: type_nf90
+    select case(type)
+    case(CABLE_NETCDF_INT)
+      type_nf90 = NF90_INT
+    case(CABLE_NETCDF_FLOAT)
+      type_nf90 = NF90_FLOAT
+    case(CABLE_NETCDF_DOUBLE)
+      type_nf90 = NF90_DOUBLE
+    case default
+      call cable_abort("Type not supported", file=__FILE__, line=__LINE__)
+    end select
+  end function type_nf90
+
+  function cmode_nf90(iotype, mode)
+    integer, intent(in) :: iotype
+    integer, intent(in), optional :: mode
+    integer :: cmode_nf90
+    select case(iotype)
+    case (CABLE_NETCDF_IOTYPE_CLASSIC, CABLE_NETCDF_IOTYPE_NETCDF)
+      cmode_nf90 = NF90_CLASSIC_MODEL
+    case (CABLE_NETCDF_IOTYPE_NETCDF4C, CABLE_NETCDF_IOTYPE_NETCDF4P)
+      cmode_nf90 = NF90_NETCDF4
+    case default
+      call cable_abort("IOtype not supported", file=__FILE__, line=__LINE__)
+    end select
+    if (present(mode)) then
+      select case(mode)
+      case (CABLE_NETCDF_MODE_NOCLOBBER)
+        cmode_nf90 = ior(cmode_nf90, NF90_NOCLOBBER)
+      case (CABLE_NETCDF_MODE_CLOBBER)
+        cmode_nf90 = ior(cmode_nf90, NF90_CLOBBER)
+      case (CABLE_NETCDF_MODE_WRITE)
+        cmode_nf90 = ior(cmode_nf90, NF90_WRITE)
+      case (CABLE_NETCDF_MODE_NOWRITE)
+        cmode_nf90 = ior(cmode_nf90, NF90_NOWRITE)
+      case default
+        call cable_abort("File mode not supported", file=__FILE__, line=__LINE__)
+      end select
+    end if
+  end function cmode_nf90
+
+  subroutine check_nf90(status)
+    integer, intent ( in) :: status
+    if(status /= NF90_NOERR) then
+      call cable_abort(trim(nf90_strerror(status)), file=__FILE__, line=__LINE__)
+    end if
+  end subroutine check_nf90
+
+  subroutine cable_netcdf_nf90_io_init(this)
+    class(cable_netcdf_nf90_io_t), intent(inout) :: this
+  end subroutine
+
+  subroutine cable_netcdf_nf90_io_finalise(this)
+    class(cable_netcdf_nf90_io_t), intent(inout) :: this
+  end subroutine
+
+  function cable_netcdf_nf90_io_create_file(this, path, iotype, mode) result(file)
+    class(cable_netcdf_nf90_io_t), intent(inout) :: this
+    character(len=*), intent(in) :: path
+    integer, intent(in) :: iotype
+    integer, intent(in), optional :: mode
+    class(cable_netcdf_file_t), allocatable :: file
+    integer :: ncid
+    call check_nf90(nf90_create(path, cmode_nf90(iotype, mode), ncid))
+    file = cable_netcdf_nf90_file_t(ncid=ncid)
+  end function
+
+  function cable_netcdf_nf90_io_open_file(this, path, iotype, mode) result(file)
+    class(cable_netcdf_nf90_io_t), intent(inout) :: this
+    character(len=*), intent(in) :: path
+    integer, intent(in) :: iotype
+    integer, intent(in), optional :: mode
+    class(cable_netcdf_file_t), allocatable :: file
+    integer :: ncid
+    call check_nf90(nf90_open(path, cmode_nf90(iotype, mode), ncid))
+    file = cable_netcdf_nf90_file_t(ncid=ncid)
+  end function
+
+  function cable_netcdf_nf90_io_create_decomp(this, compmap, dims, type) result(decomp)
+    class(cable_netcdf_nf90_io_t), intent(inout) :: this
+    integer, intent(in) :: compmap(:), dims(:)
+    integer, intent(in) :: type
+    class(cable_netcdf_decomp_t), allocatable :: decomp
+    select case(type)
+    case (CABLE_NETCDF_INT)
+      block
+        type(cable_netcdf_nf90_decomp_int32_t) :: decomp_int32
+        decomp_int32 = cable_netcdf_nf90_decomp_int32_t(compmap=compmap, dims=dims)
+        allocate(decomp_int32%values_filled(product(dims)))
+        decomp = decomp_int32
+      end block
+    case (CABLE_NETCDF_FLOAT)
+      block
+        type(cable_netcdf_nf90_decomp_real32_t) :: decomp_real32
+        decomp_real32 = cable_netcdf_nf90_decomp_real32_t(compmap=compmap, dims=dims)
+        allocate(decomp_real32%values_filled(product(dims)))
+        decomp = decomp_real32
+      end block
+    case (CABLE_NETCDF_DOUBLE)
+      block
+        type(cable_netcdf_nf90_decomp_real64_t) :: decomp_real64
+        decomp_real64 = cable_netcdf_nf90_decomp_real64_t(compmap=compmap, dims=dims)
+        allocate(decomp_real64%values_filled(product(dims)))
+        decomp = decomp_real64
+      end block
+    case default
+      call cable_abort("Type not supported", file=__FILE__, line=__LINE__)
+    end select
+  end function
+
+  subroutine cable_netcdf_nf90_file_close(this)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    call check_nf90(nf90_close(this%ncid))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_end_def(this)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    call check_nf90(nf90_enddef(this%ncid))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_redef(this)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    call check_nf90(nf90_redef(this%ncid))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_sync(this)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    call check_nf90(nf90_sync(this%ncid))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_def_dims(this, dim_names, dim_lens)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: dim_names(:)
+    integer, intent(in) :: dim_lens(:)
+    integer :: i, tmp
+    do i = 1, size(dim_names)
+      if (dim_lens(i) == CABLE_NETCDF_UNLIMITED) then
+        call check_nf90(nf90_def_dim(this%ncid, dim_names(i), NF90_UNLIMITED, tmp))
+      else
+        call check_nf90(nf90_def_dim(this%ncid, dim_names(i), dim_lens(i), tmp))
+      end if
+    end do
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_def_var(this, var_name, type, dim_names)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer, intent(in) :: type
+    character(len=*), intent(in), optional :: dim_names(:)
+    integer, allocatable :: dimids(:)
+    integer :: i, tmp
+
+    if (.not. present(dim_names)) then
+      call check_nf90(nf90_def_var(this%ncid, var_name, type_nf90(type), tmp))
+      return
+    end if
+
+    allocate(dimids(size(dim_names)))
+    do i = 1, size(dimids)
+      call check_nf90(nf90_inq_dimid(this%ncid, dim_names(i), dimids(i)))
+    end do
+    call check_nf90(nf90_def_var(this%ncid, var_name, type_nf90(type), dimids, tmp))
+
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_put_att_global_string(this, att_name, att_value)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: att_name, att_value
+    call check_nf90(nf90_put_att(this%ncid, NF90_GLOBAL, att_name, att_value))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_put_att_global_int32(this, att_name, att_value)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: att_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(in) :: att_value
+    call check_nf90(nf90_put_att(this%ncid, NF90_GLOBAL, att_name, att_value))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_put_att_global_real32(this, att_name, att_value)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: att_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(in) :: att_value
+    call check_nf90(nf90_put_att(this%ncid, NF90_GLOBAL, att_name, att_value))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_put_att_global_real64(this, att_name, att_value)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: att_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(in) :: att_value
+    call check_nf90(nf90_put_att(this%ncid, NF90_GLOBAL, att_name, att_value))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_put_att_var_string(this, var_name, att_name, att_value)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name, att_name, att_value
+    integer varid
+    call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+    call check_nf90(nf90_put_att(this%ncid, varid, att_name, att_value))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_put_att_var_int32(this, var_name, att_name, att_value)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name, att_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(in) :: att_value
+    integer varid
+    call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+    call check_nf90(nf90_put_att(this%ncid, varid, att_name, att_value))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_put_att_var_real32(this, var_name, att_name, att_value)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name, att_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(in) :: att_value
+    integer varid
+    call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+    call check_nf90(nf90_put_att(this%ncid, varid, att_name, att_value))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_put_att_var_real64(this, var_name, att_name, att_value)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name, att_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(in) :: att_value
+    integer varid
+    call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+    call check_nf90(nf90_put_att(this%ncid, varid, att_name, att_value))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_get_att_global_string(this, att_name, att_value)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: att_name
+    character(len=*), intent(out) :: att_value
+    call check_nf90(nf90_get_att(this%ncid, NF90_GLOBAL, att_name, att_value))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_get_att_global_int32(this, att_name, att_value)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: att_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(out) :: att_value
+    call check_nf90(nf90_get_att(this%ncid, NF90_GLOBAL, att_name, att_value))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_get_att_global_real32(this, att_name, att_value)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: att_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(out) :: att_value
+    call check_nf90(nf90_get_att(this%ncid, NF90_GLOBAL, att_name, att_value))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_get_att_global_real64(this, att_name, att_value)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: att_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(out) :: att_value
+    call check_nf90(nf90_get_att(this%ncid, NF90_GLOBAL, att_name, att_value))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_get_att_var_string(this, var_name, att_name, att_value)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name, att_name
+    character(len=*), intent(out) :: att_value
+    integer varid
+    call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+    call check_nf90(nf90_get_att(this%ncid, varid, att_name, att_value))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_get_att_var_int32(this, var_name, att_name, att_value)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name, att_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(out) :: att_value
+    integer varid
+    call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+    call check_nf90(nf90_get_att(this%ncid, varid, att_name, att_value))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_get_att_var_real32(this, var_name, att_name, att_value)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name, att_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(out) :: att_value
+    integer varid
+    call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+    call check_nf90(nf90_get_att(this%ncid, varid, att_name, att_value))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_get_att_var_real64(this, var_name, att_name, att_value)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name, att_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(out) :: att_value
+    integer varid
+    call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+    call check_nf90(nf90_get_att(this%ncid, varid, att_name, att_value))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_inq_dim_len(this, dim_name, dim_len)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: dim_name
+    integer, intent(out) :: dim_len
+    integer :: dimid
+    call check_nf90(nf90_inq_dimid(this%ncid, dim_name, dimid))
+    call check_nf90(nf90_inquire_dimension(this%ncid, dimid, len=dim_len))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_inq_var_ndims(this, var_name, ndims)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer, intent(out) :: ndims
+    integer :: varid
+    call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+    call check_nf90(nf90_inquire_variable(this%ncid, varid, ndims=ndims))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_put_var_int32_0d(this, var_name, values, start, count)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(in) :: values
+    integer, intent(in), optional :: start(:), count(:)
+    integer varid
+    call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+    call check_nf90(nf90_put_var(this%ncid, varid, values, start=start))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_put_var_int32_1d(this, var_name, values, start, count)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(in) :: values(:)
+    integer, intent(in), optional :: start(:), count(:)
+    integer varid
+    call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+    call check_nf90(nf90_put_var(this%ncid, varid, values, start=start, count=count))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_put_var_int32_2d(this, var_name, values, start, count)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(in) :: values(:, :)
+    integer, intent(in), optional :: start(:), count(:)
+    integer varid
+    call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+    call check_nf90(nf90_put_var(this%ncid, varid, values, start=start, count=count))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_put_var_int32_3d(this, var_name, values, start, count)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(in) :: values(:, :, :)
+    integer, intent(in), optional :: start(:), count(:)
+    integer varid
+    call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+    call check_nf90(nf90_put_var(this%ncid, varid, values, start=start, count=count))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_put_var_real32_0d(this, var_name, values, start, count)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(in) :: values
+    integer, intent(in), optional :: start(:), count(:)
+    integer varid
+    call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+    call check_nf90(nf90_put_var(this%ncid, varid, values, start=start))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_put_var_real32_1d(this, var_name, values, start, count)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(in) :: values(:)
+    integer, intent(in), optional :: start(:), count(:)
+    integer varid
+    call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+    call check_nf90(nf90_put_var(this%ncid, varid, values, start=start, count=count))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_put_var_real32_2d(this, var_name, values, start, count)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(in) :: values(:, :)
+    integer, intent(in), optional :: start(:), count(:)
+    integer varid
+    call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+    call check_nf90(nf90_put_var(this%ncid, varid, values, start=start, count=count))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_put_var_real32_3d(this, var_name, values, start, count)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(in) :: values(:, :, :)
+    integer, intent(in), optional :: start(:), count(:)
+    integer varid
+    call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+    call check_nf90(nf90_put_var(this%ncid, varid, values, start=start, count=count))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_put_var_real64_0d(this, var_name, values, start, count)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(in) :: values
+    integer, intent(in), optional :: start(:), count(:)
+    integer varid
+    call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+    call check_nf90(nf90_put_var(this%ncid, varid, values, start=start))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_put_var_real64_1d(this, var_name, values, start, count)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(in) :: values(:)
+    integer, intent(in), optional :: start(:), count(:)
+    integer varid
+    call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+    call check_nf90(nf90_put_var(this%ncid, varid, values, start=start, count=count))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_put_var_real64_2d(this, var_name, values, start, count)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(in) :: values(:, :)
+    integer, intent(in), optional :: start(:), count(:)
+    integer varid
+    call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+    call check_nf90(nf90_put_var(this%ncid, varid, values, start=start, count=count))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_put_var_real64_3d(this, var_name, values, start, count)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(in) :: values(:, :, :)
+    integer, intent(in), optional :: start(:), count(:)
+    integer varid
+    call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+    call check_nf90(nf90_put_var(this%ncid, varid, values, start=start, count=count))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_write_darray_int32_1d(this, var_name, values, decomp, fill_value, frame)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(in) :: values(:)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(in), optional :: fill_value
+    integer, intent(in), optional :: frame
+    integer :: i, varid, ndims
+    integer :: dimids(NF90_MAX_VAR_DIMS), starts(NF90_MAX_VAR_DIMS), counts(NF90_MAX_VAR_DIMS)
+    select type (decomp)
+    type is (cable_netcdf_nf90_decomp_int32_t)
+      call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+      if (present(fill_value)) then
+        decomp%values_filled = fill_value
+      else
+        decomp%values_filled = NF90_FILL_INT
+      end if
+      do i = 1, size(values)
+        decomp%values_filled(decomp%compmap(i)) = values(i)
+      end do
+      call check_nf90(nf90_inquire_variable(this%ncid, varid, dimids=dimids, ndims=ndims))
+      do i = 1, ndims
+        starts(i) = 1
+        call check_nf90(nf90_inquire_dimension(this%ncid, dimids(i), len=counts(i)))
+      end do
+      if (present(frame)) then
+        starts(ndims) = frame
+        counts(ndims) = 1
+      end if
+      call check_nf90( &
+        nf90_put_var( &
+          this%ncid, &
+          varid, &
+          decomp%values_filled, &
+          start=starts(:ndims), &
+          count=counts(:ndims), &
+          map=[1, (product(decomp%dims(:i)), i = 1, size(decomp%dims) - 1)] &
+        ) &
+      )
+    class default
+      call cable_abort("Decomposition object must be of type cable_netcdf_nf90_decomp_int32_t", file=__FILE__, line=__LINE__)
+    end select
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_write_darray_int32_2d(this, var_name, values, decomp, fill_value, frame)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(in) :: values(:, :)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(in), optional :: fill_value
+    integer, intent(in), optional :: frame
+    integer :: i, varid, ndims
+    integer :: dimids(NF90_MAX_VAR_DIMS), starts(NF90_MAX_VAR_DIMS), counts(NF90_MAX_VAR_DIMS), mem_index(2)
+    select type (decomp)
+    type is (cable_netcdf_nf90_decomp_int32_t)
+      call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+      if (present(fill_value)) then
+        decomp%values_filled = fill_value
+      else
+        decomp%values_filled = NF90_FILL_INT
+      end if
+      do i = 1, size(values)
+        call array_index(i, shape(values), mem_index(:2))
+        decomp%values_filled(decomp%compmap(i)) = values(mem_index(1), mem_index(2))
+      end do
+      call check_nf90(nf90_inquire_variable(this%ncid, varid, dimids=dimids, ndims=ndims))
+      do i = 1, ndims
+        starts(i) = 1
+        call check_nf90(nf90_inquire_dimension(this%ncid, dimids(i), len=counts(i)))
+      end do
+      if (present(frame)) then
+        starts(ndims) = frame
+        counts(ndims) = 1
+      end if
+      call check_nf90( &
+        nf90_put_var( &
+          this%ncid, &
+          varid, &
+          decomp%values_filled, &
+          start=starts(:ndims), &
+          count=counts(:ndims), &
+          map=[1, (product(decomp%dims(:i)), i = 1, size(decomp%dims) - 1)] &
+        ) &
+      )
+    class default
+      call cable_abort("Decomposition object must be of type cable_netcdf_nf90_decomp_int32_t", file=__FILE__, line=__LINE__)
+    end select
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_write_darray_int32_3d(this, var_name, values, decomp, fill_value, frame)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(in) :: values(:, :, :)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(in), optional :: fill_value
+    integer, intent(in), optional :: frame
+    integer :: i, varid, ndims
+    integer :: dimids(NF90_MAX_VAR_DIMS), starts(NF90_MAX_VAR_DIMS), counts(NF90_MAX_VAR_DIMS), mem_index(3)
+    select type (decomp)
+    type is (cable_netcdf_nf90_decomp_int32_t)
+      call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+      if (present(fill_value)) then
+        decomp%values_filled = fill_value
+      else
+        decomp%values_filled = NF90_FILL_INT
+      end if
+      do i = 1, size(values)
+        call array_index(i, shape(values), mem_index(:3))
+        decomp%values_filled(decomp%compmap(i)) = values(mem_index(1), mem_index(2), mem_index(3))
+      end do
+      call check_nf90(nf90_inquire_variable(this%ncid, varid, dimids=dimids, ndims=ndims))
+      do i = 1, ndims
+        starts(i) = 1
+        call check_nf90(nf90_inquire_dimension(this%ncid, dimids(i), len=counts(i)))
+      end do
+      if (present(frame)) then
+        starts(ndims) = frame
+        counts(ndims) = 1
+      end if
+      call check_nf90( &
+        nf90_put_var( &
+          this%ncid, &
+          varid, &
+          decomp%values_filled, &
+          start=starts(:ndims), &
+          count=counts(:ndims), &
+          map=[1, (product(decomp%dims(:i)), i = 1, size(decomp%dims) - 1)] &
+        ) &
+      )
+    class default
+      call cable_abort("Decomposition object must be of type cable_netcdf_nf90_decomp_int32_t", file=__FILE__, line=__LINE__)
+    end select
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_write_darray_real32_1d(this, var_name, values, decomp, fill_value, frame)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(in) :: values(:)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(in), optional :: fill_value
+    integer, intent(in), optional :: frame
+    integer :: i, varid, ndims
+    integer :: dimids(NF90_MAX_VAR_DIMS), starts(NF90_MAX_VAR_DIMS), counts(NF90_MAX_VAR_DIMS)
+    select type (decomp)
+    type is (cable_netcdf_nf90_decomp_real32_t)
+      call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+      if (present(fill_value)) then
+        decomp%values_filled = fill_value
+      else
+        decomp%values_filled = NF90_FILL_FLOAT
+      end if
+      do i = 1, size(values)
+        decomp%values_filled(decomp%compmap(i)) = values(i)
+      end do
+      call check_nf90(nf90_inquire_variable(this%ncid, varid, dimids=dimids, ndims=ndims))
+      do i = 1, ndims
+        starts(i) = 1
+        call check_nf90(nf90_inquire_dimension(this%ncid, dimids(i), len=counts(i)))
+      end do
+      if (present(frame)) then
+        starts(ndims) = frame
+        counts(ndims) = 1
+      end if
+      call check_nf90( &
+        nf90_put_var( &
+          this%ncid, &
+          varid, &
+          decomp%values_filled, &
+          start=starts(:ndims), &
+          count=counts(:ndims), &
+          map=[1, (product(decomp%dims(:i)), i = 1, size(decomp%dims) - 1)] &
+        ) &
+      )
+    class default
+      call cable_abort("Decomposition object must be of type cable_netcdf_nf90_decomp_real32_t", file=__FILE__, line=__LINE__)
+    end select
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_write_darray_real32_2d(this, var_name, values, decomp, fill_value, frame)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(in) :: values(:, :)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(in), optional :: fill_value
+    integer, intent(in), optional :: frame
+    integer :: i, varid, ndims
+    integer :: dimids(NF90_MAX_VAR_DIMS), starts(NF90_MAX_VAR_DIMS), counts(NF90_MAX_VAR_DIMS), mem_index(2)
+    select type (decomp)
+    type is (cable_netcdf_nf90_decomp_real32_t)
+      call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+      if (present(fill_value)) then
+        decomp%values_filled = fill_value
+      else
+        decomp%values_filled = NF90_FILL_FLOAT
+      end if
+      do i = 1, size(values)
+        call array_index(i, shape(values), mem_index(:2))
+        decomp%values_filled(decomp%compmap(i)) = values(mem_index(1), mem_index(2))
+      end do
+      call check_nf90(nf90_inquire_variable(this%ncid, varid, dimids=dimids, ndims=ndims))
+      do i = 1, ndims
+        starts(i) = 1
+        call check_nf90(nf90_inquire_dimension(this%ncid, dimids(i), len=counts(i)))
+      end do
+      if (present(frame)) then
+        starts(ndims) = frame
+        counts(ndims) = 1
+      end if
+      call check_nf90( &
+        nf90_put_var( &
+          this%ncid, &
+          varid, &
+          decomp%values_filled, &
+          start=starts(:ndims), &
+          count=counts(:ndims), &
+          map=[1, (product(decomp%dims(:i)), i = 1, size(decomp%dims) - 1)] &
+        ) &
+      )
+    class default
+      call cable_abort("Decomposition object must be of type cable_netcdf_nf90_decomp_real32_t", file=__FILE__, line=__LINE__)
+    end select
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_write_darray_real32_3d(this, var_name, values, decomp, fill_value, frame)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(in) :: values(:, :, :)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(in), optional :: fill_value
+    integer, intent(in), optional :: frame
+    integer :: i, varid, ndims
+    integer :: dimids(NF90_MAX_VAR_DIMS), starts(NF90_MAX_VAR_DIMS), counts(NF90_MAX_VAR_DIMS), mem_index(3)
+    select type (decomp)
+    type is (cable_netcdf_nf90_decomp_real32_t)
+      call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+      if (present(fill_value)) then
+        decomp%values_filled = fill_value
+      else
+        decomp%values_filled = NF90_FILL_FLOAT
+      end if
+      do i = 1, size(values)
+        call array_index(i, shape(values), mem_index(:3))
+        decomp%values_filled(decomp%compmap(i)) = values(mem_index(1), mem_index(2), mem_index(3))
+      end do
+      call check_nf90(nf90_inquire_variable(this%ncid, varid, dimids=dimids, ndims=ndims))
+      do i = 1, ndims
+        starts(i) = 1
+        call check_nf90(nf90_inquire_dimension(this%ncid, dimids(i), len=counts(i)))
+      end do
+      if (present(frame)) then
+        starts(ndims) = frame
+        counts(ndims) = 1
+      end if
+      call check_nf90( &
+        nf90_put_var( &
+          this%ncid, &
+          varid, &
+          decomp%values_filled, &
+          start=starts(:ndims), &
+          count=counts(:ndims), &
+          map=[1, (product(decomp%dims(:i)), i = 1, size(decomp%dims) - 1)] &
+        ) &
+      )
+    class default
+      call cable_abort("Decomposition object must be of type cable_netcdf_nf90_decomp_real32_t", file=__FILE__, line=__LINE__)
+    end select
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_write_darray_real64_1d(this, var_name, values, decomp, fill_value, frame)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(in) :: values(:)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(in), optional :: fill_value
+    integer, intent(in), optional :: frame
+    integer :: i, varid, ndims
+    integer :: dimids(NF90_MAX_VAR_DIMS), starts(NF90_MAX_VAR_DIMS), counts(NF90_MAX_VAR_DIMS)
+    select type (decomp)
+    type is (cable_netcdf_nf90_decomp_real64_t)
+      call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+      if (present(fill_value)) then
+        decomp%values_filled = fill_value
+      else
+        decomp%values_filled = NF90_FILL_DOUBLE
+      end if
+      do i = 1, size(values)
+        decomp%values_filled(decomp%compmap(i)) = values(i)
+      end do
+      call check_nf90(nf90_inquire_variable(this%ncid, varid, dimids=dimids, ndims=ndims))
+      do i = 1, ndims
+        starts(i) = 1
+        call check_nf90(nf90_inquire_dimension(this%ncid, dimids(i), len=counts(i)))
+      end do
+      if (present(frame)) then
+        starts(ndims) = frame
+        counts(ndims) = 1
+      end if
+      call check_nf90( &
+        nf90_put_var( &
+          this%ncid, &
+          varid, &
+          decomp%values_filled, &
+          start=starts(:ndims), &
+          count=counts(:ndims), &
+          map=[1, (product(decomp%dims(:i)), i = 1, size(decomp%dims) - 1)] &
+        ) &
+      )
+    class default
+      call cable_abort("Decomposition object must be of type cable_netcdf_nf90_decomp_real64_t", file=__FILE__, line=__LINE__)
+    end select
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_write_darray_real64_2d(this, var_name, values, decomp, fill_value, frame)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(in) :: values(:, :)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(in), optional :: fill_value
+    integer, intent(in), optional :: frame
+    integer :: i, varid, ndims
+    integer :: dimids(NF90_MAX_VAR_DIMS), starts(NF90_MAX_VAR_DIMS), counts(NF90_MAX_VAR_DIMS), mem_index(2)
+    select type (decomp)
+    type is (cable_netcdf_nf90_decomp_real64_t)
+      call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+      if (present(fill_value)) then
+        decomp%values_filled = fill_value
+      else
+        decomp%values_filled = NF90_FILL_DOUBLE
+      end if
+      do i = 1, size(values)
+        call array_index(i, shape(values), mem_index(:2))
+        decomp%values_filled(decomp%compmap(i)) = values(mem_index(1), mem_index(2))
+      end do
+      call check_nf90(nf90_inquire_variable(this%ncid, varid, dimids=dimids, ndims=ndims))
+      do i = 1, ndims
+        starts(i) = 1
+        call check_nf90(nf90_inquire_dimension(this%ncid, dimids(i), len=counts(i)))
+      end do
+      if (present(frame)) then
+        starts(ndims) = frame
+        counts(ndims) = 1
+      end if
+      call check_nf90( &
+        nf90_put_var( &
+          this%ncid, &
+          varid, &
+          decomp%values_filled, &
+          start=starts(:ndims), &
+          count=counts(:ndims), &
+          map=[1, (product(decomp%dims(:i)), i = 1, size(decomp%dims) - 1)] &
+        ) &
+      )
+    class default
+      call cable_abort("Decomposition object must be of type cable_netcdf_nf90_decomp_real64_t", file=__FILE__, line=__LINE__)
+    end select
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_write_darray_real64_3d(this, var_name, values, decomp, fill_value, frame)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(in) :: values(:, :, :)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(in), optional :: fill_value
+    integer, intent(in), optional :: frame
+    integer :: i, varid, ndims
+    integer :: dimids(NF90_MAX_VAR_DIMS), starts(NF90_MAX_VAR_DIMS), counts(NF90_MAX_VAR_DIMS), mem_index(3)
+    select type (decomp)
+    type is (cable_netcdf_nf90_decomp_real64_t)
+      call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+      if (present(fill_value)) then
+        decomp%values_filled = fill_value
+      else
+        decomp%values_filled = NF90_FILL_DOUBLE
+      end if
+      do i = 1, size(values)
+        call array_index(i, shape(values), mem_index(:3))
+        decomp%values_filled(decomp%compmap(i)) = values(mem_index(1), mem_index(2), mem_index(3))
+      end do
+      call check_nf90(nf90_inquire_variable(this%ncid, varid, dimids=dimids, ndims=ndims))
+      do i = 1, ndims
+        starts(i) = 1
+        call check_nf90(nf90_inquire_dimension(this%ncid, dimids(i), len=counts(i)))
+      end do
+      if (present(frame)) then
+        starts(ndims) = frame
+        counts(ndims) = 1
+      end if
+      call check_nf90( &
+        nf90_put_var( &
+          this%ncid, &
+          varid, &
+          decomp%values_filled, &
+          start=starts(:ndims), &
+          count=counts(:ndims), &
+          map=[1, (product(decomp%dims(:i)), i = 1, size(decomp%dims) - 1)] &
+        ) &
+      )
+    class default
+      call cable_abort("Decomposition object must be of type cable_netcdf_nf90_decomp_real64_t", file=__FILE__, line=__LINE__)
+    end select
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_get_var_int32_0d(this, var_name, values, start, count)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(out) :: values
+    integer, intent(in), optional :: start(:), count(:)
+    integer varid
+    call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+    call check_nf90(nf90_get_var(this%ncid, varid, values, start=start))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_get_var_int32_1d(this, var_name, values, start, count)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(out) :: values(:)
+    integer, intent(in), optional :: start(:), count(:)
+    integer varid
+    call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+    call check_nf90(nf90_get_var(this%ncid, varid, values, start=start, count=count))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_get_var_int32_2d(this, var_name, values, start, count)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(out) :: values(:, :)
+    integer, intent(in), optional :: start(:), count(:)
+    integer varid
+    call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+    call check_nf90(nf90_get_var(this%ncid, varid, values, start=start, count=count))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_get_var_int32_3d(this, var_name, values, start, count)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(out) :: values(:, :, :)
+    integer, intent(in), optional :: start(:), count(:)
+    integer varid
+    call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+    call check_nf90(nf90_get_var(this%ncid, varid, values, start=start, count=count))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_get_var_real32_0d(this, var_name, values, start, count)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(out) :: values
+    integer, intent(in), optional :: start(:), count(:)
+    integer varid
+    call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+    call check_nf90(nf90_get_var(this%ncid, varid, values, start=start))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_get_var_real32_1d(this, var_name, values, start, count)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(out) :: values(:)
+    integer, intent(in), optional :: start(:), count(:)
+    integer varid
+    call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+    call check_nf90(nf90_get_var(this%ncid, varid, values, start=start, count=count))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_get_var_real32_2d(this, var_name, values, start, count)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(out) :: values(:, :)
+    integer, intent(in), optional :: start(:), count(:)
+    integer varid
+    call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+    call check_nf90(nf90_get_var(this%ncid, varid, values, start=start, count=count))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_get_var_real32_3d(this, var_name, values, start, count)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(out) :: values(:, :, :)
+    integer, intent(in), optional :: start(:), count(:)
+    integer varid
+    call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+    call check_nf90(nf90_get_var(this%ncid, varid, values, start=start, count=count))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_get_var_real64_0d(this, var_name, values, start, count)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(out) :: values
+    integer, intent(in), optional :: start(:), count(:)
+    integer varid
+    call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+    call check_nf90(nf90_get_var(this%ncid, varid, values, start=start))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_get_var_real64_1d(this, var_name, values, start, count)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(out) :: values(:)
+    integer, intent(in), optional :: start(:), count(:)
+    integer varid
+    call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+    call check_nf90(nf90_get_var(this%ncid, varid, values, start=start, count=count))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_get_var_real64_2d(this, var_name, values, start, count)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(out) :: values(:, :)
+    integer, intent(in), optional :: start(:), count(:)
+    integer varid
+    call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+    call check_nf90(nf90_get_var(this%ncid, varid, values, start=start, count=count))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_get_var_real64_3d(this, var_name, values, start, count)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(out) :: values(:, :, :)
+    integer, intent(in), optional :: start(:), count(:)
+    integer varid
+    call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+    call check_nf90(nf90_get_var(this%ncid, varid, values, start=start, count=count))
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_read_darray_int32_1d(this, var_name, values, decomp, frame)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(out) :: values(:)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    integer, intent(in), optional :: frame
+    integer :: i, varid, ndims
+    integer :: dimids(NF90_MAX_VAR_DIMS), starts(NF90_MAX_VAR_DIMS), counts(NF90_MAX_VAR_DIMS)
+    select type (decomp)
+    type is (cable_netcdf_nf90_decomp_int32_t)
+      call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+      call check_nf90(nf90_inquire_variable(this%ncid, varid, dimids=dimids, ndims=ndims))
+      do i = 1, ndims
+        starts(i) = 1
+        call check_nf90(nf90_inquire_dimension(this%ncid, dimids(i), len=counts(i)))
+      end do
+      if (present(frame)) then
+        starts(ndims) = frame
+        counts(ndims) = 1
+      end if
+      call check_nf90( &
+        nf90_get_var( &
+          this%ncid, &
+          varid, &
+          decomp%values_filled, &
+          start=starts(:ndims), &
+          count=counts(:ndims), &
+          map=[1, (product(decomp%dims(:i)), i = 1, size(decomp%dims) - 1)] &
+        ) &
+      )
+      do i = 1, size(values)
+        values(i) = decomp%values_filled(decomp%compmap(i))
+      end do
+    class default
+      call cable_abort("Decomposition object must be of type cable_netcdf_nf90_decomp_int32_t", file=__FILE__, line=__LINE__)
+    end select
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_read_darray_int32_2d(this, var_name, values, decomp, frame)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(out) :: values(:, :)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    integer, intent(in), optional :: frame
+    integer :: i, varid, ndims
+    integer :: dimids(NF90_MAX_VAR_DIMS), starts(NF90_MAX_VAR_DIMS), counts(NF90_MAX_VAR_DIMS), mem_index(2)
+    select type (decomp)
+    type is (cable_netcdf_nf90_decomp_int32_t)
+      call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+      call check_nf90(nf90_inquire_variable(this%ncid, varid, dimids=dimids, ndims=ndims))
+      do i = 1, ndims
+        starts(i) = 1
+        call check_nf90(nf90_inquire_dimension(this%ncid, dimids(i), len=counts(i)))
+      end do
+      if (present(frame)) then
+        starts(ndims) = frame
+        counts(ndims) = 1
+      end if
+      call check_nf90( &
+        nf90_get_var( &
+          this%ncid, &
+          varid, &
+          decomp%values_filled, &
+          start=starts(:ndims), &
+          count=counts(:ndims), &
+          map=[1, (product(decomp%dims(:i)), i = 1, size(decomp%dims) - 1)] &
+        ) &
+      )
+      do i = 1, size(values)
+        call array_index(i, shape(values), mem_index(:2))
+        values(mem_index(1), mem_index(2)) = decomp%values_filled(decomp%compmap(i))
+      end do
+    class default
+      call cable_abort("Decomposition object must be of type cable_netcdf_nf90_decomp_int32_t", file=__FILE__, line=__LINE__)
+    end select
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_read_darray_int32_3d(this, var_name, values, decomp, frame)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(out) :: values(:, :, :)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    integer, intent(in), optional :: frame
+    integer :: i, varid, ndims
+    integer :: dimids(NF90_MAX_VAR_DIMS), starts(NF90_MAX_VAR_DIMS), counts(NF90_MAX_VAR_DIMS), mem_index(3)
+    select type (decomp)
+    type is (cable_netcdf_nf90_decomp_int32_t)
+      call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+      call check_nf90(nf90_inquire_variable(this%ncid, varid, dimids=dimids, ndims=ndims))
+      do i = 1, ndims
+        starts(i) = 1
+        call check_nf90(nf90_inquire_dimension(this%ncid, dimids(i), len=counts(i)))
+      end do
+      if (present(frame)) then
+        starts(ndims) = frame
+        counts(ndims) = 1
+      end if
+      call check_nf90( &
+        nf90_get_var( &
+          this%ncid, &
+          varid, &
+          decomp%values_filled, &
+          start=starts(:ndims), &
+          count=counts(:ndims), &
+          map=[1, (product(decomp%dims(:i)), i = 1, size(decomp%dims) - 1)] &
+        ) &
+      )
+      do i = 1, size(values)
+        call array_index(i, shape(values), mem_index(:3))
+        values(mem_index(1), mem_index(2), mem_index(3)) = decomp%values_filled(decomp%compmap(i))
+      end do
+    class default
+      call cable_abort("Decomposition object must be of type cable_netcdf_nf90_decomp_int32_t", file=__FILE__, line=__LINE__)
+    end select
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_read_darray_real32_1d(this, var_name, values, decomp, frame)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(out) :: values(:)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    integer, intent(in), optional :: frame
+    integer :: i, varid, ndims
+    integer :: dimids(NF90_MAX_VAR_DIMS), starts(NF90_MAX_VAR_DIMS), counts(NF90_MAX_VAR_DIMS)
+    select type (decomp)
+    type is (cable_netcdf_nf90_decomp_real32_t)
+      call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+      call check_nf90(nf90_inquire_variable(this%ncid, varid, dimids=dimids, ndims=ndims))
+      do i = 1, ndims
+        starts(i) = 1
+        call check_nf90(nf90_inquire_dimension(this%ncid, dimids(i), len=counts(i)))
+      end do
+      if (present(frame)) then
+        starts(ndims) = frame
+        counts(ndims) = 1
+      end if
+      call check_nf90( &
+        nf90_get_var( &
+          this%ncid, &
+          varid, &
+          decomp%values_filled, &
+          start=starts(:ndims), &
+          count=counts(:ndims), &
+          map=[1, (product(decomp%dims(:i)), i = 1, size(decomp%dims) - 1)] &
+        ) &
+      )
+      do i = 1, size(values)
+        values(i) = decomp%values_filled(decomp%compmap(i))
+      end do
+    class default
+      call cable_abort("Decomposition object must be of type cable_netcdf_nf90_decomp_real32_t", file=__FILE__, line=__LINE__)
+    end select
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_read_darray_real32_2d(this, var_name, values, decomp, frame)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(out) :: values(:, :)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    integer, intent(in), optional :: frame
+    integer :: i, varid, ndims
+    integer :: dimids(NF90_MAX_VAR_DIMS), starts(NF90_MAX_VAR_DIMS), counts(NF90_MAX_VAR_DIMS), mem_index(2)
+    select type (decomp)
+    type is (cable_netcdf_nf90_decomp_real32_t)
+      call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+      call check_nf90(nf90_inquire_variable(this%ncid, varid, dimids=dimids, ndims=ndims))
+      do i = 1, ndims
+        starts(i) = 1
+        call check_nf90(nf90_inquire_dimension(this%ncid, dimids(i), len=counts(i)))
+      end do
+      if (present(frame)) then
+        starts(ndims) = frame
+        counts(ndims) = 1
+      end if
+      call check_nf90( &
+        nf90_get_var( &
+          this%ncid, &
+          varid, &
+          decomp%values_filled, &
+          start=starts(:ndims), &
+          count=counts(:ndims), &
+          map=[1, (product(decomp%dims(:i)), i = 1, size(decomp%dims) - 1)] &
+        ) &
+      )
+      do i = 1, size(values)
+        call array_index(i, shape(values), mem_index(:2))
+        values(mem_index(1), mem_index(2)) = decomp%values_filled(decomp%compmap(i))
+      end do
+    class default
+      call cable_abort("Decomposition object must be of type cable_netcdf_nf90_decomp_real32_t", file=__FILE__, line=__LINE__)
+    end select
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_read_darray_real32_3d(this, var_name, values, decomp, frame)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(out) :: values(:, :, :)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    integer, intent(in), optional :: frame
+    integer :: i, varid, ndims
+    integer :: dimids(NF90_MAX_VAR_DIMS), starts(NF90_MAX_VAR_DIMS), counts(NF90_MAX_VAR_DIMS), mem_index(3)
+    select type (decomp)
+    type is (cable_netcdf_nf90_decomp_real32_t)
+      call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+      call check_nf90(nf90_inquire_variable(this%ncid, varid, dimids=dimids, ndims=ndims))
+      do i = 1, ndims
+        starts(i) = 1
+        call check_nf90(nf90_inquire_dimension(this%ncid, dimids(i), len=counts(i)))
+      end do
+      if (present(frame)) then
+        starts(ndims) = frame
+        counts(ndims) = 1
+      end if
+      call check_nf90( &
+        nf90_get_var( &
+          this%ncid, &
+          varid, &
+          decomp%values_filled, &
+          start=starts(:ndims), &
+          count=counts(:ndims), &
+          map=[1, (product(decomp%dims(:i)), i = 1, size(decomp%dims) - 1)] &
+        ) &
+      )
+      do i = 1, size(values)
+        call array_index(i, shape(values), mem_index(:3))
+        values(mem_index(1), mem_index(2), mem_index(3)) = decomp%values_filled(decomp%compmap(i))
+      end do
+    class default
+      call cable_abort("Decomposition object must be of type cable_netcdf_nf90_decomp_real32_t", file=__FILE__, line=__LINE__)
+    end select
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_read_darray_real64_1d(this, var_name, values, decomp, frame)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(out) :: values(:)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    integer, intent(in), optional :: frame
+    integer :: i, varid, ndims
+    integer :: dimids(NF90_MAX_VAR_DIMS), starts(NF90_MAX_VAR_DIMS), counts(NF90_MAX_VAR_DIMS)
+    select type (decomp)
+    type is (cable_netcdf_nf90_decomp_real64_t)
+      call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+      call check_nf90(nf90_inquire_variable(this%ncid, varid, dimids=dimids, ndims=ndims))
+      do i = 1, ndims
+        starts(i) = 1
+        call check_nf90(nf90_inquire_dimension(this%ncid, dimids(i), len=counts(i)))
+      end do
+      if (present(frame)) then
+        starts(ndims) = frame
+        counts(ndims) = 1
+      end if
+      call check_nf90( &
+        nf90_get_var( &
+          this%ncid, &
+          varid, &
+          decomp%values_filled, &
+          start=starts(:ndims), &
+          count=counts(:ndims), &
+          map=[1, (product(decomp%dims(:i)), i = 1, size(decomp%dims) - 1)] &
+        ) &
+      )
+      do i = 1, size(values)
+        values(i) = decomp%values_filled(decomp%compmap(i))
+      end do
+    class default
+      call cable_abort("Decomposition object must be of type cable_netcdf_nf90_decomp_real64_t", file=__FILE__, line=__LINE__)
+    end select
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_read_darray_real64_2d(this, var_name, values, decomp, frame)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(out) :: values(:, :)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    integer, intent(in), optional :: frame
+    integer :: i, varid, ndims
+    integer :: dimids(NF90_MAX_VAR_DIMS), starts(NF90_MAX_VAR_DIMS), counts(NF90_MAX_VAR_DIMS), mem_index(2)
+    select type (decomp)
+    type is (cable_netcdf_nf90_decomp_real64_t)
+      call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+      call check_nf90(nf90_inquire_variable(this%ncid, varid, dimids=dimids, ndims=ndims))
+      do i = 1, ndims
+        starts(i) = 1
+        call check_nf90(nf90_inquire_dimension(this%ncid, dimids(i), len=counts(i)))
+      end do
+      if (present(frame)) then
+        starts(ndims) = frame
+        counts(ndims) = 1
+      end if
+      call check_nf90( &
+        nf90_get_var( &
+          this%ncid, &
+          varid, &
+          decomp%values_filled, &
+          start=starts(:ndims), &
+          count=counts(:ndims), &
+          map=[1, (product(decomp%dims(:i)), i = 1, size(decomp%dims) - 1)] &
+        ) &
+      )
+      do i = 1, size(values)
+        call array_index(i, shape(values), mem_index(:2))
+        values(mem_index(1), mem_index(2)) = decomp%values_filled(decomp%compmap(i))
+      end do
+    class default
+      call cable_abort("Decomposition object must be of type cable_netcdf_nf90_decomp_real64_t", file=__FILE__, line=__LINE__)
+    end select
+  end subroutine
+
+  subroutine cable_netcdf_nf90_file_read_darray_real64_3d(this, var_name, values, decomp, frame)
+    class(cable_netcdf_nf90_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(out) :: values(:, :, :)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    integer, intent(in), optional :: frame
+    integer :: i, varid, ndims
+    integer :: dimids(NF90_MAX_VAR_DIMS), starts(NF90_MAX_VAR_DIMS), counts(NF90_MAX_VAR_DIMS), mem_index(3)
+    select type (decomp)
+    type is (cable_netcdf_nf90_decomp_real64_t)
+      call check_nf90(nf90_inq_varid(this%ncid, var_name, varid))
+      call check_nf90(nf90_inquire_variable(this%ncid, varid, dimids=dimids, ndims=ndims))
+      do i = 1, ndims
+        starts(i) = 1
+        call check_nf90(nf90_inquire_dimension(this%ncid, dimids(i), len=counts(i)))
+      end do
+      if (present(frame)) then
+        starts(ndims) = frame
+        counts(ndims) = 1
+      end if
+      call check_nf90( &
+        nf90_get_var( &
+          this%ncid, &
+          varid, &
+          decomp%values_filled, &
+          start=starts(:ndims), &
+          count=counts(:ndims), &
+          map=[1, (product(decomp%dims(:i)), i = 1, size(decomp%dims) - 1)] &
+        ) &
+      )
+      do i = 1, size(values)
+        call array_index(i, shape(values), mem_index(:3))
+        values(mem_index(1), mem_index(2), mem_index(3)) = decomp%values_filled(decomp%compmap(i))
+      end do
+    class default
+      call cable_abort("Decomposition object must be of type cable_netcdf_nf90_decomp_real64_t", file=__FILE__, line=__LINE__)
+    end select
+  end subroutine
+
+end module cable_netcdf_nf90_mod

--- a/src/util/netcdf/pio/cable_netcdf_pio.F90
+++ b/src/util/netcdf/pio/cable_netcdf_pio.F90
@@ -1,0 +1,1199 @@
+! CSIRO Open Source Software License Agreement (variation of the BSD / MIT License)
+! Copyright (c) 2015, Commonwealth Scientific and Industrial Research Organisation
+! (CSIRO) ABN 41 687 119 230.
+
+module cable_netcdf_pio_mod
+  !* The ParallelIO (PIO) implementation of the netCDF file handling interface in CABLE.
+  !
+  ! For more information on the PIO library please refer to:
+  !
+  ! - <https://ncar.github.io/ParallelIO/index.html>
+  ! - <https://github.com/NCAR/ParallelIO>
+  ! - The paper "An application-level parallel I/O library for Earth system
+  !   models" Denis et al. (2011)
+  !   [[10.1177/1094342011428143](https://www.doi.org/10.1177/1094342011428143)]
+
+  use cable_netcdf_mod
+
+  use cable_mpi_mod, only: mpi_grp_t
+  use cable_error_handler_mod, only: cable_abort
+  use cable_common_module, only: pio_settings
+
+  use pio, only: pio_file_desc_t => file_desc_t
+  use pio, only: pio_iosystem_desc_t => iosystem_desc_t
+  use pio, only: pio_io_desc_t => io_desc_t
+  use pio, only: pio_var_desc_t => var_desc_t
+  use pio, only: pio_init
+  use pio, only: pio_initdecomp
+  use pio, only: pio_createfile
+  use pio, only: pio_openfile
+  use pio, only: pio_closefile
+  use pio, only: pio_syncfile
+  use pio, only: pio_def_dim
+  use pio, only: pio_def_var
+  use pio, only: pio_put_att
+  use pio, only: pio_get_att
+  use pio, only: pio_put_var
+  use pio, only: pio_get_var
+  use pio, only: pio_setframe
+  use pio, only: pio_write_darray
+  use pio, only: pio_read_darray
+  use pio, only: pio_strerror
+  use pio, only: pio_enddef
+  use pio, only: pio_redef
+  use pio, only: pio_inq_dimid
+  use pio, only: pio_inquire_dimension
+  use pio, only: pio_inquire_variable
+  use pio, only: pio_inq_varid
+  use pio, only: pio_finalize
+  use pio, only: PIO_MAX_NAME
+  use pio, only: PIO_OFFSET_KIND
+  use pio, only: PIO_INT
+  use pio, only: PIO_REAL
+  use pio, only: PIO_DOUBLE
+  use pio, only: PIO_REARR_BOX
+  use pio, only: PIO_REARR_SUBSET
+  use pio, only: PIO_IOTYPE_NETCDF
+  use pio, only: PIO_IOTYPE_PNETCDF
+  use pio, only: PIO_IOTYPE_NETCDF4C
+  use pio, only: PIO_IOTYPE_NETCDF4P
+  use pio, only: PIO_CLOBBER
+  use pio, only: PIO_NOCLOBBER
+  use pio, only: PIO_WRITE
+  use pio, only: PIO_NOWRITE
+  use pio, only: PIO_UNLIMITED
+  use pio, only: PIO_NOERR
+  use pio, only: PIO_GLOBAL
+
+  implicit none
+
+  private
+  public :: cable_netcdf_pio_io_t
+
+  type, extends(cable_netcdf_decomp_t) :: cable_netcdf_pio_decomp_t
+    !! The PIO implementation of the netCDF decomposition interface in CABLE.
+    type(pio_io_desc_t), private :: pio_io_desc
+  end type
+
+  type, extends(cable_netcdf_io_t) :: cable_netcdf_pio_io_t
+    !! The PIO implementation of the netCDF I/O handler interface in CABLE.
+    private
+    type(mpi_grp_t) :: mpi_grp
+    type(pio_iosystem_desc_t) :: pio_iosystem_desc
+  contains
+    procedure :: init => cable_netcdf_pio_io_init
+    procedure :: finalise => cable_netcdf_pio_io_finalise
+    procedure :: create_file => cable_netcdf_pio_io_create_file
+    procedure :: open_file => cable_netcdf_pio_io_open_file
+    procedure :: create_decomp => cable_netcdf_pio_io_create_decomp
+  end type
+
+  interface cable_netcdf_pio_io_t
+    procedure cable_netcdf_pio_io_constructor
+  end interface
+
+  type, extends(cable_netcdf_file_t) :: cable_netcdf_pio_file_t
+    !! The PIO implementation of the netCDF file handling interface in CABLE.
+    type(pio_file_desc_t), private :: pio_file_desc
+  contains
+    procedure :: close => cable_netcdf_pio_file_close
+    procedure :: end_def => cable_netcdf_pio_file_end_def
+    procedure :: redef => cable_netcdf_pio_file_redef
+    procedure :: sync => cable_netcdf_pio_file_sync
+    procedure :: def_dims => cable_netcdf_pio_file_def_dims
+    procedure :: def_var => cable_netcdf_pio_file_def_var
+    procedure :: put_att_global_string => cable_netcdf_pio_file_put_att_global_string
+    procedure :: put_att_global_int32 => cable_netcdf_pio_file_put_att_global_int32
+    procedure :: put_att_global_real32 => cable_netcdf_pio_file_put_att_global_real32
+    procedure :: put_att_global_real64 => cable_netcdf_pio_file_put_att_global_real64
+    procedure :: put_att_var_string => cable_netcdf_pio_file_put_att_var_string
+    procedure :: put_att_var_int32 => cable_netcdf_pio_file_put_att_var_int32
+    procedure :: put_att_var_real32 => cable_netcdf_pio_file_put_att_var_real32
+    procedure :: put_att_var_real64 => cable_netcdf_pio_file_put_att_var_real64
+    procedure :: get_att_global_string => cable_netcdf_pio_file_get_att_global_string
+    procedure :: get_att_global_int32 => cable_netcdf_pio_file_get_att_global_int32
+    procedure :: get_att_global_real32 => cable_netcdf_pio_file_get_att_global_real32
+    procedure :: get_att_global_real64 => cable_netcdf_pio_file_get_att_global_real64
+    procedure :: get_att_var_string => cable_netcdf_pio_file_get_att_var_string
+    procedure :: get_att_var_int32 => cable_netcdf_pio_file_get_att_var_int32
+    procedure :: get_att_var_real32 => cable_netcdf_pio_file_get_att_var_real32
+    procedure :: get_att_var_real64 => cable_netcdf_pio_file_get_att_var_real64
+    procedure :: inq_dim_len => cable_netcdf_pio_file_inq_dim_len
+    procedure :: inq_var_ndims => cable_netcdf_pio_file_inq_var_ndims
+    procedure :: put_var_int32_0d => cable_netcdf_pio_file_put_var_int32_0d
+    procedure :: put_var_int32_1d => cable_netcdf_pio_file_put_var_int32_1d
+    procedure :: put_var_int32_2d => cable_netcdf_pio_file_put_var_int32_2d
+    procedure :: put_var_int32_3d => cable_netcdf_pio_file_put_var_int32_3d
+    procedure :: put_var_real32_0d => cable_netcdf_pio_file_put_var_real32_0d
+    procedure :: put_var_real32_1d => cable_netcdf_pio_file_put_var_real32_1d
+    procedure :: put_var_real32_2d => cable_netcdf_pio_file_put_var_real32_2d
+    procedure :: put_var_real32_3d => cable_netcdf_pio_file_put_var_real32_3d
+    procedure :: put_var_real64_0d => cable_netcdf_pio_file_put_var_real64_0d
+    procedure :: put_var_real64_1d => cable_netcdf_pio_file_put_var_real64_1d
+    procedure :: put_var_real64_2d => cable_netcdf_pio_file_put_var_real64_2d
+    procedure :: put_var_real64_3d => cable_netcdf_pio_file_put_var_real64_3d
+    procedure :: write_darray_int32_1d => cable_netcdf_pio_file_write_darray_int32_1d
+    procedure :: write_darray_int32_2d => cable_netcdf_pio_file_write_darray_int32_2d
+    procedure :: write_darray_int32_3d => cable_netcdf_pio_file_write_darray_int32_3d
+    procedure :: write_darray_real32_1d => cable_netcdf_pio_file_write_darray_real32_1d
+    procedure :: write_darray_real32_2d => cable_netcdf_pio_file_write_darray_real32_2d
+    procedure :: write_darray_real32_3d => cable_netcdf_pio_file_write_darray_real32_3d
+    procedure :: write_darray_real64_1d => cable_netcdf_pio_file_write_darray_real64_1d
+    procedure :: write_darray_real64_2d => cable_netcdf_pio_file_write_darray_real64_2d
+    procedure :: write_darray_real64_3d => cable_netcdf_pio_file_write_darray_real64_3d
+    procedure :: get_var_int32_0d => cable_netcdf_pio_file_get_var_int32_0d
+    procedure :: get_var_int32_1d => cable_netcdf_pio_file_get_var_int32_1d
+    procedure :: get_var_int32_2d => cable_netcdf_pio_file_get_var_int32_2d
+    procedure :: get_var_int32_3d => cable_netcdf_pio_file_get_var_int32_3d
+    procedure :: get_var_real32_0d => cable_netcdf_pio_file_get_var_real32_0d
+    procedure :: get_var_real32_1d => cable_netcdf_pio_file_get_var_real32_1d
+    procedure :: get_var_real32_2d => cable_netcdf_pio_file_get_var_real32_2d
+    procedure :: get_var_real32_3d => cable_netcdf_pio_file_get_var_real32_3d
+    procedure :: get_var_real64_0d => cable_netcdf_pio_file_get_var_real64_0d
+    procedure :: get_var_real64_1d => cable_netcdf_pio_file_get_var_real64_1d
+    procedure :: get_var_real64_2d => cable_netcdf_pio_file_get_var_real64_2d
+    procedure :: get_var_real64_3d => cable_netcdf_pio_file_get_var_real64_3d
+    procedure :: read_darray_int32_1d => cable_netcdf_pio_file_read_darray_int32_1d
+    procedure :: read_darray_int32_2d => cable_netcdf_pio_file_read_darray_int32_2d
+    procedure :: read_darray_int32_3d => cable_netcdf_pio_file_read_darray_int32_3d
+    procedure :: read_darray_real32_1d => cable_netcdf_pio_file_read_darray_real32_1d
+    procedure :: read_darray_real32_2d => cable_netcdf_pio_file_read_darray_real32_2d
+    procedure :: read_darray_real32_3d => cable_netcdf_pio_file_read_darray_real32_3d
+    procedure :: read_darray_real64_1d => cable_netcdf_pio_file_read_darray_real64_1d
+    procedure :: read_darray_real64_2d => cable_netcdf_pio_file_read_darray_real64_2d
+    procedure :: read_darray_real64_3d => cable_netcdf_pio_file_read_darray_real64_3d
+  end type
+
+contains
+
+  function type_pio(basetype)
+    integer, intent(in) :: basetype
+    integer :: type_pio
+    select case(basetype)
+    case(CABLE_NETCDF_INT)
+      type_pio = PIO_INT
+    case(CABLE_NETCDF_FLOAT)
+      type_pio = PIO_REAL
+    case(CABLE_NETCDF_DOUBLE)
+      type_pio = PIO_DOUBLE
+    case default
+      call cable_abort("Type not supported", file=__FILE__, line=__LINE__)
+    end select
+  end function type_pio
+
+  function iotype_pio(iotype)
+    integer, intent(in) :: iotype
+    integer :: iotype_pio
+    select case(iotype)
+    case(CABLE_NETCDF_IOTYPE_CLASSIC)
+      iotype_pio = PIO_IOTYPE_PNETCDF
+    case(CABLE_NETCDF_IOTYPE_NETCDF)
+      iotype_pio = PIO_IOTYPE_NETCDF
+    case(CABLE_NETCDF_IOTYPE_NETCDF4C)
+      iotype_pio = PIO_IOTYPE_NETCDF4C
+    case(CABLE_NETCDF_IOTYPE_NETCDF4P)
+      iotype_pio = PIO_IOTYPE_NETCDF4P
+    case default
+      call cable_abort("IOtype not supported", file=__FILE__, line=__LINE__)
+    end select
+  end function iotype_pio
+
+  function mode_pio(mode)
+    integer, intent(in), optional :: mode
+    integer :: mode_pio
+    if (.not. present(mode)) then
+      mode_pio = PIO_WRITE
+      return
+    end if
+    select case(mode)
+    case(CABLE_NETCDF_MODE_CLOBBER)
+      mode_pio = PIO_CLOBBER
+    case(CABLE_NETCDF_MODE_NOCLOBBER)
+      mode_pio = PIO_NOCLOBBER
+    case(CABLE_NETCDF_MODE_WRITE)
+      mode_pio = PIO_WRITE
+    case(CABLE_NETCDF_MODE_NOWRITE)
+      mode_pio = PIO_NOWRITE
+    case default
+      call cable_abort("File mode not supported", file=__FILE__, line=__LINE__)
+    end select
+  end function mode_pio
+
+  function rearranger_pio(rearr)
+    character(len=*), intent(in) :: rearr
+    integer :: rearranger_pio
+    select case (trim(rearr))
+    case ("box")
+      rearranger_pio = PIO_REARR_BOX
+    case ("subset")
+      rearranger_pio = PIO_REARR_SUBSET
+    case default
+      call cable_abort("Invalid rearranger", file=__FILE__, line=__LINE__)
+    end select
+  end function rearranger_pio
+
+  subroutine check_pio(status)
+    integer, intent(in) :: status
+    integer :: strerror_status
+    character(len=PIO_MAX_NAME) :: err_msg
+    if (status /= PIO_NOERR) then
+        strerror_status = pio_strerror(status, err_msg)
+        call cable_abort(trim(err_msg), file=__FILE__, line=__LINE__)
+    end if
+  end subroutine check_pio
+
+  subroutine get_start_count_nonoptionals(start_nonopt, count_nonopt, shape, start, count)
+    integer, allocatable, intent(out) :: start_nonopt(:), count_nonopt(:)
+    integer, intent(in) :: shape(:)
+    integer, optional, intent(in) :: start(:), count(:)
+    if (present(start)) then
+      start_nonopt = start
+    else
+      allocate(start_nonopt, mold=shape)
+      start_nonopt = 1
+    end if
+    if (present(count)) then
+      count_nonopt = count
+    else
+      allocate(count_nonopt, source=shape)
+    end if
+  end subroutine
+
+  function cable_netcdf_pio_io_constructor(mpi_grp) result(this)
+    type(cable_netcdf_pio_io_t) :: this
+    type(mpi_grp_t), intent(in) :: mpi_grp
+    this%mpi_grp = mpi_grp
+  end function
+
+  subroutine cable_netcdf_pio_io_init(this)
+    class(cable_netcdf_pio_io_t), intent(inout) :: this
+    call pio_init( &
+      comp_rank=this%mpi_grp%rank, &
+      comp_comm=this%mpi_grp%comm%mpi_val, &
+      num_iotasks=pio_settings%io_tasks, &
+      num_aggregator=0, & ! This argument is obsolete (see https://github.com/NCAR/ParallelIO/issues/1888)
+      stride=pio_settings%stride, &
+      rearr=rearranger_pio(pio_settings%rearr), &
+      iosystem=this%pio_iosystem_desc, &
+      base=pio_settings%base &
+    )
+  end subroutine
+
+  subroutine cable_netcdf_pio_io_finalise(this)
+    class(cable_netcdf_pio_io_t), intent(inout) :: this
+    integer :: status
+    call pio_finalize(this%pio_iosystem_desc, status)
+    call check_pio(status)
+  end subroutine
+
+  function cable_netcdf_pio_io_create_file(this, path, iotype, mode) result(file)
+    class(cable_netcdf_pio_io_t), intent(inout) :: this
+    character(len=*), intent(in) :: path
+    integer, intent(in) :: iotype
+    integer, intent(in), optional :: mode
+    class(cable_netcdf_file_t), allocatable :: file
+    type(pio_file_desc_t) :: pio_file_desc
+    call check_pio(pio_createfile(this%pio_iosystem_desc, pio_file_desc, iotype_pio(iotype), path, mode_pio(mode)))
+    file = cable_netcdf_pio_file_t(pio_file_desc)
+  end function
+
+  function cable_netcdf_pio_io_open_file(this, path, iotype, mode) result(file)
+    class(cable_netcdf_pio_io_t), intent(inout) :: this
+    character(len=*), intent(in) :: path
+    integer, intent(in) :: iotype
+    integer, intent(in), optional :: mode
+    class(cable_netcdf_file_t), allocatable :: file
+    type(pio_file_desc_t) :: pio_file_desc
+    call check_pio(pio_openfile(this%pio_iosystem_desc, pio_file_desc, iotype_pio(iotype), path, mode_pio(mode)))
+    file = cable_netcdf_pio_file_t(pio_file_desc)
+  end function
+
+  function cable_netcdf_pio_io_create_decomp(this, compmap, dims, type) result(decomp)
+    class(cable_netcdf_pio_io_t), intent(inout) :: this
+    integer, intent(in) :: compmap(:), dims(:)
+    integer, intent(in) :: type
+    class(cable_netcdf_decomp_t), allocatable :: decomp
+    type(pio_io_desc_t) :: pio_io_desc
+    call pio_initdecomp( &
+      this%pio_iosystem_desc, &
+      type_pio(type), &
+      dims, &
+      compmap, &
+      pio_io_desc &
+    )
+    decomp = cable_netcdf_pio_decomp_t(pio_io_desc)
+  end function
+
+  subroutine cable_netcdf_pio_file_close(this)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    call pio_closefile(this%pio_file_desc)
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_end_def(this)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    call check_pio(pio_enddef(this%pio_file_desc))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_redef(this)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    call check_pio(pio_redef(this%pio_file_desc))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_sync(this)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    call pio_syncfile(this%pio_file_desc)
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_def_dims(this, dim_names, dim_lens)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: dim_names(:)
+    integer, intent(in) :: dim_lens(:)
+    integer :: i, tmp
+    do i = 1, size(dim_names)
+      if (dim_lens(i) == CABLE_NETCDF_UNLIMITED) then
+        call check_pio(pio_def_dim(this%pio_file_desc, dim_names(i), PIO_UNLIMITED, tmp))
+      else
+        call check_pio(pio_def_dim(this%pio_file_desc, dim_names(i), dim_lens(i), tmp))
+      end if
+    end do
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_def_var(this, var_name, type, dim_names)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer, intent(in) :: type
+    character(len=*), intent(in), optional :: dim_names(:)
+    integer, allocatable :: dimids(:)
+    integer :: i
+    type(pio_var_desc_t) :: tmp
+    if (.not. present(dim_names)) then
+      call check_pio(pio_def_var(this%pio_file_desc, var_name, type_pio(type), tmp))
+      return
+    end if
+    allocate(dimids(size(dim_names)))
+    do i = 1, size(dimids)
+      call check_pio(pio_inq_dimid(this%pio_file_desc, dim_names(i), dimids(i)))
+    end do
+    call check_pio(pio_def_var(this%pio_file_desc, var_name, type_pio(type), dimids, tmp))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_put_att_global_string(this, att_name, att_value)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: att_name, att_value
+    call check_pio(pio_put_att(this%pio_file_desc, PIO_GLOBAL, att_name, att_value))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_put_att_global_int32(this, att_name, att_value)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: att_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(in) :: att_value
+    call check_pio(pio_put_att(this%pio_file_desc, PIO_GLOBAL, att_name, att_value))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_put_att_global_real32(this, att_name, att_value)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: att_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(in) :: att_value
+    call check_pio(pio_put_att(this%pio_file_desc, PIO_GLOBAL, att_name, att_value))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_put_att_global_real64(this, att_name, att_value)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: att_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(in) :: att_value
+    call check_pio(pio_put_att(this%pio_file_desc, PIO_GLOBAL, att_name, att_value))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_put_att_var_string(this, var_name, att_name, att_value)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name, att_name, att_value
+    type(pio_var_desc_t) :: var_desc
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    call check_pio(pio_put_att(this%pio_file_desc, var_desc, att_name, att_value))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_put_att_var_int32(this, var_name, att_name, att_value)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name, att_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(in) :: att_value
+    type(pio_var_desc_t) :: var_desc
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    call check_pio(pio_put_att(this%pio_file_desc, var_desc, att_name, att_value))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_put_att_var_real32(this, var_name, att_name, att_value)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name, att_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(in) :: att_value
+    type(pio_var_desc_t) :: var_desc
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    call check_pio(pio_put_att(this%pio_file_desc, var_desc, att_name, att_value))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_put_att_var_real64(this, var_name, att_name, att_value)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name, att_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(in) :: att_value
+    type(pio_var_desc_t) :: var_desc
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    call check_pio(pio_put_att(this%pio_file_desc, var_desc, att_name, att_value))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_get_att_global_string(this, att_name, att_value)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: att_name
+    character(len=*), intent(out) :: att_value
+    call check_pio(pio_get_att(this%pio_file_desc, PIO_GLOBAL, att_name, att_value))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_get_att_global_int32(this, att_name, att_value)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: att_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(out) :: att_value
+    call check_pio(pio_get_att(this%pio_file_desc, PIO_GLOBAL, att_name, att_value))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_get_att_global_real32(this, att_name, att_value)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: att_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(out) :: att_value
+    call check_pio(pio_get_att(this%pio_file_desc, PIO_GLOBAL, att_name, att_value))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_get_att_global_real64(this, att_name, att_value)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: att_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(out) :: att_value
+    call check_pio(pio_get_att(this%pio_file_desc, PIO_GLOBAL, att_name, att_value))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_get_att_var_string(this, var_name, att_name, att_value)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name, att_name
+    character(len=*), intent(out) :: att_value
+    type(pio_var_desc_t) :: var_desc
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    call check_pio(pio_get_att(this%pio_file_desc, var_desc, att_name, att_value))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_get_att_var_int32(this, var_name, att_name, att_value)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name, att_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(out) :: att_value
+    type(pio_var_desc_t) :: var_desc
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    call check_pio(pio_get_att(this%pio_file_desc, var_desc, att_name, att_value))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_get_att_var_real32(this, var_name, att_name, att_value)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name, att_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(out) :: att_value
+    type(pio_var_desc_t) :: var_desc
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    call check_pio(pio_get_att(this%pio_file_desc, var_desc, att_name, att_value))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_get_att_var_real64(this, var_name, att_name, att_value)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name, att_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(out) :: att_value
+    type(pio_var_desc_t) :: var_desc
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    call check_pio(pio_get_att(this%pio_file_desc, var_desc, att_name, att_value))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_inq_dim_len(this, dim_name, dim_len)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: dim_name
+    integer, intent(out) :: dim_len
+    integer :: dimid
+    call check_pio(pio_inq_dimid(this%pio_file_desc, dim_name, dimid))
+    call check_pio(pio_inquire_dimension(this%pio_file_desc, dimid, len=dim_len))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_inq_var_ndims(this, var_name, ndims)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer, intent(out) :: ndims
+    integer :: varid
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, varid))
+    call check_pio(pio_inquire_variable(this%pio_file_desc, varid, ndims=ndims))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_put_var_int32_0d(this, var_name, values, start, count)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(in) :: values
+    integer, intent(in), optional :: start(:), count(:)
+    integer, allocatable :: start_nonopt(:), count_nonopt(:)
+    type(pio_var_desc_t) :: var_desc
+    call get_start_count_nonoptionals(start_nonopt, count_nonopt, [1], start, count)
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    call check_pio(pio_put_var(this%pio_file_desc, var_desc, start_nonopt, values))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_put_var_int32_1d(this, var_name, values, start, count)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(in) :: values(:)
+    integer, intent(in), optional :: start(:), count(:)
+    integer, allocatable :: start_nonopt(:), count_nonopt(:)
+    type(pio_var_desc_t) :: var_desc
+    call get_start_count_nonoptionals(start_nonopt, count_nonopt, shape(values), start, count)
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    call check_pio(pio_put_var(this%pio_file_desc, var_desc, start_nonopt, count_nonopt, values))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_put_var_int32_2d(this, var_name, values, start, count)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(in) :: values(:, :)
+    integer, intent(in), optional :: start(:), count(:)
+    integer, allocatable :: start_nonopt(:), count_nonopt(:)
+    type(pio_var_desc_t) :: var_desc
+    call get_start_count_nonoptionals(start_nonopt, count_nonopt, shape(values), start, count)
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    call check_pio(pio_put_var(this%pio_file_desc, var_desc, start_nonopt, count_nonopt, values))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_put_var_int32_3d(this, var_name, values, start, count)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(in) :: values(:, :, :)
+    integer, intent(in), optional :: start(:), count(:)
+    integer, allocatable :: start_nonopt(:), count_nonopt(:)
+    type(pio_var_desc_t) :: var_desc
+    call get_start_count_nonoptionals(start_nonopt, count_nonopt, shape(values), start, count)
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    call check_pio(pio_put_var(this%pio_file_desc, var_desc, start_nonopt, count_nonopt, values))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_put_var_real32_0d(this, var_name, values, start, count)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(in) :: values
+    integer, intent(in), optional :: start(:), count(:)
+    integer, allocatable :: start_nonopt(:), count_nonopt(:)
+    type(pio_var_desc_t) :: var_desc
+    call get_start_count_nonoptionals(start_nonopt, count_nonopt, [1], start, count)
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    call check_pio(pio_put_var(this%pio_file_desc, var_desc, start_nonopt, values))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_put_var_real32_1d(this, var_name, values, start, count)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(in) :: values(:)
+    integer, intent(in), optional :: start(:), count(:)
+    integer, allocatable :: start_nonopt(:), count_nonopt(:)
+    type(pio_var_desc_t) :: var_desc
+    call get_start_count_nonoptionals(start_nonopt, count_nonopt, shape(values), start, count)
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    call check_pio(pio_put_var(this%pio_file_desc, var_desc, start_nonopt, count_nonopt, values))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_put_var_real32_2d(this, var_name, values, start, count)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(in) :: values(:, :)
+    integer, intent(in), optional :: start(:), count(:)
+    integer, allocatable :: start_nonopt(:), count_nonopt(:)
+    type(pio_var_desc_t) :: var_desc
+    call get_start_count_nonoptionals(start_nonopt, count_nonopt, shape(values), start, count)
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    call check_pio(pio_put_var(this%pio_file_desc, var_desc, start_nonopt, count_nonopt, values))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_put_var_real32_3d(this, var_name, values, start, count)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(in) :: values(:, :, :)
+    integer, intent(in), optional :: start(:), count(:)
+    integer, allocatable :: start_nonopt(:), count_nonopt(:)
+    type(pio_var_desc_t) :: var_desc
+    call get_start_count_nonoptionals(start_nonopt, count_nonopt, shape(values), start, count)
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    call check_pio(pio_put_var(this%pio_file_desc, var_desc, start_nonopt, count_nonopt, values))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_put_var_real64_0d(this, var_name, values, start, count)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(in) :: values
+    integer, intent(in), optional :: start(:), count(:)
+    integer, allocatable :: start_nonopt(:), count_nonopt(:)
+    type(pio_var_desc_t) :: var_desc
+    call get_start_count_nonoptionals(start_nonopt, count_nonopt, [1], start, count)
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    call check_pio(pio_put_var(this%pio_file_desc, var_desc, start_nonopt, values))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_put_var_real64_1d(this, var_name, values, start, count)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(in) :: values(:)
+    integer, intent(in), optional :: start(:), count(:)
+    integer, allocatable :: start_nonopt(:), count_nonopt(:)
+    type(pio_var_desc_t) :: var_desc
+    call get_start_count_nonoptionals(start_nonopt, count_nonopt, shape(values), start, count)
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    call check_pio(pio_put_var(this%pio_file_desc, var_desc, start_nonopt, count_nonopt, values))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_put_var_real64_2d(this, var_name, values, start, count)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(in) :: values(:, :)
+    integer, intent(in), optional :: start(:), count(:)
+    integer, allocatable :: start_nonopt(:), count_nonopt(:)
+    type(pio_var_desc_t) :: var_desc
+    call get_start_count_nonoptionals(start_nonopt, count_nonopt, shape(values), start, count)
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    call check_pio(pio_put_var(this%pio_file_desc, var_desc, start_nonopt, count_nonopt, values))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_put_var_real64_3d(this, var_name, values, start, count)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(in) :: values(:, :, :)
+    integer, intent(in), optional :: start(:), count(:)
+    integer, allocatable :: start_nonopt(:), count_nonopt(:)
+    type(pio_var_desc_t) :: var_desc
+    call get_start_count_nonoptionals(start_nonopt, count_nonopt, shape(values), start, count)
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    call check_pio(pio_put_var(this%pio_file_desc, var_desc, start_nonopt, count_nonopt, values))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_write_darray_int32_1d(this, var_name, values, decomp, fill_value, frame)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(in) :: values(:)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(in), optional :: fill_value
+    integer, intent(in), optional :: frame
+    integer :: status
+    type(pio_var_desc_t) :: var_desc
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    if (present(frame)) then
+      call pio_setframe(this%pio_file_desc, var_desc, int(frame, PIO_OFFSET_KIND))
+    end if
+    select type(decomp)
+    type is (cable_netcdf_pio_decomp_t)
+      call pio_write_darray(this%pio_file_desc, var_desc, decomp%pio_io_desc, values, status, fill_value)
+      call check_pio(status)
+    class default
+      call cable_abort("Decomposition object must be of type cable_netcdf_pio_decomp_t", file=__FILE__, line=__LINE__)
+    end select
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_write_darray_int32_2d(this, var_name, values, decomp, fill_value, frame)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(in) :: values(:, :)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(in), optional :: fill_value
+    integer, intent(in), optional :: frame
+    integer :: status
+    type(pio_var_desc_t) :: var_desc
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    if (present(frame)) then
+      call pio_setframe(this%pio_file_desc, var_desc, int(frame, PIO_OFFSET_KIND))
+    end if
+    select type(decomp)
+    type is (cable_netcdf_pio_decomp_t)
+      call pio_write_darray(this%pio_file_desc, var_desc, decomp%pio_io_desc, values, status, fill_value)
+      call check_pio(status)
+    class default
+      call cable_abort("Decomposition object must be of type cable_netcdf_pio_decomp_t", file=__FILE__, line=__LINE__)
+    end select
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_write_darray_int32_3d(this, var_name, values, decomp, fill_value, frame)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(in) :: values(:, :, :)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(in), optional :: fill_value
+    integer, intent(in), optional :: frame
+    integer :: status
+    type(pio_var_desc_t) :: var_desc
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    if (present(frame)) then
+      call pio_setframe(this%pio_file_desc, var_desc, int(frame, PIO_OFFSET_KIND))
+    end if
+    select type(decomp)
+    type is (cable_netcdf_pio_decomp_t)
+      call pio_write_darray(this%pio_file_desc, var_desc, decomp%pio_io_desc, values, status, fill_value)
+      call check_pio(status)
+    class default
+      call cable_abort("Decomposition object must be of type cable_netcdf_pio_decomp_t", file=__FILE__, line=__LINE__)
+    end select
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_write_darray_real32_1d(this, var_name, values, decomp, fill_value, frame)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(in) :: values(:)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(in), optional :: fill_value
+    integer, intent(in), optional :: frame
+    integer :: status
+    type(pio_var_desc_t) :: var_desc
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    if (present(frame)) then
+      call pio_setframe(this%pio_file_desc, var_desc, int(frame, PIO_OFFSET_KIND))
+    end if
+    select type(decomp)
+    type is (cable_netcdf_pio_decomp_t)
+      call pio_write_darray(this%pio_file_desc, var_desc, decomp%pio_io_desc, values, status, fill_value)
+      call check_pio(status)
+    class default
+      call cable_abort("Decomposition object must be of type cable_netcdf_pio_decomp_t", file=__FILE__, line=__LINE__)
+    end select
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_write_darray_real32_2d(this, var_name, values, decomp, fill_value, frame)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(in) :: values(:, :)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(in), optional :: fill_value
+    integer, intent(in), optional :: frame
+    integer :: status
+    type(pio_var_desc_t) :: var_desc
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    if (present(frame)) then
+      call pio_setframe(this%pio_file_desc, var_desc, int(frame, PIO_OFFSET_KIND))
+    end if
+    select type(decomp)
+    type is (cable_netcdf_pio_decomp_t)
+      call pio_write_darray(this%pio_file_desc, var_desc, decomp%pio_io_desc, values, status, fill_value)
+      call check_pio(status)
+    class default
+      call cable_abort("Decomposition object must be of type cable_netcdf_pio_decomp_t", file=__FILE__, line=__LINE__)
+    end select
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_write_darray_real32_3d(this, var_name, values, decomp, fill_value, frame)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(in) :: values(:, :, :)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(in), optional :: fill_value
+    integer, intent(in), optional :: frame
+    integer :: status
+    type(pio_var_desc_t) :: var_desc
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    if (present(frame)) then
+      call pio_setframe(this%pio_file_desc, var_desc, int(frame, PIO_OFFSET_KIND))
+    end if
+    select type(decomp)
+    type is (cable_netcdf_pio_decomp_t)
+      call pio_write_darray(this%pio_file_desc, var_desc, decomp%pio_io_desc, values, status, fill_value)
+      call check_pio(status)
+    class default
+      call cable_abort("Decomposition object must be of type cable_netcdf_pio_decomp_t", file=__FILE__, line=__LINE__)
+    end select
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_write_darray_real64_1d(this, var_name, values, decomp, fill_value, frame)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(in) :: values(:)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(in), optional :: fill_value
+    integer, intent(in), optional :: frame
+    integer :: status
+    type(pio_var_desc_t) :: var_desc
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    if (present(frame)) then
+      call pio_setframe(this%pio_file_desc, var_desc, int(frame, PIO_OFFSET_KIND))
+    end if
+    select type(decomp)
+    type is (cable_netcdf_pio_decomp_t)
+      call pio_write_darray(this%pio_file_desc, var_desc, decomp%pio_io_desc, values, status, fill_value)
+      call check_pio(status)
+    class default
+      call cable_abort("Decomposition object must be of type cable_netcdf_pio_decomp_t", file=__FILE__, line=__LINE__)
+    end select
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_write_darray_real64_2d(this, var_name, values, decomp, fill_value, frame)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(in) :: values(:, :)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(in), optional :: fill_value
+    integer, intent(in), optional :: frame
+    integer :: status
+    type(pio_var_desc_t) :: var_desc
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    if (present(frame)) then
+      call pio_setframe(this%pio_file_desc, var_desc, int(frame, PIO_OFFSET_KIND))
+    end if
+    select type(decomp)
+    type is (cable_netcdf_pio_decomp_t)
+      call pio_write_darray(this%pio_file_desc, var_desc, decomp%pio_io_desc, values, status, fill_value)
+      call check_pio(status)
+    class default
+      call cable_abort("Decomposition object must be of type cable_netcdf_pio_decomp_t", file=__FILE__, line=__LINE__)
+    end select
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_write_darray_real64_3d(this, var_name, values, decomp, fill_value, frame)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(in) :: values(:, :, :)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(in), optional :: fill_value
+    integer, intent(in), optional :: frame
+    integer :: status
+    type(pio_var_desc_t) :: var_desc
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    if (present(frame)) then
+      call pio_setframe(this%pio_file_desc, var_desc, int(frame, PIO_OFFSET_KIND))
+    end if
+    select type(decomp)
+    type is (cable_netcdf_pio_decomp_t)
+      call pio_write_darray(this%pio_file_desc, var_desc, decomp%pio_io_desc, values, status, fill_value)
+      call check_pio(status)
+    class default
+      call cable_abort("Decomposition object must be of type cable_netcdf_pio_decomp_t", file=__FILE__, line=__LINE__)
+    end select
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_get_var_int32_0d(this, var_name, values, start, count)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(out) :: values
+    integer, intent(in), optional :: start(:), count(:)
+    integer, allocatable :: start_nonopt(:), count_nonopt(:)
+    type(pio_var_desc_t) :: var_desc
+    call get_start_count_nonoptionals(start_nonopt, count_nonopt, [1], start, count)
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    call check_pio(pio_get_var(this%pio_file_desc, var_desc, start_nonopt, values))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_get_var_int32_1d(this, var_name, values, start, count)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(out) :: values(:)
+    integer, intent(in), optional :: start(:), count(:)
+    integer, allocatable :: start_nonopt(:), count_nonopt(:)
+    type(pio_var_desc_t) :: var_desc
+    call get_start_count_nonoptionals(start_nonopt, count_nonopt, shape(values), start, count)
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    call check_pio(pio_get_var(this%pio_file_desc, var_desc, start_nonopt, count_nonopt, values))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_get_var_int32_2d(this, var_name, values, start, count)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(out) :: values(:, :)
+    integer, intent(in), optional :: start(:), count(:)
+    integer, allocatable :: start_nonopt(:), count_nonopt(:)
+    type(pio_var_desc_t) :: var_desc
+    call get_start_count_nonoptionals(start_nonopt, count_nonopt, shape(values), start, count)
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    call check_pio(pio_get_var(this%pio_file_desc, var_desc, start_nonopt, count_nonopt, values))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_get_var_int32_3d(this, var_name, values, start, count)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(out) :: values(:, :, :)
+    integer, intent(in), optional :: start(:), count(:)
+    integer, allocatable :: start_nonopt(:), count_nonopt(:)
+    type(pio_var_desc_t) :: var_desc
+    call get_start_count_nonoptionals(start_nonopt, count_nonopt, shape(values), start, count)
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    call check_pio(pio_get_var(this%pio_file_desc, var_desc, start_nonopt, count_nonopt, values))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_get_var_real32_0d(this, var_name, values, start, count)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(out) :: values
+    integer, intent(in), optional :: start(:), count(:)
+    integer, allocatable :: start_nonopt(:), count_nonopt(:)
+    type(pio_var_desc_t) :: var_desc
+    call get_start_count_nonoptionals(start_nonopt, count_nonopt, [1], start, count)
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    call check_pio(pio_get_var(this%pio_file_desc, var_desc, start_nonopt, values))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_get_var_real32_1d(this, var_name, values, start, count)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(out) :: values(:)
+    integer, intent(in), optional :: start(:), count(:)
+    integer, allocatable :: start_nonopt(:), count_nonopt(:)
+    type(pio_var_desc_t) :: var_desc
+    call get_start_count_nonoptionals(start_nonopt, count_nonopt, shape(values), start, count)
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    call check_pio(pio_get_var(this%pio_file_desc, var_desc, start_nonopt, count_nonopt, values))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_get_var_real32_2d(this, var_name, values, start, count)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(out) :: values(:, :)
+    integer, intent(in), optional :: start(:), count(:)
+    integer, allocatable :: start_nonopt(:), count_nonopt(:)
+    type(pio_var_desc_t) :: var_desc
+    call get_start_count_nonoptionals(start_nonopt, count_nonopt, shape(values), start, count)
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    call check_pio(pio_get_var(this%pio_file_desc, var_desc, start_nonopt, count_nonopt, values))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_get_var_real32_3d(this, var_name, values, start, count)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(out) :: values(:, :, :)
+    integer, intent(in), optional :: start(:), count(:)
+    integer, allocatable :: start_nonopt(:), count_nonopt(:)
+    type(pio_var_desc_t) :: var_desc
+    call get_start_count_nonoptionals(start_nonopt, count_nonopt, shape(values), start, count)
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    call check_pio(pio_get_var(this%pio_file_desc, var_desc, start_nonopt, count_nonopt, values))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_get_var_real64_0d(this, var_name, values, start, count)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(out) :: values
+    integer, intent(in), optional :: start(:), count(:)
+    integer, allocatable :: start_nonopt(:), count_nonopt(:)
+    type(pio_var_desc_t) :: var_desc
+    call get_start_count_nonoptionals(start_nonopt, count_nonopt, [1], start, count)
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    call check_pio(pio_get_var(this%pio_file_desc, var_desc, start_nonopt, values))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_get_var_real64_1d(this, var_name, values, start, count)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(out) :: values(:)
+    integer, intent(in), optional :: start(:), count(:)
+    integer, allocatable :: start_nonopt(:), count_nonopt(:)
+    type(pio_var_desc_t) :: var_desc
+    call get_start_count_nonoptionals(start_nonopt, count_nonopt, shape(values), start, count)
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    call check_pio(pio_get_var(this%pio_file_desc, var_desc, start_nonopt, count_nonopt, values))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_get_var_real64_2d(this, var_name, values, start, count)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(out) :: values(:, :)
+    integer, intent(in), optional :: start(:), count(:)
+    integer, allocatable :: start_nonopt(:), count_nonopt(:)
+    type(pio_var_desc_t) :: var_desc
+    call get_start_count_nonoptionals(start_nonopt, count_nonopt, shape(values), start, count)
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    call check_pio(pio_get_var(this%pio_file_desc, var_desc, start_nonopt, count_nonopt, values))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_get_var_real64_3d(this, var_name, values, start, count)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(out) :: values(:, :, :)
+    integer, intent(in), optional :: start(:), count(:)
+    integer, allocatable :: start_nonopt(:), count_nonopt(:)
+    type(pio_var_desc_t) :: var_desc
+    call get_start_count_nonoptionals(start_nonopt, count_nonopt, shape(values), start, count)
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    call check_pio(pio_get_var(this%pio_file_desc, var_desc, start_nonopt, count_nonopt, values))
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_read_darray_int32_1d(this, var_name, values, decomp, frame)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(out) :: values(:)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    integer, intent(in), optional :: frame
+    integer :: status
+    type(pio_var_desc_t) :: var_desc
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    if (present(frame)) then
+      call pio_setframe(this%pio_file_desc, var_desc, int(frame, PIO_OFFSET_KIND))
+    end if
+    select type(decomp)
+    type is (cable_netcdf_pio_decomp_t)
+      call pio_read_darray(this%pio_file_desc, var_desc, decomp%pio_io_desc, values, status)
+      call check_pio(status)
+    class default
+      call cable_abort("Decomposition object must be of type cable_netcdf_pio_decomp_t", file=__FILE__, line=__LINE__)
+    end select
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_read_darray_int32_2d(this, var_name, values, decomp, frame)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(out) :: values(:, :)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    integer, intent(in), optional :: frame
+    integer :: status
+    type(pio_var_desc_t) :: var_desc
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    if (present(frame)) then
+      call pio_setframe(this%pio_file_desc, var_desc, int(frame, PIO_OFFSET_KIND))
+    end if
+    select type(decomp)
+    type is (cable_netcdf_pio_decomp_t)
+      call pio_read_darray(this%pio_file_desc, var_desc, decomp%pio_io_desc, values, status)
+      call check_pio(status)
+    class default
+      call cable_abort("Decomposition object must be of type cable_netcdf_pio_decomp_t", file=__FILE__, line=__LINE__)
+    end select
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_read_darray_int32_3d(this, var_name, values, decomp, frame)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    integer(kind=CABLE_NETCDF_INT32_KIND), intent(out) :: values(:, :, :)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    integer, intent(in), optional :: frame
+    integer :: status
+    type(pio_var_desc_t) :: var_desc
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    if (present(frame)) then
+      call pio_setframe(this%pio_file_desc, var_desc, int(frame, PIO_OFFSET_KIND))
+    end if
+    select type(decomp)
+    type is (cable_netcdf_pio_decomp_t)
+      call pio_read_darray(this%pio_file_desc, var_desc, decomp%pio_io_desc, values, status)
+      call check_pio(status)
+    class default
+      call cable_abort("Decomposition object must be of type cable_netcdf_pio_decomp_t", file=__FILE__, line=__LINE__)
+    end select
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_read_darray_real32_1d(this, var_name, values, decomp, frame)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(out) :: values(:)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    integer, intent(in), optional :: frame
+    integer :: status
+    type(pio_var_desc_t) :: var_desc
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    if (present(frame)) then
+      call pio_setframe(this%pio_file_desc, var_desc, int(frame, PIO_OFFSET_KIND))
+    end if
+    select type(decomp)
+    type is (cable_netcdf_pio_decomp_t)
+      call pio_read_darray(this%pio_file_desc, var_desc, decomp%pio_io_desc, values, status)
+      call check_pio(status)
+    class default
+      call cable_abort("Decomposition object must be of type cable_netcdf_pio_decomp_t", file=__FILE__, line=__LINE__)
+    end select
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_read_darray_real32_2d(this, var_name, values, decomp, frame)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(out) :: values(:, :)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    integer, intent(in), optional :: frame
+    integer :: status
+    type(pio_var_desc_t) :: var_desc
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    if (present(frame)) then
+      call pio_setframe(this%pio_file_desc, var_desc, int(frame, PIO_OFFSET_KIND))
+    end if
+    select type(decomp)
+    type is (cable_netcdf_pio_decomp_t)
+      call pio_read_darray(this%pio_file_desc, var_desc, decomp%pio_io_desc, values, status)
+      call check_pio(status)
+    class default
+      call cable_abort("Decomposition object must be of type cable_netcdf_pio_decomp_t", file=__FILE__, line=__LINE__)
+    end select
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_read_darray_real32_3d(this, var_name, values, decomp, frame)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL32_KIND), intent(out) :: values(:, :, :)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    integer, intent(in), optional :: frame
+    integer :: status
+    type(pio_var_desc_t) :: var_desc
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    if (present(frame)) then
+      call pio_setframe(this%pio_file_desc, var_desc, int(frame, PIO_OFFSET_KIND))
+    end if
+    select type(decomp)
+    type is (cable_netcdf_pio_decomp_t)
+      call pio_read_darray(this%pio_file_desc, var_desc, decomp%pio_io_desc, values, status)
+      call check_pio(status)
+    class default
+      call cable_abort("Decomposition object must be of type cable_netcdf_pio_decomp_t", file=__FILE__, line=__LINE__)
+    end select
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_read_darray_real64_1d(this, var_name, values, decomp, frame)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(out) :: values(:)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    integer, intent(in), optional :: frame
+    integer :: status
+    type(pio_var_desc_t) :: var_desc
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    if (present(frame)) then
+      call pio_setframe(this%pio_file_desc, var_desc, int(frame, PIO_OFFSET_KIND))
+    end if
+    select type(decomp)
+    type is (cable_netcdf_pio_decomp_t)
+      call pio_read_darray(this%pio_file_desc, var_desc, decomp%pio_io_desc, values, status)
+      call check_pio(status)
+    class default
+      call cable_abort("Decomposition object must be of type cable_netcdf_pio_decomp_t", file=__FILE__, line=__LINE__)
+    end select
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_read_darray_real64_2d(this, var_name, values, decomp, frame)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(out) :: values(:, :)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    integer, intent(in), optional :: frame
+    integer :: status
+    type(pio_var_desc_t) :: var_desc
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    if (present(frame)) then
+      call pio_setframe(this%pio_file_desc, var_desc, int(frame, PIO_OFFSET_KIND))
+    end if
+    select type(decomp)
+    type is (cable_netcdf_pio_decomp_t)
+      call pio_read_darray(this%pio_file_desc, var_desc, decomp%pio_io_desc, values, status)
+      call check_pio(status)
+    class default
+      call cable_abort("Decomposition object must be of type cable_netcdf_pio_decomp_t", file=__FILE__, line=__LINE__)
+    end select
+  end subroutine
+
+  subroutine cable_netcdf_pio_file_read_darray_real64_3d(this, var_name, values, decomp, frame)
+    class(cable_netcdf_pio_file_t), intent(inout) :: this
+    character(len=*), intent(in) :: var_name
+    real(kind=CABLE_NETCDF_REAL64_KIND), intent(out) :: values(:, :, :)
+    class(cable_netcdf_decomp_t), intent(inout) :: decomp
+    integer, intent(in), optional :: frame
+    integer :: status
+    type(pio_var_desc_t) :: var_desc
+    call check_pio(pio_inq_varid(this%pio_file_desc, var_name, var_desc))
+    if (present(frame)) then
+      call pio_setframe(this%pio_file_desc, var_desc, int(frame, PIO_OFFSET_KIND))
+    end if
+    select type(decomp)
+    type is (cable_netcdf_pio_decomp_t)
+      call pio_read_darray(this%pio_file_desc, var_desc, decomp%pio_io_desc, values, status)
+      call check_pio(status)
+    class default
+      call cable_abort("Decomposition object must be of type cable_netcdf_pio_decomp_t", file=__FILE__, line=__LINE__)
+    end select
+  end subroutine
+
+end module cable_netcdf_pio_mod

--- a/src/util/netcdf/pio/cable_netcdf_pio_stub.F90
+++ b/src/util/netcdf/pio/cable_netcdf_pio_stub.F90
@@ -1,0 +1,29 @@
+! CSIRO Open Source Software License Agreement (variation of the BSD / MIT License)
+! Copyright (c) 2015, Commonwealth Scientific and Industrial Research Organisation
+! (CSIRO) ABN 41 687 119 230.
+
+module cable_netcdf_pio_mod
+  !! A stub implementation of the netCDF file handling interface for when PIO is unavailable.
+  use cable_netcdf_mod
+  use cable_mpi_mod, only: mpi_grp_t
+  use cable_error_handler_mod, only: cable_abort
+  use cable_netcdf_stub_types_mod, only: cable_netcdf_stub_io_t
+  implicit none
+
+  type, extends(cable_netcdf_stub_io_t) :: cable_netcdf_pio_io_t
+  end type
+
+  interface cable_netcdf_pio_io_t
+    procedure cable_netcdf_pio_io_constructor
+  end interface
+
+contains
+
+  function cable_netcdf_pio_io_constructor(mpi_grp) result(this)
+    type(cable_netcdf_pio_io_t) :: this
+    type(mpi_grp_t), intent(in) :: mpi_grp
+    call cable_abort("Attempting to instantiate cable_netcdf_pio_io_t when PIO support is unavailable", file=__FILE__, line=__LINE__)
+    this = cable_netcdf_pio_io_t()
+  end function
+
+end module cable_netcdf_pio_mod

--- a/tests/fixtures/cable_netcdf_fixtures.F90
+++ b/tests/fixtures/cable_netcdf_fixtures.F90
@@ -1,0 +1,114 @@
+! CSIRO Open Source Software License Agreement (variation of the BSD / MIT License)
+! Copyright (c) 2015, Commonwealth Scientific and Industrial Research Organisation
+! (CSIRO) ABN 41 687 119 230.
+
+module cable_netcdf_fixtures_mod
+  !! Fixtures for testing cable_netcdf_mod.
+
+  use fortuno_interface_mod, only: test_case_t
+  use fortuno_interface_mod, only: test_item_t
+  use fortuno_interface_mod, only: skip
+  use fortuno_interface_mod, only: check
+  use fortuno_interface_mod, only: check_failed
+  use fortuno_interface_mod, only: global_comm
+  use fortuno_interface_mod, only: num_ranks
+  use fortuno_interface_mod, only: this_rank
+
+  use cable_mpi_mod, only: mpi_grp_t
+
+  use file_utils, only: file_delete
+
+  use cable_netcdf_mod, only: cable_netcdf_io_t
+  use cable_netcdf_nf90_mod, only: cable_netcdf_nf90_io_t
+  use cable_netcdf_pio_mod, only: cable_netcdf_pio_io_t
+
+  implicit none
+
+  private
+
+  public :: test_case_nf90
+  public :: test_case_pio
+  public :: io_handler_factory_interface
+
+  character(16), parameter :: nc_file_name = "file.nc"
+
+  type, extends(test_case_t) :: test_case_cable_netcdf_nf90_t
+    procedure(cable_netcdf_test_interface), pointer, nopass :: test
+  contains
+    procedure :: run => run_test_cable_netcdf_nf90
+  end type test_case_cable_netcdf_nf90_t
+
+  type, extends(test_case_t) :: test_case_cable_netcdf_pio_t
+    procedure(cable_netcdf_test_interface), pointer, nopass :: test
+  contains
+    procedure :: run => run_test_pio
+  end type test_case_cable_netcdf_pio_t
+
+  abstract interface
+    function io_handler_factory_interface() result(io_handler)
+      import cable_netcdf_io_t
+      class(cable_netcdf_io_t), allocatable :: io_handler
+    end function
+    subroutine cable_netcdf_test_interface(io_handler_factory, file_name)
+      import io_handler_factory_interface
+      procedure(io_handler_factory_interface) :: io_handler_factory
+      character(*), intent(in) :: file_name
+    end subroutine
+  end interface
+
+contains
+
+  function test_case_nf90(name, test) result(testitem)
+    character(*), intent(in) :: name
+    procedure(cable_netcdf_test_interface) :: test
+    type(test_item_t) :: testitem
+    testitem = test_item_t(test_case_cable_netcdf_nf90_t(name=name, test=test))
+  end function test_case_nf90
+
+  function nf90_io_handler() result(io_handler)
+    class(cable_netcdf_io_t), allocatable :: io_handler
+    io_handler = cable_netcdf_nf90_io_t()
+  end function
+
+  subroutine run_test_cable_netcdf_nf90(this)
+    class(test_case_cable_netcdf_nf90_t), intent(in) :: this
+
+    call check(num_ranks() == 1, msg="NetCDF tests must be run with a single process.")
+    if (check_failed()) return
+
+    call this%test(nf90_io_handler, nc_file_name)
+    call file_delete(nc_file_name)
+
+  end subroutine run_test_cable_netcdf_nf90
+
+  function test_case_pio(name, test) result(testitem)
+    character(*), intent(in) :: name
+    procedure(cable_netcdf_test_interface) :: test
+    type(test_item_t) :: testitem
+    testitem = test_item_t(test_case_cable_netcdf_pio_t(name=name, test=test))
+  end function test_case_pio
+
+  function pio_io_handler() result(io_handler)
+    class(cable_netcdf_io_t), allocatable :: io_handler
+    io_handler = cable_netcdf_pio_io_t(mpi_grp_t(global_comm()))
+  end function
+
+  subroutine run_test_pio(this)
+    class(test_case_cable_netcdf_pio_t), intent(in) :: this
+    type(mpi_grp_t) :: mpi_grp
+
+#ifdef SKIP_PIO_TESTS
+    call skip()
+    return
+#endif
+
+    mpi_grp = mpi_grp_t(global_comm())
+    call check(mpi_grp%comm_defined(), msg="MPI communicator must be defined for PIO tests")
+    if (check_failed()) return
+
+    call this%test(pio_io_handler, nc_file_name)
+    call file_delete(nc_file_name)
+
+  end subroutine run_test_pio
+
+end module cable_netcdf_fixtures_mod

--- a/tests/test_cable_netcdf.F90
+++ b/tests/test_cable_netcdf.F90
@@ -1,0 +1,450 @@
+! CSIRO Open Source Software License Agreement (variation of the BSD / MIT License)
+! Copyright (c) 2015, Commonwealth Scientific and Industrial Research Organisation
+! (CSIRO) ABN 41 687 119 230.
+
+module test_cable_netcdf
+  !! Tests for cable_netcdf_mod.
+
+  use fortuno_interface_mod, only: test_list_t
+  use fortuno_interface_mod, only: test_suite
+  use fortuno_interface_mod, only: num_ranks
+  use fortuno_interface_mod, only: this_rank
+  use fortuno_interface_mod, only: check
+  use fortuno_interface_mod, only: check_failed
+  use fortuno_interface_mod, only: all_equal
+  use fortuno_interface_mod, only: all_close
+
+  use cable_netcdf_fixtures_mod, only: test_case_nf90
+  use cable_netcdf_fixtures_mod, only: test_case_pio
+  use cable_netcdf_fixtures_mod, only: io_handler_factory_interface
+
+  use cable_netcdf_mod
+
+  implicit none
+
+  private
+
+  public :: cable_netcdf_test_list
+
+  integer, parameter :: LEN = 16
+  integer, parameter :: VAL = 42
+
+contains
+
+  function cable_netcdf_test_list()
+    type(test_list_t) :: cable_netcdf_test_list
+
+    cable_netcdf_test_list = test_list_t([&
+      test_case_nf90("test_cable_netcdf_nf90_write_read_darray_int32_1d", test_write_read_darray_int32_1d),&
+      test_case_nf90("test_cable_netcdf_nf90_write_read_darray_int32_2d", test_write_read_darray_int32_2d),&
+      test_case_nf90("test_cable_netcdf_nf90_write_read_darray_int32_3d", test_write_read_darray_int32_3d),&
+      test_case_nf90("test_cable_netcdf_nf90_write_read_darray_real32_1d", test_write_read_darray_real32_1d),&
+      test_case_nf90("test_cable_netcdf_nf90_write_read_darray_real32_2d", test_write_read_darray_real32_2d),&
+      test_case_nf90("test_cable_netcdf_nf90_write_read_darray_real32_3d", test_write_read_darray_real32_3d),&
+      test_case_nf90("test_cable_netcdf_nf90_write_read_darray_real64_1d", test_write_read_darray_real64_1d),&
+      test_case_nf90("test_cable_netcdf_nf90_write_read_darray_real64_2d", test_write_read_darray_real64_2d),&
+      test_case_nf90("test_cable_netcdf_nf90_write_read_darray_real64_3d", test_write_read_darray_real64_3d),&
+      test_suite("parallel", test_list_t([&
+        test_case_pio("test_cable_netcdf_pio_write_read_darray_int32_1d", test_write_read_darray_int32_1d),&
+        test_case_pio("test_cable_netcdf_pio_write_read_darray_int32_2d", test_write_read_darray_int32_2d),&
+        test_case_pio("test_cable_netcdf_pio_write_read_darray_int32_3d", test_write_read_darray_int32_3d),&
+        test_case_pio("test_cable_netcdf_pio_write_read_darray_real32_1d", test_write_read_darray_real32_1d),&
+        test_case_pio("test_cable_netcdf_pio_write_read_darray_real32_2d", test_write_read_darray_real32_2d),&
+        test_case_pio("test_cable_netcdf_pio_write_read_darray_real32_3d", test_write_read_darray_real32_3d),&
+        test_case_pio("test_cable_netcdf_pio_write_read_darray_real64_1d", test_write_read_darray_real64_1d),&
+        test_case_pio("test_cable_netcdf_pio_write_read_darray_real64_2d", test_write_read_darray_real64_2d),&
+        test_case_pio("test_cable_netcdf_pio_write_read_darray_real64_1d", test_write_read_darray_real64_3d)&
+      ]))&
+    ])
+
+  end function cable_netcdf_test_list
+
+  logical function init_decomp(compmap, start, end, block_per_pe) result(result)
+    !* Intialise the `compmap` mapping, `start` and `end` indexes for the current
+    ! rank, and the number of elements each rank will process (`block_per_pe`).
+    !
+    ! Returns `.true.` if any pre-checks fail, `.false.` otherwise.
+    integer, allocatable, intent(out) :: compmap(:)
+    integer, intent(out) :: start, end, block_per_pe
+    integer i
+
+    block_per_pe = LEN / num_ranks()
+
+    result = .false.
+    call check(mod(LEN, num_ranks()) == 0, msg="test_cable_netcdf.F90: work not divisible by number of ranks")
+    call check(block_per_pe > 0, msg="test_cable_netcdf.F90: not enough work to distribute among pes")
+    call check(mod(block_per_pe, 4) == 0, msg="test_cable_netcdf.F90: block_per_pe must be divisible by 4")
+    if (check_failed()) then
+      result = .true.
+      return
+    end if
+
+    start = this_rank() * block_per_pe + 1
+    end = start + block_per_pe - 1
+
+    allocate(compmap(start:end))
+    compmap(start:end) = [(i, i=start, end, 1)]
+
+  end function init_decomp
+
+  subroutine test_write_read_darray_int32_1d(io_handler_factory, file_name)
+    !! Test writing and reading 1D integer arrays using the darray API.
+    procedure(io_handler_factory_interface) :: io_handler_factory
+      !! Factory procedure to create an IO handler (e.g., NetCDF or PIO)
+    character(*), intent(in) :: file_name
+      !! Name of the file to create and read from during the test
+    class(cable_netcdf_io_t), allocatable :: io_handler
+    class(cable_netcdf_file_t), allocatable :: file
+    class(cable_netcdf_decomp_t), allocatable :: decomp
+    integer, allocatable :: compmap(:)
+    integer :: block_per_pe, start, end
+    integer(kind=CABLE_NETCDF_INT32_KIND), allocatable :: write_buffer(:), read_buffer(:)
+
+    if (init_decomp(compmap, start, end, block_per_pe)) return
+
+    allocate(write_buffer(start:end), source=int(this_rank() + VAL, kind=CABLE_NETCDF_INT32_KIND))
+    allocate(read_buffer(start:end), source=int(0, kind=CABLE_NETCDF_INT32_KIND))
+
+    io_handler = io_handler_factory()
+
+    call io_handler%init()
+
+    decomp = io_handler%create_decomp(compmap, dims=[LEN], type=CABLE_NETCDF_INT)
+
+    file = io_handler%create_file(file_name, iotype=CABLE_NETCDF_IOTYPE_NETCDF4P)
+
+    call file%def_dims(["i"], [LEN])
+    call file%def_var("values", CABLE_NETCDF_INT, ["i"])
+    call file%end_def()
+    call file%write_darray("values", write_buffer, decomp)
+    call file%sync()
+    call file%read_darray("values", read_buffer, decomp)
+    call file%close()
+
+    call check(all_equal(write_buffer, read_buffer))
+
+    call io_handler%finalise()
+
+  end subroutine test_write_read_darray_int32_1d
+
+  subroutine test_write_read_darray_int32_2d(io_handler_factory, file_name)
+    !! Test writing and reading 2D integer arrays using the darray API.
+    procedure(io_handler_factory_interface) :: io_handler_factory
+      !! Factory procedure to create an IO handler (e.g., NetCDF or PIO)
+    character(*), intent(in) :: file_name
+      !! Name of the file to create and read from during the test
+    class(cable_netcdf_io_t), allocatable :: io_handler
+    class(cable_netcdf_file_t), allocatable :: file
+    class(cable_netcdf_decomp_t), allocatable :: decomp
+    integer, allocatable :: compmap(:)
+    integer :: block_per_pe, start, end
+    integer(kind=CABLE_NETCDF_INT32_KIND), allocatable :: write_buffer(:, :), read_buffer(:, :)
+
+    if (init_decomp(compmap, start, end, block_per_pe)) return
+
+    allocate(write_buffer(block_per_pe / 4, 4), source=int(this_rank() + VAL, kind=CABLE_NETCDF_INT32_KIND))
+    allocate(read_buffer(block_per_pe / 4, 4), source=int(0, kind=CABLE_NETCDF_INT32_KIND))
+
+    io_handler = io_handler_factory()
+
+    call io_handler%init()
+
+    decomp = io_handler%create_decomp(compmap, dims=[LEN], type=CABLE_NETCDF_INT)
+
+    file = io_handler%create_file(file_name, iotype=CABLE_NETCDF_IOTYPE_NETCDF4P)
+
+    call file%def_dims(["i"], [LEN])
+    call file%def_var("values", CABLE_NETCDF_INT, ["i"])
+    call file%end_def()
+    call file%write_darray("values", write_buffer, decomp)
+    call file%sync()
+    call file%read_darray("values", read_buffer, decomp)
+    call file%close()
+
+    call check(all_equal(reshape(write_buffer, [block_per_pe]), reshape(read_buffer, [block_per_pe])))
+
+    call io_handler%finalise()
+
+  end subroutine test_write_read_darray_int32_2d
+
+  subroutine test_write_read_darray_int32_3d(io_handler_factory, file_name)
+    !! Test writing and reading 3D integer arrays using the darray API.
+    procedure(io_handler_factory_interface) :: io_handler_factory
+      !! Factory procedure to create an IO handler (e.g., NetCDF or PIO)
+    character(*), intent(in) :: file_name
+      !! Name of the file to create and read from during the test
+    class(cable_netcdf_io_t), allocatable :: io_handler
+    class(cable_netcdf_file_t), allocatable :: file
+    class(cable_netcdf_decomp_t), allocatable :: decomp
+    integer, allocatable :: compmap(:)
+    integer :: block_per_pe, start, end
+    integer(kind=CABLE_NETCDF_INT32_KIND), allocatable :: write_buffer(:, :, :), read_buffer(:, :, :)
+
+    if (init_decomp(compmap, start, end, block_per_pe)) return
+
+    allocate(write_buffer(block_per_pe / 4, 2, 2), source=int(this_rank() + VAL, kind=CABLE_NETCDF_INT32_KIND))
+    allocate(read_buffer(block_per_pe / 4, 2, 2), source=int(0, kind=CABLE_NETCDF_INT32_KIND))
+
+    io_handler = io_handler_factory()
+
+    call io_handler%init()
+
+    decomp = io_handler%create_decomp(compmap, dims=[LEN], type=CABLE_NETCDF_INT)
+
+    file = io_handler%create_file(file_name, iotype=CABLE_NETCDF_IOTYPE_NETCDF4P)
+
+    call file%def_dims(["i"], [LEN])
+    call file%def_var("values", CABLE_NETCDF_INT, ["i"])
+    call file%end_def()
+    call file%write_darray("values", write_buffer, decomp)
+    call file%sync()
+    call file%read_darray("values", read_buffer, decomp)
+    call file%close()
+
+    call check(all_equal(reshape(write_buffer, [block_per_pe]), reshape(read_buffer, [block_per_pe])))
+
+    call io_handler%finalise()
+
+  end subroutine test_write_read_darray_int32_3d
+
+  subroutine test_write_read_darray_real32_1d(io_handler_factory, file_name)
+    !! Test writing and reading 1D 32-bit real arrays using the darray API.
+    procedure(io_handler_factory_interface) :: io_handler_factory
+      !! Factory procedure to create an IO handler (e.g., NetCDF or PIO)
+    character(*), intent(in) :: file_name
+      !! Name of the file to create and read from during the test
+    class(cable_netcdf_io_t), allocatable :: io_handler
+    class(cable_netcdf_file_t), allocatable :: file
+    class(cable_netcdf_decomp_t), allocatable :: decomp
+    integer, allocatable :: compmap(:)
+    integer :: block_per_pe, start, end
+    real(kind=CABLE_NETCDF_REAL32_KIND), allocatable :: write_buffer(:), read_buffer(:)
+
+    if (init_decomp(compmap, start, end, block_per_pe)) return
+
+    allocate(write_buffer(start:end), source=real(this_rank() + VAL, kind=CABLE_NETCDF_REAL32_KIND))
+    allocate(read_buffer(start:end), source=real(0, kind=CABLE_NETCDF_REAL32_KIND))
+
+    io_handler = io_handler_factory()
+
+    call io_handler%init()
+
+    decomp = io_handler%create_decomp(compmap, dims=[LEN], type=CABLE_NETCDF_FLOAT)
+
+    file = io_handler%create_file(file_name, iotype=CABLE_NETCDF_IOTYPE_NETCDF4P)
+
+    call file%def_dims(["i"], [LEN])
+    call file%def_var("values", CABLE_NETCDF_FLOAT, ["i"])
+    call file%end_def()
+    call file%write_darray("values", write_buffer, decomp)
+    call file%sync()
+    call file%read_darray("values", read_buffer, decomp)
+    call file%close()
+
+    call check(all_close(write_buffer, read_buffer))
+
+    call io_handler%finalise()
+
+  end subroutine test_write_read_darray_real32_1d
+
+  subroutine test_write_read_darray_real32_2d(io_handler_factory, file_name)
+    !! Test writing and reading 2D 32-bit real arrays using the darray API.
+    procedure(io_handler_factory_interface) :: io_handler_factory
+      !! Factory procedure to create an IO handler (e.g., NetCDF or PIO)
+    character(*), intent(in) :: file_name
+      !! Name of the file to create and read from during the test
+    class(cable_netcdf_io_t), allocatable :: io_handler
+    class(cable_netcdf_file_t), allocatable :: file
+    class(cable_netcdf_decomp_t), allocatable :: decomp
+    integer, allocatable :: compmap(:)
+    integer :: block_per_pe, start, end
+    real(kind=CABLE_NETCDF_REAL32_KIND), allocatable :: write_buffer(:, :), read_buffer(:, :)
+
+    if (init_decomp(compmap, start, end, block_per_pe)) return
+
+    allocate(write_buffer(block_per_pe / 4, 4), source=real(this_rank() + VAL, kind=CABLE_NETCDF_REAL32_KIND))
+    allocate(read_buffer(block_per_pe / 4, 4), source=real(0, kind=CABLE_NETCDF_REAL32_KIND))
+
+    io_handler = io_handler_factory()
+
+    call io_handler%init()
+
+    decomp = io_handler%create_decomp(compmap, dims=[LEN], type=CABLE_NETCDF_FLOAT)
+
+    file = io_handler%create_file(file_name, iotype=CABLE_NETCDF_IOTYPE_NETCDF4P)
+
+    call file%def_dims(["i"], [LEN])
+    call file%def_var("values", CABLE_NETCDF_FLOAT, ["i"])
+    call file%end_def()
+    call file%write_darray("values", write_buffer, decomp)
+    call file%sync()
+    call file%read_darray("values", read_buffer, decomp)
+    call file%close()
+
+    call check(all_close(reshape(write_buffer, [block_per_pe]), reshape(read_buffer, [block_per_pe])))
+
+    call io_handler%finalise()
+
+  end subroutine test_write_read_darray_real32_2d
+
+  subroutine test_write_read_darray_real32_3d(io_handler_factory, file_name)
+    !! Test writing and reading 3D 32-bit real arrays using the darray API.
+    procedure(io_handler_factory_interface) :: io_handler_factory
+      !! Factory procedure to create an IO handler (e.g., NetCDF or PIO)
+    character(*), intent(in) :: file_name
+      !! Name of the file to create and read from during the test
+    class(cable_netcdf_io_t), allocatable :: io_handler
+    class(cable_netcdf_file_t), allocatable :: file
+    class(cable_netcdf_decomp_t), allocatable :: decomp
+    integer, allocatable :: compmap(:)
+    integer :: block_per_pe, start, end
+    real(kind=CABLE_NETCDF_REAL32_KIND), allocatable :: write_buffer(:, :, :), read_buffer(:, :, :)
+
+    if (init_decomp(compmap, start, end, block_per_pe)) return
+
+    allocate(write_buffer(block_per_pe / 4, 2, 2), source=real(this_rank() + VAL, kind=CABLE_NETCDF_REAL32_KIND))
+    allocate(read_buffer(block_per_pe / 4, 2, 2), source=real(0, kind=CABLE_NETCDF_REAL32_KIND))
+
+    io_handler = io_handler_factory()
+
+    call io_handler%init()
+
+    decomp = io_handler%create_decomp(compmap, dims=[LEN], type=CABLE_NETCDF_FLOAT)
+
+    file = io_handler%create_file(file_name, iotype=CABLE_NETCDF_IOTYPE_NETCDF4P)
+
+    call file%def_dims(["i"], [LEN])
+    call file%def_var("values", CABLE_NETCDF_FLOAT, ["i"])
+    call file%end_def()
+    call file%write_darray("values", write_buffer, decomp)
+    call file%sync()
+    call file%read_darray("values", read_buffer, decomp)
+    call file%close()
+
+    call check(all_close(reshape(write_buffer, [block_per_pe]), reshape(read_buffer, [block_per_pe])))
+
+    call io_handler%finalise()
+
+  end subroutine test_write_read_darray_real32_3d
+
+  subroutine test_write_read_darray_real64_1d(io_handler_factory, file_name)
+    !! Test writing and reading 1D 64-bit real arrays using the darray API.
+    procedure(io_handler_factory_interface) :: io_handler_factory
+      !! Factory procedure to create an IO handler (e.g., NetCDF or PIO)
+    character(*), intent(in) :: file_name
+      !! Name of the file to create and read from during the test
+    class(cable_netcdf_io_t), allocatable :: io_handler
+    class(cable_netcdf_file_t), allocatable :: file
+    class(cable_netcdf_decomp_t), allocatable :: decomp
+    integer, allocatable :: compmap(:)
+    integer :: block_per_pe, start, end
+    real(kind=CABLE_NETCDF_REAL64_KIND), allocatable :: write_buffer(:), read_buffer(:)
+
+    if (init_decomp(compmap, start, end, block_per_pe)) return
+
+    allocate(write_buffer(start:end), source=real(this_rank() + VAL, kind=CABLE_NETCDF_REAL64_KIND))
+    allocate(read_buffer(start:end), source=real(0, kind=CABLE_NETCDF_REAL64_KIND))
+
+    io_handler = io_handler_factory()
+
+    call io_handler%init()
+
+    decomp = io_handler%create_decomp(compmap, dims=[LEN], type=CABLE_NETCDF_DOUBLE)
+
+    file = io_handler%create_file(file_name, iotype=CABLE_NETCDF_IOTYPE_NETCDF4P)
+
+    call file%def_dims(["i"], [LEN])
+    call file%def_var("values", CABLE_NETCDF_DOUBLE, ["i"])
+    call file%end_def()
+    call file%write_darray("values", write_buffer, decomp)
+    call file%sync()
+    call file%read_darray("values", read_buffer, decomp)
+    call file%close()
+
+    call check(all_close(write_buffer, read_buffer))
+
+    call io_handler%finalise()
+
+  end subroutine test_write_read_darray_real64_1d
+
+  subroutine test_write_read_darray_real64_2d(io_handler_factory, file_name)
+    !! Test writing and reading 2D 64-bit real arrays using the darray API.
+    procedure(io_handler_factory_interface) :: io_handler_factory
+      !! Factory procedure to create an IO handler (e.g., NetCDF or PIO)
+    character(*), intent(in) :: file_name
+      !! Name of the file to create and read from during the test
+    class(cable_netcdf_io_t), allocatable :: io_handler
+    class(cable_netcdf_file_t), allocatable :: file
+    class(cable_netcdf_decomp_t), allocatable :: decomp
+    integer, allocatable :: compmap(:)
+    integer :: block_per_pe, start, end
+    real(kind=CABLE_NETCDF_REAL64_KIND), allocatable :: write_buffer(:, :), read_buffer(:, :)
+
+    if (init_decomp(compmap, start, end, block_per_pe)) return
+
+    allocate(write_buffer(block_per_pe / 4, 4), source=real(this_rank() + VAL, kind=CABLE_NETCDF_REAL64_KIND))
+    allocate(read_buffer(block_per_pe / 4, 4), source=real(0, kind=CABLE_NETCDF_REAL64_KIND))
+
+    io_handler = io_handler_factory()
+
+    call io_handler%init()
+
+    decomp = io_handler%create_decomp(compmap, dims=[LEN], type=CABLE_NETCDF_DOUBLE)
+
+    file = io_handler%create_file(file_name, iotype=CABLE_NETCDF_IOTYPE_NETCDF4P)
+
+    call file%def_dims(["i"], [LEN])
+    call file%def_var("values", CABLE_NETCDF_DOUBLE, ["i"])
+    call file%end_def()
+    call file%write_darray("values", write_buffer, decomp)
+    call file%sync()
+    call file%read_darray("values", read_buffer, decomp)
+    call file%close()
+
+    call check(all_close(reshape(write_buffer, [block_per_pe]), reshape(read_buffer, [block_per_pe])))
+
+    call io_handler%finalise()
+
+  end subroutine test_write_read_darray_real64_2d
+
+  subroutine test_write_read_darray_real64_3d(io_handler_factory, file_name)
+    !! Test writing and reading 3D 64-bit real arrays using the darray API.
+    procedure(io_handler_factory_interface) :: io_handler_factory
+      !! Factory procedure to create an IO handler (e.g., NetCDF or PIO)
+    character(*), intent(in) :: file_name
+      !! Name of the file to create and read from during the test
+    class(cable_netcdf_io_t), allocatable :: io_handler
+    class(cable_netcdf_file_t), allocatable :: file
+    class(cable_netcdf_decomp_t), allocatable :: decomp
+    integer, allocatable :: compmap(:)
+    integer :: block_per_pe, start, end
+    real(kind=CABLE_NETCDF_REAL64_KIND), allocatable :: write_buffer(:, :, :), read_buffer(:, :, :)
+
+    if (init_decomp(compmap, start, end, block_per_pe)) return
+
+    allocate(write_buffer(block_per_pe / 4, 2, 2), source=real(this_rank() + VAL, kind=CABLE_NETCDF_REAL64_KIND))
+    allocate(read_buffer(block_per_pe / 4, 2, 2), source=real(0, kind=CABLE_NETCDF_REAL64_KIND))
+
+    io_handler = io_handler_factory()
+
+    call io_handler%init()
+
+    decomp = io_handler%create_decomp(compmap, dims=[LEN], type=CABLE_NETCDF_DOUBLE)
+
+    file = io_handler%create_file(file_name, iotype=CABLE_NETCDF_IOTYPE_NETCDF4P)
+
+    call file%def_dims(["i"], [LEN])
+    call file%def_var("values", CABLE_NETCDF_DOUBLE, ["i"])
+    call file%end_def()
+    call file%write_darray("values", write_buffer, decomp)
+    call file%sync()
+    call file%read_darray("values", read_buffer, decomp)
+    call file%close()
+
+    call check(all_close(reshape(write_buffer, [block_per_pe]), reshape(read_buffer, [block_per_pe])))
+
+    call io_handler%finalise()
+
+  end subroutine test_write_read_darray_real64_3d
+
+end module test_cable_netcdf

--- a/tests/testapp.F90
+++ b/tests/testapp.F90
@@ -6,11 +6,11 @@
 program testapp
   use fortuno_interface_mod, only: execute_cmd_app
   use fortuno_interface_mod, only: test_list => test_list_t
-  use test_example_mod, only: test_example
+  use test_cable_netcdf, only: cable_netcdf_test_list
   implicit none
 
   call execute_cmd_app(test_list([ &
-      test_example() &
+      cable_netcdf_test_list() &
   ]))
 
 end program testapp

--- a/tests/utils/file_utils.F90
+++ b/tests/utils/file_utils.F90
@@ -1,0 +1,34 @@
+! CSIRO Open Source Software License Agreement (variation of the BSD / MIT License)
+! Copyright (c) 2015, Commonwealth Scientific and Industrial Research Organisation
+! (CSIRO) ABN 41 687 119 230.
+
+module file_utils
+  use fortuno_interface_mod, only: global_comm
+  use cable_mpi_mod, only: mpi_grp_t
+  implicit none
+
+  private
+
+  public file_exists
+  public file_delete
+
+contains
+
+  function file_exists(file_name)
+    character(len=*), intent(in) :: file_name
+    logical :: file_exists
+    inquire(file=trim(file_name), exist=file_exists)
+  end function
+
+  subroutine file_delete(file_name)
+    character(len=*), intent(in) :: file_name
+    integer :: file_unit
+    type(mpi_grp_t) :: mpi_grp
+    mpi_grp = mpi_grp_t(global_comm())
+    if (mpi_grp%rank /= 0) return
+    if (.not. file_exists(file_name)) return
+    open(file=file_name, newunit=file_unit)
+    close(file_unit, status="delete")
+  end subroutine
+
+end module file_utils


### PR DESCRIPTION
This change brings in the interface layer for working with the NetCDF Fortran and ParallelIO (PIO) libraries in CABLE. PIO allows for each MPI rank to participate in I/O operations collectively and is a first step in adding MPI support to the serial offline driver, and eventually, to replace the legacy MPI implementation (https://github.com/CABLE-LSM/CABLE/issues/358).

To keep CABLE dependencies as minimal as possible for running in serial mode (without MPI), the interface layer is designed such that PIO support is optional.

To build CABLE with PIO, PIO version 2.6.8 or greater is required.

## Type of change

Please delete options that are not relevant.

- [x] New feature
- [x] New or updated documentation

## Checklist

- [x] The new content is accessible and located in the appropriate section
- [x] I have checked that links are valid and point to the intended content
- [x] I have checked my code/text and corrected any misspellings

## Testing

- [x] Are the changes bitwise-compatible with the main branch? If working on an optional feature, are the results bitwise-compatible when this feature is off? If yes, copy benchcab output showing successful completion of the bitwise compatibility tests or equivalent results below this line.

```
2026-03-17 12:43:56,608 - INFO - benchcab.benchcab.py:380 - Running comparison tasks...
2026-03-17 12:43:56,634 - INFO - benchcab.benchcab.py:381 - tasks: 168 (models: 2, sites: 42, science configurations: 4)
2026-03-17 12:46:38,124 - INFO - benchcab.benchcab.py:391 - 0 failed, 168 passed
```

<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--706.org.readthedocs.build/en/706/

<!-- readthedocs-preview cable end -->