### PR TITLE
documentation/mkdocs.yml: Remove malicious polyfill extra

### DIFF
--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -64,7 +64,6 @@ markdown_extensions:
 
 extra_javascript:
   - javascripts/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
 
 # Navigation


### PR DESCRIPTION
The current documentation will open a login prompt asking you to enter a username and password. This seems to be related to polyfill domain which was sold and used to inject malware. This change removes the polyfill extra to remove the extension.

## Type of change

- [x] New or updated documentation

## Checklist

- [x] The new content is accessible and located in the appropriate section
- [x] I have checked that links are valid and point to the intended content
- [x] I have checked my code/text and corrected any misspellings

<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--734.org.readthedocs.build/en/734/

<!-- readthedocs-preview cable end -->