### PR TITLE
Bring up to date with ACCESS3 science

### DIFF
--- a/src/coupled/AM3/control/cable/CM3/cbl_cbm_mod.F90
+++ b/src/coupled/AM3/control/cable/CM3/cbl_cbm_mod.F90
@@ -77,7 +77,6 @@ REAL :: veg_wt(mp)
 REAL :: veg_trad(mp)      
 REAL :: soil_wt(mp)       
 REAL :: soil_trad(mp)     
-REAL :: trad_corr(mp)     
 
 CHARACTER(LEN=8),  PARAMETER :: subr_name = "ExpCbmT_"
 
@@ -173,9 +172,8 @@ veg_wt    = 1.0 - rad%transd
 veg_trad  = Cemleaf * canopy%tv**4
 soil_wt   = rad%transd 
 soil_trad = Cemsoil * ssnow%otss**4
-trad_corr = canopy%fns_cor/CSBOLTZ
 
-rad%trad = ( veg_wt * veg_trad )  + ( soil_wt * soil_trad ) + trad_corr  
+rad%trad = ( veg_wt * veg_trad )  + ( soil_wt * soil_trad )
 rad%trad = rad%trad**0.25
 
 RETURN
@@ -260,7 +258,6 @@ REAL ::  veg_wt(mp)
 REAL ::  veg_trad(mp)      
 REAL ::  soil_wt(mp)       
 REAL ::  soil_trad(mp)     
-REAL ::  trad_corr(mp)     
 
 CHARACTER(LEN=8),  PARAMETER :: subr_name = "cbm_impl"
 
@@ -375,9 +372,8 @@ veg_wt    = 1.0 - rad%transd
 veg_trad  = Cemleaf * canopy%tv**4
 soil_wt   = rad%transd 
 soil_trad = Cemsoil * ssnow%otss**4
-trad_corr = canopy%fns_cor/CSBOLTZ
 
-rad%trad = ( veg_wt * veg_trad )  + ( soil_wt * soil_trad ) + trad_corr  
+rad%trad = ( veg_wt * veg_trad )  + ( soil_wt * soil_trad )
 rad%trad = rad%trad**0.25
 
 ! In physical model only (i.e. without CASA-CNP)

--- a/src/coupled/AM3/control/cable/CM3/cbl_cbm_mod.F90
+++ b/src/coupled/AM3/control/cable/CM3/cbl_cbm_mod.F90
@@ -171,7 +171,7 @@ canopy%rnet = canopy%fns + canopy%fnv
 veg_wt    = 1.0 - rad%transd
 veg_trad  = Cemleaf * canopy%tv**4
 soil_wt   = rad%transd 
-soil_trad = Cemsoil * ssnow%otss**4
+soil_trad = Cemsoil * ssnow%tss**4
 
 rad%trad = ( veg_wt * veg_trad )  + ( soil_wt * soil_trad )
 rad%trad = rad%trad**0.25
@@ -371,7 +371,7 @@ canopy%rnet = canopy%fns + canopy%fnv
 veg_wt    = 1.0 - rad%transd
 veg_trad  = Cemleaf * canopy%tv**4
 soil_wt   = rad%transd 
-soil_trad = Cemsoil * ssnow%otss**4
+soil_trad = Cemsoil * ssnow%tss**4
 
 rad%trad = ( veg_wt * veg_trad )  + ( soil_wt * soil_trad )
 rad%trad = rad%trad**0.25

--- a/src/science/soilsnow/cbl_soilsnow_main.F90
+++ b/src/science/soilsnow/cbl_soilsnow_main.F90
@@ -86,17 +86,6 @@ USE cable_phys_constants_mod,  ONLY: density_liq, density_ice
 
     ssnow%wbliq = ssnow%wb - ssnow%wbice
 
-  ! soilsnow_init_spec, special initalizations in um_init NA for ESM1.5
-
-   xx=soil%css * soil%rhosoil
-   IF (ktau <= 1)                                                              &
-     ssnow%gammzz(:,1) = MAX( (1.0 - soil%ssat) * soil%css * soil%rhosoil      &
-            & + (ssnow%wb(:,1) - ssnow%wbice(:,1) ) * Ccswat * Cdensity_liq           &
-            & + ssnow%wbice(:,1) * Ccsice * Cdensity_ice, xx ) * soil%zse(1) +   &
-            & (1. - ssnow%isflag) * Ccgsnow * ssnow%snowd
-
-
-
     DO k = 1, ms ! for stempv
 
        ! Set liquid soil water fraction (fraction of saturation value):


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

These are the science changes that occurred in the CABLE code that sits within JULES for AM3, that we want to move into the library. The changes removing the calculation of `gamzz` and `trad_corr` were discussed in the CABLE science update PR, [here](https://github.com/ACCESS-NRI/JULES/pull/324#discussion_r2719795074) and [here](https://github.com/ACCESS-NRI/JULES/issues/320#issuecomment-3765844984). I had missed the change from using `ssnow%otss` to `snow%tss` in the `soil_trad` calculation, but appears to be a deliberate change from [this JULES commit](https://github.com/ACCESS-NRI/JULES/commit/77e4ef1da95a7244863c06cefad99d9bc7b6e10d).

I am a little confused though- in your comment [here](https://github.com/ACCESS-NRI/JULES/issues/320#issuecomment-3765844984) @har917, you said that the `trad_corr` is still required in the `impl` call, but [this JULES commit](https://github.com/ACCESS-NRI/JULES/commit/77e4ef1da95a7244863c06cefad99d9bc7b6e10d) removes it from both `expl` and `impl` call. Should the `trad_corr` be re-introduced to the `impl` call?

It may also be preferred to leave `cbl_cbm_mod.F90` within JULES- at the moment, I only moved it since it lived in the same directory as all the geophysics type definitions, which must live within the library, but this isn't required for any of the science code. It may make more sense to leave it within JULES.

## Testing

- [x] Are the changes bitwise-compatible with the main branch? If working on an optional feature, are the results bitwise-compatible when this feature is off? If yes, copy benchcab output showing successful completion of the bitwise compatibility tests or equivalent results below this line.

2026-07-03 12:23:52,415 - INFO - benchcab.benchcab.py:391 - 0 failed, 168 passed

<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--729.org.readthedocs.build/en/729/

<!-- readthedocs-preview cable end -->