### PR TITLE
Fix library build for ESM1.6

### DIFF
--- a/.github/build-ci/compilers/spack.yaml
+++ b/.github/build-ci/compilers/spack.yaml
@@ -2,6 +2,7 @@ spack:
   specs:
   - gcc@13.2.0 %gcc@8.5.0
   - intel-oneapi-compilers-classic@2021.10.0
+  - intel-oneapi-compilers@2025.2.0
   view: false
   concretizer:
     unify: false

--- a/.github/build-ci/data/standard.json
+++ b/.github/build-ci/data/standard.json
@@ -1,3 +1,5 @@
 {
+    "gcc_compiler_ver": "13.2.0",
+    "oneapi_compiler_ver": "2021.10.0",
     "target": "x86_64"
 }

--- a/.github/build-ci/data/standard.json
+++ b/.github/build-ci/data/standard.json
@@ -1,5 +1,6 @@
 {
     "gcc_compiler_ver": "13.2.0",
-    "oneapi_compiler_ver": "2021.10.0",
+    "oneapi_compiler_classic_ver": "2021.10.0",
+    "oneapi_compiler_ver": "2025.2.0",
     "target": "x86_64"
 }

--- a/.github/build-ci/manifests/gcc.spack.yaml.j2
+++ b/.github/build-ci/manifests/gcc.spack.yaml.j2
@@ -1,14 +1,17 @@
 spack:
   specs:
   - cable@git.{{ ref }}
+
   packages:
     gcc:
       require:
       - '@13.2.0'
+
     all:
       require:
       - '%access_gcc'  # https://github.com/ACCESS-NRI/spack-config/blob/main/v1.1/toolchains.yaml
       - target={{ target }}
+
   concretizer:
     unify: false
   view: false

--- a/.github/build-ci/manifests/gcc.spack.yaml.j2
+++ b/.github/build-ci/manifests/gcc.spack.yaml.j2
@@ -5,7 +5,7 @@ spack:
   packages:
     gcc:
       require:
-      - '@13.2.0'
+      - '@{{ gcc_compiler_ver }}'
 
     all:
       require:

--- a/.github/build-ci/manifests/intel.spack.yaml.j2
+++ b/.github/build-ci/manifests/intel.spack.yaml.j2
@@ -2,6 +2,7 @@ spack:
   specs:
   - cable@git.{{ ref }}
 
+  packages:
     intel-oneapi-compilers-classic:
       require:
       - '@{{ oneapi_compiler_ver }}'

--- a/.github/build-ci/manifests/intel.spack.yaml.j2
+++ b/.github/build-ci/manifests/intel.spack.yaml.j2
@@ -5,7 +5,7 @@ spack:
   packages:
     intel-oneapi-compilers-classic:
       require:
-      - '@{{ oneapi_compiler_ver }}'
+      - '@{{ oneapi_compiler_classic_ver }}'
 
     all:
       require:

--- a/.github/build-ci/manifests/intel.spack.yaml.j2
+++ b/.github/build-ci/manifests/intel.spack.yaml.j2
@@ -4,7 +4,7 @@ spack:
 
     intel-oneapi-compilers-classic:
       require:
-      - '@2021.10.0'
+      - '@{{ oneapi_compiler_ver }}'
 
     all:
       require:

--- a/.github/build-ci/manifests/intel.spack.yaml.j2
+++ b/.github/build-ci/manifests/intel.spack.yaml.j2
@@ -1,17 +1,16 @@
 spack:
   specs:
   - cable@git.{{ ref }}
-  packages:
-    python:
-      require:
-        - '@3.11.14'
+
     intel-oneapi-compilers-classic:
       require:
       - '@2021.10.0'
+
     all:
       require:
       - '%access_intel'  # https://github.com/ACCESS-NRI/spack-config/blob/main/v1.1/toolchains.yaml
       - target={{ target }}
+
   concretizer:
     unify: false
   view: false

--- a/.github/build-ci/manifests/library-gcc.spack.yaml.j2
+++ b/.github/build-ci/manifests/library-gcc.spack.yaml.j2
@@ -5,7 +5,7 @@ spack:
   packages:
     gcc:
       require:
-      - '@13.2.0'
+      - '@{{ gcc_compiler_ver }}'
 
     all:
       require:

--- a/.github/build-ci/manifests/library-gcc.spack.yaml.j2
+++ b/.github/build-ci/manifests/library-gcc.spack.yaml.j2
@@ -1,0 +1,17 @@
+spack:
+  specs:
+  - cable@git.{{ ref }} ~mpi library=access-esm1.6
+
+  packages:
+    gcc:
+      require:
+      - '@13.2.0'
+
+    all:
+      require:
+      - '%access_gcc'
+      - 'target={{ target }}'
+
+  concretizer:
+    unify: false
+  view: false

--- a/.github/build-ci/manifests/library-intel.spack.yaml.j2
+++ b/.github/build-ci/manifests/library-intel.spack.yaml.j2
@@ -5,7 +5,7 @@ spack:
   packages:
     intel-oneapi-compilers-classic:
       require:
