### PR TITLE
Update um-access3.spack.yaml.j2 references

### DIFF
--- a/.github/build-ci/manifests/um-access3.spack.yaml.j2
+++ b/.github/build-ci/manifests/um-access3.spack.yaml.j2
@@ -1,6 +1,6 @@
 spack:
   specs:
-  - um@13.0 +cable model=vn13 um_ref="AM3-dev" jules_ref="AM3-dev" ukca_ref="AM3-2026.03.0"
+  - um@13.0 +cable model=vn13 um_ref="AM3-dev" jules_ref="AM3-dev" ukca_ref="AM3-2026.08.000" shumlib_ref="2026.07.0" casim_ref="um13.8" socrates_ref="um13.8"
 
   packages:
     cable:


### PR DESCRIPTION
# CABLE

Thank you for submitting a pull request to the CABLE Project.

## Description

The CI manifests were set up when the heads of JULES and UM were on 13.1. They have been upgraded to 13.8, but the rest of the components weren't. This updates the rest of the components.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## Checklist

- [x] The new content is accessible and located in the appropriate section
- [x] I have checked that links are valid and point to the intended content
- [x] I have checked my code/text and corrected any misspellings

## Testing

- [x] Are the changes bitwise-compatible with the main branch? If working on an optional feature, are the results bitwise-compatible when this feature is off? If yes, copy benchcab output showing successful completion of the bitwise compatibility tests or equivalent results below this line.


<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--735.org.readthedocs.build/en/735/

<!-- readthedocs-preview cable end -->