### PR TITLE
Update CI to be consistent with other MCRs

### DIFF
--- a/.github/build-ci/compilers/spack.yaml
+++ b/.github/build-ci/compilers/spack.yaml
@@ -1,0 +1,7 @@
+spack:
+  specs:
+  - gcc@13.2.0 %gcc@8.5.0
+  - intel-oneapi-compilers-classic@2021.10.0
+  view: false
+  concretizer:
+    unify: false

--- a/.github/build-ci/compilers/spack.yaml
+++ b/.github/build-ci/compilers/spack.yaml
@@ -1,7 +1,0 @@
-spack:
-  specs:
-  - gcc@13.2.0 %gcc@8.5.0
-  - intel-oneapi-compilers-classic@2021.10.0
-  view: false
-  concretizer:
-    unify: false

--- a/.github/build-ci/data/standard.json
+++ b/.github/build-ci/data/standard.json
@@ -1,3 +1,5 @@
 {
+    "gcc_compiler_ver": "@13.2.0",
+    "oneapi_compiler_ver": "@2021.10.0",
     "target": "x86_64"
 }

--- a/.github/build-ci/data/standard.json
+++ b/.github/build-ci/data/standard.json
@@ -1,5 +1,5 @@
 {
-    "gcc_compiler_ver": "@13.2.0",
-    "oneapi_compiler_ver": "@2021.10.0",
+    "gcc_compiler_ver": "13.2.0",
+    "oneapi_compiler_ver": "2021.10.0",
     "target": "x86_64"
 }

--- a/.github/build-ci/manifests/gcc.spack.yaml.j2
+++ b/.github/build-ci/manifests/gcc.spack.yaml.j2
@@ -4,7 +4,7 @@ spack:
   packages:
     gcc:
       require:
-      - '@13.2.0'
+      - '@{{ gcc_compiler_version }}'
     all:
       require:
       - '%access_gcc'  # https://github.com/ACCESS-NRI/spack-config/blob/main/v1.1/toolchains.yaml

--- a/.github/build-ci/manifests/gcc.spack.yaml.j2
+++ b/.github/build-ci/manifests/gcc.spack.yaml.j2
@@ -4,7 +4,7 @@ spack:
   packages:
     gcc:
       require:
-      - '@{{ gcc_compiler_version }}'
+      - '@{{ gcc_compiler_ver }}'
     all:
       require:
       - '%access_gcc'  # https://github.com/ACCESS-NRI/spack-config/blob/main/v1.1/toolchains.yaml

--- a/.github/build-ci/manifests/intel.spack.yaml.j2
+++ b/.github/build-ci/manifests/intel.spack.yaml.j2
@@ -7,7 +7,7 @@ spack:
         - '@3.11.14'
     intel-oneapi-compilers-classic:
       require:
-      - '@{{ oneapi_compiler_version }}'
+      - '@{{ oneapi_compiler_ver }}'
     all:
       require:
       - '%access_intel'  # https://github.com/ACCESS-NRI/spack-config/blob/main/v1.1/toolchains.yaml

--- a/.github/build-ci/manifests/intel.spack.yaml.j2
+++ b/.github/build-ci/manifests/intel.spack.yaml.j2
@@ -7,7 +7,7 @@ spack:
         - '@3.11.14'
     intel-oneapi-compilers-classic:
       require:
-      - '@2021.10.0'
+      - '@{{ oneapi_compiler_version }}'
     all:
       require:
       - '%access_intel'  # https://github.com/ACCESS-NRI/spack-config/blob/main/v1.1/toolchains.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
       allow-ssh-into-spack-install: false  # If true, PR author must ssh into instance to complete job
       spack-manifest-data-path: .github/build-ci/data/standard.json
       spack-oci-buildcache-url: oci://ghcr.io/CABLE-LSM/build-ci-buildcache