-      - '@{{ oneapi_compiler_ver }}'
+      - '@{{ oneapi_compiler_classic_ver }}'
 
     all:
       require:

--- a/.github/build-ci/manifests/library-intel.spack.yaml.j2
+++ b/.github/build-ci/manifests/library-intel.spack.yaml.j2
@@ -1,0 +1,17 @@
+spack:
+  specs:
+  - cable@git.{{ ref }} ~mpi library=access-esm1.6
+
+  packages:
+    intel-oneapi-compilers-classic:
+      require:
+      - '@2021.10.0'
+
+    all:
+      require:
+      - '%access_intel'
+      - target={{ target }}
+
+  concretizer:
+    unify: false
+  view:false

--- a/.github/build-ci/manifests/library-intel.spack.yaml.j2
+++ b/.github/build-ci/manifests/library-intel.spack.yaml.j2
@@ -5,7 +5,7 @@ spack:
   packages:
     intel-oneapi-compilers-classic:
       require:
-      - '@2021.10.0'
+      - '@{{ oneapi_compiler_ver }}'
 
     all:
       require:

--- a/.github/build-ci/manifests/library-intel.spack.yaml.j2
+++ b/.github/build-ci/manifests/library-intel.spack.yaml.j2
@@ -10,8 +10,8 @@ spack:
     all:
       require:
       - '%access_intel'
-      - target={{ target }}
+      - 'target={{ target }}'
 
   concretizer:
     unify: false
-  view:false
+  view: false

--- a/.github/build-ci/manifests/um7-acces-esm1p6.spack.yaml.j2
+++ b/.github/build-ci/manifests/um7-acces-esm1p6.spack.yaml.j2
@@ -1,0 +1,38 @@
+# Building UM7 stand-alone using access-esm1.6 spack version
+spack:
+  specs:
+  - 'um7@access-esm1.6'
+  packages:
+    dummygrib:
+      require:
+        - '@1.0'
+    oasis3-mct:
+      require:
+        - '@git.access-esm1.5-2025.03.001=access-esm1.5'
+    cable:
+      require:
+      - '@{{ ref }}'
+      - library=access-esm1.6
+    openmpi:
+      require:
+        - '@5.0.8'
+    netcdf-c:
+      require:
+        - '@4.9.2'
+    netcdf-fortran:
+      require:
+        - '@4.5.2'
+    fcm:
+      require:
+        - '@2021.05.0'
+        - 'site=nci-gadi'
+    intel-oneapi-compilers:
+      require:
+      - '@{{ oneapi_compiler_version }}'
+    all:
+      require:
+      - '%access_oneapi'
+      - 'target={{ target }}'
+  concretizer:
+    unify: false
+  view: false

--- a/.github/build-ci/manifests/um7-acces-esm1p6.spack.yaml.j2
+++ b/.github/build-ci/manifests/um7-acces-esm1p6.spack.yaml.j2
@@ -28,7 +28,7 @@ spack:
         - 'site=nci-gadi'
     intel-oneapi-compilers:
       require:
-      - '@{{ oneapi_compiler_version }}'
+      - '@{{ oneapi_compiler_ver }}'
     all:
       require:
       - '%access_oneapi'

--- a/.github/build-ci/manifests/um7-acces-esm1p6.spack.yaml.j2
+++ b/.github/build-ci/manifests/um7-acces-esm1p6.spack.yaml.j2
@@ -1,7 +1,7 @@
 # Building UM7 stand-alone using access-esm1.6 spack version
 spack:
   specs:
-  - 'um7@access-esm1.6'
+  - 'um7'
   packages:
     dummygrib:
       require:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,28 +1,45 @@
 name: Build
 on:
   pull_request:
+  push:
     branches:
-      - main
+      - '[0-9]*.[0-9]*' # Default branch naming
 jobs:
+  pre-ci:
+    name: Pre-CI
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up matrix
+        id: set-matrix
+        # Find all relevant files under .github/build-ci/manifests
+        # then output them as a JSON array (minus the last comma)
+        run: |
+          files=$(find .github/build-ci/manifests/ -iname '*.j2' -printf '"%p",')
+          echo "matrix=[${files%,}]" >> $GITHUB_OUTPUT
+
   ci:
     name: CI
+    needs: pre-ci
     strategy:
       fail-fast: false
+      max-parallel: 5
       matrix:
-        spack-manifest-path:
-          - .github/build-ci/manifests/gcc.spack.yaml.j2
-          - .github/build-ci/manifests/intel.spack.yaml.j2
-          - .github/build-ci/manifests/library-intel.spack.yaml.j2
+        file: ${{ fromJson(needs.pre-ci.outputs.matrix) }}
     uses: access-nri/build-ci/.github/workflows/ci.yml@v3
     with:
-      # For defaults for args not specified here (eg. spack/packages/config refs), see https://github.com/ACCESS-NRI/build-ci/blob/v3/.github/workflows/README.md
-      spack-manifest-path: ${{ matrix.spack-manifest-path }}
+      spack-manifest-path: ${{ matrix.file }}
+      allow-ssh-into-spack-install: false  # If true, PR author must ssh into instance to complete job
       spack-manifest-data-path: .github/build-ci/data/standard.json
