### PR TITLE
Add library to build to build-ci workflow

### DIFF
--- a/.github/build-ci/manifests/gcc.spack.yaml.j2
+++ b/.github/build-ci/manifests/gcc.spack.yaml.j2
@@ -1,6 +1,7 @@
 spack:
   specs:
   - cable@git.{{ ref }}
+  - cable@git.{{ ref }} library=access-esm1.6
   packages:
     all:
       require:

--- a/.github/build-ci/manifests/intel.spack.yaml.j2
+++ b/.github/build-ci/manifests/intel.spack.yaml.j2
@@ -1,6 +1,7 @@
 spack:
   specs:
   - cable@git.{{ ref }}
+  - cable@git.{{ ref }} library=access-esm1.6
   packages:
     all:
       require:


### PR DESCRIPTION
This change adds the ACCESS-ESM1.6 library build to the `build-ci` workflow.

## Type of change

- [x] New feature

## Checklist

- [x] The new content is accessible and located in the appropriate section
- [x] I have checked that links are valid and point to the intended content
- [x] I have checked my code/text and corrected any misspellings

## Testing

- [x] Are the changes bitwise-compatible with the main branch? If working on an optional feature, are the results bitwise-compatible when this feature is off? If yes, copy benchcab output showing successful completion of the bitwise compatibility tests or equivalent results below this line.

Source files which change results are unaffected by this change

<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--707.org.readthedocs.build/en/707/

<!-- readthedocs-preview cable end -->