### PR TITLE
Initialize land_decomp_start to 1

### DIFF
--- a/src/offline/cable_iovars.F90
+++ b/src/offline/cable_iovars.F90
@@ -106,7 +106,7 @@ MODULE cable_IO_vars_module
        max_vegpatches,   & ! The maximum # of patches in any grid cell
        nmetpatches         ! size of patch dimension in met file, if exists
 
-  INTEGER :: land_decomp_start
+  INTEGER :: land_decomp_start = 0
     !! Starting land point index of this MPI rank in global land array
   INTEGER :: land_decomp_end
     !! Ending land point index of this MPI rank in global land array

--- a/src/offline/cable_iovars.F90
+++ b/src/offline/cable_iovars.F90
@@ -106,7 +106,7 @@ MODULE cable_IO_vars_module
        max_vegpatches,   & ! The maximum # of patches in any grid cell
        nmetpatches         ! size of patch dimension in met file, if exists
 
-  INTEGER :: land_decomp_start = 1
+  INTEGER :: land_decomp_start
     !! Starting land point index of this MPI rank in global land array
   INTEGER :: land_decomp_end
     !! Ending land point index of this MPI rank in global land array
@@ -574,6 +574,12 @@ CONTAINS
     END IF
 
   END SUBROUTINE set_group_output_values
+
+  SUBROUTINE set_decomp_for_coupled()
+    ! In coupled mode, we leave the decomposition up to the controlling UM-
+    ! treat every process as it's own simulation
+    land_decomp_start = 1
+  END SUBROUTINE set_decomp_for_coupled
 
   FUNCTION to_land_index_global(land_index_local) RESULT(land_index_global)
     !! Translate local land index on current MPI rank to global land index

--- a/src/offline/cable_iovars.F90
+++ b/src/offline/cable_iovars.F90
@@ -106,7 +106,7 @@ MODULE cable_IO_vars_module
        max_vegpatches,   & ! The maximum # of patches in any grid cell
        nmetpatches         ! size of patch dimension in met file, if exists
 
-  INTEGER :: land_decomp_start = 0
+  INTEGER :: land_decomp_start = 1
     !! Starting land point index of this MPI rank in global land array
   INTEGER :: land_decomp_end
     !! Ending land point index of this MPI rank in global land array


### PR DESCRIPTION
# CABLE

## Description

The recent addition of `to_land_index_global` in `src/offline/cable_iovars.F90` is currently not compatible with running in coupled mode. This routine is called in the land use code, which is intended to be included in coupled applications, so it does need to be included in coupled mode. I believe initialising `land_decomp_start` to 1 will make this function as expected in coupled applications, where we never call the decomposition initialisation. Do you think this is correct @SeanBryan51?

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## Checklist

- [ ] The new content is accessible and located in the appropriate section
- [ ] I have checked that links are valid and point to the intended content
- [ ] I have checked my code/text and corrected any misspellings

## Testing

- [ ] Are the changes bitwise-compatible with the main branch? If working on an optional feature, are the results bitwise-compatible when this feature is off? If yes, copy benchcab output showing successful completion of the bitwise compatibility tests or equivalent results below this line.

- [ ] Are the changes non bitwise-compatible with the main branch because of a bug fix or a feature being newly implemented or improved? If yes, add the link to the modelevaluation.org analysis versus the main branch or equivalent results below this line.


<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--725.org.readthedocs.build/en/725/

<!-- readthedocs-preview cable end -->