-      # We need to install the compilers manually here because the upstream image is too large to run on GitHub-hosted runners
+      spack-oci-buildcache-url: oci://ghcr.io/CABLE-LSM/build-ci-buildcache
       spack-compiler-manifest-path: .github/build-ci/compilers/spack.yaml
-      allow-ssh-into-spack-install: false
-      spack-oci-buildcache-url: oci://ghcr.io/CABLE-LSM/build-ci-buildcache  # https://github.com/orgs/CABLE-LSM/packages/container/package/build-ci-buildcache
-      # Since CABLE-LSM can't access ACCESS-NRI's self-hosted runners, we use a GitHub-hosted version
+      # builtin-spack-packages-ref: develop
+      # access-spack-packages-ref: api-v2
+      # spack-config-ref: main
+      # spack-ref: releases/v1.1
+      
+      # CABLE isn't part of the ACCESS-NRI org so can't access the runners
       run-self-hosted: false
-    permissions:
-      packages: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
         spack-manifest-path:
           - .github/build-ci/manifests/gcc.spack.yaml.j2
           - .github/build-ci/manifests/intel.spack.yaml.j2
+          - .github/build-ci/manifests/intel-library.spack.yaml.j2
     uses: access-nri/build-ci/.github/workflows/ci.yml@v3
     with:
       # For defaults for args not specified here (eg. spack/packages/config refs), see https://github.com/ACCESS-NRI/build-ci/blob/v3/.github/workflows/README.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         spack-manifest-path:
           - .github/build-ci/manifests/gcc.spack.yaml.j2
           - .github/build-ci/manifests/intel.spack.yaml.j2
-          - .github/build-ci/manifests/intel-library.spack.yaml.j2
+          - .github/build-ci/manifests/library-intel.spack.yaml.j2
     uses: access-nri/build-ci/.github/workflows/ci.yml@v3
     with:
       # For defaults for args not specified here (eg. spack/packages/config refs), see https://github.com/ACCESS-NRI/build-ci/blob/v3/.github/workflows/README.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,7 @@ jobs:
       
       # CABLE isn't part of the ACCESS-NRI org so can't access the runners
       run-self-hosted: false
+
+    secrets:
+      # Needed to access private ACCESS-NRI repos
+      spack-install-command-path: ${{ secrets.SPACK_INSTALL_COMMAND_PAT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,4 +46,4 @@ jobs:
 
     secrets:
       # Needed to access private ACCESS-NRI repos
-      spack-install-command-path: ${{ secrets.SPACK_INSTALL_COMMAND_PAT }}
+      spack-install-command-pat: ${{ secrets.SPACK_INSTALL_COMMAND_PAT }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,11 +145,11 @@ if(CABLE_LIBRARY)
         src/coupled/shared/cable_veg_type_mod.F90
         src/util/cable_climate_type_mod.F90
         src/util/masks_cbl.F90
+        src/offline/cable_iovars.F90
     )
 
     if(CABLE_LIBRARY_TARGET STREQUAL "access-esm1.6")
         list(APPEND SOURCES
-            src/coupled/esm/cable_iovars.F90
             src/coupled/esm/cable_surface_types.F90
             src/coupled/esm/cable_define_types.F90
             src/coupled/esm/cable_soil_params_mod.F90


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

This fixes the ESM1.6 library build. The cause of the breakage was indirectly a small change to `src/science/landuse/landuse3.F90` in [this commit](https://github.com/CABLE-LSM/CABLE/commit/9d5457bf9e78b997196e4a6fbc0bfffb8f3c4bc9#diff-a9e63c5c5e70456053f09751927e847fcac3607a400f29390fb60f282f6831a0). This code is not used coupled model, but is referenced in the other science code so required for compilation. The indexer used there is defined in `src/offline/cable_iovars.F90`, which has diverged from `src/coupled/esm/cable_iovars.F90`. The offline version has some changes which are strict additions and one which is an effective change, which is the change of the checks mechanism. This is only called during the offline I/O, and has no effect on the coupled model.

The `cable_IO_vars_module` doesn't seem to be included in the AM3 build (without library), although it is in code that is not part of a module (I didn't even know that was possible... see [this `src/science/landuse/landuse3.F90` code](https://github.com/CABLE-LSM/CABLE/blob/285ff0a11c98b50b3b690a52b57ef33a6b726094/src/science/landuse/landuse3.F90#L730-L734) that also appears in JULES). The offline version of `cable_iovars.F90` also seems to work with AM3.

The gist is, we have multiple versions of `cable_iovars.F90`, but only need 1. The dependence of the science code on stuff in the IO vars module should be removed, but that is a future problem.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## Checklist

- [x] The new content is accessible and located in the appropriate section
- [x] I have checked that links are valid and point to the intended content
- [x] I have checked my code/text and corrected any misspellings

## Testing

- [x] Are the changes bitwise-compatible with the main branch? If working on an optional feature, are the results bitwise-compatible when this feature is off? If yes, copy benchcab output showing successful completion of the bitwise compatibility tests or equivalent results below this line.


<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--730.org.readthedocs.build/en/730/

<!-- readthedocs-preview cable end -->