-      allow-ssh-into-spack-install: false
       spack-compiler-manifest-path: .github/build-ci/compilers/spack.yaml
       # builtin-spack-packages-ref: develop
       # access-spack-packages-ref: api-v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,6 @@ jobs:
       # access-spack-packages-ref: api-v2
       # spack-config-ref: main
       # spack-ref: releases/v1.1
+      
+      # CABLE isn't part of the ACCESS-NRI org so can't access the runners
+      run-self-hosted: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,27 +1,40 @@
 name: Build
 on:
   pull_request:
+  push:
     branches:
-      - main
+      - '[0-9]*.[0-9]*' # Default branch naming
 jobs:
+  pre-ci:
+    name: Pre-CI
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up matrix
+        id: set-matrix
+        # Find all relevant files under .github/build-ci/manifests
+        # then output them as a JSON array (minus the last comma)
+        run: |
+          files=$(find .github/build-ci/manifests/ -iname '*.j2' -printf '"%p",')
+          echo "matrix=[${files%,}]" >> $GITHUB_OUTPUT
+
   ci:
     name: CI
+    needs: pre-ci
     strategy:
       fail-fast: false
+      max-parallel: 5
       matrix:
-        spack-manifest-path:
-          - .github/build-ci/manifests/gcc.spack.yaml.j2
-          - .github/build-ci/manifests/intel.spack.yaml.j2
+        file: ${{ fromJson(needs.pre-ci.outputs.matrix) }}
     uses: access-nri/build-ci/.github/workflows/ci.yml@v3
     with:
-      # For defaults for args not specified here (eg. spack/packages/config refs), see https://github.com/ACCESS-NRI/build-ci/blob/v3/.github/workflows/README.md
-      spack-manifest-path: ${{ matrix.spack-manifest-path }}
+      spack-manifest-path: ${{ matrix.file }}
+      allow-ssh-into-spack-install: false  # If true, PR author must ssh into instance to complete job
       spack-manifest-data-path: .github/build-ci/data/standard.json
-      # We need to install the compilers manually here because the upstream image is too large to run on GitHub-hosted runners
-      spack-compiler-manifest-path: .github/build-ci/compilers/spack.yaml
-      allow-ssh-into-spack-install: false
-      spack-oci-buildcache-url: oci://ghcr.io/CABLE-LSM/build-ci-buildcache  # https://github.com/orgs/CABLE-LSM/packages/container/package/build-ci-buildcache
-      # Since CABLE-LSM can't access ACCESS-NRI's self-hosted runners, we use a GitHub-hosted version
-      run-self-hosted: false
-    permissions:
-      packages: write
+      # builtin-spack-packages-ref: develop
+      # access-spack-packages-ref: api-v2
+      # spack-config-ref: main
+      # spack-ref: releases/v1.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
       allow-ssh-into-spack-install: false  # If true, PR author must ssh into instance to complete job
       spack-manifest-data-path: .github/build-ci/data/standard.json
       spack-oci-buildcache-url: oci://ghcr.io/CABLE-LSM/build-ci-buildcache
+      allow-ssh-into-spack-install: false
+      spack-compiler-manifest-path: .github/build-ci/compilers/spack.yaml
       # builtin-spack-packages-ref: develop
       # access-spack-packages-ref: api-v2
       # spack-config-ref: main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
       spack-manifest-path: ${{ matrix.file }}
       allow-ssh-into-spack-install: false  # If true, PR author must ssh into instance to complete job
       spack-manifest-data-path: .github/build-ci/data/standard.json
+      spack-oci-buildcache-url: oci://ghcr.io/CABLE-LSM/build-ci-buildcache
       # builtin-spack-packages-ref: develop
       # access-spack-packages-ref: api-v2
       # spack-config-ref: main


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

This brings the CABLE CI more in line with our other model component repositories. Uses the `data/standards.json` to define targets and compiler versions, and uses the two-step CI workflow.

<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--732.org.readthedocs.build/en/732/

<!-- readthedocs-preview cable end -->