### PR TITLE
Add `@git.` section to `cable` component for `um7` `esm1p6` build

### DIFF
--- a/.github/build-ci/manifests/um7-acces-esm1p6.spack.yaml.j2
+++ b/.github/build-ci/manifests/um7-acces-esm1p6.spack.yaml.j2
@@ -11,7 +11,7 @@ spack:
         - '@git.access-esm1.5-2025.03.001=access-esm1.5'
     cable:
       require:
-      - '@{{ ref }}'
+      - '@git.{{ ref }}'
       - library=access-esm1.6
     openmpi:
       require:


### PR DESCRIPTION
## Background

We didn't add an `@git.` section to one of the `cable` builds, which led to a failure when building with a non-commit-hash build - see https://github.com/ACCESS-NRI/upstream-spack-packages/actions/runs/32436095811/job/96640684757?pr=7. 

Spack accepts 40-char git hashes as part of `@` and `@git.`, which is why this hasn't shown up in the CI here (which only uses commit hashes for the `{{ ref }}`. But in `access-spack-packages` (which uses branch refs), it tried to do `@main` - looking for a particular `version("main")` in the `package.py` which didn't exist.

## The PR

* Add `@git`-style versioning to the `um7`-based `esm1p6` manifest to correctly do branch-based versions. 


<!-- readthedocs-preview cable start -->
----
📚 Documentation preview 📚: https://cable--736.org.readthedocs.build/en/736/

<!-- readthedocs-preview cable end -->