### PR TITLE
src/offline/pftlookup.csv: Delete broken symlink

### DIFF
--- a/src/offline/pftlookup.csv
+++ b/src/offline/pftlookup.csv
@@ -1,1 +1,0 @@
-/scratch/p66/jxs599/MGK_Benchmarking/CABLE-3.0/CABLE-3.0_Allsites/src/CABLE-AUX/core/biogeochem/pftlookup_csiro_v16_17tiles_Ticket2.csv


### PR DESCRIPTION
Delete broken symlink to `pftlookup.csv`. This seems to be left over from the SVN-GitHub transition (see #714).

## Type of change

- [x] Cleanup

<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--717.org.readthedocs.build/en/717/

<!-- readthedocs-preview cable end -->